### PR TITLE
Rework Manage Users Doc

### DIFF
--- a/cloud/stable/06_resources/01_release-notes.md
+++ b/cloud/stable/06_resources/01_release-notes.md
@@ -136,5 +136,3 @@ For more details on this new feature, reference our ["Environment Variables" doc
 ## Platform Changelog & Prior Releases
 
 In addition to release notes, our team publishes an itemized changelog [on GitHub](https://github.com/astronomer/astronomer/blob/master/CHANGELOG.md).
-
-To view earlier release notes, change the version of this doc on the top right menu.

--- a/enterprise/next/06_manage-astronomer/02_manage-platform-users.md
+++ b/enterprise/next/06_manage-astronomer/02_manage-platform-users.md
@@ -8,7 +8,7 @@ description: "How to add and customize user permissions on the platform, enable 
 
 In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
 
-Read below for a high-level overview of user management and guidelines around public sign-ups, role customization and adding System Admins.
+Read below for a high-level overview of user management and guidelines around public signups, role customization and adding System Admins.
 
 ## Add Users to Astronomer
 
@@ -16,19 +16,21 @@ When Astronomer Enterprise is first deployed, the first user to log in is grante
 
 - Invitation to a Workspace by a Workspace Admin
 - Invitation to Astronomer by a System Admin
-- Signing up via the Astronomer UI without an invitation (requires "Public Sign-Ups")
+- Signing up via the Astronomer UI without an invitation (requires "Public Signups")
 
-On Astronomer, administrators have the option to either open the platform to public sign-ups or limit sign-ups to users invited by others.
+On Astronomer, administrators have the option to either open the platform to public signups or limit account creation to users invited by others.
 
-### Enable Public Sign-Ups
+### Enable Public Signups
 
-As noted above, public sign-ups allow any user with access to the platform URL (the Astronomer UI) to create an account. If Public sign-ups are *disabled*, users that try to access Astronomer without an invitation from another user will be met with an error.
+As noted above, public signups allow any user with access to the platform URL (the Astronomer UI) to create an account. If public signups are *disabled*, users that try to access Astronomer without an invitation from another user will be met with an error.
 
-In cases where SMTP credentials are difficult to acquire, enabling this flag might facilitate initial setup, as disabling public sign-ups requires that a user accept an email invitation. Public Sign-Ups are a configuration available in Astronomer's Houston API and can be enabled in the `config.yaml` file of your Helm chart.
+In cases where SMTP credentials are difficult to acquire, enabling this flag might facilitate initial setup, as disabling public signups requires that a user accept an email invitation. Public signups are a configuration available in Astronomer's Houston API and can be enabled in the `config.yaml` file of your Helm chart.
+
+To enable or disable public signups, follow the guidelines below.
 
 #### Modify your `config.yaml`
 
-To *enable* Public Sign-Ups, add the following yaml snippet to your `config.yaml` file:
+To *enable* public signups, add the following yaml snippet to your `config.yaml` file:
 
 ```
 astronomer:
@@ -85,7 +87,7 @@ Once on the platform, administrators can customize permissions across teams. On 
 1. Workspace Level (Viewer, Editor, Admin)
 2. System Level (Viewer, Editor, Admin)
 
-Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace Level Roles on Astronomer (Viewer, Editor and Admin), refer to our [Role-Based Access Control](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
+Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace-level roles on Astronomer (Viewer, Editor and Admin), refer to our ["Manage User Permissions on an Astronomer Workspace"](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
 
 ## Customize Permissions
 

--- a/enterprise/next/06_manage-astronomer/02_manage-platform-users.md
+++ b/enterprise/next/06_manage-astronomer/02_manage-platform-users.md
@@ -6,13 +6,13 @@ description: "How to add and customize user permissions on the platform, enable 
 
 ## Overview
 
-In addition to the [Role-Based Access Control (RBAC) functionality](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
+In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
 
 Read below for a high-level overview of user management and guidelines around public sign-ups, role customization and adding System Admins.
 
-### Adding Users to Astronomer
+## Add Users to Astronomer
 
-When Astronomer Enterprise is first deployed, the first user to log in is granted "System Admin" permissions by default. From there, a user is created on Astronomer Enterprise by:
+When Astronomer Enterprise is first deployed, the first user to log in is granted "System Admin" permissions by default (more on that below). From there, a user is created on Astronomer Enterprise by:
 
 - Invitation to a Workspace by a Workspace Admin
 - Invitation to Astronomer by a System Admin
@@ -20,26 +20,13 @@ When Astronomer Enterprise is first deployed, the first user to log in is grante
 
 On Astronomer, administrators have the option to either open the platform to public sign-ups or limit sign-ups to users invited by others.
 
-### Managing Users
-
-Once on the platform, administrators can customize permissions across teams. On Astronomer, users can be assigned roles at 2 levels:
-
-1. Workspace Level (Viewer, Editor, Admin)
-2. System Level (Viewer, Editor, Admin)
-
-Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace Level Roles on Astronomer (Viewer, Editor and Admin), refer to our [Role Based Access Control](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
-
-## Public Sign-Ups
+### Enable Public Sign-Ups
 
 As noted above, public sign-ups allow any user with access to the platform URL (the Astronomer UI) to create an account. If Public sign-ups are *disabled*, users that try to access Astronomer without an invitation from another user will be met with an error.
 
-In cases where SMTP credentials are difficult to acquire, enabling this flag might facilitate initial setup, as disabling public sign-ups requires that a user accept an email invitation.
+In cases where SMTP credentials are difficult to acquire, enabling this flag might facilitate initial setup, as disabling public sign-ups requires that a user accept an email invitation. Public Sign-Ups are a configuration available in Astronomer's Houston API and can be enabled in the `config.yaml` file of your Helm chart.
 
-### Enable Public Sign-Ups
-
-Public Sign-Ups are a configuration available in Astronomer's Houston API and can be enabled in the `config.yaml` file of your Helm chart.
-
-#### Modify your Configuration
+#### Modify your `config.yaml`
 
 To *enable* Public Sign-Ups, add the following yaml snippet to your `config.yaml` file:
 
@@ -88,16 +75,113 @@ $ helm ls
 NAME                	REVISION	UPDATED                 	STATUS  	CHART                           	APP VERSION	NAMESPACE                                       
 calico-crab         	4       	Fri Nov 22 09:36:51 2019	DEPLOYED	astronomer-platform-0.10.3-fix.1	0.10.3     	astro                    
 
-$ helm upgrade calico-crab -f config.yaml --version=0.15.5 astronomer/astronomer -n calico-crab
+$ helm upgrade calico-crab -f config.yaml --version=0.16.4 astronomer/astronomer -n calico-crab
 ```
 
-## System Admins
+### User Roles on Astronomer
+
+Once on the platform, administrators can customize permissions across teams. On Astronomer, users can be assigned roles at 2 levels:
+
+1. Workspace Level (Viewer, Editor, Admin)
+2. System Level (Viewer, Editor, Admin)
+
+Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace Level Roles on Astronomer (Viewer, Editor and Admin), refer to our [Role-Based Access Control](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
+
+## Customize Permissions
+
+Permissions are defined on Astronomer as `scope.entity.action`, where:
+
+- `scope`: The layer of our application to which the permission applies
+- `entity`: The object or role being operated on
+- `action`: The verb describing the operation being performed on the `entity`
+
+For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view our [default Houston API configuration](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L200). Each permission is applied to the role under which it is listed.
+
+> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles ([source code here](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L266)).
+
+To customize permissions, follow the steps below.
+
+### Identify a Permission Change
+
+First, take a look at our default roles and permissions linked above and identify two things:
+
+1. What role do you want to configure? (e.g. [`DEPLOYMENT_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L356))
+2. What permission(s) would you like to add to or remove from that role? (e.g. [`deployment.images.push`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L362))
+
+For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKSPACE_EDITOR`) from deploying code to all Airflow Deployments within a Workspace and instead limit that action to users assigned the `DEPLOYMENT_ADMIN` role.
+
+#### Limit Workspace Creation
+
+Unless otherwise configured, a user who creates a Workspace on Astronomer is automatically granted the `WORKSPACE_ADMIN` role and is thus able to create an unlimited number of Airflow Deployments within that Workspace. For teams looking to more strictly control resources, our platform supports limiting the Workspace creation function via a `USER` role.
+
+Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L377).
+
+If you're an administrator on Astronomer who wants to limit Workspace Creation, you can:
+
+- Remove the `system.workspace.create` permission from the `USER` role [here](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L382)
+- Attach it to a separate role of your choice
+
+If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
+
+To configure and apply this change, follow the steps below.
+
+### Modify your `config.yaml`
+
+Now, apply the role and permission change to your platform's `config.yaml` file. Following the `deployment.images.push` example above, that would mean specifying this:
+
+```yaml
+astronomer:
+  houston:
+    config:
+      roles:
+        DEPLOYMENT_EDITOR:
+          permissions:
+            deployment.images.push: false
+```
+
+In the same way you can _remove_ permissions from a particular role by setting any permission to `:false`, you can _add_ permissions to a role at any time.
+
+For example, if you want to allow any `DEPLOYMENT_VIEWER` (and therefore `WORKSPACE_VIEWER`) to push code directly to any Airflow Deployment within a Workspace, you'd specify the following:
+
+```yaml
+astronomer:
+  houston:
+    config:
+      roles:
+        DEPLOYMENT_VIEWER:
+          permissions:
+            deployment.images.push: true
+```
+
+### Apply your Changes
+
+Once you've made changes to your `config.yaml` file, trigger a platform upgrade from the `astronomer` repo by running:
+
+```
+$ helm ls
+```
+
+```
+$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+```
+
+For example, you might run:
+
+```
+$ helm ls
+NAME                	REVISION	UPDATED                 	STATUS  	CHART                           	APP VERSION	NAMESPACE                                       
+calico-crab         	4       	Fri Nov 22 09:36:51 2019	DEPLOYED	astronomer-platform-0.10.3-fix.1	0.16.4     	astro                    
+
+$ helm upgrade calico-crab -f config.yaml --version=0.16.4 astronomer/astronomer -n calico-crab
+```
+
+## System Roles
 
 ### Overview
 
 The System Admin role on Astronomer Enterprise brings a range of cluster-wide permissions that supercedes Workspace-level access and allows a user to monitor and take action across Workspaces, Deployments and Users within a single cluster.
 
-On Astronomer, System Admins can:
+On Astronomer, System Admins specifically can:
 
 - List and search *all* users
 - List and search *all* deployments
@@ -109,7 +193,7 @@ On Astronomer, System Admins can:
 
 By default, the first user to log into an Astronomer Enterprise installation is granted the System Admin permission set.
 
-#### System Editor, Viewer
+### System Editor, Viewer
 
 In addition to the commonly used System Admin role, the Astronomer platform also supports both a System Editor and System Viewer permission set.
 
@@ -119,7 +203,7 @@ All three permission sets are entirely customizable on Astronomer Enterprise. Fo
 
 For guidelines on assigning users any System Level role, read below.
 
-### Assigning Users System-Level Roles
+#### Assign Users System-Level Roles
 
 System Admins can be added to Astronomer Enterprise via the 'System Admin' tab of the Astronomer UI.
 
@@ -137,24 +221,4 @@ To verify a user was successfully granted the SysAdmin role, ensure they can do 
 - Navigate to `kibana.BASEDOMAIN`
 - Access the 'System Admin' tab from the top left menu of the Astronomer UI
 
-## Customizing Roles and Permissions
 
-On Astronomer Enterprise, platform administrators can customize the definitions of both Workspace and System Level roles from the same `config.yaml` file.
-
-For guidelines on how a user might limit the permission to create a Workspace, read below. For step-by-step instructions on how to customize and apply changes to permission sets across the platform, refer to our [Configuring Permissions](/docs/enterprise/stable/manage-astronomer/manage-platform-users/) doc.
-
-### Limiting Workspace Creation
-
-For larger teams on Astronomer Enterprise, our platform supports limiting the ability for any user on the platform to create a Workspace and provision Airflow resources.
-
-By default, all users have the ability to create a new Workspace. Unless otherwise configured, a user who creates a Workspace is automatically granted the "Workspace Admin" role and is thus able to create an unlimited number of Airflow Deployments within that Workspace.
-
-For those who want to limit user access to the Workspace creation function, administrators can leverage and customize our platform's `USER` role.
-
-#### Astronomer's `USER` Role
-
-Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L324).
-
-If you're an administrator on Astronomer who wants to limit its scope, you can remove the `system.workspace.create` permission from all users and instead attach it to a separate role of your choice. If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
-
-To configure and apply this change, follow the steps in our [Configuring Permissions](/docs/enterprise/stable/manage-astronomer/manage-platform-users/) doc.

--- a/enterprise/v0.12/06_manage-astronomer/02_manage-platform-users.md
+++ b/enterprise/v0.12/06_manage-astronomer/02_manage-platform-users.md
@@ -186,5 +186,3 @@ For those who want to limit user access to the Workspace creation function, admi
 Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L324).
 
 If you're an administrator on Astronomer who wants to limit its scope, you can remove the `system.workspace.create` permission from all users and instead attach it to a separate role of your choice. If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
-
-To configure and apply this change, follow the steps in our [Configuring Permissions](/docs/enterprise/v0.12/manage-astronomer/manage-platform-users/) doc.

--- a/enterprise/v0.13/06_manage-astronomer/02_manage-platform-users.md
+++ b/enterprise/v0.13/06_manage-astronomer/02_manage-platform-users.md
@@ -6,7 +6,7 @@ description: "How to add and customize user permissions on the platform, enable 
 
 ## Overview
 
-In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
+In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/v0.13/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
 
 Read below for a high-level overview of user management and guidelines around public signups, role customization and adding System Admins.
 
@@ -87,7 +87,7 @@ Once on the platform, administrators can customize permissions across teams. On 
 1. Workspace Level (Viewer, Editor, Admin)
 2. System Level (Viewer, Editor, Admin)
 
-Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace-level roles on Astronomer (Viewer, Editor and Admin), refer to our ["Manage User Permissions on an Astronomer Workspace"](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
+Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace-level roles on Astronomer (Viewer, Editor and Admin), refer to our ["Manage User Permissions on an Astronomer Workspace"](/docs/enterprise/v0.13/manage-astronomer/workspace-permissions/) doc.
 
 ## Customize Permissions
 
@@ -213,7 +213,7 @@ Keep in mind that:
 - Only existing System Admins can grant the SysAdmin role to another user
 - The user must have a verified email address and already exist in the system
 
-> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/stable/manage-astronomer/houston-api/).
+> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/v0.13/manage-astronomer/houston-api/).
 
 #### Verify SysAdmin Access
 

--- a/enterprise/v0.13/06_manage-astronomer/02_manage-platform-users.md
+++ b/enterprise/v0.13/06_manage-astronomer/02_manage-platform-users.md
@@ -6,42 +6,31 @@ description: "How to add and customize user permissions on the platform, enable 
 
 ## Overview
 
-In addition to the [Role-Based Access Control (RBAC) functionality](/docs/enterprise/v0.13/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
+In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
 
-Read below for a high-level overview of user management and guidelines around public sign-ups, role customization and adding System Admins.
+Read below for a high-level overview of user management and guidelines around public signups, role customization and adding System Admins.
 
-### Adding Users to Astronomer
+## Add Users to Astronomer
 
-When Astronomer Enterprise is first deployed, the first user to log in is granted "System Admin" permissions by default. From there, a user is created on Astronomer Enterprise by:
+When Astronomer Enterprise is first deployed, the first user to log in is granted "System Admin" permissions by default (more on that below). From there, a user is created on Astronomer Enterprise by:
 
 - Invitation to a Workspace by a Workspace Admin
 - Invitation to Astronomer by a System Admin
-- Signing up via the Astronomer UI without an invitation (requires "Public Sign-Ups")
+- Signing up via the Astronomer UI without an invitation (requires "Public Signups")
 
-On Astronomer, administrators have the option to either open the platform to public sign-ups or limit sign-ups to users invited by others.
+On Astronomer, administrators have the option to either open the platform to public signups or limit account creation to users invited by others.
 
-### Managing Users
+### Enable Public Signups
 
-Once on the platform, administrators can customize permissions across teams. On Astronomer, users can be assigned roles at 2 levels:
+As noted above, public signups allow any user with access to the platform URL (the Astronomer UI) to create an account. If public signups are *disabled*, users that try to access Astronomer without an invitation from another user will be met with an error.
 
-1. Workspace Level (Viewer, Editor, Admin)
-2. System Level (Viewer, Editor, Admin)
+In cases where SMTP credentials are difficult to acquire, enabling this flag might facilitate initial setup, as disabling public signups requires that a user accept an email invitation. Public signups are a configuration available in Astronomer's Houston API and can be enabled in the `config.yaml` file of your Helm chart.
 
-Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace Level Roles on Astronomer (Viewer, Editor and Admin), refer to our [Role Based Access Control](/docs/enterprise/v0.13/manage-astronomer/workspace-permissions/) doc.
+To enable or disable public signups, follow the guidelines below.
 
-## Public Sign-Ups
+#### Modify your `config.yaml`
 
-As noted above, public sign-ups allow any user with access to the platform URL (the Astronomer UI) to create an account. If Public sign-ups are *disabled*, users that try to access Astronomer without an invitation from another user will be met with an error.
-
-In cases where SMTP credentials are difficult to acquire, enabling this flag might facilitate initial setup, as disabling public sign-ups requires that a user accept an email invitation.
-
-### Enable Public Sign-Ups
-
-Public Sign-Ups are a configuration available in Astronomer's Houston API and can be enabled in the `config.yaml` file of your Helm chart.
-
-#### Modify your Configuration
-
-To *enable* Public Sign-Ups, add the following yaml snippet to your `config.yaml` file:
+To *enable* public signups, add the following yaml snippet to your `config.yaml` file:
 
 ```
 astronomer:
@@ -88,16 +77,113 @@ $ helm ls
 NAME                	REVISION	UPDATED                 	STATUS  	CHART                           	APP VERSION	NAMESPACE                                       
 calico-crab         	4       	Fri Nov 22 09:36:51 2019	DEPLOYED	astronomer-platform-0.10.3-fix.1	0.10.3     	astro                    
 
-$ helm upgrade calico-crab -f config.yaml --version=0.15.5 astronomer/astronomer -n calico-crab
+$ helm upgrade calico-crab -f config.yaml --version=0.16.4 astronomer/astronomer -n calico-crab
 ```
 
-## System Admins
+### User Roles on Astronomer
+
+Once on the platform, administrators can customize permissions across teams. On Astronomer, users can be assigned roles at 2 levels:
+
+1. Workspace Level (Viewer, Editor, Admin)
+2. System Level (Viewer, Editor, Admin)
+
+Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace-level roles on Astronomer (Viewer, Editor and Admin), refer to our ["Manage User Permissions on an Astronomer Workspace"](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
+
+## Customize Permissions
+
+Permissions are defined on Astronomer as `scope.entity.action`, where:
+
+- `scope`: The layer of our application to which the permission applies
+- `entity`: The object or role being operated on
+- `action`: The verb describing the operation being performed on the `entity`
+
+For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view our [default Houston API configuration](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L200). Each permission is applied to the role under which it is listed.
+
+> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles ([source code here](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L266)).
+
+To customize permissions, follow the steps below.
+
+### Identify a Permission Change
+
+First, take a look at our default roles and permissions linked above and identify two things:
+
+1. What role do you want to configure? (e.g. [`DEPLOYMENT_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L356))
+2. What permission(s) would you like to add to or remove from that role? (e.g. [`deployment.images.push`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L362))
+
+For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKSPACE_EDITOR`) from deploying code to all Airflow Deployments within a Workspace and instead limit that action to users assigned the `DEPLOYMENT_ADMIN` role.
+
+#### Limit Workspace Creation
+
+Unless otherwise configured, a user who creates a Workspace on Astronomer is automatically granted the `WORKSPACE_ADMIN` role and is thus able to create an unlimited number of Airflow Deployments within that Workspace. For teams looking to more strictly control resources, our platform supports limiting the Workspace creation function via a `USER` role.
+
+Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L377).
+
+If you're an administrator on Astronomer who wants to limit Workspace Creation, you can:
+
+- Remove the `system.workspace.create` permission from the `USER` role [here](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L382)
+- Attach it to a separate role of your choice
+
+If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
+
+To configure and apply this change, follow the steps below.
+
+### Modify your `config.yaml`
+
+Now, apply the role and permission change to your platform's `config.yaml` file. Following the `deployment.images.push` example above, that would mean specifying this:
+
+```yaml
+astronomer:
+  houston:
+    config:
+      roles:
+        DEPLOYMENT_EDITOR:
+          permissions:
+            deployment.images.push: false
+```
+
+In the same way you can _remove_ permissions from a particular role by setting any permission to `:false`, you can _add_ permissions to a role at any time.
+
+For example, if you want to allow any `DEPLOYMENT_VIEWER` (and therefore `WORKSPACE_VIEWER`) to push code directly to any Airflow Deployment within a Workspace, you'd specify the following:
+
+```yaml
+astronomer:
+  houston:
+    config:
+      roles:
+        DEPLOYMENT_VIEWER:
+          permissions:
+            deployment.images.push: true
+```
+
+### Apply your Changes
+
+Once you've made changes to your `config.yaml` file, trigger a platform upgrade from the `astronomer` repo by running:
+
+```
+$ helm ls
+```
+
+```
+$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+```
+
+For example, you might run:
+
+```
+$ helm ls
+NAME                	REVISION	UPDATED                 	STATUS  	CHART                           	APP VERSION	NAMESPACE                                       
+calico-crab         	4       	Fri Nov 22 09:36:51 2019	DEPLOYED	astronomer-platform-0.10.3-fix.1	0.16.4     	astro                    
+
+$ helm upgrade calico-crab -f config.yaml --version=0.16.4 astronomer/astronomer -n calico-crab
+```
+
+## System Roles
 
 ### Overview
 
 The System Admin role on Astronomer Enterprise brings a range of cluster-wide permissions that supercedes Workspace-level access and allows a user to monitor and take action across Workspaces, Deployments and Users within a single cluster.
 
-On Astronomer, System Admins can:
+On Astronomer, System Admins specifically can:
 
 - List and search *all* users
 - List and search *all* deployments
@@ -109,7 +195,7 @@ On Astronomer, System Admins can:
 
 By default, the first user to log into an Astronomer Enterprise installation is granted the System Admin permission set.
 
-#### System Editor, Viewer
+### System Editor, Viewer
 
 In addition to the commonly used System Admin role, the Astronomer platform also supports both a System Editor and System Viewer permission set.
 
@@ -119,7 +205,7 @@ All three permission sets are entirely customizable on Astronomer Enterprise. Fo
 
 For guidelines on assigning users any System Level role, read below.
 
-### Assigning Users System-Level Roles
+#### Assign Users System-Level Roles
 
 System Admins can be added to Astronomer Enterprise via the 'System Admin' tab of the Astronomer UI.
 
@@ -127,7 +213,7 @@ Keep in mind that:
 - Only existing System Admins can grant the SysAdmin role to another user
 - The user must have a verified email address and already exist in the system
 
-> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/v0.13/manage-astronomer/houston-api/).
+> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/stable/manage-astronomer/houston-api/).
 
 #### Verify SysAdmin Access
 
@@ -137,24 +223,3 @@ To verify a user was successfully granted the SysAdmin role, ensure they can do 
 - Navigate to `kibana.BASEDOMAIN`
 - Access the 'System Admin' tab from the top left menu of the Astronomer UI
 
-## Customizing Roles and Permissions
-
-On Astronomer Enterprise, platform administrators can customize the definitions of both Workspace and System Level roles from the same `config.yaml` file.
-
-For guidelines on how a user might limit the permission to create a Workspace, read below. For step-by-step instructions on how to customize and apply changes to permission sets across the platform, refer to our [Configuring Permissions](/docs/enterprise/v0.13/manage-astronomer/manage-platform-users/) doc.
-
-### Limiting Workspace Creation
-
-For larger teams on Astronomer Enterprise, our platform supports limiting the ability for any user on the platform to create a Workspace and provision Airflow resources.
-
-By default, all users have the ability to create a new Workspace. Unless otherwise configured, a user who creates a Workspace is automatically granted the "Workspace Admin" role and is thus able to create an unlimited number of Airflow Deployments within that Workspace.
-
-For those who want to limit user access to the Workspace creation function, administrators can leverage and customize our platform's `USER` role.
-
-#### Astronomer's `USER` Role
-
-Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L324).
-
-If you're an administrator on Astronomer who wants to limit its scope, you can remove the `system.workspace.create` permission from all users and instead attach it to a separate role of your choice. If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
-
-To configure and apply this change, follow the steps in our [Configuring Permissions](/docs/enterprise/v0.13/manage-astronomer/manage-platform-users/) doc.

--- a/enterprise/v0.14/06_manage-astronomer/02_manage-platform-users.md
+++ b/enterprise/v0.14/06_manage-astronomer/02_manage-platform-users.md
@@ -6,7 +6,7 @@ description: "How to add and customize user permissions on the platform, enable 
 
 ## Overview
 
-In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
+In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/v0.14/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
 
 Read below for a high-level overview of user management and guidelines around public signups, role customization and adding System Admins.
 
@@ -87,7 +87,7 @@ Once on the platform, administrators can customize permissions across teams. On 
 1. Workspace Level (Viewer, Editor, Admin)
 2. System Level (Viewer, Editor, Admin)
 
-Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace-level roles on Astronomer (Viewer, Editor and Admin), refer to our ["Manage User Permissions on an Astronomer Workspace"](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
+Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace-level roles on Astronomer (Viewer, Editor and Admin), refer to our ["Manage User Permissions on an Astronomer Workspace"](/docs/enterprise/v0.14/manage-astronomer/workspace-permissions/) doc.
 
 ## Customize Permissions
 
@@ -213,7 +213,7 @@ Keep in mind that:
 - Only existing System Admins can grant the SysAdmin role to another user
 - The user must have a verified email address and already exist in the system
 
-> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/stable/manage-astronomer/houston-api/).
+> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/v0.14/manage-astronomer/houston-api/).
 
 #### Verify SysAdmin Access
 

--- a/enterprise/v0.14/06_manage-astronomer/02_manage-platform-users.md
+++ b/enterprise/v0.14/06_manage-astronomer/02_manage-platform-users.md
@@ -6,42 +6,31 @@ description: "How to add and customize user permissions on the platform, enable 
 
 ## Overview
 
-In addition to the [Role-Based Access Control (RBAC) functionality](/docs/enterprise/v0.14/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
+In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
 
-Read below for a high-level overview of user management and guidelines around public sign-ups, role customization and adding System Admins.
+Read below for a high-level overview of user management and guidelines around public signups, role customization and adding System Admins.
 
-### Adding Users to Astronomer
+## Add Users to Astronomer
 
-When Astronomer Enterprise is first deployed, the first user to log in is granted "System Admin" permissions by default. From there, a user is created on Astronomer Enterprise by:
+When Astronomer Enterprise is first deployed, the first user to log in is granted "System Admin" permissions by default (more on that below). From there, a user is created on Astronomer Enterprise by:
 
 - Invitation to a Workspace by a Workspace Admin
 - Invitation to Astronomer by a System Admin
-- Signing up via the Astronomer UI without an invitation (requires "Public Sign-Ups")
+- Signing up via the Astronomer UI without an invitation (requires "Public Signups")
 
-On Astronomer, administrators have the option to either open the platform to public sign-ups or limit sign-ups to users invited by others.
+On Astronomer, administrators have the option to either open the platform to public signups or limit account creation to users invited by others.
 
-### Managing Users
+### Enable Public Signups
 
-Once on the platform, administrators can customize permissions across teams. On Astronomer, users can be assigned roles at 2 levels:
+As noted above, public signups allow any user with access to the platform URL (the Astronomer UI) to create an account. If public signups are *disabled*, users that try to access Astronomer without an invitation from another user will be met with an error.
 
-1. Workspace Level (Viewer, Editor, Admin)
-2. System Level (Viewer, Editor, Admin)
+In cases where SMTP credentials are difficult to acquire, enabling this flag might facilitate initial setup, as disabling public signups requires that a user accept an email invitation. Public signups are a configuration available in Astronomer's Houston API and can be enabled in the `config.yaml` file of your Helm chart.
 
-Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace Level Roles on Astronomer (Viewer, Editor and Admin), refer to our [Role Based Access Control](/docs/enterprise/v0.14/manage-astronomer/workspace-permissions/) doc.
+To enable or disable public signups, follow the guidelines below.
 
-## Public Sign-Ups
+#### Modify your `config.yaml`
 
-As noted above, public sign-ups allow any user with access to the platform URL (the Astronomer UI) to create an account. If Public sign-ups are *disabled*, users that try to access Astronomer without an invitation from another user will be met with an error.
-
-In cases where SMTP credentials are difficult to acquire, enabling this flag might facilitate initial setup, as disabling public sign-ups requires that a user accept an email invitation.
-
-### Enable Public Sign-Ups
-
-Public Sign-Ups are a configuration available in Astronomer's Houston API and can be enabled in the `config.yaml` file of your Helm chart.
-
-#### Modify your Configuration
-
-To *enable* Public Sign-Ups, add the following yaml snippet to your `config.yaml` file:
+To *enable* public signups, add the following yaml snippet to your `config.yaml` file:
 
 ```
 astronomer:
@@ -88,16 +77,113 @@ $ helm ls
 NAME                	REVISION	UPDATED                 	STATUS  	CHART                           	APP VERSION	NAMESPACE                                       
 calico-crab         	4       	Fri Nov 22 09:36:51 2019	DEPLOYED	astronomer-platform-0.10.3-fix.1	0.10.3     	astro                    
 
-$ helm upgrade calico-crab -f config.yaml --version=0.15.5 astronomer/astronomer -n calico-crab
+$ helm upgrade calico-crab -f config.yaml --version=0.16.4 astronomer/astronomer -n calico-crab
 ```
 
-## System Admins
+### User Roles on Astronomer
+
+Once on the platform, administrators can customize permissions across teams. On Astronomer, users can be assigned roles at 2 levels:
+
+1. Workspace Level (Viewer, Editor, Admin)
+2. System Level (Viewer, Editor, Admin)
+
+Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace-level roles on Astronomer (Viewer, Editor and Admin), refer to our ["Manage User Permissions on an Astronomer Workspace"](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
+
+## Customize Permissions
+
+Permissions are defined on Astronomer as `scope.entity.action`, where:
+
+- `scope`: The layer of our application to which the permission applies
+- `entity`: The object or role being operated on
+- `action`: The verb describing the operation being performed on the `entity`
+
+For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view our [default Houston API configuration](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L200). Each permission is applied to the role under which it is listed.
+
+> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles ([source code here](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L266)).
+
+To customize permissions, follow the steps below.
+
+### Identify a Permission Change
+
+First, take a look at our default roles and permissions linked above and identify two things:
+
+1. What role do you want to configure? (e.g. [`DEPLOYMENT_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L356))
+2. What permission(s) would you like to add to or remove from that role? (e.g. [`deployment.images.push`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L362))
+
+For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKSPACE_EDITOR`) from deploying code to all Airflow Deployments within a Workspace and instead limit that action to users assigned the `DEPLOYMENT_ADMIN` role.
+
+#### Limit Workspace Creation
+
+Unless otherwise configured, a user who creates a Workspace on Astronomer is automatically granted the `WORKSPACE_ADMIN` role and is thus able to create an unlimited number of Airflow Deployments within that Workspace. For teams looking to more strictly control resources, our platform supports limiting the Workspace creation function via a `USER` role.
+
+Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L377).
+
+If you're an administrator on Astronomer who wants to limit Workspace Creation, you can:
+
+- Remove the `system.workspace.create` permission from the `USER` role [here](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L382)
+- Attach it to a separate role of your choice
+
+If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
+
+To configure and apply this change, follow the steps below.
+
+### Modify your `config.yaml`
+
+Now, apply the role and permission change to your platform's `config.yaml` file. Following the `deployment.images.push` example above, that would mean specifying this:
+
+```yaml
+astronomer:
+  houston:
+    config:
+      roles:
+        DEPLOYMENT_EDITOR:
+          permissions:
+            deployment.images.push: false
+```
+
+In the same way you can _remove_ permissions from a particular role by setting any permission to `:false`, you can _add_ permissions to a role at any time.
+
+For example, if you want to allow any `DEPLOYMENT_VIEWER` (and therefore `WORKSPACE_VIEWER`) to push code directly to any Airflow Deployment within a Workspace, you'd specify the following:
+
+```yaml
+astronomer:
+  houston:
+    config:
+      roles:
+        DEPLOYMENT_VIEWER:
+          permissions:
+            deployment.images.push: true
+```
+
+### Apply your Changes
+
+Once you've made changes to your `config.yaml` file, trigger a platform upgrade from the `astronomer` repo by running:
+
+```
+$ helm ls
+```
+
+```
+$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+```
+
+For example, you might run:
+
+```
+$ helm ls
+NAME                	REVISION	UPDATED                 	STATUS  	CHART                           	APP VERSION	NAMESPACE                                       
+calico-crab         	4       	Fri Nov 22 09:36:51 2019	DEPLOYED	astronomer-platform-0.10.3-fix.1	0.16.4     	astro                    
+
+$ helm upgrade calico-crab -f config.yaml --version=0.16.4 astronomer/astronomer -n calico-crab
+```
+
+## System Roles
 
 ### Overview
 
 The System Admin role on Astronomer Enterprise brings a range of cluster-wide permissions that supercedes Workspace-level access and allows a user to monitor and take action across Workspaces, Deployments and Users within a single cluster.
 
-On Astronomer, System Admins can:
+On Astronomer, System Admins specifically can:
 
 - List and search *all* users
 - List and search *all* deployments
@@ -109,7 +195,7 @@ On Astronomer, System Admins can:
 
 By default, the first user to log into an Astronomer Enterprise installation is granted the System Admin permission set.
 
-#### System Editor, Viewer
+### System Editor, Viewer
 
 In addition to the commonly used System Admin role, the Astronomer platform also supports both a System Editor and System Viewer permission set.
 
@@ -119,7 +205,7 @@ All three permission sets are entirely customizable on Astronomer Enterprise. Fo
 
 For guidelines on assigning users any System Level role, read below.
 
-### Assigning Users System-Level Roles
+#### Assign Users System-Level Roles
 
 System Admins can be added to Astronomer Enterprise via the 'System Admin' tab of the Astronomer UI.
 
@@ -127,7 +213,7 @@ Keep in mind that:
 - Only existing System Admins can grant the SysAdmin role to another user
 - The user must have a verified email address and already exist in the system
 
-> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/v0.14/manage-astronomer/houston-api/).
+> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/stable/manage-astronomer/houston-api/).
 
 #### Verify SysAdmin Access
 
@@ -137,24 +223,3 @@ To verify a user was successfully granted the SysAdmin role, ensure they can do 
 - Navigate to `kibana.BASEDOMAIN`
 - Access the 'System Admin' tab from the top left menu of the Astronomer UI
 
-## Customizing Roles and Permissions
-
-On Astronomer Enterprise, platform administrators can customize the definitions of both Workspace and System Level roles from the same `config.yaml` file.
-
-For guidelines on how a user might limit the permission to create a Workspace, read below. For step-by-step instructions on how to customize and apply changes to permission sets across the platform, refer to our [Configuring Permissions](/docs/enterprise/v0.14/manage-astronomer/manage-platform-users/) doc.
-
-### Limiting Workspace Creation
-
-For larger teams on Astronomer Enterprise, our platform supports limiting the ability for any user on the platform to create a Workspace and provision Airflow resources.
-
-By default, all users have the ability to create a new Workspace. Unless otherwise configured, a user who creates a Workspace is automatically granted the "Workspace Admin" role and is thus able to create an unlimited number of Airflow Deployments within that Workspace.
-
-For those who want to limit user access to the Workspace creation function, administrators can leverage and customize our platform's `USER` role.
-
-#### Astronomer's `USER` Role
-
-Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L324).
-
-If you're an administrator on Astronomer who wants to limit its scope, you can remove the `system.workspace.create` permission from all users and instead attach it to a separate role of your choice. If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
-
-To configure and apply this change, follow the steps in our [Configuring Permissions](/docs/enterprise/v0.14/manage-astronomer/manage-platform-users/) doc.

--- a/enterprise/v0.15/06_manage-astronomer/02_manage-platform-users.md
+++ b/enterprise/v0.15/06_manage-astronomer/02_manage-platform-users.md
@@ -6,42 +6,31 @@ description: "How to add and customize user permissions on the platform, enable 
 
 ## Overview
 
-In addition to the [Role-Based Access Control (RBAC) functionality](/docs/enterprise/v0.15/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
+In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
 
-Read below for a high-level overview of user management and guidelines around public sign-ups, role customization and adding System Admins.
+Read below for a high-level overview of user management and guidelines around public signups, role customization and adding System Admins.
 
-### Adding Users to Astronomer
+## Add Users to Astronomer
 
-When Astronomer Enterprise is first deployed, the first user to log in is granted "System Admin" permissions by default. From there, a user is created on Astronomer Enterprise by:
+When Astronomer Enterprise is first deployed, the first user to log in is granted "System Admin" permissions by default (more on that below). From there, a user is created on Astronomer Enterprise by:
 
 - Invitation to a Workspace by a Workspace Admin
 - Invitation to Astronomer by a System Admin
-- Signing up via the Astronomer UI without an invitation (requires "Public Sign-Ups")
+- Signing up via the Astronomer UI without an invitation (requires "Public Signups")
 
-On Astronomer, administrators have the option to either open the platform to public sign-ups or limit sign-ups to users invited by others.
+On Astronomer, administrators have the option to either open the platform to public signups or limit account creation to users invited by others.
 
-### Managing Users
+### Enable Public Signups
 
-Once on the platform, administrators can customize permissions across teams. On Astronomer, users can be assigned roles at 2 levels:
+As noted above, public signups allow any user with access to the platform URL (the Astronomer UI) to create an account. If public signups are *disabled*, users that try to access Astronomer without an invitation from another user will be met with an error.
 
-1. Workspace Level (Viewer, Editor, Admin)
-2. System Level (Viewer, Editor, Admin)
+In cases where SMTP credentials are difficult to acquire, enabling this flag might facilitate initial setup, as disabling public signups requires that a user accept an email invitation. Public signups are a configuration available in Astronomer's Houston API and can be enabled in the `config.yaml` file of your Helm chart.
 
-Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace Level Roles on Astronomer (Viewer, Editor and Admin), refer to our [Role Based Access Control](/docs/enterprise/v0.15/manage-astronomer/workspace-permissions/) doc.
+To enable or disable public signups, follow the guidelines below.
 
-## Public Sign-Ups
+#### Modify your `config.yaml`
 
-As noted above, public sign-ups allow any user with access to the platform URL (the Astronomer UI) to create an account. If Public sign-ups are *disabled*, users that try to access Astronomer without an invitation from another user will be met with an error.
-
-In cases where SMTP credentials are difficult to acquire, enabling this flag might facilitate initial setup, as disabling public sign-ups requires that a user accept an email invitation.
-
-### Enable Public Sign-Ups
-
-Public Sign-Ups are a configuration available in Astronomer's Houston API and can be enabled in the `config.yaml` file of your Helm chart.
-
-#### Modify your Configuration
-
-To *enable* Public Sign-Ups, add the following yaml snippet to your `config.yaml` file:
+To *enable* public signups, add the following yaml snippet to your `config.yaml` file:
 
 ```
 astronomer:
@@ -88,16 +77,113 @@ $ helm ls
 NAME                	REVISION	UPDATED                 	STATUS  	CHART                           	APP VERSION	NAMESPACE                                       
 calico-crab         	4       	Fri Nov 22 09:36:51 2019	DEPLOYED	astronomer-platform-0.10.3-fix.1	0.10.3     	astro                    
 
-$ helm upgrade calico-crab -f config.yaml --version=0.15.5 astronomer/astronomer -n calico-crab
+$ helm upgrade calico-crab -f config.yaml --version=0.16.4 astronomer/astronomer -n calico-crab
 ```
 
-## System Admins
+### User Roles on Astronomer
+
+Once on the platform, administrators can customize permissions across teams. On Astronomer, users can be assigned roles at 2 levels:
+
+1. Workspace Level (Viewer, Editor, Admin)
+2. System Level (Viewer, Editor, Admin)
+
+Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace-level roles on Astronomer (Viewer, Editor and Admin), refer to our ["Manage User Permissions on an Astronomer Workspace"](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
+
+## Customize Permissions
+
+Permissions are defined on Astronomer as `scope.entity.action`, where:
+
+- `scope`: The layer of our application to which the permission applies
+- `entity`: The object or role being operated on
+- `action`: The verb describing the operation being performed on the `entity`
+
+For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view our [default Houston API configuration](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L200). Each permission is applied to the role under which it is listed.
+
+> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles ([source code here](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L266)).
+
+To customize permissions, follow the steps below.
+
+### Identify a Permission Change
+
+First, take a look at our default roles and permissions linked above and identify two things:
+
+1. What role do you want to configure? (e.g. [`DEPLOYMENT_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L356))
+2. What permission(s) would you like to add to or remove from that role? (e.g. [`deployment.images.push`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L362))
+
+For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKSPACE_EDITOR`) from deploying code to all Airflow Deployments within a Workspace and instead limit that action to users assigned the `DEPLOYMENT_ADMIN` role.
+
+#### Limit Workspace Creation
+
+Unless otherwise configured, a user who creates a Workspace on Astronomer is automatically granted the `WORKSPACE_ADMIN` role and is thus able to create an unlimited number of Airflow Deployments within that Workspace. For teams looking to more strictly control resources, our platform supports limiting the Workspace creation function via a `USER` role.
+
+Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L377).
+
+If you're an administrator on Astronomer who wants to limit Workspace Creation, you can:
+
+- Remove the `system.workspace.create` permission from the `USER` role [here](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L382)
+- Attach it to a separate role of your choice
+
+If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
+
+To configure and apply this change, follow the steps below.
+
+### Modify your `config.yaml`
+
+Now, apply the role and permission change to your platform's `config.yaml` file. Following the `deployment.images.push` example above, that would mean specifying this:
+
+```yaml
+astronomer:
+  houston:
+    config:
+      roles:
+        DEPLOYMENT_EDITOR:
+          permissions:
+            deployment.images.push: false
+```
+
+In the same way you can _remove_ permissions from a particular role by setting any permission to `:false`, you can _add_ permissions to a role at any time.
+
+For example, if you want to allow any `DEPLOYMENT_VIEWER` (and therefore `WORKSPACE_VIEWER`) to push code directly to any Airflow Deployment within a Workspace, you'd specify the following:
+
+```yaml
+astronomer:
+  houston:
+    config:
+      roles:
+        DEPLOYMENT_VIEWER:
+          permissions:
+            deployment.images.push: true
+```
+
+### Apply your Changes
+
+Once you've made changes to your `config.yaml` file, trigger a platform upgrade from the `astronomer` repo by running:
+
+```
+$ helm ls
+```
+
+```
+$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+```
+
+For example, you might run:
+
+```
+$ helm ls
+NAME                	REVISION	UPDATED                 	STATUS  	CHART                           	APP VERSION	NAMESPACE                                       
+calico-crab         	4       	Fri Nov 22 09:36:51 2019	DEPLOYED	astronomer-platform-0.10.3-fix.1	0.16.4     	astro                    
+
+$ helm upgrade calico-crab -f config.yaml --version=0.16.4 astronomer/astronomer -n calico-crab
+```
+
+## System Roles
 
 ### Overview
 
 The System Admin role on Astronomer Enterprise brings a range of cluster-wide permissions that supercedes Workspace-level access and allows a user to monitor and take action across Workspaces, Deployments and Users within a single cluster.
 
-On Astronomer, System Admins can:
+On Astronomer, System Admins specifically can:
 
 - List and search *all* users
 - List and search *all* deployments
@@ -109,7 +195,7 @@ On Astronomer, System Admins can:
 
 By default, the first user to log into an Astronomer Enterprise installation is granted the System Admin permission set.
 
-#### System Editor, Viewer
+### System Editor, Viewer
 
 In addition to the commonly used System Admin role, the Astronomer platform also supports both a System Editor and System Viewer permission set.
 
@@ -119,7 +205,7 @@ All three permission sets are entirely customizable on Astronomer Enterprise. Fo
 
 For guidelines on assigning users any System Level role, read below.
 
-### Assigning Users System-Level Roles
+#### Assign Users System-Level Roles
 
 System Admins can be added to Astronomer Enterprise via the 'System Admin' tab of the Astronomer UI.
 
@@ -127,7 +213,7 @@ Keep in mind that:
 - Only existing System Admins can grant the SysAdmin role to another user
 - The user must have a verified email address and already exist in the system
 
-> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/v0.15/manage-astronomer/houston-api/).
+> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/stable/manage-astronomer/houston-api/).
 
 #### Verify SysAdmin Access
 
@@ -137,24 +223,3 @@ To verify a user was successfully granted the SysAdmin role, ensure they can do 
 - Navigate to `kibana.BASEDOMAIN`
 - Access the 'System Admin' tab from the top left menu of the Astronomer UI
 
-## Customizing Roles and Permissions
-
-On Astronomer Enterprise, platform administrators can customize the definitions of both Workspace and System Level roles from the same `config.yaml` file.
-
-For guidelines on how a user might limit the permission to create a Workspace, read below. For step-by-step instructions on how to customize and apply changes to permission sets across the platform, refer to our [Configuring Permissions](/docs/enterprise/v0.15/manage-astronomer/manage-platform-users/) doc.
-
-### Limiting Workspace Creation
-
-For larger teams on Astronomer Enterprise, our platform supports limiting the ability for any user on the platform to create a Workspace and provision Airflow resources.
-
-By default, all users have the ability to create a new Workspace. Unless otherwise configured, a user who creates a Workspace is automatically granted the "Workspace Admin" role and is thus able to create an unlimited number of Airflow Deployments within that Workspace.
-
-For those who want to limit user access to the Workspace creation function, administrators can leverage and customize our platform's `USER` role.
-
-#### Astronomer's `USER` Role
-
-Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L324).
-
-If you're an administrator on Astronomer who wants to limit its scope, you can remove the `system.workspace.create` permission from all users and instead attach it to a separate role of your choice. If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
-
-To configure and apply this change, follow the steps in our [Configuring Permissions](/docs/enterprise/v0.15/manage-astronomer/manage-platform-users/) doc.

--- a/enterprise/v0.15/06_manage-astronomer/02_manage-platform-users.md
+++ b/enterprise/v0.15/06_manage-astronomer/02_manage-platform-users.md
@@ -6,7 +6,7 @@ description: "How to add and customize user permissions on the platform, enable 
 
 ## Overview
 
-In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
+In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/v0.15/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
 
 Read below for a high-level overview of user management and guidelines around public signups, role customization and adding System Admins.
 
@@ -87,7 +87,7 @@ Once on the platform, administrators can customize permissions across teams. On 
 1. Workspace Level (Viewer, Editor, Admin)
 2. System Level (Viewer, Editor, Admin)
 
-Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace-level roles on Astronomer (Viewer, Editor and Admin), refer to our ["Manage User Permissions on an Astronomer Workspace"](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
+Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace-level roles on Astronomer (Viewer, Editor and Admin), refer to our ["Manage User Permissions on an Astronomer Workspace"](/docs/enterprise/v0.15/manage-astronomer/workspace-permissions/) doc.
 
 ## Customize Permissions
 
@@ -213,7 +213,7 @@ Keep in mind that:
 - Only existing System Admins can grant the SysAdmin role to another user
 - The user must have a verified email address and already exist in the system
 
-> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/stable/manage-astronomer/houston-api/).
+> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/v0.15/manage-astronomer/houston-api/).
 
 #### Verify SysAdmin Access
 

--- a/enterprise/v0.16/06_manage-astronomer/02_manage-platform-users.md
+++ b/enterprise/v0.16/06_manage-astronomer/02_manage-platform-users.md
@@ -6,7 +6,7 @@ description: "How to add and customize user permissions on the platform, enable 
 
 ## Overview
 
-In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
+In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/v0.16/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
 
 Read below for a high-level overview of user management and guidelines around public signups, role customization and adding System Admins.
 
@@ -87,7 +87,7 @@ Once on the platform, administrators can customize permissions across teams. On 
 1. Workspace Level (Viewer, Editor, Admin)
 2. System Level (Viewer, Editor, Admin)
 
-Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace-level roles on Astronomer (Viewer, Editor and Admin), refer to our ["Manage User Permissions on an Astronomer Workspace"](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
+Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace-level roles on Astronomer (Viewer, Editor and Admin), refer to our ["Manage User Permissions on an Astronomer Workspace"](/docs/enterprise/v0.16/manage-astronomer/workspace-permissions/) doc.
 
 ## Customize Permissions
 
@@ -213,7 +213,7 @@ Keep in mind that:
 - Only existing System Admins can grant the SysAdmin role to another user
 - The user must have a verified email address and already exist in the system
 
-> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/stable/manage-astronomer/houston-api/).
+> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L220) or [`SYSTEM_EDITOR`](https://github.com/astronomer/houston-api/blob/main/config/default.yaml#L227)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/docs/enterprise/v0.16/manage-astronomer/houston-api/).
 
 #### Verify SysAdmin Access
 

--- a/enterprise/v0.16/06_manage-astronomer/02_manage-platform-users.md
+++ b/enterprise/v0.16/06_manage-astronomer/02_manage-platform-users.md
@@ -8,7 +8,7 @@ description: "How to add and customize user permissions on the platform, enable 
 
 In addition to Workspace-level [role-based access control (RBAC) functionality](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) core to our platform, Astronomer Enterprise allows teams to customize *how* they want users to create accounts on Astronomer and what they're able to do on the platform - both on Astronomer and Airflow.
 
-Read below for a high-level overview of user management and guidelines around public sign-ups, role customization and adding System Admins.
+Read below for a high-level overview of user management and guidelines around public signups, role customization and adding System Admins.
 
 ## Add Users to Astronomer
 
@@ -16,19 +16,21 @@ When Astronomer Enterprise is first deployed, the first user to log in is grante
 
 - Invitation to a Workspace by a Workspace Admin
 - Invitation to Astronomer by a System Admin
-- Signing up via the Astronomer UI without an invitation (requires "Public Sign-Ups")
+- Signing up via the Astronomer UI without an invitation (requires "Public Signups")
 
-On Astronomer, administrators have the option to either open the platform to public sign-ups or limit sign-ups to users invited by others.
+On Astronomer, administrators have the option to either open the platform to public signups or limit account creation to users invited by others.
 
-### Enable Public Sign-Ups
+### Enable Public Signups
 
-As noted above, public sign-ups allow any user with access to the platform URL (the Astronomer UI) to create an account. If Public sign-ups are *disabled*, users that try to access Astronomer without an invitation from another user will be met with an error.
+As noted above, public signups allow any user with access to the platform URL (the Astronomer UI) to create an account. If public signups are *disabled*, users that try to access Astronomer without an invitation from another user will be met with an error.
 
-In cases where SMTP credentials are difficult to acquire, enabling this flag might facilitate initial setup, as disabling public sign-ups requires that a user accept an email invitation. Public Sign-Ups are a configuration available in Astronomer's Houston API and can be enabled in the `config.yaml` file of your Helm chart.
+In cases where SMTP credentials are difficult to acquire, enabling this flag might facilitate initial setup, as disabling public signups requires that a user accept an email invitation. Public signups are a configuration available in Astronomer's Houston API and can be enabled in the `config.yaml` file of your Helm chart.
+
+To enable or disable public signups, follow the guidelines below.
 
 #### Modify your `config.yaml`
 
-To *enable* Public Sign-Ups, add the following yaml snippet to your `config.yaml` file:
+To *enable* public signups, add the following yaml snippet to your `config.yaml` file:
 
 ```
 astronomer:
@@ -85,7 +87,7 @@ Once on the platform, administrators can customize permissions across teams. On 
 1. Workspace Level (Viewer, Editor, Admin)
 2. System Level (Viewer, Editor, Admin)
 
-Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace Level Roles on Astronomer (Viewer, Editor and Admin), refer to our [Role-Based Access Control](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
+Workspace roles apply to all Airflow Deployments within a single Workspace, whereas System Roles apply to *all* Workspaces across a single cluster. For a detailed breakdown of the 3 Workspace-level roles on Astronomer (Viewer, Editor and Admin), refer to our ["Manage User Permissions on an Astronomer Workspace"](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
 
 ## Customize Permissions
 


### PR DESCRIPTION
@ashb Pointed out a broken link in this doc that referenced our old "Configure Permissions" doc which was not transferred over to this repo. File here: https://github.com/astronomer/docs-legacy-archived/blob/main/v0.16/ee-configuring-permissions.md

I went to fix the link and realized that we hadn't incorporated the content in that doc, so I:

- Added instructions on how to make and apply permission changes
- Reformatted some headers/hierarchy