### PR TITLE
Update the AWS Terraform documentation

### DIFF
--- a/v0.11/ee-installation-terraform-aws.md
+++ b/v0.11/ee-installation-terraform-aws.md
@@ -45,9 +45,23 @@ Run the following command and enter the appropriate values when prompted. If you
 aws configure
 ```
 
+Confirm you are authenticated
+
+```
+aws sts get-caller-identity
+```
+
 ### Write the Terraform
 
 ```
+provider "aws" {
+  region = "us-east-1"
+}
+
+provider "acme" {
+  server_url = "https://acme-v02.api.letsencrypt.org/directory"
+}
+
 terraform {
   required_version = ">= 0.12"
   backend "s3" {


### PR DESCRIPTION
I dropped coverage for reconfiguring the platform. Seems out of scope for this in my opinion.

Let's wait to merge the PR until after the 0.11 upgrade test meeting today.