### PR TITLE
New logs doc #104

### DIFF
--- a/v0.8/deployment-level-logs.md
+++ b/v0.8/deployment-level-logs.md
@@ -7,9 +7,20 @@ slug: "deployment-level-logs"
 
 ## Overview
 
-As of Astronomer v0.8, the Astronomer UI allows you to look up and search Airflow logs emitted by your Webserver, Scheduler and Worker(s) for any deployment within your Workspace.
+As of Astronomer v0.8, the Astronomer UI allows you to look up and search Airflow logs emitted by your Webserver, Scheduler and Worker(s) for any deployment you have access to.
 
-**Note**: These are deployment level logs that will help you monitor the health of your deployment's components, _not_ task-level logs that you'd find in the Airflow Web UI.
+### Interpreting Logs
+
+We've designed this view to give you access to deployment level logs that will help you monitor the health of your deployment's component (Webserver, Scheduler, Worker).
+
+**Note:** These are _not_ task-level logs that you'd find in the Airflow Web UI. Logs on Astronomer are not a replacement for task-level logging in the Airflow UI.
+
+A few use cases:
+
+- See your Scheduler, Webserver, and Workers all restart after you push `astro airflow deploy`
+- If your Airflow UI is not loading as expected - is your Webserver in a CrashLoop?
+- How quickly is your Scheduler queuing up tasks?
+- Is your Celery worker behaving unexpectedly?
 
 ### Pre-Requisites
 
@@ -26,7 +37,7 @@ In the dropdown on the top-right, you'll see a button where you can toggle betwe
 
 - Scheduler
 - Webserver
-- Celery Workers (*if applicable*)
+- Workers (*if applicable*)
 
 ![Webserver Logs Page](https://assets2.astronomer.io/main/docs/logs/logs-webserver.png)
 

--- a/v0.8/logs.md
+++ b/v0.8/logs.md
@@ -1,0 +1,67 @@
+---
+title: "Deployment-Level Logs"
+description: "How to access Worker, Scheduler, and Webserver Logs in the Astronomer UI"
+date: 2019-06-17T00:00:00.000Z
+slug: "deployment-level-logs"
+---
+
+## Overview
+
+As of Astronomer v0.8, the Astronomer UI allows you to look up and search Airflow logs emitted by your Webserver, Scheduler and Worker(s) for any deployment within your Workspace.
+
+**Note**: These are deployment level logs that will help you monitor the health of your deployment's components, _not_ task-level logs that you'd find in the Airflow Web UI.
+
+### Pre-Requisites
+
+To view logs on Astronomer, you'll need:
+
+- An account on Astronomer Cloud OR access to an Astronomer Enterprise Installation
+- An Airflow deployment on Astronomer
+
+## View Logs
+
+To view Airflow logs, log into Astronomer and navigate to: Deployment > Logs.
+
+In the dropdown on the top-right, you'll see a button where you can toggle between logs for your:
+
+- Scheduler
+- Webserver
+- Celery Workers (*if applicable*)
+
+![Webserver Logs Page](https://assets2.astronomer.io/main/docs/logs/logs-webserver.png)
+
+### Filter by Time/Date
+
+As you manage logs, you can filter by:
+
+- Past 5 minutes
+- Past hour
+- Today
+- All time
+
+To adjust this filter, toggle the top right menu.
+
+### Search Logs
+
+On Astronomer, you can search for logs with a text string on the top left.
+
+![Search Logs](https://assets2.astronomer.io/main/docs/logs/logs-search.png)
+
+## Local Logs
+
+For guidelines on how to tail logs locally via the CLI, check out [this doc](https://www.astronomer.io/docs/logs-and-source-control/).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
@vparekh94 I just spun up a new doc that's meant to show off Astro v0.8+'s log feature.

I'd love your input since it hasn't been released on Cloud and I haven't worked with a ton of customers that have leveraged this feature.

- There's admittedly not a ton of content here and the content that I wrote up is super straightforward - is there anything else customers need to know?
- Any related best practices you can think of off the top of your head that'd be worth including? When you're going through scheduler and webserver logs, what do you personally look for?
- Any other existing content we should link out to?

I named it "Deployment Level Logs" - thoughts on that? Should we simplify to just "Logs"?
