### PR TITLE
Astronomer Cloud v0.22 Release Notes

### DIFF
--- a/cloud/stable/06_resources/01_release-notes.md
+++ b/cloud/stable/06_resources/01_release-notes.md
@@ -28,11 +28,9 @@ For more information, refer to ["Manage Airflow Versions"](https://www.astronome
 
 #### Support for Multiple Schedulers
 
-Airflow 2.0 is around the corner and will allow users to provision multiple Airflow Schedulers for high-availability and enhanced scalability.
+Airflow 2.0 is around the corner and will allow users to provision multiple Airflow Schedulers for high-availability and scale. While Airflow 2.0 is not generally available just yet, Astronomer v0.22 pre-emptively supports the ability to provision up to 4 Schedulers via the Astronomer UI for Airflow Deployments running Airflow 2.0+.
 
-While Airflow 2.0 is not yet generally available, Astronomer v0.22 comes with support for provisioning up to 4 Schedulers via the Astronomer UI.
-
-Once Airflow 2.0 is released, users on Astronomer Cloud will be able to leverage this exciting feature on Day 1. To read more about the momentous Airflow release, check out our blog post, ["Introducing Airflow 2.0"](https://www.astronomer.io/blog/introducing-airflow-2-0/). More Airflow 2.0 announcements coming soon.
+Once Airflow 2.0 is released, you'll be able to leverage this feature as an Astronomer Cloud user as soon as you upgrade. To read more Airflow 2.0, check out our blog post, ["Introducing Airflow 2.0"](https://www.astronomer.io/blog/introducing-airflow-2-0/).
 
 #### Bug Fixes & Improvements
 

--- a/cloud/stable/06_resources/01_release-notes.md
+++ b/cloud/stable/06_resources/01_release-notes.md
@@ -26,8 +26,6 @@ Users can now see the version of Airflow they're running in the **Settings** pag
 
 For more information, refer to ["Manage Airflow Versions"](https://www.astronomer.io/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
 
-> **Note:** Support for Astronomer Certified 1.10.5 is ending soon. As of Astronomer v0.22, users will NOT be able to create a new Airflow Deployment with 1.10.5. We'll continue to support existing 1.10.5 users through December 31, 2020 but strongly recommend you upgrade to AC 1.10.7+.
-
 #### Support for Multiple Schedulers
 
 Airflow 2.0 is around the corner and will allow users to provision multiple Airflow Schedulers for high-availability and scale. While Airflow 2.0 is not generally available just yet, Astronomer v0.22 pre-emptively supports the ability to provision up to 4 Schedulers via the Astronomer UI for Airflow Deployments running Airflow 2.0+.

--- a/cloud/stable/06_resources/01_release-notes.md
+++ b/cloud/stable/06_resources/01_release-notes.md
@@ -6,7 +6,7 @@ description: "Astronomer Cloud Release Notes."
 
 ## Astronomer v0.22 Release Notes
 
-### v0.22.0
+### v0.22.3
 
 Release Date: November 12, 2020
 

--- a/cloud/stable/06_resources/01_release-notes.md
+++ b/cloud/stable/06_resources/01_release-notes.md
@@ -4,6 +4,42 @@ navTitle: "Release Notes"
 description: "Astronomer Cloud Release Notes."
 ---
 
+## Astronomer v0.22 Release Notes
+
+### v0.22.0
+
+Release Date: November 12, 2020
+
+#### New Deployment-level Permissions
+
+Astronomer v0.22 introduces deployment-level permissions, a much-awaited feature for teams running multiple Airflow Deployments on Astronomer.
+
+Users can now configure and assign 1 of 3 roles specific to each individual Deployment - _Admin_, _Editor_ and _Viewer_. If you have a "Prod" and "Dev" Airflow Deployment, for example, you can restrict a user's access to "Prod" but grant them full access to "Dev" - all in the same Workspace.
+
+This new framework comes with support via the Astronomer UI/API and a new set of commands for the Astro CLI. For more information, refer to our re-factored ["User Permissions" doc](https://www.astronomer.io/docs/cloud/stable/manage-astronomer/workspace-permissions/).
+
+#### Airflow Version Selection & Upgrade in Astronomer UI/CLI
+
+This release formally introduces "Airflow Version" to the Astronomer UI, CLI and API for an enhanced version selection and Airflow upgrade experience.
+
+Users can now see the version of Airflow they're running in the **Settings** page of a Deployment and indicate interest in upgrading to a higher version. Users who initialize the upgrade process via the Astronomer UI or CLI will be instructed to update the Astronomer Certified (AC) Docker image in their Dockerfile and be given feedback along the way.
+
+For more information, refer to ["Manage Airflow Versions"](https://www.astronomer.io/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
+
+#### Support for Multiple Schedulers
+
+Airflow 2.0 is around the corner and will allow users to provision multiple Airflow Schedulers for high-availability and enhanced scalability.
+
+While Airflow 2.0 is not yet generally available, Astronomer v0.22 comes with support for provisioning up to 4 Schedulers via the Astronomer UI.
+
+Once Airflow 2.0 is released, users on Astronomer Cloud will be able to leverage this exciting feature on Day 1. To read more about the momentous Airflow release, check out our blog post, ["Introducing Airflow 2.0"](https://www.astronomer.io/blog/introducing-airflow-2-0/). More Airflow 2.0 announcements coming soon.
+
+#### Bug Fixes & Improvements
+
+- Improved error handling on `$ astro auth login` when Docker isn't running
+- BugFix: Alert are not triggered when Airflow components resource threshold is breached
+- BugFix: Some Airflow metrics not rendering in Astronomer UI (`Zombies Killed`, `Task Stream`, `DagBag Count`, `Task Success Rate`, `Task Failure Rate`).
+
 ## Astronomer v0.21 Release Notes
 
 ### v0.21.2

--- a/cloud/stable/06_resources/01_release-notes.md
+++ b/cloud/stable/06_resources/01_release-notes.md
@@ -26,6 +26,8 @@ Users can now see the version of Airflow they're running in the **Settings** pag
 
 For more information, refer to ["Manage Airflow Versions"](https://www.astronomer.io/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
 
+> **Note:** Support for Astronomer Certified 1.10.5 is ending soon. As of Astronomer v0.22, users will NOT be able to create a new Airflow Deployment with 1.10.5. We'll continue to support existing 1.10.5 users through December 31, 2020 but strongly recommend you upgrade to AC 1.10.7+.
+
 #### Support for Multiple Schedulers
 
 Airflow 2.0 is around the corner and will allow users to provision multiple Airflow Schedulers for high-availability and scale. While Airflow 2.0 is not generally available just yet, Astronomer v0.22 pre-emptively supports the ability to provision up to 4 Schedulers via the Astronomer UI for Airflow Deployments running Airflow 2.0+.

--- a/cloud/stable/06_resources/01_release-notes.md
+++ b/cloud/stable/06_resources/01_release-notes.md
@@ -28,9 +28,9 @@ For more information, refer to ["Manage Airflow Versions"](https://www.astronome
 
 #### Support for Multiple Schedulers
 
-Airflow 2.0 is around the corner and will allow users to provision multiple Airflow Schedulers for high-availability and scale. While Airflow 2.0 is not generally available just yet, Astronomer v0.22 pre-emptively supports the ability to provision up to 4 Schedulers via the Astronomer UI for Airflow Deployments running Airflow 2.0+.
+Airflow 2.0 is around the corner and will allow users to provision multiple Airflow Schedulers for ultimate high-availability and scale. While Airflow 2.0 is not generally available just yet, Astronomer v0.22 pre-emptively supports the ability to provision up to 4 Schedulers via the Astronomer UI for Airflow Deployments running Airflow 2.0+.
 
-Once Airflow 2.0 is released, you'll be able to leverage this feature as an Astronomer Cloud user as soon as you upgrade. To read more Airflow 2.0, check out our blog post, ["Introducing Airflow 2.0"](https://www.astronomer.io/blog/introducing-airflow-2-0/).
+Once Airflow 2.0 is released, you'll be able to leverage this feature as an Astronomer Cloud user as soon as you upgrade Airflow versions. To read more on Airflow 2.0, check out our blog post, ["Introducing Airflow 2.0"](https://www.astronomer.io/blog/introducing-airflow-2-0/).
 
 #### Bug Fixes & Improvements
 

--- a/cloud/stable/06_resources/01_release-notes.md
+++ b/cloud/stable/06_resources/01_release-notes.md
@@ -26,7 +26,7 @@ Users can now see the version of Airflow they're running in the **Settings** pag
 
 For more information, refer to ["Manage Airflow Versions"](https://www.astronomer.io/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
 
-#### Support for Multiple Schedulers
+#### Support for Multiple Schedulers (_Airflow 2.0+_)
 
 Airflow 2.0 is around the corner and will allow users to provision multiple Airflow Schedulers for ultimate high-availability and scale. While Airflow 2.0 is not generally available just yet, Astronomer v0.22 pre-emptively supports the ability to provision up to 4 Schedulers via the Astronomer UI for Airflow Deployments running Airflow 2.0+.
 

--- a/cloud/stable/06_resources/01_release-notes.md
+++ b/cloud/stable/06_resources/01_release-notes.md
@@ -14,7 +14,7 @@ Release Date: November 12, 2020
 
 Astronomer v0.22 introduces deployment-level permissions, a much-awaited feature for teams running multiple Airflow Deployments on Astronomer.
 
-Users can now configure and assign 1 of 3 roles specific to each individual Deployment - _Admin_, _Editor_ and _Viewer_. If you have a "Prod" and "Dev" Airflow Deployment, for example, you can restrict a user's access to "Prod" but grant them full access to "Dev" - all in the same Workspace.
+Users can now configure and be assigned 1 of 3 user roles within each Deployment - _Admin_, _Editor_ and _Viewer_. If you have a "Prod" and "Dev" Airflow Deployment, for example, you can restrict a user's access to "Prod" as a _Viewer_ but grant them full access to "Dev" as an _Admin_ - all within the same Workspace. Similarly, the level of access that Workspace _Admins_ have to the Airflow Deployments within that Workpace can now be customized without limiting their ability to manage Billing and Workspace user invites, for example.
 
 This new framework comes with support via the Astronomer UI/API and a new set of commands for the Astro CLI. For more information, refer to our re-factored ["User Permissions" doc](https://www.astronomer.io/docs/cloud/stable/manage-astronomer/workspace-permissions/).
 

--- a/enterprise/next/09_resources/01_release-notes.md
+++ b/enterprise/next/09_resources/01_release-notes.md
@@ -14,7 +14,15 @@ We're committed to testing all quarterly Astronomer Enterprise versions for scal
 
 ## Astronomer v0.16 Release Notes
 
-Latest Patch Release: **v0.16.10**
+Latest Patch Release: **v0.16.11**
+
+### v0.16.11
+
+Release Date: November 2, 2020
+
+##### Bug Fixes & Improvements
+
+- BugFix: Fix conditionally disabling subcharts
 
 ### v0.16.10
 

--- a/enterprise/v0.16/09_resources/01_release-notes.md
+++ b/enterprise/v0.16/09_resources/01_release-notes.md
@@ -14,7 +14,15 @@ We're committed to testing all quarterly Astronomer Enterprise versions for scal
 
 ## Astronomer v0.16 Release Notes
 
-Latest Patch Release: **v0.16.10**
+Latest Patch Release: **v0.16.11**
+
+### v0.16.11
+
+Release Date: November 2, 2020
+
+##### Bug Fixes & Improvements
+
+- BugFix: Fix conditionally disabling subcharts
 
 ### v0.16.10
 


### PR DESCRIPTION
Basing these on this list: https://github.com/astronomer/issues/issues?page=3&q=is%3Aissue+milestone%3A0.22+is%3Aclosed

@vishwas-astro Could you take a look at these? 2 questions:

1. Should I include multiple scheduler support? I actually think it could be a nice teaser for Airflow 2.0
2. Looks like we actually pushed `v0.22.3` so I'll skip specifying those first 2 patches, let me know if you think otherwise
P.S. Let me make sure to add Enterprise v0.16.11 release notes - looks like they're not in here