### PR TITLE
Refactored "Airflow Versioning" Doc

### DIFF
--- a/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
@@ -13,7 +13,7 @@ Included in that build is your `Dockerfile`, a file that is automatically genera
 To upgrade your Airflow Deployment to a higher version of Airflow, there are two steps:
 
 1. Indicate your intent to upgrade your Deployment to some higher version of Airflow via the Astronomer UI or CLI
-2. Change the FROM statement in your project's Dockerfile to reference the new AC image of your choice.
+2. Change the FROM statement in your project's Dockerfile to reference the new AC image of your choice
 
 Read below for details.
 
@@ -34,13 +34,13 @@ Astronomer Certified offers support for the following versions of Apache Airflow
 
 The first step to upgrading your Deployment to a higher version of Apache Airflow is to indicate your intent to do so via the Astronomer UI or CLI.
 
-> **Note::** The Astronomer UI and CLI will only make available versions of Airflow that are _higher_ than the version you're currently running in your `Dockerfile`. For example, if you're currently running Airflow `1.10.10`, `1.10.7` will _not_ be available for selection.
+> **Note:** The Astronomer UI and CLI will only make available versions of Airflow that are _higher_ than the version you're currently running in your `Dockerfile`. For example, if you're currently running Airflow `1.10.10`, `1.10.7` will _not_ be available for selection.
 
 #### via the Astronomer UI
 
 To initialize the Airflow upgrade process via the Astronomer UI, navigate to **Deployment** > **Settings** > **Basics** > **Airflow Version**. Next to **Airflow Version**,
 
-1. Select your desired version of Airflow from the drop-down menu
+1. Select your desired version of Airflow
 2. Click **Upgrade**
 
 [INSERT SCREENSHOT/GIF OF AIRFOW UPGRADE MODAL IN ASTRO UI]

--- a/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
@@ -13,7 +13,7 @@ Included in that build is your `Dockerfile`, a file that is automatically genera
 To upgrade your Airflow Deployment to a higher version of Airflow, there are three steps:
 
 1. Initialize the Airflow Upgrade via the Astronomer UI or CLI
-2. Change the FROM statement in your project's Dockerfile to reference the new AC image of your choice
+2. Change the FROM statement in your project's Dockerfile to reference a new, corresponding AC image
 3. Deploy to Astronomer
 
 Read below for details.
@@ -48,7 +48,7 @@ To initialize the Airflow upgrade process via the Astronomer UI, navigate to **D
 
 This action will NOT interrupt or otherwise impact your Airflow Deployment or trigger a code change - it is simply a signal to our platform that you _intend_ to upgrade such that we can guide your experience through the rest of the process.
 
-Once you select a version, you can expect to see a banner at the top of the **Settings** tab that reads, `Airflow Deployment in Progress...`.
+Once you select a version, you can expect to see a banner at the top of the **Settings** tab that reads `Airflow Deployment in Progress...`.
 
 > **Note:** If you'd like to change your selected version of Airflow to upgrade to, you can do so at anytime as long as long as you re-click **Upgrade** after making your selection.
 
@@ -94,13 +94,13 @@ The upgrade from Airflow 1.10.10 to 1.10.12 has been started. To complete this p
 
 As noted above, this action will NOT interrupt or otherwise impact your Airflow Deployment or trigger a code change - it is simply a signal to our platform that you _intend_ to upgrade such that we can guide your experience through the rest of the process.
 
-To complete the upgrade, all you have to do is add a new, corresponding AC image to your Dockerfile.
+To complete the upgrade, all you have to do is add a corresponding AC image to your Dockerfile.
 
 #### Cancel Airflow Upgrade Initialization
 
-If you begin the upgrade process for your Airflow Deployment and would like to cancel it, you can do so at any time either via the Astronomer UI or CLI as long as you have NOT yet changed the Astronomer Certified Image in your Dockerfile.
+If you begin the upgrade process for your Airflow Deployment and would like to cancel it, you can do so at any time either via the Astronomer UI or CLI as long as you have NOT changed the Astronomer Certified Image in your Dockerfile and deployed it.
 
-Via the Astronomer UI, select **Cancel** next to **Airflow Version**.
+Via the Astronomer UI, select **Cancel Upgrade** next to **Airflow Version**.
 
 [INSERT SCREENSHOT OF CANCEL AIRFOW UPGRADE IN ASTRO UI]
 
@@ -110,7 +110,7 @@ Via the Astronomer CLI, run:
 $ astro deployment airflow upgrade --cancel --deployment-id=<deployment-id>
 ```
 
-After running that command, you can expect the following:
+After running that command, you should see:
 
 ```bash
 Airflow upgrade process has been successfully canceled. Your Deployment was not interrupted and you are still running Airflow 1.10.5.
@@ -122,7 +122,7 @@ Canceling the Airflow Upgrade process will NOT interrupt or otherwise impact you
 
 #### Locate your Dockerfile in your Project Directory
 
-First, open the `Dockerfile` within your Astronomer directory. When you initialiazed an Airflow project via the Astronomer CLI, the following files should have been automatially generated:
+First, open the `Dockerfile` within your Astronomer directory. When you initialized an Airflow project via the Astronomer CLI, the following files should have been automatially generated:
 
 ```
 .
@@ -197,16 +197,17 @@ Once there, you should see your correct Airflow version listed.
 
 If you're on Astronomer Cloud, navigate to your Airflow Deployment page on the Astronomer UI.
 
+[INSERT SCREENSHOT OF AIRFLOW UI VERSION]
+
 ### Patch Versions of Astronomer Certified
 
 In addition to supporting the latest versions of open-source Airflow on Astronomer Certified (AC), our team regularly ships bug and security fixes to AC images as _patch_ releases.
 
-For example, Astronomer Certified 1.10.10 has been enhanced with 4 additional patches since its initial release:
+For example, Astronomer Certified 1.10.10 has been enhanced with 4 additional patches since its initial release: 
 
 - 1.10.10-2
 - 1.10.10-3
-- 1.10.10-4
-- 1.10.10-5
+- 1.10.10-4 etc.
 
 All generally available patch releases are listed in a corresponding changelog, which specifies the date the patch was released and all individual changes made to it. Bugs that are reported by the wider Airflow community are often backported by our team and made available prior to the subsequent open-source release.
 

--- a/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
@@ -12,8 +12,8 @@ Included in that build is your `Dockerfile`, a file that is automatically genera
 
 To upgrade your Airflow Deployment to a higher version of Airflow, there are three steps:
 
-1. Initialize the Airflow Upgrade via the Astronomer UI or CLI
-2. Change the FROM statement in your project's Dockerfile to reference a new, corresponding AC image
+1. Initialize the upgrade by selecting a new Airflow version via the Astronomer UI or CLI
+2. Change the FROM statement in your project's Dockerfile to reference an AC image that corresponds to the Airflow version indicated in Step 1
 3. Deploy to Astronomer
 
 Read below for details.
@@ -50,7 +50,7 @@ This action will NOT interrupt or otherwise impact your Airflow Deployment or tr
 
 Once you select a version, you can expect to see a banner at the top of the **Settings** tab that reads `Airflow Deployment in Progress...`.
 
-> **Note:** If you'd like to change your selected version of Airflow to upgrade to, you can do so at anytime as long as long as you re-click **Upgrade** after making your selection.
+> **Note:** If you'd like to change your selected version of Airflow to upgrade to, you can do so at anytime as long as you re-click **Upgrade** after making your selection.
 
 #### via the Astronomer CLI
 
@@ -76,7 +76,7 @@ With that `Deployment ID`, run:
 $ astro deployment airflow upgrade --deployment-id=<deployment-id>
 ```
 
-This command will output a list of available versions of Airflow you can choose from. You should see something like the following:
+This command will output a list of available versions of Airflow you can choose from and prompt you to pick one. For example, a user upgrading from Airflow 1.10.5 to Airflow 1.10.12 should see the following:
 
 ```
 astro deployment airflow upgrade --deployment-id=ckguogf6x0685ewxtebr4v04x
@@ -86,10 +86,10 @@ astro deployment airflow upgrade --deployment-id=ckguogf6x0685ewxtebr4v04x
 3     1.10.12
 
 > 3
- NAME                                   DEPLOYMENT NAME       ASTRO       DEPLOYMENT ID                 AIRFLOW VERSION
- new-deployment-1-10-10-airflow-k8s     new-velocity-8501     v0.17.0     ckguogf6x0685ewxtebr4v04x     1.10.12
+ NAME                  DEPLOYMENT NAME       ASTRO       DEPLOYMENT ID                 AIRFLOW VERSION
+ Astronomer Stagings   new-velocity-8501     v0.17.0     ckguogf6x0685ewxtebr4v04x     1.10.12
 
-The upgrade from Airflow 1.10.10 to 1.10.12 has been started. To complete this process, add an Airflow 1.10.12 image to your Dockerfile and deploy to Astronomer.
+The upgrade from Airflow 1.10.5 to 1.10.12 has been started. To complete this process, add an Airflow 1.10.12 image to your Dockerfile and deploy to Astronomer.
 ```
 
 As noted above, this action will NOT interrupt or otherwise impact your Airflow Deployment or trigger a code change - it is simply a signal to our platform that you _intend_ to upgrade such that we can guide your experience through the rest of the process.
@@ -110,9 +110,11 @@ Via the Astronomer CLI, run:
 $ astro deployment airflow upgrade --cancel --deployment-id=<deployment-id>
 ```
 
-After running that command, you should see:
+For example, if the user mentioned above canceled the initialized upgrade from Airflow 1.10.5 to Airflow 1.10.12 via the CLI, they would see the following:
 
 ```bash
+astro deployment airflow upgrade --cancel --deployment-id=ckguogf6x0685ewxtebr4v04x
+
 Airflow upgrade process has been successfully canceled. Your Deployment was not interrupted and you are still running Airflow 1.10.5.
 ```
 

--- a/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
@@ -35,7 +35,7 @@ Astronomer Certified offers support for the following versions of Apache Airflow
 
 The first step to upgrading your Deployment to a higher version of Apache Airflow is to indicate your intent to do so via the Astronomer UI or CLI.
 
-> **Note:** The Astronomer UI and CLI will only make available versions of Airflow that are _higher_ than the version you're currently running in your `Dockerfile`. For example, if you're currently running Airflow `1.10.10`, `1.10.7` will _not_ be available for selection.
+> **Note:** The Astronomer UI and CLI will only make available versions of Airflow that are _higher_ than the version you're currently running in your `Dockerfile`. For example, Airflow `1.10.7` would not be available for an Airflow Deployment running `1.10.10`.
 
 #### via the Astronomer UI
 
@@ -44,13 +44,13 @@ To initialize the Airflow upgrade process via the Astronomer UI, navigate to **D
 1. Select your desired version of Airflow
 2. Click **Upgrade**
 
-[INSERT SCREENSHOT/GIF OF AIRFOW UPGRADE MODAL IN ASTRO UI]
+![Airflow Upgrade via Astronomer UI](https://assets2.astronomer.io/main/docs/manage-airflow-versions/airflow-upgrade-astro-ui.gif)
 
 This action will NOT interrupt or otherwise impact your Airflow Deployment or trigger a code change - it is simply a signal to our platform that you _intend_ to upgrade such that we can guide your experience through the rest of the process.
 
-Once you select a version, you can expect to see a banner at the top of the **Settings** tab that reads `Airflow Deployment in Progress...`.
+Once you select a version, you can expect to see a banner next to **Airflow Version** indicating that the upgrade is in progress. For a user upgrading from 1.10.7 to 1.10.12, that banner would read `Upgrade from 1.10.7 to 1.10.12 in progress…`
 
-> **Note:** If you'd like to change your selected version of Airflow to upgrade to, you can do so at anytime as long as you re-click **Upgrade** after making your selection.
+> **Note:** If you'd like to change the version of Airflow you'd like to upgrade to, you can do so at anytime by clicking **Cancel**, re-selecting a new version and once again clicking **Upgrade**. More on that below.
 
 #### via the Astronomer CLI
 
@@ -100,9 +100,9 @@ To complete the upgrade, all you have to do is add a corresponding AC image to y
 
 If you begin the upgrade process for your Airflow Deployment and would like to cancel it, you can do so at any time either via the Astronomer UI or CLI as long as you have NOT changed the Astronomer Certified Image in your Dockerfile and deployed it.
 
-Via the Astronomer UI, select **Cancel Upgrade** next to **Airflow Version**.
+Via the Astronomer UI, select **Cancel** next to **Airflow Version**.
 
-[INSERT SCREENSHOT OF CANCEL AIRFOW UPGRADE IN ASTRO UI]
+![Airflow Upgrade via Astronomer UI](https://assets2.astronomer.io/main/docs/manage-airflow-versions/airflow-upgrade-astro-ui-cancel.gif)
 
 Via the Astronomer CLI, run:
 
@@ -110,12 +110,12 @@ Via the Astronomer CLI, run:
 $ astro deployment airflow upgrade --cancel --deployment-id=<deployment-id>
 ```
 
-For example, if the user mentioned above canceled the initialized upgrade from Airflow 1.10.5 to Airflow 1.10.12 via the CLI, they would see the following:
+For example, if a user cancels an initialized upgrade from Airflow 1.10.7 to Airflow 1.10.12 via the CLI, they would see the following:
 
 ```bash
 astro deployment airflow upgrade --cancel --deployment-id=ckguogf6x0685ewxtebr4v04x
 
-Airflow upgrade process has been successfully canceled. Your Deployment was not interrupted and you are still running Airflow 1.10.5.
+Airflow upgrade process has been successfully canceled. Your Deployment was not interrupted and you are still running Airflow 1.10.7.
 ```
 
 Canceling the Airflow Upgrade process will NOT interrupt or otherwise impact your Airflow Deployment or code that's running with it. To re-initialize an upgrade, follow the steps above.

--- a/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
@@ -102,7 +102,7 @@ If you begin the upgrade process for your Airflow Deployment and would like to c
 
 Via the Astronomer UI, select **Cancel** next to **Airflow Version**.
 
-![Airflow Upgrade via Astronomer UI](https://assets2.astronomer.io/main/docs/manage-airflow-versions/airflow-upgrade-astro-ui-cancel.gif)
+![Cancel Airflow Upgrade via Astronomer UI](https://assets2.astronomer.io/main/docs/manage-airflow-versions/airflow-upgrade-astro-ui-cancel.gif)
 
 Via the Astronomer CLI, run:
 
@@ -197,9 +197,11 @@ Once there, you should see your correct Airflow version listed.
 
 #### On Astronomer
 
-If you're on Astronomer Cloud, navigate to your Airflow Deployment page on the Astronomer UI.
+If you're on Astronomer Cloud, navigate to your Airflow Deployment via Astronomer and navigate to **About** > **Version**.
 
-[INSERT SCREENSHOT OF AIRFLOW UI VERSION]
+![Verify Airflow Version in Airflow UI](https://assets2.astronomer.io/main/docs/manage-airflow-versions/airflow-ui-version.png)
+
+> **Note:** In Airflow 2.0, the **Version** page referenced above will be deprecated. Check the footer of the Airflow UI to validate Airflow version instead.
 
 ### Patch Versions of Astronomer Certified
 

--- a/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
@@ -143,7 +143,7 @@ Depending on the OS distribution and version of Airflow you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
 
-For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow/tags).
+For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
 
 > **Note:** AC 1.10.12 will be the _last_ version to support an Alpine-based image. In an effort to standardize our offering and optimize for reliability, we'll exclusively build, test and support Debian-based images starting with AC 1.10.13. A guide for how to migrate from Alpine to Debian coming soon.
 

--- a/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
@@ -1,20 +1,25 @@
 ---
-title: "Managing Airflow Versions on Astronomer"
-navTitle: "Airflow Versioning"
+title: "Manage Airflow Versions on Astronomer"
+navTitle: "Manage Airflow Versions"
 description: "How to adjust and upgrade Airflow versions on Astronomer."
 ---
 
 ## Overview
 
-On Astronomer, the process of pushing up your code to an individual Airflow deployment involves customizing a locally built Docker image —— with your DAG code, Python Packages, plugins, and so on —— that's then bundled, tagged, and pushed to Astronomer Cloud's Docker Registry.
+On Astronomer, the process of pushing up your code to an individual Airflow Deployment involves customizing a locally built Docker image —— with your DAG code, Python Packages, plugins, and so on —— that's then bundled, tagged, and pushed to Astronomer Cloud's Docker Registry.
 
 Included in that build is your `Dockerfile`, a file that is automatically generated when you initialize an Airflow project on Astronomer via our CLI. Every successful build on Astronomer must include a `Dockerfile` that references an Astronomer Certified Docker Image. Astronomer Certified (AC) is a production-ready distribution of Apache Airflow that mirrors the open-source project and undergoes additional levels of rigorous testing conducted by our team.
 
-To upgrade your Airflow Deployment to a higher version of Airflow, all it takes is changing the FROM statement in your project's Dockerfile to reference the AC image of your choice. Read below for details.
+To upgrade your Airflow Deployment to a higher version of Airflow, there are two steps:
+
+1. Indicate your intent to upgrade your Deployment to some higher version of Airflow via the Astronomer UI or CLI
+2. Change the FROM statement in your project's Dockerfile to reference the new AC image of your choice.
+
+Read below for details.
 
 > **Note:** For more thorough guidelines on customizing your image, reference our ["Customize Your Image" doc](/docs/cloud/stable/develop/customize-image/).
 
-## Upgrade Airflow Version
+## Available Astronomer Certified Versions
 
 Astronomer Certified offers support for the following versions of Apache Airflow:
 
@@ -23,7 +28,99 @@ Astronomer Certified offers support for the following versions of Apache Airflow
 - [Airflow 1.10.10](https://airflow.apache.org/blog/airflow-1.10.10/)
 - [Airflow 1.10.12](https://airflow.apache.org/blog/airflow-1.10.12/)
 
-### 1. Locate your Dockerfile in your Project Directory
+## Upgrade Airflow
+
+### 1. Initialize the Upgrade Process
+
+The first step to upgrading your Deployment to a higher version of Apache Airflow is to indicate your intent to do so via the Astronomer UI or CLI.
+
+> **Note::** The Astronomer UI and CLI will only make available versions of Airflow that are _higher_ than the version you're currently running in your `Dockerfile`. For example, if you're currently running Airflow `1.10.10`, `1.10.7` will _not_ be available for selection.
+
+#### via the Astronomer UI
+
+To initialize the Airflow upgrade process via the Astronomer UI, navigate to **Deployment** > **Settings** > **Basics** > **Airflow Version**. Next to **Airflow Version**,
+
+1. Select your desired version of Airflow from the drop-down menu
+2. Click **Upgrade**
+
+[INSERT SCREENSHOT/GIF OF AIRFOW UPGRADE MODAL IN ASTRO UI]
+
+This action will NOT interrupt or otherwise impact your Airflow Deployment or trigger a code change - it is simply a signal to our platform that you _intend_ to upgrade such that we can guide your experience through the rest of the process.
+
+Once you select a version, you can expect to see a banner at the top of the **Settings** tab that reads, `Airflow Deployment in Progress...`.
+
+> **Note:** If you'd like to change your selected version of Airflow to upgrade to, you can do so at anytime as long as long as you re-click **Upgrade** after making your selection.
+
+#### via the Astronomer CLI
+
+To initialize the Airflow upgrade process via the Astronomer CLI, first make sure you're authenticated by running `$ astro auth login gcp0001.us-east4.astronomer.io`.
+
+Once authenticated, grab the `Deployment ID` of the Airflow Deployment you'd like to upgrade by running:
+
+```
+$ astro deployment list
+```
+
+You can expect the following output:
+
+```
+astro deployment list
+ NAME                                            DEPLOYMENT NAME                 DEPLOYMENT ID                 AIRFLOW VERSION
+ new-deployment-1-10-10-airflow-k8s-2            elementary-rotation-5522        ckgwdq8cs037169xtbt2rtu15     1.10.12
+```
+
+With that `Deployment ID`, run:
+
+```
+$ astro deployment airflow upgrade --deployment-id=<deployment-id>
+```
+
+This command will output a list of available versions of Airflow you can choose from. You should see something like the following:
+
+```
+astro deployment airflow upgrade --deployment-id=ckguogf6x0685ewxtebr4v04x
+#     AIRFLOW VERSION
+1     1.10.7
+2     1.10.10
+3     1.10.12
+
+> 3
+ NAME                                   DEPLOYMENT NAME       ASTRO       DEPLOYMENT ID                 AIRFLOW VERSION
+ new-deployment-1-10-10-airflow-k8s     new-velocity-8501     v0.17.0     ckguogf6x0685ewxtebr4v04x     1.10.12
+
+The upgrade from Airflow 1.10.10 to 1.10.12 has been started. To complete this process, add an Airflow 1.10.12 image to your Dockerfile and deploy to Astronomer.
+```
+
+As noted above, this action will NOT interrupt or otherwise impact your Airflow Deployment or trigger a code change - it is simply a signal to our platform that you _intend_ to upgrade such that we can guide your experience through the rest of the process.
+
+To complete the upgrade, all you have to do is add a new, corresponding AC image to your Dockerfile.
+
+#### Cancel Airflow Upgrade Initialization
+
+If you begin the upgrade process for your Airflow Deployment and would like to cancel it, you can do so at any time either via the Astronomer UI or CLI as long as you have NOT yet changed the Astronomer Certified Image in your Dockerfile.
+
+Via the Astronomer UI, select **Cancel** next to **Airflow Version**.
+
+[INSERT SCREENSHOT OF CANCEL AIRFOW UPGRADE IN ASTRO UI]
+
+Via the Astronomer CLI, run:
+
+```
+$ astro deployment airflow upgrade --cancel --deployment-id=<deployment-id>
+```
+
+You can expect the following output from the Astronomer CLI:
+
+```bash
+Airflow upgrade process has been successfully canceled.
+Your Deployment was not interrupted and you are still running Airflow 1.10.5.
+```
+
+Canceling the Airflow Upgrade process will NOT interrupt or otherwise impact your Airflow Deployment or code that's running with it. To re-initialize an upgrade, follow the steps above.
+
+### 2. Deploy a New Astronomer Certified Image
+
+#### Locate your Dockerfile in your Project Directory
 
 First, open the `Dockerfile` within your Astronomer directory. When you initialiazed an Airflow project via the Astronomer CLI, the following files should have been automatially generated:
 
@@ -38,15 +135,15 @@ First, open the `Dockerfile` within your Astronomer directory. When you initiali
 └── requirements.txt # For any Python packages
 ```
 
-### 2. Change the FROM Statement in your Dockerfile
-
 Depending on the OS distribution and version of Airflow you want to run, you'll want to reference the corresponding Astronomer Certified image in the FROM statement of your Dockerfile.
 
-#### Alpine and Debian-based Images
+#### Choose your new Astronomer Certified Image
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow/tags).
+For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow/tags).
+
+> **Note:** AC 1.10.12 will be the _last_ version to support an Alpine-based image. In an effort to standardize our offering and optimize for reliability, we'll exclusively build, test and support Debian-based images starting with AC 1.10.13. A guide for how to migrate from Alpine to Debian coming soon.
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|
@@ -73,7 +170,7 @@ If you're developing locally, make sure to save your changes and issue the follo
 
 #### On Astronomer
 
-If you don't need to test this locally and just want to push to Astronomer Cloud, you can issue:
+Once you're ready to push to Astronomer Cloud, you can issue:
 
 ```bash
 $ astro deploy

--- a/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
@@ -10,10 +10,11 @@ On Astronomer, the process of pushing up your code to an individual Airflow Depl
 
 Included in that build is your `Dockerfile`, a file that is automatically generated when you initialize an Airflow project on Astronomer via our CLI. Every successful build on Astronomer must include a `Dockerfile` that references an Astronomer Certified Docker Image. Astronomer Certified (AC) is a production-ready distribution of Apache Airflow that mirrors the open-source project and undergoes additional levels of rigorous testing conducted by our team.
 
-To upgrade your Airflow Deployment to a higher version of Airflow, there are two steps:
+To upgrade your Airflow Deployment to a higher version of Airflow, there are three steps:
 
-1. Indicate your intent to upgrade your Deployment to some higher version of Airflow via the Astronomer UI or CLI
+1. Initialize the Airflow Upgrade via the Astronomer UI or CLI
 2. Change the FROM statement in your project's Dockerfile to reference the new AC image of your choice
+3. Deploy to Astronomer
 
 Read below for details.
 
@@ -109,11 +110,10 @@ Via the Astronomer CLI, run:
 $ astro deployment airflow upgrade --cancel --deployment-id=<deployment-id>
 ```
 
-You can expect the following output from the Astronomer CLI:
+After running that command, you can expect the following:
 
 ```bash
-Airflow upgrade process has been successfully canceled.
-Your Deployment was not interrupted and you are still running Airflow 1.10.5.
+Airflow upgrade process has been successfully canceled. Your Deployment was not interrupted and you are still running Airflow 1.10.5.
 ```
 
 Canceling the Airflow Upgrade process will NOT interrupt or otherwise impact your Airflow Deployment or code that's running with it. To re-initialize an upgrade, follow the steps above.


### PR DESCRIPTION
This PR refactors our existing Airflow Versioning doc to incorporate 0.22 changes to the user experience of upgrading Airflow versions. Resolves: https://github.com/astronomer/issues/issues/2109

- [x]  Change Title to "Manage Airflow Versions"
- [x]  Add redirect to new URL in website (PR here: https://github.com/astronomer/website/pull/721)
- [x]  via Astro CLI
- [x]  via Astro UI
- [ ]  ~Error Scenarios~
- [x]  Cancel Upgrade
- [x] Add Screenshots

@samblackk @vishwas-astro Feel free to take a look at this - still need to add screenshots and considering incorporating error scenarios.