### PR TITLE
Avoid the use of "Click here" links.

### DIFF
--- a/v0.9/ee-integrating-auth-systems.md
+++ b/v0.9/ee-integrating-auth-systems.md
@@ -17,12 +17,12 @@ astronomer:
     config:
       auth:
         openIdConnect:
-        clockTolerance: 0 // A field that can optionally be set to adjust for clock skew on the server.
+          clockTolerance: 0 # A field that can optionally be set to adjust for clock skew on the server.
           <provider-name>:
             enabled: true
             discoveryUrl: <provider-discovery-url>
             clientId: <provider-client-id>
-            authUrlParams: // Additional required params set on case-by-case basis
+            authUrlParams: # Additional required params set on case-by-case basis
 ```
 
 ## Okta Example
@@ -53,7 +53,7 @@ astronomer:
             discoveryUrl: "https://<okta-base-domain>"
 ```
 
-Note that your okta-base-domain may be different from the basedomain of your Astronomer installation. You can read their docs on [finding your Okta domain](https://developer.okta.com/docs/api/getting_started/finding_your_domain/) if you are unsure what this value should be.
+Note that your okta-base-domain will be different from the basedomain of your Astronomer installation. You can read [Okta's docs on finding your domain](https://developer.okta.com/docs/api/getting_started/finding_your_domain/) if you are unsure what this value should be.
 
 
 ## Auth0 Example
@@ -62,17 +62,17 @@ Note that your okta-base-domain may be different from the basedomain of your Ast
 
 #### Create Auth0 Account
 
-You'll need an Auth0 account in order to set up connections with the identity provider of your choice. Sign up for an Auth0 account [here](https://auth0.com/signup).
+You'll need an Auth0 account in order to set up connections with the identity provider of your choice. [Sign up for an Auth0 account](https://auth0.com/signup) if you need to.
 
 #### Create Auth0 Tenant Domain
 
-On initial login you'll be prompted to create a tenant domain. You can use the default or your own unique`tenant-name`. Your full tenant domain will look something like `astronomer.auth0.com`.
+On initial login you'll be prompted to create a tenant domain. You can use the default or your own unique `tenant-name`. Your full tenant domain will look something like `astronomer.auth0.com`.
 
 *NOTE - Your full tenant domain name may differ if you've created it outside the United States.*
 
 #### Create Connection between Auth0 and your Identity Management Provider
 
-The steps required for establishing a connection will vary by identity provider. Auth0 provides connection guides for each identity provider [here](https://auth0.com/docs/identityproviders). Follow the link and click on your identity provider of choice for detailed instructions. Continue on to Step 4 once your connection is established.
+The steps required for establishing a connection will vary by identity provider - Auth0 provides [connection guides](https://auth0.com/docs/identityproviders) for each identity provider. Follow the link and click on your identity provider of choice for detailed instructions. Continue on to Step 4 once your connection is established.
 
 #### Configure Auth0 Application Settings
 
@@ -112,7 +112,7 @@ astronomer:
           auth0:
             enabled: true
             clientId: "<default-app-client-id>"
-            discoveryUrl: https://"<tenant-name>.auth0.com"
+            discoveryUrl: https://<tenant-name>.auth0.com
 ```
 
 #### Upgrade your Astronomer Deployment


### PR DESCRIPTION
To provider a nicer experience for screen readers it is good practice to
give a link text that works without context. Read more at
http://stephanieleary.com/2015/05/why-click-here-is-a-terrible-link-and-what-to-write-instead/