### PR TITLE
fix: add note about python 3

### DIFF
--- a/enterprise/next/03_install/01_aws/02_install-aws-terraform.md
+++ b/enterprise/next/03_install/01_aws/02_install-aws-terraform.md
@@ -33,6 +33,7 @@ Install the necessary tools:
 * [Terraform](https://www.terraform.io/downloads.html) *Use version 0.12.3 - 0.12.28*
 * [Helm client](https://github.com/helm/helm#install) *Use version 3.2.1*
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) *Use the version appropriate for your Kubernetes cluster version*
+* [Python 3](https://www.python.org/download/releases/3.0/) *Must be available under the name `python3`*
 
 ## Installation
 

--- a/enterprise/v0.12/03_install/01_aws/02_install-aws-terraform.md
+++ b/enterprise/v0.12/03_install/01_aws/02_install-aws-terraform.md
@@ -33,6 +33,7 @@ Install the necessary tools:
 * [Terraform](https://www.terraform.io/downloads.html) *Use version 0.12.3 or later*
 * [Helm client](https://github.com/helm/helm#install) *Use version 2.16.1*
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) *Use the version appropriate for your Kubernetes cluster version*
+* [Python 3](https://www.python.org/download/releases/3.0/) *Must be available under the name `python3`*
 
 ## Installation
 

--- a/enterprise/v0.13/03_install/01_aws/02_install-aws-terraform.md
+++ b/enterprise/v0.13/03_install/01_aws/02_install-aws-terraform.md
@@ -33,6 +33,7 @@ Install the necessary tools:
 * [Terraform](https://www.terraform.io/downloads.html) *Use version 0.12.3 or later*
 * [Helm client](https://github.com/helm/helm#install) *Use version 2.16.1*
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) *Use the version appropriate for your Kubernetes cluster version*
+* [Python 3](https://www.python.org/download/releases/3.0/) *Must be available under the name `python3`*
 
 ## Installation
 

--- a/enterprise/v0.14/03_install/01_aws/02_install-aws-terraform.md
+++ b/enterprise/v0.14/03_install/01_aws/02_install-aws-terraform.md
@@ -33,6 +33,7 @@ Install the necessary tools:
 * [Terraform](https://www.terraform.io/downloads.html) *Use version 0.12.3 or later*
 * [Helm client](https://github.com/helm/helm#install) *Use version 2.16.1*
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) *Use the version appropriate for your Kubernetes cluster version*
+* [Python 3](https://www.python.org/download/releases/3.0/) *Must be available under the name `python3`*
 
 ## Installation
 

--- a/enterprise/v0.15/03_install/01_aws/02_install-aws-terraform.md
+++ b/enterprise/v0.15/03_install/01_aws/02_install-aws-terraform.md
@@ -33,6 +33,7 @@ Install the necessary tools:
 * [Terraform](https://www.terraform.io/downloads.html) *Use version 0.12.3 or later*
 * [Helm client](https://github.com/helm/helm#install) *Use version 2.16.1*
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) *Use the version appropriate for your Kubernetes cluster version*
+* [Python 3](https://www.python.org/download/releases/3.0/) *Must be available under the name `python3`*
 
 ## Installation
 

--- a/enterprise/v0.16/03_install/01_aws/02_install-aws-terraform.md
+++ b/enterprise/v0.16/03_install/01_aws/02_install-aws-terraform.md
@@ -33,6 +33,7 @@ Install the necessary tools:
 * [Terraform](https://www.terraform.io/downloads.html) *Use version 0.12.3 - 0.12.28*
 * [Helm client](https://github.com/helm/helm#install) *Use version 3.2.1*
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) *Use the version appropriate for your Kubernetes cluster version*
+* [Python 3](https://www.python.org/download/releases/3.0/) *Must be available under the name `python3`*
 
 ## Installation
 


### PR DESCRIPTION
If Python 3 is installed but not available under the name `python3` I think these would fail, so just adding a note about that.

<img width="501" alt="image" src="https://user-images.githubusercontent.com/12520493/96375704-0bf8ea80-116a-11eb-97a1-f0967e01c1a5.png">
