### PR TITLE
Guide for calling Airflow API - astronomer/issues/#1813

### DIFF
--- a/cloud/stable/04_customize-airflow/06_airflow_api.md
+++ b/cloud/stable/04_customize-airflow/06_airflow_api.md
@@ -1,0 +1,56 @@
+---
+title: "Calling the Airflow API Programmatically"
+navTitle: "Airflow API"
+description: "How to add Airflow API calls to your scripts"
+---
+
+## Overview
+
+Airflow is a very flexible solution, with multiple ways of defining and orchestrating your workflows. One such tool at your disposal is the Airflow API, which you can call to programmatically kick off DAGs. 
+
+
+## The Airflow API on Astronomer
+Each call to the Airflow API on Astronomer will need to contain an authentication token. For Astronomer Cloud users, the token generated upon login at https://app.gcp0001.us-east4.astronomer.io/token can be used, but it is recommended that any workflows hitting the API use a long lived service account token.
+
+![Service Account](https://assets2.astronomer.io/main/docs/airflow_api/service_account_api.png)
+These service accounts tokens can also be created from the Astronomer CLI:
+
+```bash
+$ astro deployment service-account
+Service-accounts represent a revokable token with access to the Astronomer platform
+Usage:
+  astro deployment service-account [command]
+Aliases:
+  service-account, sa
+Available Commands:
+  create      Create a service-account in the astronomer platform
+  delete      Delete a service-account in the astronomer platform
+  get         Get a service-account by entity type and entity id
+Flags:
+  -h, --help   help for service-account
+Global Flags:
+      --workspace-id string   workspace assigned to deployment
+Use "astro deployment service-account [command] --help" for more information about a command.
+```
+
+## Test a Request
+Now that a service account has been created, requests can be made at https://deployments.gcp0001.us-east4.astronomer.io/<deployment_name>, subbing in the appropriate deployment name in the url. 
+
+An example API call could look like:
+```python
+python
+import requests
+token="<token_id>"
+base_url="https://deployments.gcp0001.us-east4.astronomer.io/"
+resp = requests.get(
+   url=base_url + "<deployment_id>/airflow/api/experimental/pools",
+   headers={"Authorization": token},
+   data={}
+)
+print(resp.json())
+>>>>  [{'description': 'Default pool', 'id': 1, 'pool': 'default_pool', 'slots': 128}]
+```
+Note that your request will have the same permissions as the role of the service account created.
+
+## Additional Endpoints
+Major improvements are planned to the Airflow API in the near future. More information can be found [on the official Airflow API AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-32%3A+Airflow+REST+API).

--- a/cloud/stable/04_customize-airflow/06_airflow_api.md
+++ b/cloud/stable/04_customize-airflow/06_airflow_api.md
@@ -1,56 +1,165 @@
 ---
 title: "Calling the Airflow API Programmatically"
 navTitle: "Airflow API"
-description: "How to add Airflow API calls to your scripts"
+description: "How to call the Airflow API on Astronomer."
 ---
 
 ## Overview
 
-Airflow is a very flexible solution, with multiple ways of defining and orchestrating your workflows. One such tool at your disposal is the Airflow API, which you can call to programmatically kick off DAGs. 
+Apache Airflow is an extensible orchestration tool that offers multiple ways to define and orchestrate data workflows. For users looking to automate actions around those workflows, Airflow exposes an ["experimental" REST API](https://airflow.apache.org/docs/stable/rest-api-ref.html) that you're free to leverage on Astronomer.
 
+If you're looking to externally trigger DAG runs without needing to access your Airflow Deployment directly, for example, you can make an HTTP request (in Python, cURL etc.) to the corresponding endpoint in Airflow's API that calls for that exact action.
 
-## The Airflow API on Astronomer
-Each call to the Airflow API on Astronomer will need to contain an authentication token. For Astronomer Cloud users, the token generated upon login at https://app.gcp0001.us-east4.astronomer.io/token can be used, but it is recommended that any workflows hitting the API use a long lived service account token.
+To get started, you'll need a Service Account on Astronomer to authenticate. Read below for guidelines.
 
-![Service Account](https://assets2.astronomer.io/main/docs/airflow_api/service_account_api.png)
-These service accounts tokens can also be created from the Astronomer CLI:
+## Create a Service Account on Astronomer
 
-```bash
-$ astro deployment service-account
-Service-accounts represent a revokable token with access to the Astronomer platform
-Usage:
-  astro deployment service-account [command]
-Aliases:
-  service-account, sa
-Available Commands:
-  create      Create a service-account in the astronomer platform
-  delete      Delete a service-account in the astronomer platform
-  get         Get a service-account by entity type and entity id
-Flags:
-  -h, --help   help for service-account
-Global Flags:
-      --workspace-id string   workspace assigned to deployment
-Use "astro deployment service-account [command] --help" for more information about a command.
+The first step to calling the Airflow API on Astronomer is to create a Deployment-level Service Account, which will assume a user role and set of permissions and output an API Key that you can use to authenticate with your request.
+
+You can create a Service Account either via the Astronomer CLI or the Astronomer UI.
+
+> **Note:** If you just need to call the Airflow API once, you could create a temporary Authentication Token (_expires in 24 hours_) on Astronomer Cloud in place of a long-lasting Service Account. To do so, navigate to: https://app.gcp0001.us-east4.astronomer.io/token.
+
+### Create a Service Account via the Astronomer CLI
+
+To create a Deployment-level Service account via the CLI, first run:
+
+```
+$ astro deployment list
 ```
 
-## Test a Request
-Now that a service account has been created, requests can be made at https://deployments.gcp0001.us-east4.astronomer.io/<deployment_name>, subbing in the appropriate deployment name in the url. 
+This will output the list of Airflow Deployments you have access to and their corresponding Deployment ID.
 
-An example API call could look like:
+With that Deployment ID, run:
+
+```
+$ astro deployment service-account create -d <deployment-id> --label <service-account-label> --role <deployment-role>
+```
+
+### Create a Service Account via the Astronomer UI
+
+If you prefer to provision a Service Account through the Astronomer UI, start by logging into Astronomer.
+
+#### Navigate to your Deployment's "Configure" Page
+
+From the Astronomer UI, navigate to: **Deployment** > **Service Accounts**.
+
+![New Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-new-service-account.png)
+
+#### Configure your Service Account
+
+As you're creating a Service Account, you'll be asked to specify its:
+
+- Name
+- User Role
+- Category (_optional_)
+
+![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
+
+> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the "Editor" or "Admin" role. For more information on Workspace roles, refer to our ["Roles and Permissions"](/docs/cloud/stable/manage-astronomer/workspace-permissions/) doc.
+
+#### Copy the API Key
+
+Once you've created your new Service Account, grab the API Key that was immediately generated. Depending on your use case, you might want to store this key in an Environment Variable or secret management tool of choice.
+
+![Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-api-key.png)
+
+
+## Test an Airflow API Request
+
+Now that you've created a Service Account, you're free to generate both GET or POST requests to any supported endpoints in Airflow's ["Rest API Reference"](https://airflow.apache.org/docs/stable/rest-api-ref.html) via this URL:
+
+```
+https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>
+```
+
+Make sure to replace the end of the URL above with your own Deployment's release name (e.g. `galactic-stars-1234`).
+
+You can make requests via the method of your choosing. Below, we'll walk through an example request via cURL to Airflow's "Trigger DAG" endpoint and an example request via Python to the "Get all Pools" endpoint.
+
+### Trigger DAG
+
+If you'd like to externally trigger a DAG run, you can start with a generic cURL command to Airflow's POST endpoint: 
+
+```
+POST /api/experimental/dags/<DAG_ID>/dag_runs
+```
+
+This command would look like this:
+
+```
+curl -v -X POST
+https://AIRFLOW_DOMAIN/api/experimental/dags/<DAG_ID>/dag_runs
+-H 'Authorization: <API_Key> ’
+-H ‘Cache-Control: no-cache’
+-H ‘content-type: application/json’ -d ‘{}’
+```
+
+To run this, replace:
+
+- **AIRFLOW_DOMAIN**: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
+- **DAG_ID**: Name of your DAG (_case-sensitive_)
+- **API_Key**: API Key from your Service Account
+
+This will successfully kick off a DAG run for your DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the “Play” button in the main "DAGs" view of the Airflow UI (Webserver).
+
+> **Note:** Your request will have the same permissions as the role of the Service Account you created on Astronomer.
+
+#### Specify Execution Date
+
+If you'd like to choose a specific `execution_date` (i.e. start timestamp) to kick off your DAG on, you can pass that in with the data parameter's JSON value `("-d'{}')`.
+
+The string needs to be in the following format (in UTC):
+
+```
+“YYYY-mm-DDTHH:MM:SS”
+```
+
+For example:
+
+```
+“2016-11-16T11:34:15”
+```
+
+Here, your request becomes:
+
+```
+curl -v -X POST
+https://AIRFLOW_DOMAIN/api/experimental/dags/customer_health_score/dag_runs
+-H ‘Authorization: XXXX’
+-H ‘Cache-Control: no-cache’
+-H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-03-05T08:30:00”}’
+```
+
+### Get all Pools
+
+If you'd like to get all existing Pools from your Airflow Deployment, you can start with a generic Python command to Airflow's GET endpoint: 
+
+```
+GET /api/experimental/pools
+```
+
+Here, your request would look like this:
+
 ```python
 python
 import requests
-token="<token_id>"
+token="<API_KEY>"
 base_url="https://deployments.gcp0001.us-east4.astronomer.io/"
 resp = requests.get(
-   url=base_url + "<deployment_id>/airflow/api/experimental/pools",
+   url=base_url + "<deployment_release_name>/airflow/api/experimental/pools",
    headers={"Authorization": token},
    data={}
 )
 print(resp.json())
 >>>>  [{'description': 'Default pool', 'id': 1, 'pool': 'default_pool', 'slots': 128}]
 ```
-Note that your request will have the same permissions as the role of the service account created.
 
-## Additional Endpoints
-Major improvements are planned to the Airflow API in the near future. More information can be found [on the official Airflow API AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-32%3A+Airflow+REST+API).
+To run this, replace:
+
+- **API_KEY**: API Key from your Service Account
+- **deployment_release_name**: Your Airflow Deployment Release Name
+
+## New REST API Coming soon
+
+An official REST API for Airflow is coming in the Airflow 2.0 release scheduled for Winter 2020. For more information, check out [AIP-32](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-32%3A+Airflow+REST+API) or [reach out to us](https://support.astronomer.io).

--- a/enterprise/next/05_customize-airflow/07_airflow-api.md
+++ b/enterprise/next/05_customize-airflow/07_airflow-api.md
@@ -1,0 +1,56 @@
+---
+title: "Calling the Airflow API Programmatically"
+navTitle: "Airflow API"
+description: "How to add Airflow API calls to your scripts"
+---
+
+## Overview
+
+Airflow is a very flexible solution, with multiple ways of defining and orchestrating your workflows. One such tool at your disposal is the Airflow API, which you can call to programmatically kick off DAGs. 
+
+
+## The Airflow API on Astronomer
+Each call to the Airflow API on Astronomer will need to contain an authentication token. For Astronomer Enterprise users, the token generated upon login at https://app.BASEDOMAIN/token can be used, but it is recommended that any workflows hitting the API use a long lived service account token.
+
+![Service Account](https://assets2.astronomer.io/main/docs/airflow_api/service_account_api.png)
+These service accounts tokens can also be created from the Astronomer CLI:
+
+```bash
+$ astro deployment service-account
+Service-accounts represent a revokable token with access to the Astronomer platform
+Usage:
+  astro deployment service-account [command]
+Aliases:
+  service-account, sa
+Available Commands:
+  create      Create a service-account in the astronomer platform
+  delete      Delete a service-account in the astronomer platform
+  get         Get a service-account by entity type and entity id
+Flags:
+  -h, --help   help for service-account
+Global Flags:
+      --workspace-id string   workspace assigned to deployment
+Use "astro deployment service-account [command] --help" for more information about a command.
+```
+
+## Test a Request
+Now that a service account has been created, requests can be made at https://deployments.BASEDOMAIN/<deployment_name>, subbing in the appropriate deployment name in the url. 
+
+An example API call could look like:
+```python
+python
+import requests
+token="<token_id>"
+base_url="https://deployments.<BASE_DOMAIN>/"
+resp = requests.get(
+   url=base_url + "<deployment_id>/airflow/api/experimental/pools",
+   headers={"Authorization": token},
+   data={}
+)
+print(resp.json())
+>>>>  [{'description': 'Default pool', 'id': 1, 'pool': 'default_pool', 'slots': 128}]
+```
+Note that your request will have the same permissions as the role of the service account created.
+
+## Additional Endpoints
+Major improvements are planned to the Airflow API in the near future. More information can be found [on the official Airflow API AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-32%3A+Airflow+REST+API).

--- a/enterprise/v0.16/05_customize-airflow/07_airflow-api.md
+++ b/enterprise/v0.16/05_customize-airflow/07_airflow-api.md
@@ -1,0 +1,56 @@
+---
+title: "Calling the Airflow API Programmatically"
+navTitle: "Airflow API"
+description: "How to add Airflow API calls to your scripts"
+---
+
+## Overview
+
+Airflow is a very flexible solution, with multiple ways of defining and orchestrating your workflows. One such tool at your disposal is the Airflow API, which you can call to programmatically kick off DAGs. 
+
+
+## The Airflow API on Astronomer
+Each call to the Airflow API on Astronomer will need to contain an authentication token. For Astronomer Enterprise users, the token generated upon login at https://app.BASEDOMAIN/token can be used, but it is recommended that any workflows hitting the API use a long lived service account token.
+
+![Service Account](https://assets2.astronomer.io/main/docs/airflow_api/service_account_api.png)
+These service accounts tokens can also be created from the Astronomer CLI:
+
+```bash
+$ astro deployment service-account
+Service-accounts represent a revokable token with access to the Astronomer platform
+Usage:
+  astro deployment service-account [command]
+Aliases:
+  service-account, sa
+Available Commands:
+  create      Create a service-account in the astronomer platform
+  delete      Delete a service-account in the astronomer platform
+  get         Get a service-account by entity type and entity id
+Flags:
+  -h, --help   help for service-account
+Global Flags:
+      --workspace-id string   workspace assigned to deployment
+Use "astro deployment service-account [command] --help" for more information about a command.
+```
+
+## Test a Request
+Now that a service account has been created, requests can be made at https://deployments.BASEDOMAIN/<deployment_name>, subbing in the appropriate deployment name in the url. 
+
+An example API call could look like:
+```python
+python
+import requests
+token="<token_id>"
+base_url="https://deployments.<BASE_DOMAIN>/"
+resp = requests.get(
+   url=base_url + "<deployment_id>/airflow/api/experimental/pools",
+   headers={"Authorization": token},
+   data={}
+)
+print(resp.json())
+>>>>  [{'description': 'Default pool', 'id': 1, 'pool': 'default_pool', 'slots': 128}]
+```
+Note that your request will have the same permissions as the role of the service account created.
+
+## Additional Endpoints
+Major improvements are planned to the Airflow API in the near future. More information can be found [on the official Airflow API AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-32%3A+Airflow+REST+API).


### PR DESCRIPTION
Wrote up Viraj's notes/doc on how to programmatically call the Airflow API using Astronomer service-account

Could use some review of "Overview" section. 
Added three docs - one to Enterprise -> Next folder, one to Enterprise -> 0.16 folder, one to Cloud. Edited all three to be specific to Enterprise vs Cloud as appropriate. 