### PR TITLE
Enterprise patch upgrade instructions

### DIFF
--- a/enterprise/next/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/next/06_manage-astronomer/05_upgrade-astronomer.md
@@ -87,6 +87,7 @@ helm3 repo update
 # restart.
 helm3 upgrade --namespace $NAMESPACE \
             -f ./config.yaml \
+            --reset-values \
             --version $ASTRO_VERSION \
             --set astronomer.houston.upgradeDeployments.enabled=false \
             $RELEASE_NAME \

--- a/enterprise/next/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/next/06_manage-astronomer/05_upgrade-astronomer.md
@@ -36,9 +36,10 @@ A few notes before you get started:
 
 Read below for specific guidelines.
 
-> **Note:** Astronomer v0.16.5 and beyond includes "Eventual Consistency" functionality that allows for Airflow Deployments to remain unaffected through a platform upgrade that includes changes to [the Airflow Chart](https://github.com/astronomer/airflow-chart).
+> **Note:** Astronomer v0.16.5 and beyond includes an improved upgrade process that allows Airflow Deployments to remain unaffected through a platform upgrade that includes changes to [the Airflow Chart](https://github.com/astronomer/airflow-chart).
 >
 > Now, Airflow Chart changes only take effect when another restart event is triggered by a user (e.g. a code push, Environment Variable change, resource or executor adjustment, etc).
+
 ### Ensure you have a copy of your Astronomer `config.yaml`
 
 First, ensure you have a copy of the `config.yaml` file of your platform namespace if you don't already.

--- a/enterprise/next/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/next/06_manage-astronomer/05_upgrade-astronomer.md
@@ -6,7 +6,7 @@ description: "How to upgrade the Astronomer Enterprise Platform."
 
 ## Overview
 
-As of Astronomer v0.16, Astronomer releases will be made generally available to Enterprise customers on a quarterly basis within a long-term support (LTS) release model. Critical security and bug fixes will be regularly backported to the latest supported Enterprise LTS version as one or more patch releases. Patch releases will be made available _between_ quarterly LTS releases and require a simple upgrade process.
+As of Astronomer v0.16, Astronomer releases will be made generally available to Enterprise customers on a quarterly basis as part of a long-term support (LTS) release model. Critical security and bug fixes will be regularly shipped as patch versions that follow LTS releases. Patch releases will be made available _between_ quarterly LTS releases and require a simple upgrade process.
 
 To help you maintain Astronomer up-to-date, the guide below will walk you through:
 
@@ -24,15 +24,22 @@ Astronomer platform releases follow a semantic versioning scheme. All versions a
 - Y: Minor Version
 - Z: Patch/Hotfix
 
-For example, upgrading Astronomer from `v0.16.4` to `v0.16.5` would be considered upgrading to a "patch" version whereas upgrading from `v0.15.0` to `v0.16.0` would be considered upgrading to a subsequent "minor" version.
+For example, upgrading Astronomer from `v0.16.4` to `v0.16.5` would be considered upgrading to a "patch" version whereas upgrading from `v0.15.0` to `v0.16.0` would be considered upgrading to the latest "minor" version.
 
 ## Upgrade to a Patch Version
 
-If you're already on Astronomer 0.16.x, you're free to upgrade Astronomer to a patch releases without our assistance as soon as they're made available.
+If you're already on Astronomer's latest minor version (v0.16), you're free to upgrade the platform to a patch release as soon as it's made available.
 
-Read below for guidelines.
+A few notes before you get started:
+- The patch upgrade process will NOT affect running tasks if `upgradeDeployments.enabled=false`
+- Patch version updates will NOT cause any downtime to Astronomer services (UI, API, etc.)
 
-### Ensure you have a copy of Astronomer `config.yaml`
+Read below for specific guidelines.
+
+> **Note:** Astronomer v0.16.5 and beyond includes "Eventual Consistency" functionality that allows for Airflow Deployments to remain unaffected through a platform upgrade that includes changes to [the Airflow Chart](https://github.com/astronomer/airflow-chart).
+>
+> Now, Airflow Chart changes only take effect when another restart event is triggered by a user (e.g. a code push, Environment Variable change, resource or executor adjustment, etc).
+### Ensure you have a copy of your Astronomer `config.yaml`
 
 First, ensure you have a copy of the `config.yaml` file of your platform namespace if you don't already.
 
@@ -42,8 +49,11 @@ To do this, you can run:
 $ helm3 get values -n <namespace> <release name of astronomer> > config.yaml
 ```
 
-Review this configuration, and you can delete the line "USER-SUPPLIED VALUES:"
-- check your current version
+Review this configuration and delete the line `"USER-SUPPLIED VALUES:"` if you see it.
+
+### Verify your current Platform Version
+
+To verify the version of Astronomer you're currently operating with, run:
 
 ```sh
 helm3 list --all-namespaces | grep astronomer
@@ -51,7 +61,13 @@ helm3 list --all-namespaces | grep astronomer
 
 ### Run Astronomer's Patch Upgrade Script
 
-- Use a script like this to update Astronomer patch versions or reconfigurations, please review this script to understand what it is doing and substitute the variables with your own values
+Now, review and run the script below to upgrade to the patch version of your choice.
+
+Make sure to substitute the following 3 variables with your own values:
+
+- `RELEASE_NAME`
+- `NAMESPACE`
+- `ASTRO_VERSION`
 
 ```sh
 #!/bin/bash
@@ -79,9 +95,7 @@ helm3 upgrade --namespace $NAMESPACE \
 
 ## Upgrade to a Minor Version
 
-In the meantime:
-
-- If you're looking to upgrade to Astronomer Enterprise [v0.16 (latest)](/docs/enterprise/stable/resources/release-notes) from an earlier minor version, submit a request to [our Support Portal](support.astronomer.io).
+If you're looking to upgrade to Astronomer Enterprise [v0.16 (latest)](/docs/enterprise/stable/resources/release-notes) from an earlier minor version, submit a request to [Astronomer Support](support.astronomer.io).
 
 We're working on a more robust and reliable upgrade process for our next Astronomer Enterprise "Long-term Support" quarterly release scheduled for Fall 2020.
 

--- a/enterprise/next/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/next/06_manage-astronomer/05_upgrade-astronomer.md
@@ -4,13 +4,84 @@ navTitle: "Upgrade Astronomer"
 description: "How to upgrade the Astronomer Enterprise Platform."
 ---
 
-_Coming soon…_
+## Overview
+
+As of Astronomer v0.16, Astronomer releases will be made generally available to Enterprise customers on a quarterly basis within a long-term support (LTS) release model. Critical security and bug fixes will be regularly backported to the latest supported Enterprise LTS version as one or more patch releases. Patch releases will be made available _between_ quarterly LTS releases and require a simple upgrade process.
+
+To help you maintain Astronomer up-to-date, the guide below will walk you through:
+
+- Astronomer Platform Versioning
+- How to upgrade to a patch version on Astronomer
+- How to upgrade to a minor version on Astronomer
+
+For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/stable/resources/release-notes/).
+
+## Astronomer Platform Versioning
+
+Astronomer platform releases follow a semantic versioning scheme. All versions are written as a 3-component number in the format of `x.y.z`. In this syntax,
+
+- X: Major Version
+- Y: Minor Version
+- Z: Patch/Hotfix
+
+For example, upgrading Astronomer from `v0.16.4` to `v0.16.5` would be considered upgrading to a "patch" version whereas upgrading from `v0.15.0` to `v0.16.0` would be considered upgrading to a subsequent "minor" version.
+
+## Upgrade to a Patch Version
+
+If you're already on Astronomer 0.16.x, you're free to upgrade Astronomer to a patch releases without our assistance as soon as they're made available.
+
+Read below for guidelines.
+
+### Ensure you have a copy of Astronomer `config.yaml`
+
+First, ensure you have a copy of the `config.yaml` file of your platform namespace if you don't already.
+
+To do this, you can run:
+
+```sh
+$ helm3 get values -n <namespace> <release name of astronomer> > config.yaml
+```
+
+Review this configuration, and you can delete the line "USER-SUPPLIED VALUES:"
+- check your current version
+
+```sh
+helm3 list --all-namespaces | grep astronomer
+```
+
+### Run Astronomer's Patch Upgrade Script
+
+- Use a script like this to update Astronomer patch versions or reconfigurations, please review this script to understand what it is doing and substitute the variables with your own values
+
+```sh
+#!/bin/bash
+set -xe
+
+RELEASE_NAME=replace-this
+NAMESPACE=replace-this
+ASTRO_VERSION=0.16.replace-patch-version
+
+helm3 repo add astronomer https://helm.astronomer.io
+helm3 repo update
+
+# upgradeDeployments false ensures that Airflow charts are not upgraded when this script is ran
+# If you deployed a config change that is intended to reconfigure something inside Airflow,
+# then you may set this value to "true" instead. When it is "true", then each Airflow chart will
+# restart.
+helm3 upgrade --namespace $NAMESPACE \
+            -f ./config.yaml \
+            --version $ASTRO_VERSION \
+            --set astronomer.houston.upgradeDeployments.enabled=false \
+            $RELEASE_NAME \
+            astronomer/astronomer
+```
+
+
+## Upgrade to a Minor Version
 
 In the meantime:
 
 - If you're looking to upgrade to Astronomer Enterprise [v0.16 (latest)](/docs/enterprise/stable/resources/release-notes) from an earlier minor version, submit a request to [our Support Portal](support.astronomer.io).
-- If you're already on Astronomer v0.16 and need to upgrade to a patch release, refer to raw instructions [here](https://github.com/astronomer/astronomer/tree/master/bin/migration-scripts#patch-version-updates). You're free to perform that upgrade without our hands-on help.
 
 We're working on a more robust and reliable upgrade process for our next Astronomer Enterprise "Long-term Support" quarterly release scheduled for Fall 2020.
 
-Onwards and upwards!

--- a/enterprise/v0.12/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/v0.12/06_manage-astronomer/05_upgrade-astronomer.md
@@ -4,13 +4,29 @@ navTitle: "Upgrade Astronomer"
 description: "How to upgrade the Astronomer Enterprise Platform."
 ---
 
-_Coming soon…_
+## Overview
 
-In the meantime:
+As of Astronomer v0.16, Astronomer releases will be made generally available to Enterprise customers on a quarterly basis as part of a long-term support (LTS) release model. Critical security and bug fixes will be regularly shipped as patch versions that follow LTS releases. Patch releases will be made available _between_ quarterly LTS releases and require a simple upgrade process.
 
-- If you're looking to upgrade to Astronomer Enterprise [v0.16 (latest)](/docs/enterprise/stable/resources/release-notes) from an earlier minor version, submit a request to [our Support Portal](support.astronomer.io).
-- If you're already on Astronomer v0.16 and need to upgrade to a patch release, refer to raw instructions [here](https://github.com/astronomer/docs/blob/main/enterprise/v0.16/06_manage-astronomer/05_upgrade-astronomer.md). You're free to perform that upgrade without our hands-on help.
+For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/stable/resources/release-notes/).
 
-We're working on a more robust and reliable upgrade process for our next Astronomer Enterprise "Long-term Support" quarterly release scheduled for Fall 2020.
+## Upgrade to Astronomer v0.16
 
-Onwards and upwards!
+If you're running Astronomer on a version below 0.16, reach out to [Astronomer Support](support.astronomer.io) to request an upgrade. Once you get in touch, our Support and Customer Succcess teams will connect with you to:
+
+- Confirm your current platform configurations (Cloud provider, database, Airflow image, # of Airflow Deployments, etc.)
+- Book time with our Infrastructure Engineering team to assist with an upgrade
+
+Beyond Astronomer v0.16 we'll be implementing a more robust and reliable upgrade process for our next Astronomer Enterprise LTS release scheduled for Fall 2020.
+
+> **Note:** If you're already on Astronomer v0.16 and need to upgrade to a patch release, refer to our instructions in the v0.16 version of this doc by toggling the version menu on the top left of this page.
+
+## Astronomer Platform Versioning
+
+Astronomer platform releases follow a semantic versioning scheme. All versions are written as a 3-component number in the format of `x.y.z`. In this syntax,
+
+- X: Major Version
+- Y: Minor Version
+- Z: Patch/Hotfix
+
+For example, upgrading Astronomer from `v0.16.4` to `v0.16.5` would be considered upgrading to a "patch" version whereas upgrading from `v0.15.0` to `v0.16.0` would be considered upgrading to the latest "minor" version.

--- a/enterprise/v0.12/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/v0.12/06_manage-astronomer/05_upgrade-astronomer.md
@@ -8,7 +8,7 @@ description: "How to upgrade the Astronomer Enterprise Platform."
 
 As of Astronomer v0.16, Astronomer releases will be made generally available to Enterprise customers on a quarterly basis as part of a long-term support (LTS) release model. Critical security and bug fixes will be regularly shipped as patch versions that follow LTS releases. Patch releases will be made available _between_ quarterly LTS releases and require a simple upgrade process.
 
-For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/stable/resources/release-notes/).
+For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/v0.12/resources/release-notes/).
 
 ## Upgrade to Astronomer v0.16
 

--- a/enterprise/v0.13/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/v0.13/06_manage-astronomer/05_upgrade-astronomer.md
@@ -4,13 +4,29 @@ navTitle: "Upgrade Astronomer"
 description: "How to upgrade the Astronomer Enterprise Platform."
 ---
 
-_Coming soon…_
+## Overview
 
-In the meantime:
+As of Astronomer v0.16, Astronomer releases will be made generally available to Enterprise customers on a quarterly basis as part of a long-term support (LTS) release model. Critical security and bug fixes will be regularly shipped as patch versions that follow LTS releases. Patch releases will be made available _between_ quarterly LTS releases and require a simple upgrade process.
 
-- If you're looking to upgrade to Astronomer Enterprise [v0.16 (latest)](/docs/enterprise/stable/resources/release-notes) from an earlier minor version, submit a request to [our Support Portal](support.astronomer.io).
-- If you're already on Astronomer v0.16 and need to upgrade to a patch release, refer to raw instructions [here](https://github.com/astronomer/docs/blob/main/enterprise/v0.16/06_manage-astronomer/05_upgrade-astronomer.md). You're free to perform that upgrade without our hands-on help.
+For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/stable/resources/release-notes/).
 
-We're working on a more robust and reliable upgrade process for our next Astronomer Enterprise "Long-term Support" quarterly release scheduled for Fall 2020.
+## Upgrade to Astronomer v0.16
 
-Onwards and upwards!
+If you're running Astronomer on a version below 0.16, reach out to [Astronomer Support](support.astronomer.io) to request an upgrade. Once you get in touch, our Support and Customer Succcess teams will connect with you to:
+
+- Confirm your current platform configurations (Cloud provider, database, Airflow image, # of Airflow Deployments, etc.)
+- Book time with our Infrastructure Engineering team to assist with an upgrade
+
+Beyond Astronomer v0.16 we'll be implementing a more robust and reliable upgrade process for our next Astronomer Enterprise LTS release scheduled for Fall 2020.
+
+> **Note:** If you're already on Astronomer v0.16 and need to upgrade to a patch release, refer to our instructions in the v0.16 version of this doc by toggling the version menu on the top left of this page.
+
+## Astronomer Platform Versioning
+
+Astronomer platform releases follow a semantic versioning scheme. All versions are written as a 3-component number in the format of `x.y.z`. In this syntax,
+
+- X: Major Version
+- Y: Minor Version
+- Z: Patch/Hotfix
+
+For example, upgrading Astronomer from `v0.16.4` to `v0.16.5` would be considered upgrading to a "patch" version whereas upgrading from `v0.15.0` to `v0.16.0` would be considered upgrading to the latest "minor" version.

--- a/enterprise/v0.13/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/v0.13/06_manage-astronomer/05_upgrade-astronomer.md
@@ -8,7 +8,7 @@ description: "How to upgrade the Astronomer Enterprise Platform."
 
 As of Astronomer v0.16, Astronomer releases will be made generally available to Enterprise customers on a quarterly basis as part of a long-term support (LTS) release model. Critical security and bug fixes will be regularly shipped as patch versions that follow LTS releases. Patch releases will be made available _between_ quarterly LTS releases and require a simple upgrade process.
 
-For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/stable/resources/release-notes/).
+For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/v0.13/resources/release-notes/).
 
 ## Upgrade to Astronomer v0.16
 

--- a/enterprise/v0.14/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/v0.14/06_manage-astronomer/05_upgrade-astronomer.md
@@ -4,13 +4,29 @@ navTitle: "Upgrade Astronomer"
 description: "How to upgrade the Astronomer Enterprise Platform."
 ---
 
-_Coming soon…_
+## Overview
 
-In the meantime:
+As of Astronomer v0.16, Astronomer releases will be made generally available to Enterprise customers on a quarterly basis as part of a long-term support (LTS) release model. Critical security and bug fixes will be regularly shipped as patch versions that follow LTS releases. Patch releases will be made available _between_ quarterly LTS releases and require a simple upgrade process.
 
-- If you're looking to upgrade to Astronomer Enterprise [v0.16 (latest)](/docs/enterprise/stable/resources/release-notes) from an earlier minor version, submit a request to [our Support Portal](support.astronomer.io).
-- If you're already on Astronomer v0.16 and need to upgrade to a patch release, refer to raw instructions [here](https://github.com/astronomer/docs/blob/main/enterprise/v0.16/06_manage-astronomer/05_upgrade-astronomer.md). You're free to perform that upgrade without our hands-on help.
+For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/stable/resources/release-notes/).
 
-We're working on a more robust and reliable upgrade process for our next Astronomer Enterprise "Long-term Support" quarterly release scheduled for Fall 2020.
+## Upgrade to Astronomer v0.16
 
-Onwards and upwards!
+If you're running Astronomer on a version below 0.16, reach out to [Astronomer Support](support.astronomer.io) to request an upgrade. Once you get in touch, our Support and Customer Succcess teams will connect with you to:
+
+- Confirm your current platform configurations (Cloud provider, database, Airflow image, # of Airflow Deployments, etc.)
+- Book time with our Infrastructure Engineering team to assist with an upgrade
+
+Beyond Astronomer v0.16 we'll be implementing a more robust and reliable upgrade process for our next Astronomer Enterprise LTS release scheduled for Fall 2020.
+
+> **Note:** If you're already on Astronomer v0.16 and need to upgrade to a patch release, refer to our instructions in the v0.16 version of this doc by toggling the version menu on the top left of this page.
+
+## Astronomer Platform Versioning
+
+Astronomer platform releases follow a semantic versioning scheme. All versions are written as a 3-component number in the format of `x.y.z`. In this syntax,
+
+- X: Major Version
+- Y: Minor Version
+- Z: Patch/Hotfix
+
+For example, upgrading Astronomer from `v0.16.4` to `v0.16.5` would be considered upgrading to a "patch" version whereas upgrading from `v0.15.0` to `v0.16.0` would be considered upgrading to the latest "minor" version.

--- a/enterprise/v0.14/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/v0.14/06_manage-astronomer/05_upgrade-astronomer.md
@@ -8,7 +8,7 @@ description: "How to upgrade the Astronomer Enterprise Platform."
 
 As of Astronomer v0.16, Astronomer releases will be made generally available to Enterprise customers on a quarterly basis as part of a long-term support (LTS) release model. Critical security and bug fixes will be regularly shipped as patch versions that follow LTS releases. Patch releases will be made available _between_ quarterly LTS releases and require a simple upgrade process.
 
-For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/stable/resources/release-notes/).
+For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/v0.14/resources/release-notes/).
 
 ## Upgrade to Astronomer v0.16
 

--- a/enterprise/v0.15/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/v0.15/06_manage-astronomer/05_upgrade-astronomer.md
@@ -8,7 +8,7 @@ description: "How to upgrade the Astronomer Enterprise Platform."
 
 As of Astronomer v0.16, Astronomer releases will be made generally available to Enterprise customers on a quarterly basis as part of a long-term support (LTS) release model. Critical security and bug fixes will be regularly shipped as patch versions that follow LTS releases. Patch releases will be made available _between_ quarterly LTS releases and require a simple upgrade process.
 
-For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/stable/resources/release-notes/).
+For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/v0.15/resources/release-notes/).
 
 ## Upgrade to Astronomer v0.16
 

--- a/enterprise/v0.15/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/v0.15/06_manage-astronomer/05_upgrade-astronomer.md
@@ -4,13 +4,30 @@ navTitle: "Upgrade Astronomer"
 description: "How to upgrade the Astronomer Enterprise Platform."
 ---
 
-_Coming soon…_
+## Overview
 
-In the meantime:
+As of Astronomer v0.16, Astronomer releases will be made generally available to Enterprise customers on a quarterly basis as part of a long-term support (LTS) release model. Critical security and bug fixes will be regularly shipped as patch versions that follow LTS releases. Patch releases will be made available _between_ quarterly LTS releases and require a simple upgrade process.
 
-- If you're looking to upgrade to Astronomer Enterprise [v0.16 (latest)](/docs/enterprise/stable/resources/release-notes) from an earlier minor version, submit a request to [our Support Portal](support.astronomer.io).
-- If you're already on Astronomer v0.16 and need to upgrade to a patch release, refer to raw instructions [here](https://github.com/astronomer/docs/blob/main/enterprise/v0.16/06_manage-astronomer/05_upgrade-astronomer.md). You're free to perform that upgrade without our hands-on help.
+For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/stable/resources/release-notes/).
 
-We're working on a more robust and reliable upgrade process for our next Astronomer Enterprise "Long-term Support" quarterly release scheduled for Fall 2020.
+## Upgrade to Astronomer v0.16
 
-Onwards and upwards!
+If you're running Astronomer on a version below 0.16, reach out to [Astronomer Support](support.astronomer.io) to request an upgrade. Once you get in touch, our Support and Customer Succcess teams will connect with you to:
+
+- Confirm your current platform configurations (Cloud provider, database, Airflow image, # of Airflow Deployments, etc.)
+- Book time with our Infrastructure Engineering team to assist with an upgrade
+
+Beyond Astronomer v0.16 we'll be implementing a more robust and reliable upgrade process for our next Astronomer Enterprise LTS release scheduled for Fall 2020.
+
+> **Note:** If you're already on Astronomer v0.16 and need to upgrade to a patch release, refer to our instructions in the v0.16 version of this doc by toggling the version menu on the top left of this page.
+
+## Astronomer Platform Versioning
+
+Astronomer platform releases follow a semantic versioning scheme. All versions are written as a 3-component number in the format of `x.y.z`. In this syntax,
+
+- X: Major Version
+- Y: Minor Version
+- Z: Patch/Hotfix
+
+For example, upgrading Astronomer from `v0.16.4` to `v0.16.5` would be considered upgrading to a "patch" version whereas upgrading from `v0.15.0` to `v0.16.0` would be considered upgrading to the latest "minor" version.
+

--- a/enterprise/v0.16/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/v0.16/06_manage-astronomer/05_upgrade-astronomer.md
@@ -87,6 +87,7 @@ helm3 repo update
 # restart.
 helm3 upgrade --namespace $NAMESPACE \
             -f ./config.yaml \
+            --reset-values \
             --version $ASTRO_VERSION \
             --set astronomer.houston.upgradeDeployments.enabled=false \
             $RELEASE_NAME \

--- a/enterprise/v0.16/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/v0.16/06_manage-astronomer/05_upgrade-astronomer.md
@@ -4,13 +4,98 @@ navTitle: "Upgrade Astronomer"
 description: "How to upgrade the Astronomer Enterprise Platform."
 ---
 
-_Coming soon…_
+## Overview
 
-In the meantime:
+As of Astronomer v0.16, Astronomer releases will be made generally available to Enterprise customers on a quarterly basis as part of a long-term support (LTS) release model. Critical security and bug fixes will be regularly shipped as patch versions that follow LTS releases. Patch releases will be made available _between_ quarterly LTS releases and require a simple upgrade process.
 
-- If you're looking to upgrade to Astronomer Enterprise [v0.16 (latest)](/docs/enterprise/stable/resources/release-notes) from an earlier minor version, submit a request to [our Support Portal](support.astronomer.io).
-- If you're already on Astronomer v0.16 and need to upgrade to a patch release, refer to raw instructions [here](https://github.com/astronomer/astronomer/tree/master/bin/migration-scripts#patch-version-updates). You're free to perform that upgrade without our hands-on help.
+To help you maintain Astronomer up-to-date, the guide below will walk you through:
+
+- Astronomer Platform Versioning
+- How to upgrade to a patch version on Astronomer
+- How to upgrade to a minor version on Astronomer
+
+For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/stable/resources/release-notes/).
+
+## Astronomer Platform Versioning
+
+Astronomer platform releases follow a semantic versioning scheme. All versions are written as a 3-component number in the format of `x.y.z`. In this syntax,
+
+- X: Major Version
+- Y: Minor Version
+- Z: Patch/Hotfix
+
+For example, upgrading Astronomer from `v0.16.4` to `v0.16.5` would be considered upgrading to a "patch" version whereas upgrading from `v0.15.0` to `v0.16.0` would be considered upgrading to the latest "minor" version.
+
+## Upgrade to a Patch Version
+
+If you're already on Astronomer's latest minor version (v0.16), you're free to upgrade the platform to a patch release as soon as it's made available.
+
+A few notes before you get started:
+- The patch upgrade process will NOT affect running tasks if `upgradeDeployments.enabled=false`
+- Patch version updates will NOT cause any downtime to Astronomer services (UI, API, etc.)
+
+Read below for specific guidelines.
+
+> **Note:** Astronomer v0.16.5 and beyond includes an improved upgrade process that allows Airflow Deployments to remain unaffected through a platform upgrade that includes changes to [the Airflow Chart](https://github.com/astronomer/airflow-chart).
+>
+> Now, Airflow Chart changes only take effect when another restart event is triggered by a user (e.g. a code push, Environment Variable change, resource or executor adjustment, etc).
+
+### Ensure you have a copy of your Astronomer `config.yaml`
+
+First, ensure you have a copy of the `config.yaml` file of your platform namespace if you don't already.
+
+To do this, you can run:
+
+```sh
+$ helm3 get values -n <namespace> <release name of astronomer> > config.yaml
+```
+
+Review this configuration and delete the line `"USER-SUPPLIED VALUES:"` if you see it.
+
+### Verify your current Platform Version
+
+To verify the version of Astronomer you're currently operating with, run:
+
+```sh
+helm3 list --all-namespaces | grep astronomer
+```
+
+### Run Astronomer's Patch Upgrade Script
+
+Now, review and run the script below to upgrade to the patch version of your choice.
+
+Make sure to substitute the following 3 variables with your own values:
+
+- `RELEASE_NAME`
+- `NAMESPACE`
+- `ASTRO_VERSION`
+
+```sh
+#!/bin/bash
+set -xe
+
+RELEASE_NAME=replace-this
+NAMESPACE=replace-this
+ASTRO_VERSION=0.16.replace-patch-version
+
+helm3 repo add astronomer https://helm.astronomer.io
+helm3 repo update
+
+# upgradeDeployments false ensures that Airflow charts are not upgraded when this script is ran
+# If you deployed a config change that is intended to reconfigure something inside Airflow,
+# then you may set this value to "true" instead. When it is "true", then each Airflow chart will
+# restart.
+helm3 upgrade --namespace $NAMESPACE \
+            -f ./config.yaml \
+            --version $ASTRO_VERSION \
+            --set astronomer.houston.upgradeDeployments.enabled=false \
+            $RELEASE_NAME \
+            astronomer/astronomer
+```
+
+
+## Upgrade to a Minor Version
+
+If you're looking to upgrade to Astronomer Enterprise [v0.16 (latest)](/docs/enterprise/stable/resources/release-notes) from an earlier minor version, submit a request to [Astronomer Support](support.astronomer.io).
 
 We're working on a more robust and reliable upgrade process for our next Astronomer Enterprise "Long-term Support" quarterly release scheduled for Fall 2020.
-
-Onwards and upwards!

--- a/enterprise/v0.16/06_manage-astronomer/05_upgrade-astronomer.md
+++ b/enterprise/v0.16/06_manage-astronomer/05_upgrade-astronomer.md
@@ -14,7 +14,7 @@ To help you maintain Astronomer up-to-date, the guide below will walk you throug
 - How to upgrade to a patch version on Astronomer
 - How to upgrade to a minor version on Astronomer
 
-For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/stable/resources/release-notes/).
+For a detailed breakdown of individual releases, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/v0.16/resources/release-notes/).
 
 ## Astronomer Platform Versioning
 
@@ -94,9 +94,8 @@ helm3 upgrade --namespace $NAMESPACE \
             astronomer/astronomer
 ```
 
-
 ## Upgrade to a Minor Version
 
-If you're looking to upgrade to Astronomer Enterprise [v0.16 (latest)](/docs/enterprise/stable/resources/release-notes) from an earlier minor version, submit a request to [Astronomer Support](support.astronomer.io).
+If you're looking to upgrade to Astronomer Enterprise [v0.16 (latest)](/docs/enterprise/v0.16/resources/release-notes) from an earlier minor version, submit a request to [Astronomer Support](support.astronomer.io).
 
 We're working on a more robust and reliable upgrade process for our next Astronomer Enterprise "Long-term Support" quarterly release scheduled for Fall 2020.


### PR DESCRIPTION
This PR addresses this GH Issue: https://github.com/astronomer/issues/issues/1633

I updated our existing "Upgrade Astronomer" doc ([lives here](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer/)) with:

- An overview of our upgrade policy
- Explanation of platform versioning
- Instructions for patch upgrades, adopted from: https://github.com/astronomer/astronomer/tree/master/bin/migration-scripts#patch-version-updates

The README in the repo I linked above has a lot more info in terms of checking to make sure pod are up, instructions for minor upgrades etc. I wasn't sure what all to include but decided to start narrow to make sure we're clear/accurate and then add info as needed.

@sjmiller609 Since I believe you wrote up those instructions, can you give this a look and make sure it's accurate? A few specific questions:

- Is there a step we can add for customers to "confirm" the patch upgrade was successful?
- Is the script you provided supposed to be prescriptive or do users need to modify it further somehow?
- Any suggestions on language around Airflow chart changes? Will patch releases by definition not include changes to the airflow chart?
- Is this still accurate given eventual consistency?
> The patch upgrade process will NOT affect running tasks if `upgradeDeployments.enabled=false`