### PR TITLE
changing config.yaml to values.yaml

### DIFF
--- a/enterprise/v0.12/06_manage-astronomer/01_integrate-auth-system.md
+++ b/enterprise/v0.12/06_manage-astronomer/01_integrate-auth-system.md
@@ -8,7 +8,7 @@ By default, the Astronomer platform allows you to authenticate using your Google
 
 ## Configuration
 
-In your `config.yaml` file in your `astronomer` directory, you can enable an OIDC provider of your choice via the following config:
+In your `values.yaml` file in your `astronomer` directory, you can enable an OIDC provider of your choice via the following config:
 
 ```yaml
 astronomer:
@@ -34,7 +34,7 @@ https://houston.BASEDOMAIN/v1/oauth/redirect
 From there, head over to Authentication and make sure that Access Tokens and ID tokens are explicitly enabled. Also verify the redirect URI
 ![authentication.png](https://assets2.astronomer.io/main/docs/auth/authentication.png)
 
-Make sure the `config.yaml` file has is udpated with the proper values
+Make sure the `values.yaml` file has is udpated with the proper values
 ```
 astronomer:
   houston:
@@ -53,7 +53,7 @@ astronomer:
 To apply the configuration:
 
 ```
-$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+$ helm upgrade <platform-release-name> -f values.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
 ```
 
 **Note:** The `discoveryURL` includes the tenant ID in this example
@@ -76,7 +76,7 @@ $ helm upgrade <platform-release-name> -f config.yaml --version=<platform-versio
 
 ### Astronomer Configuration
 
-Add the following to your `config.yaml` file in your `astronomer` directory:
+Add the following to your `values.yaml` file in your `astronomer` directory:
 
 ```yaml
 astronomer:
@@ -138,7 +138,7 @@ The steps required for establishing a connection will vary by identity provider 
 
 ### Astronomer Configuration
 
-Add the following to your `config.yaml` file in your `astronomer/` directory. You can find your `clientID` value at `https://manage.auth0.com/dashboard/us/<tenant-name>/applications` listed next to `Default App`:
+Add the following to your `values.yaml` file in your `astronomer/` directory. You can find your `clientID` value at `https://manage.auth0.com/dashboard/us/<tenant-name>/applications` listed next to `Default App`:
 
 ```yaml
 astronomer:
@@ -161,7 +161,7 @@ $ helm ls --namespace <your-namespace>
 
 ```
 ```
-$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+$ helm upgrade <platform-release-name> -f values.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
 ```
 
 ## Running behind an HTTPS Proxy
@@ -170,7 +170,7 @@ The Identity provider integration of the Astronomer platform requires that Houst
 
 If your install is configured without a direct connection to the internet you will need to configure an HTTPS proxy server for Houston.
 
-To configure the proxy server used we need to set the `GLOBAL_AGENT_HTTPS_PROXY` environment variable for the Houston deployment, which we do by adding the following to your `config.yaml` file in your `astronomer/` directory. The houston section of this file should now look something like this:
+To configure the proxy server used we need to set the `GLOBAL_AGENT_HTTPS_PROXY` environment variable for the Houston deployment, which we do by adding the following to your `values.yaml` file in your `astronomer/` directory. The houston section of this file should now look something like this:
 
 
 ```yaml

--- a/enterprise/v0.13/06_manage-astronomer/01_integrate-auth-system.md
+++ b/enterprise/v0.13/06_manage-astronomer/01_integrate-auth-system.md
@@ -8,7 +8,7 @@ By default, the Astronomer platform allows you to authenticate using your Google
 
 ## Configuration
 
-In your `config.yaml` file in your `astronomer` directory, you can enable an OIDC provider of your choice via the following config:
+In your `values.yaml` file in your `astronomer` directory, you can enable an OIDC provider of your choice via the following config:
 
 ```yaml
 astronomer:
@@ -34,7 +34,7 @@ https://houston.BASEDOMAIN/v1/oauth/redirect
 From there, head over to Authentication and make sure that Access Tokens and ID tokens are explicitly enabled. Also verify the redirect URI
 ![authentication.png](https://assets2.astronomer.io/main/docs/auth/authentication.png)
 
-Make sure the `config.yaml` file has is udpated with the proper values
+Make sure the `values.yaml` file has is udpated with the proper values
 ```
 astronomer:
   houston:
@@ -53,7 +53,7 @@ astronomer:
 To apply the configuration:
 
 ```
-$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+$ helm upgrade <platform-release-name> -f values.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
 ```
 
 **Note:** The `discoveryURL` includes the tenant ID in this example
@@ -76,7 +76,7 @@ $ helm upgrade <platform-release-name> -f config.yaml --version=<platform-versio
 
 ### Astronomer Configuration
 
-Add the following to your `config.yaml` file in your `astronomer` directory:
+Add the following to your `values.yaml` file in your `astronomer` directory:
 
 ```yaml
 astronomer:
@@ -138,7 +138,7 @@ The steps required for establishing a connection will vary by identity provider 
 
 ### Astronomer Configuration
 
-Add the following to your `config.yaml` file in your `astronomer/` directory. You can find your `clientID` value at `https://manage.auth0.com/dashboard/us/<tenant-name>/applications` listed next to `Default App`:
+Add the following to your `values.yaml` file in your `astronomer/` directory. You can find your `clientID` value at `https://manage.auth0.com/dashboard/us/<tenant-name>/applications` listed next to `Default App`:
 
 ```yaml
 astronomer:
@@ -161,7 +161,7 @@ $ helm ls --namespace <your-namespace>
 
 ```
 ```
-$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+$ helm upgrade <platform-release-name> -f values.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
 ```
 
 ## Running behind an HTTPS Proxy
@@ -170,7 +170,7 @@ The Identity provider integration of the Astronomer platform requires that Houst
 
 If your install is configured without a direct connection to the internet you will need to configure an HTTPS proxy server for Houston.
 
-To configure the proxy server used we need to set the `GLOBAL_AGENT_HTTPS_PROXY` environment variable for the Houston deployment, which we do by adding the following to your `config.yaml` file in your `astronomer/` directory. The houston section of this file should now look something like this:
+To configure the proxy server used we need to set the `GLOBAL_AGENT_HTTPS_PROXY` environment variable for the Houston deployment, which we do by adding the following to your `values.yaml` file in your `astronomer/` directory. The houston section of this file should now look something like this:
 
 
 ```yaml

--- a/enterprise/v0.14/06_manage-astronomer/01_integrate-auth-system.md
+++ b/enterprise/v0.14/06_manage-astronomer/01_integrate-auth-system.md
@@ -8,7 +8,7 @@ By default, the Astronomer platform allows you to authenticate using your Google
 
 ## Configuration
 
-In your `config.yaml` file in your `astronomer` directory, you can enable an OIDC provider of your choice via the following config:
+In your `values.yaml` file in your `astronomer` directory, you can enable an OIDC provider of your choice via the following config:
 
 ```yaml
 astronomer:
@@ -34,7 +34,7 @@ https://houston.BASEDOMAIN/v1/oauth/redirect
 From there, head over to Authentication and make sure that Access Tokens and ID tokens are explicitly enabled. Also verify the redirect URI
 ![authentication.png](https://assets2.astronomer.io/main/docs/auth/authentication.png)
 
-Make sure the `config.yaml` file has is udpated with the proper values
+Make sure the `values.yaml` file has is udpated with the proper values
 ```
 astronomer:
   houston:
@@ -53,7 +53,7 @@ astronomer:
 To apply the configuration:
 
 ```
-$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+$ helm upgrade <platform-release-name> -f values.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
 ```
 
 **Note:** The `discoveryURL` includes the tenant ID in this example
@@ -76,7 +76,7 @@ $ helm upgrade <platform-release-name> -f config.yaml --version=<platform-versio
 
 ### Astronomer Configuration
 
-Add the following to your `config.yaml` file in your `astronomer` directory:
+Add the following to your `values.yaml` file in your `astronomer` directory:
 
 ```yaml
 astronomer:
@@ -138,7 +138,7 @@ The steps required for establishing a connection will vary by identity provider 
 
 ### Astronomer Configuration
 
-Add the following to your `config.yaml` file in your `astronomer/` directory. You can find your `clientID` value at `https://manage.auth0.com/dashboard/us/<tenant-name>/applications` listed next to `Default App`:
+Add the following to your `values.yaml` file in your `astronomer/` directory. You can find your `clientID` value at `https://manage.auth0.com/dashboard/us/<tenant-name>/applications` listed next to `Default App`:
 
 ```yaml
 astronomer:
@@ -161,7 +161,7 @@ $ helm ls --namespace <your-namespace>
 
 ```
 ```
-$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+$ helm upgrade <platform-release-name> -f values.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
 ```
 
 ## Running behind an HTTPS Proxy
@@ -170,7 +170,7 @@ The Identity provider integration of the Astronomer platform requires that Houst
 
 If your install is configured without a direct connection to the internet you will need to configure an HTTPS proxy server for Houston.
 
-To configure the proxy server used we need to set the `GLOBAL_AGENT_HTTPS_PROXY` environment variable for the Houston deployment, which we do by adding the following to your `config.yaml` file in your `astronomer/` directory. The houston section of this file should now look something like this:
+To configure the proxy server used we need to set the `GLOBAL_AGENT_HTTPS_PROXY` environment variable for the Houston deployment, which we do by adding the following to your `values.yaml` file in your `astronomer/` directory. The houston section of this file should now look something like this:
 
 
 ```yaml

--- a/enterprise/v0.15/06_manage-astronomer/01_integrate-auth-system.md
+++ b/enterprise/v0.15/06_manage-astronomer/01_integrate-auth-system.md
@@ -8,7 +8,7 @@ By default, the Astronomer platform allows you to authenticate using your Google
 
 ## Configuration
 
-In your `config.yaml` file in your `astronomer` directory, you can enable an OIDC provider of your choice via the following config:
+In your `values.yaml` file in your `astronomer` directory, you can enable an OIDC provider of your choice via the following config:
 
 ```yaml
 astronomer:
@@ -34,7 +34,7 @@ https://houston.BASEDOMAIN/v1/oauth/redirect
 From there, head over to Authentication and make sure that Access Tokens and ID tokens are explicitly enabled. Also verify the redirect URI
 ![authentication.png](https://assets2.astronomer.io/main/docs/auth/authentication.png)
 
-Make sure the `config.yaml` file has is udpated with the proper values
+Make sure the `values.yaml` file has is udpated with the proper values
 ```
 astronomer:
   houston:
@@ -53,7 +53,7 @@ astronomer:
 To apply the configuration:
 
 ```
-$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+$ helm upgrade <platform-release-name> -f values.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
 ```
 
 **Note:** The `discoveryURL` includes the tenant ID in this example
@@ -76,7 +76,7 @@ $ helm upgrade <platform-release-name> -f config.yaml --version=<platform-versio
 
 ### Astronomer Configuration
 
-Add the following to your `config.yaml` file in your `astronomer` directory:
+Add the following to your `values.yaml` file in your `astronomer` directory:
 
 ```yaml
 astronomer:
@@ -138,7 +138,7 @@ The steps required for establishing a connection will vary by identity provider 
 
 ### Astronomer Configuration
 
-Add the following to your `config.yaml` file in your `astronomer/` directory. You can find your `clientID` value at `https://manage.auth0.com/dashboard/us/<tenant-name>/applications` listed next to `Default App`:
+Add the following to your `values.yaml` file in your `astronomer/` directory. You can find your `clientID` value at `https://manage.auth0.com/dashboard/us/<tenant-name>/applications` listed next to `Default App`:
 
 ```yaml
 astronomer:
@@ -161,7 +161,7 @@ $ helm ls --namespace <your-namespace>
 
 ```
 ```
-$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+$ helm upgrade <platform-release-name> -f values.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
 ```
 
 ## Running behind an HTTPS Proxy
@@ -170,7 +170,7 @@ The Identity provider integration of the Astronomer platform requires that Houst
 
 If your install is configured without a direct connection to the internet you will need to configure an HTTPS proxy server for Houston.
 
-To configure the proxy server used we need to set the `GLOBAL_AGENT_HTTPS_PROXY` environment variable for the Houston deployment, which we do by adding the following to your `config.yaml` file in your `astronomer/` directory. The houston section of this file should now look something like this:
+To configure the proxy server used we need to set the `GLOBAL_AGENT_HTTPS_PROXY` environment variable for the Houston deployment, which we do by adding the following to your `values.yaml` file in your `astronomer/` directory. The houston section of this file should now look something like this:
 
 
 ```yaml

--- a/enterprise/v0.16/06_manage-astronomer/01_integrate-auth-system.md
+++ b/enterprise/v0.16/06_manage-astronomer/01_integrate-auth-system.md
@@ -24,7 +24,7 @@ The doc below will walk through how to both enable local authentication and conf
 
 If you'd like to enable the ability for users to authenticate to Astronomer with a local username and password, follow the steps below.
 
-### Enable Local Auth in your `config.yaml`:
+### Enable Local Auth in your `values.yaml`:
 
 ```yaml
 astronomer:
@@ -37,15 +37,15 @@ astronomer:
 
 ### Apply your Changes
 
-To apply the changes to your `config.yaml`, run the following:
+To apply the changes to your `values.yaml`, run the following:
 
 ```
-$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+$ helm upgrade <platform-release-name> -f values.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
 ```
 
 ## General OIDC Configuration
 
-If you'd like to integrate an OIDC provider with Astronomer Enterprise, you can enable that configuration in the `config.yaml` file of your `astronomer` directory.
+If you'd like to integrate an OIDC provider with Astronomer Enterprise, you can enable that configuration in the `values.yaml` file of your `astronomer` directory.
 
 Example:
 
@@ -86,9 +86,9 @@ Example:
 
 ![authentication.png](https://assets2.astronomer.io/main/docs/auth/authentication.png)
 
-### Enable Azure AD in your `config.yaml`
+### Enable Azure AD in your `values.yaml`
 
-Make sure the `config.yaml` file in your `astronomer` directory is updated with the proper values:
+Make sure the `values.yaml` file in your `astronomer` directory is updated with the proper values:
 
 ```yaml
 astronomer:
@@ -111,14 +111,14 @@ astronomer:
 
 ### Apply your Changes
 
-To apply the changes to your `config.yaml`, run the following:
+To apply the changes to your `values.yaml`, run the following:
 
 ```
 $ helm ls --namespace <your-namespace>
 ```
 
 ```
-$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+$ helm upgrade <platform-release-name> -f values.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
 ```
 
 ## Okta
@@ -139,9 +139,9 @@ Follow the steps below.
 
 4. Save the `Client ID` generated for this Okta app for use in the next steps
 
-### Enable Okta in your `config.yaml`
+### Enable Okta in your `values.yaml`
 
-Add the following to your `config.yaml` file in your `astronomer` directory:
+Add the following to your `values.yaml` file in your `astronomer` directory:
 
 ```yaml
 astronomer:
@@ -159,14 +159,14 @@ astronomer:
 
 ### Apply your Changes
 
-To apply the changes to your `config.yaml`, run the following:
+To apply the changes to your `values.yaml`, run the following:
 
 ```
 $ helm ls --namespace <your-namespace>
 ```
 
 ```
-$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+$ helm upgrade <platform-release-name> -f values.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
 ```
 
 ## Auth0
@@ -214,9 +214,9 @@ For instructions, navigate to Auth0's [connection guides](https://auth0.com/docs
 * Under `Identifier`, enter `astronomer-ee`.
 * Leave the value under `Signing Algorithm` as `RS256`.
 
-### Enable Auth0 in your `config.yaml`
+### Enable Auth0 in your `values.yaml`
 
-Add the following to your `config.yaml` file in your `astronomer` directory:
+Add the following to your `values.yaml` file in your `astronomer` directory:
 
 ```yaml
 astronomer:
@@ -234,14 +234,14 @@ You can find your `clientID` value at `https://manage.auth0.com/dashboard/us/<te
 
 ### Apply your Changes
 
-To apply the changes to your `config.yaml`, run the following:
+To apply the changes to your `values.yaml`, run the following:
 
 ```
 $ helm ls --namespace <your-namespace>
 ```
 
 ```
-$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+$ helm upgrade <platform-release-name> -f values.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
 ```
 
 ## Running behind an HTTPS Proxy
@@ -256,7 +256,7 @@ If your install is configured _without_ a direct connection to the internet you 
 
 To configure the proxy server used we need to set the `GLOBAL_AGENT_HTTPS_PROXY` Environment Variable for the Houston deployment.
 
-To do so, add the following to the Houston section of the `config.yaml` file in your `astronomer` directory:
+To do so, add the following to the Houston section of the `values.yaml` file in your `astronomer` directory:
 
 
 ```yaml
@@ -276,12 +276,12 @@ astronomer:
 
 ### Apply your Changes
 
-To apply the changes to your `config.yaml`, run the following:
+To apply the changes to your `values.yaml`, run the following:
 
 ```
 $ helm ls --namespace <your-namespace>
 ```
 
 ```
-$ helm upgrade <platform-release-name> -f config.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
+$ helm upgrade <platform-release-name> -f values.yaml --version=<platform-version> astronomer/astronomer -n <your-namespace>
 ```


### PR DESCRIPTION
we reference "config.yaml" on these pages, but by default there's only "values.yaml"