### PR TITLE
Rename Airflow Versioning Doc + Replace doc references w/ new URL

### DIFF
--- a/ac/next/03_security.md
+++ b/ac/next/03_security.md
@@ -13,7 +13,7 @@ Currently, our officially supported Astronomer Certified images are listed in tw
 - [Astronomer Downloads](/downloads/)
 - [Astronomer's DockerHub](https://hub.docker.com/r/astronomerinc/ap-airflow)
 
-If you run on Astronomer Cloud or Enterprise, you can refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/airflow-versioning/) for detailed guidelines on how to upgrade between Airflow versions on the platform.
+If you run on Astronomer Cloud or Enterprise, you can refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/) for detailed guidelines on how to upgrade between Airflow versions on the platform.
 
 ## Reporting Vulnerabilities and Security Concerns
 

--- a/ac/v1.10.10/01_get-started/03_security.md
+++ b/ac/v1.10.10/01_get-started/03_security.md
@@ -13,7 +13,7 @@ Currently, our officially supported Astronomer Certified images are listed in tw
 - [Astronomer Downloads](/downloads/)
 - [Astronomer's DockerHub](https://hub.docker.com/r/astronomerinc/ap-airflow)
 
-If you run on Astronomer Cloud or Enterprise, you can refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/airflow-versioning/) for detailed guidelines on how to upgrade between Airflow versions on the platform.
+If you run on Astronomer Cloud or Enterprise, you can refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/) for detailed guidelines on how to upgrade between Airflow versions on the platform.
 
 ## Reporting Vulnerabilities and Security Concerns
 

--- a/cloud/stable/01_get-started/01_quickstart.md
+++ b/cloud/stable/01_get-started/01_quickstart.md
@@ -213,7 +213,7 @@ Astronomer currently supports both Alpine and Debian based Airflow images for Ai
 
 As noted above, the Astronomer Certified image will by default install the latest version of Airflow available on [Alpine Linux](https://alpinelinux.org/), though users leveraging Machine Learning Python Libraries or more complex dependencies might find Debian to be more appropriate.
 
-If you're interested in upgrading Airflow versions or switching to a Debian-based image, refer to our ["Airflow Versioning" doc](/docs/cloud/stable/customize-airflow/airflow-versioning/).
+If you're interested in upgrading Airflow versions or switching to a Debian-based image, refer to our ["Airflow Versioning" doc](/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
 
 #### Add DAGs, Packages and Environment Variables
 

--- a/cloud/stable/01_get-started/02_cloud-faq.md
+++ b/cloud/stable/01_get-started/02_cloud-faq.md
@@ -11,7 +11,7 @@ If you're thinking about Astronomer Cloud, you might have a few questions on you
 
 ### What version of Airflow is Astronomer Cloud currently running?
 
-Astronomer Cloud is officially compatible with Airflow v1.10.5 and higher. For our list of supported images and guidelines on how to upgrade versions, check out our [Airflow Versioning](/docs/cloud/stable/customize-airflow/airflow-versioning/) doc.
+Astronomer Cloud is officially compatible with Airflow v1.10.5 and higher. For our list of supported images and guidelines on how to upgrade versions, check out our [Airflow Versioning](/docs/cloud/stable/customize-airflow/manage-airflow-versions/) doc.
 
 ### What Airflow Executors do you currently support?
 

--- a/cloud/stable/02_develop/01_cli-quickstart.md
+++ b/cloud/stable/02_develop/01_cli-quickstart.md
@@ -241,7 +241,7 @@ If you're looking for guidance beyond the Astronomer CLI, we'd encourage you to 
 
 * [Deploying to Astronomer](/docs/cloud/stable/deploy/deploy-cli/)
 * [Customizing your Image](/docs/cloud/stable/develop/customize-image/)
-* [Managing Airflow Versions](/docs/cloud/stable/customize-airflow/airflow-versioning/)
+* [Manage Airflow Versions](/docs/cloud/stable/customize-airflow/manage-airflow-versions/)
 * [CI/CD](/docs/cloud/stable/deploy/ci-cd/)
 
 As always, don't hesitate to reach out to the [Astronomer Support Portal](https://support.astronomer.io/hc/en-us) for additional questions or reference the [Astronomer Forum](https://forum.astronomer.io/).

--- a/cloud/stable/02_develop/02_customize-image.md
+++ b/cloud/stable/02_develop/02_customize-image.md
@@ -71,7 +71,7 @@ $ docker exec -it <scheduler-container-id> pip freeze | grep pymongo
 pymongo==3.7.2
 ```
 
-> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/cloud/stable/customize-airflow/airflow-versioning/).
+> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
 
 ## Add Other Dependencies
 
@@ -267,7 +267,7 @@ If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, 
 FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
-For a list of all Airflow Images supported on Astronomer, refer to our ["Airflow Versioning" doc](/docs/cloud/stable/customize-airflow/airflow-versioning/).
+For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
 
 > **Note:**  Do NOT include `on-build` at the end of your Airflow Image as you typically would in your Dockerfile.
 

--- a/cloud/stable/06_resources/01_release-notes.md
+++ b/cloud/stable/06_resources/01_release-notes.md
@@ -74,7 +74,7 @@ Airflow 1.10.12 notably includes:
 - Support for grabbing Airflow configs with sensitive data from Secret Backends ([commit]((https://github.com/apache/airflow/pull/9645)))
 - Support for AirfowClusterPolicyViolation support in Airflow local settings ([commit](https://github.com/apache/airflow/pull/10282)).
 
-For a detailed breakdown of all changes, refer to the [AC 1.10.12 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md). For instructions on how to upgrade to 1.10.12 on Astronomer, refer to ["Airflow Versioning"](https://www.astronomer.io/docs/cloud/stable/customize-airflow/airflow-versioning/).
+For a detailed breakdown of all changes, refer to the [AC 1.10.12 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md). For instructions on how to upgrade to 1.10.12 on Astronomer, refer to ["Airflow Versioning"](https://www.astronomer.io/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
 
 > **Note:** AC 1.10.12 will be the _last_ version to support an Alpine-based image. In an effort to standardize our offering and optimize for reliability, we'll exclusively build, test and support Debian-based images starting with AC 1.10.13. A guide for how to migrate from Alpine to Debian coming soon.
 
@@ -131,7 +131,7 @@ Astronomer v0.18 includes support for the latest patch releases from Astronomer 
 
 For a full list, reference the changelogs in our [`ap-airflow` repo](https://github.com/astronomer/ap-airflow) for the AC version of your choice (e.g. changelog for 1.10.10 [here](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)).
 
-To be notified of AC releases, feel free to [subscribe to our AC Newsletter](/downloads/). For information on how to upgrade Astronomer Certified versions, refer to our ["Airflow Versioning" doc](/docs/cloud/stable/customize-airflow/airflow-versioning/).
+To be notified of AC releases, feel free to [subscribe to our AC Newsletter](/downloads/). For information on how to upgrade Astronomer Certified versions, refer to our ["Manage Airflow Versions" doc](/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
 
 #### Houston API Improvements
 

--- a/enterprise/next/02_develop/01_cli-quickstart.md
+++ b/enterprise/next/02_develop/01_cli-quickstart.md
@@ -241,7 +241,7 @@ If you're looking for guidance beyond the Astronomer CLI, we'd encourage you to 
 
 * [Deploying to Astronomer](/docs/enterprise/stable/deploy/deploy-code/)
 * [Customizing your Image](/docs/enterprise/stable/develop/customize-image/)
-* [Managing Airflow Versions](/docs/enterprise/stable/customize-airflow/airflow-versioning/)
+* [Manage Airflow Versions](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/)
 * [CI/CD](/docs/enterprise/stable/deploy/ci-cd/)
 
 As always, don't hesitate to reach out to the [Astronomer Support Portal](https://support.astronomer.io/hc/en-us) for additional questions or reference the [Astronomer Forum](https://forum.astronomer.io/).

--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -71,7 +71,7 @@ $ docker exec -it <scheduler-container-id> pip freeze | grep pymongo
 pymongo==3.7.2
 ```
 
-> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/airflow-versioning/).
+> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/).
 
 ## Add Other Dependencies
 
@@ -267,7 +267,7 @@ If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, 
 FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
-For a list of all Airflow Images supported on Astronomer, refer to our ["Airflow Versioning" doc](/docs/enterprise/stable/customize-airflow/airflow-versioning/).
+For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/).
 
 > **Note:**  Do NOT include `on-build` at the end of your Airflow Image as you typically would in your Dockerfile.
 

--- a/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
@@ -1,6 +1,6 @@
 ---
-title: "Managing Airflow Versions on Astronomer"
-navTitle: "Airflow Versioning"
+title: "Manage Airflow Versions on Astronomer"
+navTitle: "Manage Airflow Versions"
 description: "How to adjust and upgrade Airflow versions on Astronomer."
 ---
 

--- a/enterprise/next/09_resources/01_release-notes.md
+++ b/enterprise/next/09_resources/01_release-notes.md
@@ -47,7 +47,7 @@ Airflow 1.10.12 notably includes:
 - Support for grabbing Airflow configs with sensitive data from Secret Backends ([commit]((https://github.com/apache/airflow/pull/9645)))
 - Support for AirfowClusterPolicyViolation support in Airflow local settings ([commit](https://github.com/apache/airflow/pull/10282)).
 
-For a detailed breakdown of all changes, refer to the [AC 1.10.12 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md). For instructions on how to upgrade to 1.10.12 on Astronomer, refer to ["Airflow Versioning"](https://www.astronomer.io/docs/cloud/stable/customize-airflow/airflow-versioning/).
+For a detailed breakdown of all changes, refer to the [AC 1.10.12 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md). For instructions on how to upgrade to 1.10.12 on Astronomer, refer to ["Airflow Versioning"](https://www.astronomer.io/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
 
 > **Note:** AC 1.10.12 will be the _last_ version to support an Alpine-based image. In an effort to standardize our offering and optimize for reliability, we'll exclusively build, test and support Debian-based images starting with AC 1.10.13. A guide for how to migrate from Alpine to Debian coming soon.
 
@@ -155,7 +155,7 @@ These patch releases most notably include:
 - BugFix: Tighten restriction for `apache-airflow` in requirements.txt to allow users to install other packages with that prefix ([commit](https://github.com/astronomer/ap-airflow/commit/c2536db))
 - BugFix: Broken PapermillOperator ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/811cc75) - 1.10.10 only).
 
-To be notified of AC releases, feel free to [subscribe to our AC Newsletter](/downloads/). For information on how to upgrade Astronomer Certified versions, refer to our ["Airflow Versioning" doc](/docs/enterprise/v0.16/customize-airflow/airflow-versioning/).
+To be notified of AC releases, feel free to [subscribe to our AC Newsletter](/downloads/). For information on how to upgrade Astronomer Certified versions, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/).
 
 #### Airflow Chart: Improved Upgrade Process
 

--- a/enterprise/next/09_resources/02_version-compatibility-reference.md
+++ b/enterprise/next/09_resources/02_version-compatibility-reference.md
@@ -30,7 +30,7 @@ It's worth noting that while the tables below reference the minimum compatible v
 | 1.10.13 (*Coming Soon*) | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
 | 2.0.0 (*Coming Soon*)   | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
 
-For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Airflow Versioning" doc](https://www.astronomer.io/docs/enterprise/v0.16/customize-airflow/airflow-versioning/).
+For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/).
 
 > **Note:** MySQL 5.7 is compatible with Airflow and Astronomer Certified 2.0 but it does NOT support the ability to run more than 1 Scheduler and is not recommended. If you'd like to leverage Airflow's new Highly-Available Scheduler, make sure you're running MySQL 8.0+.
 

--- a/enterprise/v0.12/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.12/02_develop/01_cli-quickstart.md
@@ -241,7 +241,7 @@ If you're looking for guidance beyond the Astronomer CLI, we'd encourage you to 
 
 * [Deploying to Astronomer](/docs/enterprise/v0.12/deploy/deploy-code/)
 * [Customizing your Image](/docs/enterprise/v0.12/develop/customize-image/)
-* [Managing Airflow Versions](/docs/enterprise/v0.12/customize-airflow/airflow-versioning/)
+* [Manage Airflow Versions](/docs/enterprise/v0.12/customize-airflow/manage-airflow-versions/)
 * [CI/CD](/docs/enterprise/v0.12/deploy/ci-cd/)
 
 As always, don't hesitate to reach out to the [Astronomer Support Portal](https://support.astronomer.io/hc/en-us) for additional questions or reference the [Astronomer Forum](https://forum.astronomer.io/).

--- a/enterprise/v0.12/02_develop/02_customize-image.md
+++ b/enterprise/v0.12/02_develop/02_customize-image.md
@@ -71,7 +71,7 @@ $ docker exec -it <scheduler-container-id> pip freeze | grep pymongo
 pymongo==3.7.2
 ```
 
-> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/v0.12/customize-airflow/airflow-versioning/).
+> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/v0.12/customize-airflow/manage-airflow-versions/).
 
 ## Add Other Dependencies
 
@@ -267,7 +267,7 @@ If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, 
 FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
-For a list of all Airflow Images supported on Astronomer, refer to our ["Airflow Versioning" doc](/docs/enterprise/v0.12/customize-airflow/airflow-versioning/).
+For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/v0.12/customize-airflow/manage-airflow-versions/).
 
 > **Note:**  Do NOT include `on-build` at the end of your Airflow Image as you typically would in your Dockerfile.
 

--- a/enterprise/v0.12/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.12/05_customize-airflow/01_manage-airflow-versions.md
@@ -1,6 +1,6 @@
 ---
-title: "Managing Airflow Versions on Astronomer"
-navTitle: "Airflow Versioning"
+title: "Manage Airflow Versions on Astronomer"
+navTitle: "Manage Airflow Versions"
 description: "How to adjust and upgrade Airflow versions on Astronomer."
 ---
 
@@ -12,7 +12,7 @@ Included in that build is your `Dockerfile`, a file that is automatically genera
 
 To upgrade or otherwise change the Airflow version you want to run, all it takes is a swap to the FROM statement held within your Dockerfile. Read below for details.
 
-> **Note:** For more thorough guidelines on customizing your image, reference our ["Customize Your Image" doc](/docs/enterprise/v0.14/develop/customize-image/).
+> **Note:** For more thorough guidelines on customizing your image, reference our ["Customize Your Image" doc](/docs/enterprise/v0.12/develop/customize-image/).
 
 ## Upgrade Airflow Version
 

--- a/enterprise/v0.13/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.13/02_develop/01_cli-quickstart.md
@@ -241,7 +241,7 @@ If you're looking for guidance beyond the Astronomer CLI, we'd encourage you to 
 
 * [Deploying to Astronomer](/docs/enterprise/v0.13/deploy/deploy-code/)
 * [Customizing your Image](/docs/enterprise/v0.13/develop/customize-image/)
-* [Managing Airflow Versions](/docs/enterprise/v0.13/customize-airflow/airflow-versioning/)
+* [Manage Airflow Versions](/docs/enterprise/v0.13/customize-airflow/manage-airflow-versions/)
 * [CI/CD](/docs/enterprise/v0.13/deploy/ci-cd/)
 
 As always, don't hesitate to reach out to the [Astronomer Support Portal](https://support.astronomer.io/hc/en-us) for additional questions or reference the [Astronomer Forum](https://forum.astronomer.io/).

--- a/enterprise/v0.13/02_develop/02_customize-image.md
+++ b/enterprise/v0.13/02_develop/02_customize-image.md
@@ -71,7 +71,7 @@ $ docker exec -it <scheduler-container-id> pip freeze | grep pymongo
 pymongo==3.7.2
 ```
 
-> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/v0.13/customize-airflow/airflow-versioning/).
+> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/v0.13/customize-airflow/manage-airflow-versions/).
 
 ## Add Other Dependencies
 
@@ -267,7 +267,7 @@ If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, 
 FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
-For a list of all Airflow Images supported on Astronomer, refer to our ["Airflow Versioning" doc](/docs/enterprise/v0.13/customize-airflow/airflow-versioning/).
+For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/v0.13/customize-airflow/manage-airflow-versions/).
 
 > **Note:**  Do NOT include `on-build` at the end of your Airflow Image as you typically would in your Dockerfile.
 

--- a/enterprise/v0.13/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.13/05_customize-airflow/01_manage-airflow-versions.md
@@ -1,6 +1,6 @@
 ---
-title: "Managing Airflow Versions on Astronomer"
-navTitle: "Airflow Versioning"
+title: "Manage Airflow Versions on Astronomer"
+navTitle: "Manage Airflow Versions"
 description: "How to adjust and upgrade Airflow versions on Astronomer."
 ---
 
@@ -12,7 +12,7 @@ Included in that build is your `Dockerfile`, a file that is automatically genera
 
 To upgrade or otherwise change the Airflow version you want to run, all it takes is a swap to the FROM statement held within your Dockerfile. Read below for details.
 
-> **Note:** For more thorough guidelines on customizing your image, reference our ["Customize Your Image" doc](/docs/enterprise/v0.15/develop/customize-image/).
+> **Note:** For more thorough guidelines on customizing your image, reference our ["Customize Your Image" doc](/docs/enterprise/v0.13/develop/customize-image/).
 
 ## Upgrade Airflow Version
 

--- a/enterprise/v0.14/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.14/02_develop/01_cli-quickstart.md
@@ -241,7 +241,7 @@ If you're looking for guidance beyond the Astronomer CLI, we'd encourage you to 
 
 * [Deploying to Astronomer](/docs/enterprise/v0.14/deploy/deploy-code/)
 * [Customizing your Image](/docs/enterprise/v0.14/develop/customize-image/)
-* [Managing Airflow Versions](/docs/enterprise/v0.14/customize-airflow/airflow-versioning/)
+* [Manage Airflow Versions](/docs/enterprise/v0.14/customize-airflow/manage-airflow-versions/)
 * [CI/CD](/docs/enterprise/v0.14/deploy/ci-cd/)
 
 As always, don't hesitate to reach out to the [Astronomer Support Portal](https://support.astronomer.io/hc/en-us) for additional questions or reference the [Astronomer Forum](https://forum.astronomer.io/).

--- a/enterprise/v0.14/02_develop/02_customize-image.md
+++ b/enterprise/v0.14/02_develop/02_customize-image.md
@@ -71,7 +71,7 @@ $ docker exec -it <scheduler-container-id> pip freeze | grep pymongo
 pymongo==3.7.2
 ```
 
-> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/v0.14/customize-airflow/airflow-versioning/).
+> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/v0.14/customize-airflow/manage-airflow-versions/).
 
 ## Add Other Dependencies
 
@@ -267,7 +267,7 @@ If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, 
 FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
-For a list of all Airflow Images supported on Astronomer, refer to our ["Airflow Versioning" doc](/docs/enterprise/v0.14/customize-airflow/airflow-versioning/).
+For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/v0.14/customize-airflow/manage-airflow-versions/).
 
 > **Note:**  Do NOT include `on-build` at the end of your Airflow Image as you typically would in your Dockerfile.
 

--- a/enterprise/v0.14/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.14/05_customize-airflow/01_manage-airflow-versions.md
@@ -1,6 +1,6 @@
 ---
-title: "Managing Airflow Versions on Astronomer"
-navTitle: "Airflow Versioning"
+title: "Manage Airflow Versions on Astronomer"
+navTitle: "Manage Airflow Versions"
 description: "How to adjust and upgrade Airflow versions on Astronomer."
 ---
 
@@ -12,7 +12,7 @@ Included in that build is your `Dockerfile`, a file that is automatically genera
 
 To upgrade or otherwise change the Airflow version you want to run, all it takes is a swap to the FROM statement held within your Dockerfile. Read below for details.
 
-> **Note:** For more thorough guidelines on customizing your image, reference our ["Customize Your Image" doc](/docs/enterprise/v0.13/develop/customize-image/).
+> **Note:** For more thorough guidelines on customizing your image, reference our ["Customize Your Image" doc](/docs/enterprise/v0.14/develop/customize-image/).
 
 ## Upgrade Airflow Version
 

--- a/enterprise/v0.15/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.15/02_develop/01_cli-quickstart.md
@@ -241,7 +241,7 @@ If you're looking for guidance beyond the Astronomer CLI, we'd encourage you to 
 
 * [Deploying to Astronomer](/docs/enterprise/v0.15/deploy/deploy-code/)
 * [Customizing your Image](/docs/enterprise/v0.15/develop/customize-image/)
-* [Managing Airflow Versions](/docs/enterprise/v0.15/customize-airflow/airflow-versioning/)
+* [Manage Airflow Versions](/docs/enterprise/v0.15/customize-airflow/manage-airflow-versions/)
 * [CI/CD](/docs/enterprise/v0.15/deploy/ci-cd/)
 
 As always, don't hesitate to reach out to the [Astronomer Support Portal](https://support.astronomer.io/hc/en-us) for additional questions or reference the [Astronomer Forum](https://forum.astronomer.io/).

--- a/enterprise/v0.15/02_develop/02_customize-image.md
+++ b/enterprise/v0.15/02_develop/02_customize-image.md
@@ -71,7 +71,7 @@ $ docker exec -it <scheduler-container-id> pip freeze | grep pymongo
 pymongo==3.7.2
 ```
 
-> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/v0.15/customize-airflow/airflow-versioning/).
+> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/v0.15/customize-airflow/manage-airflow-versions/).
 
 ## Add Other Dependencies
 
@@ -267,7 +267,7 @@ If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, 
 FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
-For a list of all Airflow Images supported on Astronomer, refer to our ["Airflow Versioning" doc](/docs/enterprise/v0.15/customize-airflow/airflow-versioning/).
+For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/v0.15/customize-airflow/manage-airflow-versions/).
 
 > **Note:**  Do NOT include `on-build` at the end of your Airflow Image as you typically would in your Dockerfile.
 

--- a/enterprise/v0.15/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.15/05_customize-airflow/01_manage-airflow-versions.md
@@ -1,6 +1,6 @@
 ---
-title: "Managing Airflow Versions on Astronomer"
-navTitle: "Airflow Versioning"
+title: "Manage Airflow Versions on Astronomer"
+navTitle: "Manage Airflow Versions"
 description: "How to adjust and upgrade Airflow versions on Astronomer."
 ---
 
@@ -12,7 +12,7 @@ Included in that build is your `Dockerfile`, a file that is automatically genera
 
 To upgrade or otherwise change the Airflow version you want to run, all it takes is a swap to the FROM statement held within your Dockerfile. Read below for details.
 
-> **Note:** For more thorough guidelines on customizing your image, reference our ["Customize Your Image" doc](/docs/enterprise/v0.12/develop/customize-image/).
+> **Note:** For more thorough guidelines on customizing your image, reference our ["Customize Your Image" doc](/docs/enterprise/v0.15/develop/customize-image/).
 
 ## Upgrade Airflow Version
 

--- a/enterprise/v0.16/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.16/02_develop/01_cli-quickstart.md
@@ -241,7 +241,7 @@ If you're looking for guidance beyond the Astronomer CLI, we'd encourage you to 
 
 * [Deploying to Astronomer](/docs/enterprise/v0.16/deploy/deploy-code/)
 * [Customizing your Image](/docs/enterprise/v0.16/develop/customize-image/)
-* [Managing Airflow Versions](/docs/enterprise/v0.16/customize-airflow/airflow-versioning/)
+* [Manage Airflow Versions](/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/)
 * [CI/CD](/docs/enterprise/v0.16/deploy/ci-cd/)
 
 As always, don't hesitate to reach out to the [Astronomer Support Portal](https://support.astronomer.io/hc/en-us) for additional questions or reference the [Astronomer Forum](https://forum.astronomer.io/).

--- a/enterprise/v0.16/02_develop/02_customize-image.md
+++ b/enterprise/v0.16/02_develop/02_customize-image.md
@@ -71,7 +71,7 @@ $ docker exec -it <scheduler-container-id> pip freeze | grep pymongo
 pymongo==3.7.2
 ```
 
-> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/v0.16/customize-airflow/airflow-versioning/).
+> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/).
 
 ## Add Other Dependencies
 
@@ -267,7 +267,7 @@ If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, 
 FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
-For a list of all Airflow Images supported on Astronomer, refer to our ["Airflow Versioning" doc](/docs/enterprise/v0.16/customize-airflow/airflow-versioning/).
+For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/).
 
 > **Note:**  Do NOT include `on-build` at the end of your Airflow Image as you typically would in your Dockerfile.
 

--- a/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
@@ -1,6 +1,6 @@
 ---
-title: "Managing Airflow Versions on Astronomer"
-navTitle: "Airflow Versioning"
+title: "Manage Airflow Versions on Astronomer"
+navTitle: "Manage Airflow Versions"
 description: "How to adjust and upgrade Airflow versions on Astronomer."
 ---
 

--- a/enterprise/v0.16/09_resources/01_release-notes.md
+++ b/enterprise/v0.16/09_resources/01_release-notes.md
@@ -47,7 +47,7 @@ Airflow 1.10.12 notably includes:
 - Support for grabbing Airflow configs with sensitive data from Secret Backends ([commit]((https://github.com/apache/airflow/pull/9645)))
 - Support for AirfowClusterPolicyViolation support in Airflow local settings ([commit](https://github.com/apache/airflow/pull/10282)).
 
-For a detailed breakdown of all changes, refer to the [AC 1.10.12 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md). For instructions on how to upgrade to 1.10.12 on Astronomer, refer to ["Airflow Versioning"](https://www.astronomer.io/docs/cloud/stable/customize-airflow/airflow-versioning/).
+For a detailed breakdown of all changes, refer to the [AC 1.10.12 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md). For instructions on how to upgrade to 1.10.12 on Astronomer, refer to ["Airflow Versioning"](https://www.astronomer.io/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
 
 > **Note:** AC 1.10.12 will be the _last_ version to support an Alpine-based image. In an effort to standardize our offering and optimize for reliability, we'll exclusively build, test and support Debian-based images starting with AC 1.10.13. A guide for how to migrate from Alpine to Debian coming soon.
 
@@ -155,7 +155,7 @@ These patch releases most notably include:
 - BugFix: Tighten restriction for `apache-airflow` in requirements.txt to allow users to install other packages with that prefix ([commit](https://github.com/astronomer/ap-airflow/commit/c2536db))
 - BugFix: Broken PapermillOperator ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/811cc75) - 1.10.10 only).
 
-To be notified of AC releases, feel free to [subscribe to our AC Newsletter](/downloads/). For information on how to upgrade Astronomer Certified versions, refer to our ["Airflow Versioning" doc](/docs/enterprise/v0.16/customize-airflow/airflow-versioning/).
+To be notified of AC releases, feel free to [subscribe to our AC Newsletter](/downloads/). For information on how to upgrade Astronomer Certified versions, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/).
 
 #### Airflow Chart: Improved Upgrade Process
 

--- a/enterprise/v0.16/09_resources/02_version-compatibility-reference.md
+++ b/enterprise/v0.16/09_resources/02_version-compatibility-reference.md
@@ -30,7 +30,7 @@ It's worth noting that while the tables below reference the minimum compatible v
 | 1.10.13 (*Coming Soon*) | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
 | 2.0.0 (*Coming Soon*)   | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
 
-For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Airflow Versioning" doc](https://www.astronomer.io/docs/enterprise/v0.16/customize-airflow/airflow-versioning/).
+For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/).
 
 > **Note:** MySQL 5.7 is compatible with Airflow and Astronomer Certified 2.0 but it does NOT support the ability to run more than 1 Scheduler and is not recommended. If you'd like to leverage Airflow's new Highly-Available Scheduler, make sure you're running MySQL 8.0+.
 


### PR DESCRIPTION
@ryanahamilton I changed the title and URL of this doc:

- `Airflow Versioning` > `Manage Airflow Versions`
- `/customize-airflow/airflow-versioning` > `/customize-airflow/manage-airflow-versions`

I changed a bunch of files so that our docs references don't require the redirect. Can you give it a quick glance to make sure I didn't miss anything obvious?