### PR TITLE
Added AWS CodeBuild to CICD doc /astronomer/issues/issues/1884

### DIFF
--- a/cloud/stable/03_deploy/06_ci-cd.md
+++ b/cloud/stable/03_deploy/06_ci-cd.md
@@ -152,7 +152,7 @@ docker build -t registry.${BASE_DOMAIN}/${RELEASE_NAME}/airflow:ci-${DRONE_BUILD
 
 If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/main/.drone.yml).
 
-### Configure Your CI/CD Pipeline
+## Configure Your CI/CD Pipeline
 
 Depending on your CI/CD tool, configuration will be slightly different. This section will focus on outlining what needs to be accomplished, not the specifics of how.
 
@@ -274,7 +274,6 @@ pipeline {
    }
  }
 }
-
 ```
 
 ## Bitbucket
@@ -299,10 +298,10 @@ pipelines:
             - docker
           caches:
             - docker
-
 ```
 
 ## Gitlab
+
 ```yaml
 astro_deploy:
   stage: deploy
@@ -319,6 +318,7 @@ astro_deploy:
 ```
 
 ## AWS Codebuild
+
 ```yaml
 version: 0.2
 phases:
@@ -340,14 +340,13 @@ phases:
       - docker push "registry.$BASE_DOMAIN/$RELEASE_NAME/airflow:ci-$GIT_VERSION"
 ```
 
-
 ## GitHub Actions CI/CD
 
 GitHub supports a growing set of native CI/CD features in ["GitHub Actions"](https://github.com/features/actions), including a "Publish Docker" action that works well with Astronomer.
 
 To use GitHub Actions on Astronomer, create a new action in your repo at `.github/workflows/main.yml` with the following:
 
-```
+```yaml
 name: CI
 
 on: [push]

--- a/cloud/stable/03_deploy/06_ci-cd.md
+++ b/cloud/stable/03_deploy/06_ci-cd.md
@@ -158,7 +158,7 @@ Depending on your CI/CD tool, configuration will be slightly different. This sec
 
 At its core, your CI/CD pipeline will first authenticate to Astronomer Cloud's private registry and then build, tag and push your Docker Image to that registry.
 
-#### DroneCI
+## DroneCI
 
 ```yaml
 pipeline:
@@ -186,7 +186,7 @@ pipeline:
       branch: [ master, release-* ]
 ```
 
-#### CircleCI
+## CircleCI
 
 ```yaml
 # Python CircleCI 2.0 configuration file
@@ -251,7 +251,7 @@ workflows:
                 - master
 ```
 
-#### Jenkins Script
+## Jenkins Script
 
 ```yaml
 pipeline {
@@ -277,7 +277,7 @@ pipeline {
 
 ```
 
-#### Bitbucket
+## Bitbucket
 
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
@@ -302,7 +302,7 @@ pipelines:
 
 ```
 
-#### Gitlab
+## Gitlab
 ```yaml
 astro_deploy:
   stage: deploy
@@ -318,7 +318,30 @@ astro_deploy:
     - master
 ```
 
-### GitHub Actions CI/CD
+## AWS Codebuild
+```yaml
+version: 0.2
+phases:
+  install:
+    runtime-versions:
+      python: latest
+​
+  pre_build:
+    commands:
+      - echo Logging in to dockerhub ...
+      - docker login "registry.$BASE_DOMAIN" -u _ -p "$API_KEY_SECRET"
+      - export GIT_VERSION="$(git rev-parse --short HEAD)"
+      - echo "GIT_VERSION = $GIT_VERSION"
+      - pip install -r requirements.txt
+​
+  build:
+    commands:
+      - docker build -t "registry.$BASE_DOMAIN/$RELEASE_NAME/airflow:ci-$GIT_VERSION" .
+      - docker push "registry.$BASE_DOMAIN/$RELEASE_NAME/airflow:ci-$GIT_VERSION"
+```
+
+
+## GitHub Actions CI/CD
 
 GitHub supports a growing set of native CI/CD features in ["GitHub Actions"](https://github.com/features/actions), including a "Publish Docker" action that works well with Astronomer.
 

--- a/enterprise/next/04_deploy/06_ci-cd.md
+++ b/enterprise/next/04_deploy/06_ci-cd.md
@@ -149,13 +149,13 @@ docker build -t registry.${BASE_DOMAIN}/${RELEASE_NAME}/airflow:ci-${DRONE_BUILD
 
 If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/main/.drone.yml).
 
-### Configure Your CI/CD Pipeline
+## Configure Your CI/CD Pipeline
 
 Depending on your CI/CD tool, configuration will be slightly different. This section will focus on outlining what needs to be accomplished, not the specifics of how.
 
 At its core, your CI/CD pipeline will be authenticating to the private registry installed with the platform, then building, tagging and pushing an image to that registry.
 
-> Note: The base image is based on the version of Astronomer you are currently running.
+> **Note:** The base image is based on the version of Astronomer you are currently running.
 
 ## DroneCI
 
@@ -273,7 +273,6 @@ pipeline {
    }
  }
 }
-
 ```
 
 ## Bitbucket
@@ -298,10 +297,10 @@ pipelines:
             - docker
           caches:
             - docker
-
 ```
 
 ## Gitlab
+
 ```yaml
 astro_deploy:
   stage: deploy
@@ -318,6 +317,7 @@ astro_deploy:
 ```
 
 ## AWS Codebuild
+
 ```yaml
 version: 0.2
 phases:
@@ -345,7 +345,7 @@ GitHub supports a growing set of native CI/CD features in ["GitHub Actions"](htt
 
 To use GitHub Actions on Astronomer, create a new action in your repo at `.github/workflows/main.yml` with the following:
 
-```
+```yaml
 name: CI
 
 on: [push]

--- a/enterprise/next/04_deploy/06_ci-cd.md
+++ b/enterprise/next/04_deploy/06_ci-cd.md
@@ -157,7 +157,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 
 > Note: The base image is based on the version of Astronomer you are currently running.
 
-#### DroneCI
+## DroneCI
 
 ```yaml
 pipeline:
@@ -185,7 +185,7 @@ pipeline:
       branch: [ master, release-* ]
 ```
 
-#### CircleCI
+## CircleCI
 
 ```yaml
 # Python CircleCI 2.0 configuration file
@@ -250,7 +250,7 @@ workflows:
                 - master
 ```
 
-#### Jenkins Script
+## Jenkins Script
 
 ```yaml
 pipeline {
@@ -276,7 +276,7 @@ pipeline {
 
 ```
 
-#### Bitbucket
+## Bitbucket
 
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
@@ -301,7 +301,7 @@ pipelines:
 
 ```
 
-#### Gitlab
+## Gitlab
 ```yaml
 astro_deploy:
   stage: deploy
@@ -317,7 +317,29 @@ astro_deploy:
     - master
 ```
 
-### GitHub Actions CI/CD
+## AWS Codebuild
+```yaml
+version: 0.2
+phases:
+  install:
+    runtime-versions:
+      python: latest
+​
+  pre_build:
+    commands:
+      - echo Logging in to dockerhub ...
+      - docker login "registry.$BASE_DOMAIN" -u _ -p "$API_KEY_SECRET"
+      - export GIT_VERSION="$(git rev-parse --short HEAD)"
+      - echo "GIT_VERSION = $GIT_VERSION"
+      - pip install -r requirements.txt
+​
+  build:
+    commands:
+      - docker build -t "registry.$BASE_DOMAIN/$RELEASE_NAME/airflow:ci-$GIT_VERSION" .
+      - docker push "registry.$BASE_DOMAIN/$RELEASE_NAME/airflow:ci-$GIT_VERSION"
+```
+
+## GitHub Actions CI/CD
 
 GitHub supports a growing set of native CI/CD features in ["GitHub Actions"](https://github.com/features/actions), including a "Publish Docker" action that works well with Astronomer.
 

--- a/enterprise/v0.16/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.16/04_deploy/06_ci-cd.md
@@ -149,13 +149,13 @@ docker build -t registry.${BASE_DOMAIN}/${RELEASE_NAME}/airflow:ci-${DRONE_BUILD
 
 If you would like to see a more complete working example please visit our [full example using Drone-CI](https://github.com/astronomer/airflow-example-dags/blob/main/.drone.yml).
 
-### Configure Your CI/CD Pipeline
+## Configure Your CI/CD Pipeline
 
 Depending on your CI/CD tool, configuration will be slightly different. This section will focus on outlining what needs to be accomplished, not the specifics of how.
 
 At its core, your CI/CD pipeline will be authenticating to the private registry installed with the platform, then building, tagging and pushing an image to that registry.
 
-> Note: The base image is based on the version of Astronomer you are currently running.
+> **Note:** The base image is based on the version of Astronomer you are currently running.
 
 ## DroneCI
 
@@ -273,7 +273,6 @@ pipeline {
    }
  }
 }
-
 ```
 
 ## Bitbucket
@@ -298,10 +297,10 @@ pipelines:
             - docker
           caches:
             - docker
-
 ```
 
 ## Gitlab
+
 ```yaml
 astro_deploy:
   stage: deploy
@@ -318,6 +317,7 @@ astro_deploy:
 ```
 
 ## AWS Codebuild
+
 ```yaml
 version: 0.2
 phases:
@@ -345,7 +345,7 @@ GitHub supports a growing set of native CI/CD features in ["GitHub Actions"](htt
 
 To use GitHub Actions on Astronomer, create a new action in your repo at `.github/workflows/main.yml` with the following:
 
-```
+```yaml
 name: CI
 
 on: [push]

--- a/enterprise/v0.16/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.16/04_deploy/06_ci-cd.md
@@ -157,7 +157,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 
 > Note: The base image is based on the version of Astronomer you are currently running.
 
-#### DroneCI
+## DroneCI
 
 ```yaml
 pipeline:
@@ -185,7 +185,7 @@ pipeline:
       branch: [ master, release-* ]
 ```
 
-#### CircleCI
+## CircleCI
 
 ```yaml
 # Python CircleCI 2.0 configuration file
@@ -250,7 +250,7 @@ workflows:
                 - master
 ```
 
-#### Jenkins Script
+## Jenkins Script
 
 ```yaml
 pipeline {
@@ -276,7 +276,7 @@ pipeline {
 
 ```
 
-#### Bitbucket
+## Bitbucket
 
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
@@ -301,7 +301,7 @@ pipelines:
 
 ```
 
-#### Gitlab
+## Gitlab
 ```yaml
 astro_deploy:
   stage: deploy
@@ -317,7 +317,29 @@ astro_deploy:
     - master
 ```
 
-### GitHub Actions CI/CD
+## AWS Codebuild
+```yaml
+version: 0.2
+phases:
+  install:
+    runtime-versions:
+      python: latest
+​
+  pre_build:
+    commands:
+      - echo Logging in to dockerhub ...
+      - docker login "registry.$BASE_DOMAIN" -u _ -p "$API_KEY_SECRET"
+      - export GIT_VERSION="$(git rev-parse --short HEAD)"
+      - echo "GIT_VERSION = $GIT_VERSION"
+      - pip install -r requirements.txt
+​
+  build:
+    commands:
+      - docker build -t "registry.$BASE_DOMAIN/$RELEASE_NAME/airflow:ci-$GIT_VERSION" .
+      - docker push "registry.$BASE_DOMAIN/$RELEASE_NAME/airflow:ci-$GIT_VERSION"
+```
+
+## GitHub Actions CI/CD
 
 GitHub supports a growing set of native CI/CD features in ["GitHub Actions"](https://github.com/features/actions), including a "Publish Docker" action that works well with Astronomer.
 


### PR DESCRIPTION
Added AWS CodeBuild to CICD doc and changed headers of example code/scripts so they are linkable (only H2 headers have built-in links)