### PR TITLE
Fixing small bug in example DAG on local KubernetesPodOperator doc

### DIFF
--- a/enterprise/v0.12/02_develop/03_kubepodoperator-local.md
+++ b/enterprise/v0.12/02_develop/03_kubepodoperator-local.md
@@ -75,7 +75,7 @@ with dag:
         name="airflow-test-pod",
         task_id="task-one",
         in_cluster=in_cluster, # if set to true, will look in the cluster, if false, looks for file
-        cluster_context='docker-for-desktop', # is ignored when in_cluster is set to True
+        cluster_context='docker-desktop', # is ignored when in_cluster is set to True
         config_file=config_file,
         is_delete_operator_pod=True,
         get_logs=True)

--- a/enterprise/v0.13/02_develop/03_kubepodoperator-local.md
+++ b/enterprise/v0.13/02_develop/03_kubepodoperator-local.md
@@ -75,7 +75,7 @@ with dag:
         name="airflow-test-pod",
         task_id="task-one",
         in_cluster=in_cluster, # if set to true, will look in the cluster, if false, looks for file
-        cluster_context='docker-for-desktop', # is ignored when in_cluster is set to True
+        cluster_context='docker-desktop', # is ignored when in_cluster is set to True
         config_file=config_file,
         is_delete_operator_pod=True,
         get_logs=True)

--- a/enterprise/v0.14/02_develop/03_kubepodoperator-local.md
+++ b/enterprise/v0.14/02_develop/03_kubepodoperator-local.md
@@ -75,7 +75,7 @@ with dag:
         name="airflow-test-pod",
         task_id="task-one",
         in_cluster=in_cluster, # if set to true, will look in the cluster, if false, looks for file
-        cluster_context='docker-for-desktop', # is ignored when in_cluster is set to True
+        cluster_context='docker-desktop', # is ignored when in_cluster is set to True
         config_file=config_file,
         is_delete_operator_pod=True,
         get_logs=True)

--- a/enterprise/v0.15/02_develop/03_kubepodoperator-local.md
+++ b/enterprise/v0.15/02_develop/03_kubepodoperator-local.md
@@ -75,7 +75,7 @@ with dag:
         name="airflow-test-pod",
         task_id="task-one",
         in_cluster=in_cluster, # if set to true, will look in the cluster, if false, looks for file
-        cluster_context='docker-for-desktop', # is ignored when in_cluster is set to True
+        cluster_context='docker-desktop', # is ignored when in_cluster is set to True
         config_file=config_file,
         is_delete_operator_pod=True,
         get_logs=True)

--- a/enterprise/v0.16/02_develop/03_kubepodoperator-local.md
+++ b/enterprise/v0.16/02_develop/03_kubepodoperator-local.md
@@ -75,7 +75,7 @@ with dag:
         name="airflow-test-pod",
         task_id="task-one",
         in_cluster=in_cluster, # if set to true, will look in the cluster, if false, looks for file
-        cluster_context='docker-for-desktop', # is ignored when in_cluster is set to True
+        cluster_context='docker-desktop', # is ignored when in_cluster is set to True
         config_file=config_file,
         is_delete_operator_pod=True,
         get_logs=True)


### PR DESCRIPTION
The default .kube/config uses 'docker-desktop' as the cluster context instead of 'docker-for-dekstop'. Updating the example DAG to match so it works without any modifications