### PR TITLE
Update docs to reflect change from DockerHub to Quay

### DIFF
--- a/ac/next/01_local.md
+++ b/ac/next/01_local.md
@@ -10,7 +10,7 @@ Designed in close partnership with both Airflow committers and users, Astronomer
 
 There are two primary ways to obtain the Astronomer Certified distribution:
 
-1. [Docker Image](https://hub.docker.com/r/quay.io/astronomer/ap-airflow)
+1. [Docker Image](https://quay.io/astronomer/ap-airflow)
 2. [Python Package](https://pip.astronomer.io/simple/apache-airflow/)
 
 Astronomer Certified currently supports Airflow versions 1.10.5 - 1.10.7. This doc should cover everything you need to know to run Astronomer Astronomer Certified via either method, including:
@@ -33,7 +33,7 @@ Once you have the pre-reqs installed, follow the below instructions to get the A
 
 The preferred way to install Astronomer Astronomer Certified is to download our latest Astronomer-hosted Docker image, each of which will generally correspond with an open-source Airflow release.
 
-For Astronomer's full collection of Docker Images, reference our public [Docker Hub repository](https://hub.docker.com/r/quay.io/astronomer/ap-airflow).
+For Astronomer's full collection of Docker Images, reference our public [Docker Hub repository](https://quay.io/astronomer/ap-airflow).
 
 #### Install and Run
 

--- a/ac/next/01_local.md
+++ b/ac/next/01_local.md
@@ -33,7 +33,7 @@ Once you have the pre-reqs installed, follow the below instructions to get the A
 
 The preferred way to install Astronomer Astronomer Certified is to download our latest Astronomer-hosted Docker image, each of which will generally correspond with an open-source Airflow release.
 
-For Astronomer's full collection of Docker Images, reference our public [Docker Hub repository](https://quay.io/astronomer/ap-airflow).
+For Astronomer's full collection of Docker Images, reference our public [Quay.io repository](https://quay.io/astronomer/ap-airflow).
 
 #### Install and Run
 

--- a/ac/next/01_local.md
+++ b/ac/next/01_local.md
@@ -10,7 +10,7 @@ Designed in close partnership with both Airflow committers and users, Astronomer
 
 There are two primary ways to obtain the Astronomer Certified distribution:
 
-1. [Docker Image](https://hub.docker.com/r/astronomerinc/ap-airflow)
+1. [Docker Image](https://hub.docker.com/r/quay.io/astronomer/ap-airflow)
 2. [Python Package](https://pip.astronomer.io/simple/apache-airflow/)
 
 Astronomer Certified currently supports Airflow versions 1.10.5 - 1.10.7. This doc should cover everything you need to know to run Astronomer Astronomer Certified via either method, including:
@@ -33,7 +33,7 @@ Once you have the pre-reqs installed, follow the below instructions to get the A
 
 The preferred way to install Astronomer Astronomer Certified is to download our latest Astronomer-hosted Docker image, each of which will generally correspond with an open-source Airflow release.
 
-For Astronomer's full collection of Docker Images, reference our public [Docker Hub repository](https://hub.docker.com/r/astronomerinc/ap-airflow).
+For Astronomer's full collection of Docker Images, reference our public [Docker Hub repository](https://hub.docker.com/r/quay.io/astronomer/ap-airflow).
 
 #### Install and Run
 
@@ -52,10 +52,10 @@ To install and run the Astronomer Certified distribution, ensure that Docker is 
     > Note: The below Dockerfile is an example and may use an outdated image. For an updated list of available images, see our [downloads page](/downloads).
 
         # For an Alpine-based image
-        FROM astronomerinc/ap-airflow:1.10.10-alpine3.10-onbuild
+        FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild
 
         # For a Debian-based image
-        FROM astronomerinc/ap-airflow:1.10.10-buster-onbuild
+        FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild
 
     Note that you can select which version you'd like to use via the tag appended to the image.
 

--- a/ac/next/02_production.md
+++ b/ac/next/02_production.md
@@ -10,7 +10,7 @@ Designed in close partnership with both Airflow committers and users, Astronomer
 
 There are two primary ways to obtain the Astronomer Certified distribution:
 
-1. [Docker Image](https://hub.docker.com/r/quay.io/astronomer/ap-airflow)
+1. [Docker Image](https://quay.io/astronomer/ap-airflow)
 2. [Python Package](https://pip.astronomer.io/simple/apache-airflow/)
 
 Astronomer Certified currently supports Airflow versions  1.10.7 and 1.10.10. This doc should cover everything you need to know to run Astronomer Certified via either method, including:

--- a/ac/next/02_production.md
+++ b/ac/next/02_production.md
@@ -10,7 +10,7 @@ Designed in close partnership with both Airflow committers and users, Astronomer
 
 There are two primary ways to obtain the Astronomer Certified distribution:
 
-1. [Docker Image](https://hub.docker.com/r/astronomerinc/ap-airflow)
+1. [Docker Image](https://hub.docker.com/r/quay.io/astronomer/ap-airflow)
 2. [Python Package](https://pip.astronomer.io/simple/apache-airflow/)
 
 Astronomer Certified currently supports Airflow versions  1.10.7 and 1.10.10. This doc should cover everything you need to know to run Astronomer Certified via either method, including:

--- a/ac/next/03_security.md
+++ b/ac/next/03_security.md
@@ -11,7 +11,7 @@ This page is the source of truth for any CVE (Common Vulnerabilities and Exposur
 Currently, our officially supported Astronomer Certified images are listed in two places:
 
 - [Astronomer Downloads](/downloads/)
-- [Astronomer's DockerHub](https://hub.docker.com/r/astronomerinc/ap-airflow)
+- [Astronomer's DockerHub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow)
 
 If you run on Astronomer Cloud or Enterprise, you can refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/) for detailed guidelines on how to upgrade between Airflow versions on the platform.
 

--- a/ac/next/03_security.md
+++ b/ac/next/03_security.md
@@ -11,7 +11,7 @@ This page is the source of truth for any CVE (Common Vulnerabilities and Exposur
 Currently, our officially supported Astronomer Certified images are listed in two places:
 
 - [Astronomer Downloads](/downloads/)
-- [Astronomer's DockerHub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow)
+- [Astronomer's DockerHub](https://quay.io/astronomer/ap-airflow)
 
 If you run on Astronomer Cloud or Enterprise, you can refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/) for detailed guidelines on how to upgrade between Airflow versions on the platform.
 

--- a/ac/next/03_security.md
+++ b/ac/next/03_security.md
@@ -11,7 +11,7 @@ This page is the source of truth for any CVE (Common Vulnerabilities and Exposur
 Currently, our officially supported Astronomer Certified images are listed in two places:
 
 - [Astronomer Downloads](/downloads/)
-- [Astronomer's DockerHub](https://quay.io/astronomer/ap-airflow)
+- [Astronomer's Quay.io](https://quay.io/astronomer/ap-airflow)
 
 If you run on Astronomer Cloud or Enterprise, you can refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/) for detailed guidelines on how to upgrade between Airflow versions on the platform.
 

--- a/ac/v1.10.10/01_get-started/01_local.md
+++ b/ac/v1.10.10/01_get-started/01_local.md
@@ -10,7 +10,7 @@ Designed in close partnership with both Airflow committers and users, Astronomer
 
 There are two primary ways to obtain the Astronomer Certified distribution:
 
-1. [Docker Image](https://hub.docker.com/r/quay.io/astronomer/ap-airflow)
+1. [Docker Image](https://quay.io/astronomer/ap-airflow)
 2. [Python Package](https://pip.astronomer.io/simple/apache-airflow/)
 
 Astronomer Certified currently supports Airflow versions 1.10.5 - 1.10.7. This doc should cover everything you need to know to run Astronomer Astronomer Certified via either method, including:
@@ -33,7 +33,7 @@ Once you have the pre-reqs installed, follow the below instructions to get the A
 
 The preferred way to install Astronomer Astronomer Certified is to download our latest Astronomer-hosted Docker image, each of which will generally correspond with an open-source Airflow release.
 
-For Astronomer's full collection of Docker Images, reference our public [Docker Hub repository](https://hub.docker.com/r/quay.io/astronomer/ap-airflow).
+For Astronomer's full collection of Docker Images, reference our public [Docker Hub repository](https://quay.io/astronomer/ap-airflow).
 
 #### Install and Run
 

--- a/ac/v1.10.10/01_get-started/01_local.md
+++ b/ac/v1.10.10/01_get-started/01_local.md
@@ -33,7 +33,7 @@ Once you have the pre-reqs installed, follow the below instructions to get the A
 
 The preferred way to install Astronomer Astronomer Certified is to download our latest Astronomer-hosted Docker image, each of which will generally correspond with an open-source Airflow release.
 
-For Astronomer's full collection of Docker Images, reference our public [Docker Hub repository](https://quay.io/astronomer/ap-airflow).
+For Astronomer's full collection of Docker Images, reference our public [Quay.io repository](https://quay.io/astronomer/ap-airflow).
 
 #### Install and Run
 

--- a/ac/v1.10.10/01_get-started/01_local.md
+++ b/ac/v1.10.10/01_get-started/01_local.md
@@ -10,7 +10,7 @@ Designed in close partnership with both Airflow committers and users, Astronomer
 
 There are two primary ways to obtain the Astronomer Certified distribution:
 
-1. [Docker Image](https://hub.docker.com/r/astronomerinc/ap-airflow)
+1. [Docker Image](https://hub.docker.com/r/quay.io/astronomer/ap-airflow)
 2. [Python Package](https://pip.astronomer.io/simple/apache-airflow/)
 
 Astronomer Certified currently supports Airflow versions 1.10.5 - 1.10.7. This doc should cover everything you need to know to run Astronomer Astronomer Certified via either method, including:
@@ -33,7 +33,7 @@ Once you have the pre-reqs installed, follow the below instructions to get the A
 
 The preferred way to install Astronomer Astronomer Certified is to download our latest Astronomer-hosted Docker image, each of which will generally correspond with an open-source Airflow release.
 
-For Astronomer's full collection of Docker Images, reference our public [Docker Hub repository](https://hub.docker.com/r/astronomerinc/ap-airflow).
+For Astronomer's full collection of Docker Images, reference our public [Docker Hub repository](https://hub.docker.com/r/quay.io/astronomer/ap-airflow).
 
 #### Install and Run
 
@@ -52,10 +52,10 @@ To install and run the Astronomer Certified distribution, ensure that Docker is 
     > Note: The below Dockerfile is an example and may use an outdated image. For an updated list of available images, see our [downloads page](/downloads).
 
         # For an Alpine-based image
-        FROM astronomerinc/ap-airflow:1.10.10-alpine3.10-onbuild
+        FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild
 
         # For a Debian-based image
-        FROM astronomerinc/ap-airflow:1.10.10-buster-onbuild
+        FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild
 
     Note that you can select which version you'd like to use via the tag appended to the image.
 

--- a/ac/v1.10.10/01_get-started/02_production.md
+++ b/ac/v1.10.10/01_get-started/02_production.md
@@ -10,7 +10,7 @@ Designed in close partnership with both Airflow committers and users, Astronomer
 
 There are two primary ways to obtain the Astronomer Certified distribution:
 
-1. [Docker Image](https://hub.docker.com/r/quay.io/astronomer/ap-airflow)
+1. [Docker Image](https://quay.io/astronomer/ap-airflow)
 2. [Python Package](https://pip.astronomer.io/simple/apache-airflow/)
 
 Astronomer Certified currently supports Airflow versions  1.10.7 and 1.10.10. This doc should cover everything you need to know to run Astronomer Certified via either method, including:

--- a/ac/v1.10.10/01_get-started/02_production.md
+++ b/ac/v1.10.10/01_get-started/02_production.md
@@ -10,7 +10,7 @@ Designed in close partnership with both Airflow committers and users, Astronomer
 
 There are two primary ways to obtain the Astronomer Certified distribution:
 
-1. [Docker Image](https://hub.docker.com/r/astronomerinc/ap-airflow)
+1. [Docker Image](https://hub.docker.com/r/quay.io/astronomer/ap-airflow)
 2. [Python Package](https://pip.astronomer.io/simple/apache-airflow/)
 
 Astronomer Certified currently supports Airflow versions  1.10.7 and 1.10.10. This doc should cover everything you need to know to run Astronomer Certified via either method, including:

--- a/ac/v1.10.10/01_get-started/03_security.md
+++ b/ac/v1.10.10/01_get-started/03_security.md
@@ -11,7 +11,7 @@ This page is the source of truth for any CVE (Common Vulnerabilities and Exposur
 Currently, our officially supported Astronomer Certified images are listed in two places:
 
 - [Astronomer Downloads](/downloads/)
-- [Astronomer's DockerHub](https://hub.docker.com/r/astronomerinc/ap-airflow)
+- [Astronomer's DockerHub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow)
 
 If you run on Astronomer Cloud or Enterprise, you can refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/) for detailed guidelines on how to upgrade between Airflow versions on the platform.
 

--- a/ac/v1.10.10/01_get-started/03_security.md
+++ b/ac/v1.10.10/01_get-started/03_security.md
@@ -11,7 +11,7 @@ This page is the source of truth for any CVE (Common Vulnerabilities and Exposur
 Currently, our officially supported Astronomer Certified images are listed in two places:
 
 - [Astronomer Downloads](/downloads/)
-- [Astronomer's DockerHub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow)
+- [Astronomer's DockerHub](https://quay.io/astronomer/ap-airflow)
 
 If you run on Astronomer Cloud or Enterprise, you can refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/) for detailed guidelines on how to upgrade between Airflow versions on the platform.
 

--- a/ac/v1.10.10/01_get-started/03_security.md
+++ b/ac/v1.10.10/01_get-started/03_security.md
@@ -11,7 +11,7 @@ This page is the source of truth for any CVE (Common Vulnerabilities and Exposur
 Currently, our officially supported Astronomer Certified images are listed in two places:
 
 - [Astronomer Downloads](/downloads/)
-- [Astronomer's DockerHub](https://quay.io/astronomer/ap-airflow)
+- [Astronomer's Quay.io](https://quay.io/astronomer/ap-airflow)
 
 If you run on Astronomer Cloud or Enterprise, you can refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/) for detailed guidelines on how to upgrade between Airflow versions on the platform.
 

--- a/cloud/stable/01_get-started/01_quickstart.md
+++ b/cloud/stable/01_get-started/01_quickstart.md
@@ -92,12 +92,12 @@ This will generate some skeleton files:
 
 #### Dockerfile
 
-Your Dockerfile will include reference to an Astronomer [Docker Image](https://hub.docker.com/r/astronomerinc/ap-airflow) that dictates the version of Airflow your deployment will run both when you're developing locally and pushing up to Astronomer Cloud.
+Your Dockerfile will include reference to an Astronomer [Docker Image](https://hub.docker.com/r/quay.io/astronomer/ap-airflow) that dictates the version of Airflow your deployment will run both when you're developing locally and pushing up to Astronomer Cloud.
 
 The Docker image you'll find by default is:
 
 ```
-FROM astronomerinc/ap-airflow:latest-onbuild
+FROM quay.io/astronomer/ap-airflow:latest-onbuild
 ```
 
 This will install an Astronomer Certified Alpine-based Airflow image running the latest version of Airflow we support. For more information on how to customize your image, refer to the "Customize your Image" section below.
@@ -132,7 +132,7 @@ You should see the following output:
 $ astro dev start
 Env file ".env" found. Loading...
 Sending build context to Docker daemon  10.75kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/cloud/stable/01_get-started/01_quickstart.md
+++ b/cloud/stable/01_get-started/01_quickstart.md
@@ -92,7 +92,7 @@ This will generate some skeleton files:
 
 #### Dockerfile
 
-Your Dockerfile will include reference to an Astronomer [Docker Image](https://hub.docker.com/r/quay.io/astronomer/ap-airflow) that dictates the version of Airflow your deployment will run both when you're developing locally and pushing up to Astronomer Cloud.
+Your Dockerfile will include reference to an Astronomer [Docker Image](https://quay.io/astronomer/ap-airflow) that dictates the version of Airflow your deployment will run both when you're developing locally and pushing up to Astronomer Cloud.
 
 The Docker image you'll find by default is:
 

--- a/cloud/stable/02_develop/02_customize-image.md
+++ b/cloud/stable/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM astronomerinc/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
 RUN ls
 ```
 
@@ -264,7 +264,7 @@ If you haven't initialized an Airflow Project on Astronomer (by running `$ astro
 If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, this would be:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
+FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
 For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
@@ -320,7 +320,7 @@ Run the following in your terminal:
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-<airflow-image> .
 ```
 
-If you have `astronomerinc/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
+If you have `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
 
 ```
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-ap-airflow:1.10.10-alpine3.10 .
@@ -334,7 +334,7 @@ Now that we've built your custom image, let's reference that custom image in you
 FROM custom-<airflow-image>
 ```
 
-If you're running `astronomerinc/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
+If you're running `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
 
 ```
 FROM custom-ap-airflow:1.10.10-alpine3.10

--- a/cloud/stable/02_develop/02_customize-image.md
+++ b/cloud/stable/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild
 RUN ls
 ```
 

--- a/cloud/stable/02_develop/04_cli-install-windows-10.md
+++ b/cloud/stable/02_develop/04_cli-install-windows-10.md
@@ -123,7 +123,7 @@ As a Windows user, you might see the following error when trying to call `astro 
 
 ```
 Sending build context to Docker daemon  8.192kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/cloud/stable/03_deploy/05_environment-variables.md
+++ b/cloud/stable/03_deploy/05_environment-variables.md
@@ -107,7 +107,7 @@ If you're working on an Airflow project locally but intend to deploy to Astronom
 To add Environment Variables, insert the value and key in your `Dockerfile` beginning with `ENV`, ensuring all-caps for all characters. With your Airflow image commonly referenced as a "FROM" statement at the top, your Dockerfile might look like this:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild
 ENV AIRFLOW__CORE__MAX_ACTIVE_RUNS_PER_DAG=1
 ENV AIRFLOW__CORE__DAG_CONCURRENCY=5
 ENV AIRFLOW__CORE__PARALLELISM=25

--- a/cloud/stable/03_deploy/06_ci-cd.md
+++ b/cloud/stable/03_deploy/06_ci-cd.md
@@ -163,7 +163,7 @@ At its core, your CI/CD pipeline will first authenticate to Astronomer Cloud's p
 ```yaml
 pipeline:
   build:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -173,7 +173,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -224,7 +224,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  astronomerio/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-build:0.0.7
     steps:
       - checkout
       - setup_remote_docker:
@@ -281,7 +281,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: astronomerio/ap-build:0.0.7
+image: quay.io/astronomer/ap-build:0.0.7
 
 pipelines:
   branches:

--- a/cloud/stable/03_deploy/06_ci-cd.md
+++ b/cloud/stable/03_deploy/06_ci-cd.md
@@ -163,7 +163,7 @@ At its core, your CI/CD pipeline will first authenticate to Astronomer Cloud's p
 ```yaml
 pipeline:
   build:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.12-buster
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -173,7 +173,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.12-buster
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -224,7 +224,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  quay.io/astronomer/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-airflow:1.10.12-buster
     steps:
       - checkout
       - setup_remote_docker:
@@ -281,7 +281,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: quay.io/astronomer/ap-build:0.0.7
+image: quay.io/astronomer/ap-airflow:1.10.12-buster
 
 pipelines:
   branches:

--- a/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
@@ -149,10 +149,10 @@ For our platform's full collection of Docker Images, reference [Astronomer on Qu
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|
-| [v1.10.5](https://github.com/astronomer/ap-airflow/blob/master/1.10.5/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.5-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.5-buster-onbuild |
-| [v1.10.7](https://github.com/astronomer/ap-airflow/blob/master/1.10.7/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.7-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild |
-| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.10-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.10-buster-onbuild |
-| [v1.10.12](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.12-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.12-buster-onbuild |
+| [v1.10.5](https://github.com/astronomer/ap-airflow/blob/master/1.10.5/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.5-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.5-buster-onbuild |
+| [v1.10.7](https://github.com/astronomer/ap-airflow/blob/master/1.10.7/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.7-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild |
+| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild |
+| [v1.10.12](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.12-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild |
 
 > **Note:** Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
 
@@ -225,7 +225,7 @@ If you're looking for the latest Astronomer Certified 1.10.10, for example, you 
 2. Identify the latest patch (e.g. `1.10.10-5`)
 3. Pin the Astronomer Certified Image in your Dockerfile to that patch version
 
-In this case, that would be: `FROM astronomerinc/ap-airflow:1.10.10-5-buster-onbuild` (Debian).
+In this case, that would be: `FROM quay.io/astronomer/ap-airflow:1.10.10-5-buster-onbuild` (Debian).
 
 > **Note:** If you're pushing code to an Airflow Deployment via the Astronomer CLI and install a new Astronomer Certified image for the first time _without_ pinning a specific patch, the latest version available will automatically be pulled.
 > 

--- a/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
@@ -141,7 +141,7 @@ Depending on the OS distribution and version of Airflow you want to run, you'll 
 
 #### Choose your new Astronomer Certified Image
 
-Below you'll find a matrix of all Astronomer Certified images supported on Astronomer. Depedending on the Airflow version you'd like to run or upgrade to, copy one of the images below to your `Dockerfile` and proceed to Step 3.
+Below you'll find a matrix of all Astronomer Certified images supported on Astronomer. Depending on the Airflow version you'd like to run or upgrade to, copy one of the images below to your `Dockerfile` and proceed to Step 3.
 
 Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
 

--- a/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
@@ -143,7 +143,7 @@ Depending on the OS distribution and version of Airflow you want to run, you'll 
 
 Below you'll find a matrix of all Astronomer Certified images supported on Astronomer. Depedending on the Airflow version you'd like to run or upgrade to, copy one of the images below to your `Dockerfile` and proceed to Step 3.
 
-Note that once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
+Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
 
 In terms of system distribution, Astronomer supports both [Alpine Linux](https://alpinelinux.org/) and [Debian](https://www.debian.org/)-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
 

--- a/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
@@ -141,11 +141,16 @@ Depending on the OS distribution and version of Airflow you want to run, you'll 
 
 #### Choose your new Astronomer Certified Image
 
-Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
+Below you'll find a matrix of all Astronomer Certified images supported on Astronomer. Depedending on the Airflow version you'd like to run or upgrade to, copy one of the images below to your `Dockerfile` and proceed to Step 3.
+
+Note that once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
+
+In terms of system distribution, Astronomer supports both [Alpine Linux](https://alpinelinux.org/) and [Debian](https://www.debian.org/)-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
 
 For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
 
 > **Note:** AC 1.10.12 will be the _last_ version to support an Alpine-based image. In an effort to standardize our offering and optimize for reliability, we'll exclusively build, test and support Debian-based images starting with AC 1.10.13. A guide for how to migrate from Alpine to Debian coming soon.
+
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|
@@ -154,7 +159,7 @@ For our platform's full collection of Docker Images, reference [Astronomer on Qu
 | [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild |
 | [v1.10.12](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.12-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild |
 
-> **Note:** Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
+> **Note:** We recently migrated from [DockerHub](https://hub.docker.com/r/astronomerinc/ap-airflow) to Quay.io as our Docker Registry due to a [recent change]((https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/)) in DockerHub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer (e.g. `toomanyrequests: You have reached your pull rate limit`).
 
 ### 3. Re-Build your Image
 

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -68,7 +68,7 @@ Astronomer Enterprise brings together best-of-class components into a complete "
 * [Prisma ORM](https://www.prisma.io/) - An interface between the HoustonGraphQL API and your Postgres database. This handles read/writes to the database as well as migrations for upgrades.
 * [Astronomer Helm](https://github.com/astronomer/astronomer) - Helm charts for the Astronomer Platform
 * [db-bootstrapper](https://github.com/astronomer/db-bootstrapper) - Init container for bootstrapping system databases
-* [Docker images](https://hub.docker.com/u/astronomerinc/) - Docker images for deploying and running Astronomer on DockerHub.
+* [Docker images](https://hub.docker.com/u/quay.io/astronomer/) - Docker images for deploying and running Astronomer on DockerHub.
 
 ## Airflow Components
 

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -68,7 +68,7 @@ Astronomer Enterprise brings together best-of-class components into a complete "
 * [Prisma ORM](https://www.prisma.io/) - An interface between the HoustonGraphQL API and your Postgres database. This handles read/writes to the database as well as migrations for upgrades.
 * [Astronomer Helm](https://github.com/astronomer/astronomer) - Helm charts for the Astronomer Platform
 * [db-bootstrapper](https://github.com/astronomer/db-bootstrapper) - Init container for bootstrapping system databases
-* [Docker images](https://hub.docker.com/u/quay.io/astronomer/) - Docker images for deploying and running Astronomer on DockerHub.
+* [Docker images](https://quay.io/astronomer/) - Docker images for deploying and running Astronomer on DockerHub.
 
 ## Airflow Components
 

--- a/enterprise/next/01_get-started/01_quickstart.md
+++ b/enterprise/next/01_get-started/01_quickstart.md
@@ -140,7 +140,7 @@ dags                   include     plugins
 $ astro dev start
 Env file ".env" found. Loading...
 Sending build context to Docker daemon  11.26kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache
@@ -195,7 +195,7 @@ WARNING! You are about to push an image using the 'latest-onbuild' tag. This is 
 Please use one of the following tags: 1.10.7-alpine3.10-onbuild.
 Are you sure you want to continue? (y/n) y
 Sending build context to Docker daemon  11.26kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM astronomerinc/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
 RUN ls
 ```
 
@@ -264,7 +264,7 @@ If you haven't initialized an Airflow Project on Astronomer (by running `astro d
 If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, this would be:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
+FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
 For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/).
@@ -320,7 +320,7 @@ Run the following in your terminal:
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-<airflow-image> .
 ```
 
-If you have `astronomerinc/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
+If you have `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
 
 ```
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-ap-airflow:1.10.10-alpine3.10 .
@@ -334,7 +334,7 @@ Now that we've built your custom image, let's reference that custom image in you
 FROM custom-<airflow-image>
 ```
 
-If you're running `astronomerinc/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
+If you're running `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
 
 ```
 FROM custom-ap-airflow:1.10.10-alpine3.10

--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild
 RUN ls
 ```
 

--- a/enterprise/next/02_develop/04_cli-install-windows-10.md
+++ b/enterprise/next/02_develop/04_cli-install-windows-10.md
@@ -123,7 +123,7 @@ As a Windows user, you might see the following error when trying to call `astro 
 
 ```
 Sending build context to Docker daemon  8.192kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/enterprise/next/04_deploy/05_environment-variables.md
+++ b/enterprise/next/04_deploy/05_environment-variables.md
@@ -107,7 +107,7 @@ If you're working on an Airflow project locally but intend to deploy to Astronom
 To add Environment Variables, insert the value and key in your `Dockerfile` beginning with `ENV`, ensuring all-caps for all characters. With your Airflow image commonly referenced as a "FROM" statement at the top, your Dockerfile might look like this:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild
 ENV AIRFLOW__CORE__MAX_ACTIVE_RUNS_PER_DAG=1
 ENV AIRFLOW__CORE__DAG_CONCURRENCY=5
 ENV AIRFLOW__CORE__PARALLELISM=25

--- a/enterprise/next/04_deploy/06_ci-cd.md
+++ b/enterprise/next/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.12-buster
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.12-buster
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  quay.io/astronomer/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-airflow:1.10.12-buster
     steps:
       - checkout
       - setup_remote_docker:
@@ -280,7 +280,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: quay.io/astronomer/ap-build:0.0.7
+image: quay.io/astronomer/ap-airflow:1.10.12-buster
 
 pipelines:
   branches:

--- a/enterprise/next/04_deploy/06_ci-cd.md
+++ b/enterprise/next/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  astronomerio/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-build:0.0.7
     steps:
       - checkout
       - setup_remote_docker:
@@ -280,7 +280,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: astronomerio/ap-build:0.0.7
+image: quay.io/astronomer/ap-build:0.0.7
 
 pipelines:
   branches:

--- a/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
@@ -42,11 +42,15 @@ First, open the `Dockerfile` within your Astronomer directory. When you initiali
 
 Depending on the OS distribution and version of Airflow you want to run, you'll want to reference the corresponding Astronomer Certified image in the FROM statement of your Dockerfile.
 
+> **Note:** Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow Metadata Database structurally changes with each release, making for backwards incompatibility across versions.
+
 #### Alpine and Debian-based Images
 
-Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
+Astronomer supports both [Alpine Linux](https://alpinelinux.org/) and [Debian](https://www.debian.org/)-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/astronomer/ap-airflow/tags).
+For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
+
+> **Note:** AC 1.10.12 will be the _last_ version to support an Alpine-based image. In an effort to standardize our offering and optimize for reliability, we'll exclusively build, test and support Debian-based images starting with AC 1.10.13. A guide for how to migrate from Alpine to Debian coming soon.
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|
@@ -55,10 +59,9 @@ Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widel
 | [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild |
 | [v1.10.12](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.12-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild |
 
-To upgrade an Airflow Deployment to Astronomer Certified 1.10.12 you _must_ be running  [v0.16.9](https://www.astronomer.io/docs/enterprise/v0.16/resources/release-notes/)+ of the Astronomer Platform. For instructions on how to upgrade the platform, refer to ["Upgrade Astronomer"](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/upgrade-astronomer/) or [reach out to us](https://support.astronomer.io).
+To upgrade an Airflow Deployment to Astronomer Certified 1.10.12 you _must_ be running  [v0.16.9](https://www.astronomer.io/docs/enterprise/v0.16/resources/release-notes/)+ of the Astronomer Platform. For instructions on how to upgrade the platform, refer to ["Upgrade Astronomer"](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer/) or [reach out to us](https://support.astronomer.io).
 
-> **Note:** Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
-
+> **Note:** We recently migrated from [DockerHub](https://hub.docker.com/r/astronomerinc/ap-airflow) to Quay.io as our Docker Registry due to a [recent change]((https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/)) in DockerHub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer or otherwise pull a Platform  Docker Image (e.g. `toomanyrequests: You have reached your pull rate limit`).
 ### 3. Re-Build your Image
 
 #### Local Development

--- a/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
@@ -50,11 +50,7 @@ Astronomer supports both [Alpine Linux](https://alpinelinux.org/) and [Debian](h
 
 For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
 
-<<<<<<< HEAD
 > **Note:** AC 1.10.12 will be the _last_ version to support an Alpine-based image. In an effort to standardize our offering and optimize for reliability, we'll exclusively build, test and support Debian-based images starting with AC 1.10.13. A guide for how to migrate from Alpine to Debian coming soon.
-=======
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
->>>>>>> ec488057bb28f5eacc77987809c66930ff7e9668
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
@@ -46,7 +46,7 @@ Depending on the OS distribution and version of Airflow you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
@@ -46,7 +46,7 @@ Depending on the OS distribution and version of Airflow you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
@@ -46,14 +46,14 @@ Depending on the OS distribution and version of Airflow you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|
-| [v1.10.5](https://github.com/astronomer/ap-airflow/blob/master/1.10.5/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.5-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.5-buster-onbuild |
-| [v1.10.7](https://github.com/astronomer/ap-airflow/blob/master/1.10.7/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.7-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild |
-| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.10-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.10-buster-onbuild |
-| [v1.10.12](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.12-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.12-buster-onbuild |
+| [v1.10.5](https://github.com/astronomer/ap-airflow/blob/master/1.10.5/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.5-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.5-buster-onbuild |
+| [v1.10.7](https://github.com/astronomer/ap-airflow/blob/master/1.10.7/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.7-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild |
+| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild |
+| [v1.10.12](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.12-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild |
 
 To upgrade an Airflow Deployment to Astronomer Certified 1.10.12 you _must_ be running  [v0.16.9](https://www.astronomer.io/docs/enterprise/v0.16/resources/release-notes/)+ of the Astronomer Platform. For instructions on how to upgrade the platform, refer to ["Upgrade Astronomer"](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/upgrade-astronomer/) or [reach out to us](https://support.astronomer.io).
 
@@ -127,7 +127,7 @@ If you're looking for the latest Astronomer Certified 1.10.10, for example, you 
 2. Identify the latest patch (e.g. `1.10.10-5`)
 3. Pin the Astronomer Certified Image in your Dockerfile to that patch version
 
-In this case, that would be: `FROM astronomerinc/ap-airflow:1.10.10-5-buster-onbuild` (Debian).
+In this case, that would be: `FROM quay.io/astronomer/ap-airflow:1.10.10-5-buster-onbuild` (Debian).
 
 > **Note:** If you're pushing code to an Airflow Deployment via the Astronomer CLI and install a new Astronomer Certified image for the first time _without_ pinning a specific patch, the latest version available will automatically be pulled.
 > 

--- a/enterprise/v0.12/01_get-started/01_quickstart.md
+++ b/enterprise/v0.12/01_get-started/01_quickstart.md
@@ -140,7 +140,7 @@ dags                   include     plugins
 $ astro dev start
 Env file ".env" found. Loading...
 Sending build context to Docker daemon  11.26kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache
@@ -195,7 +195,7 @@ WARNING! You are about to push an image using the 'latest-onbuild' tag. This is 
 Please use one of the following tags: 1.10.7-alpine3.10-onbuild.
 Are you sure you want to continue? (y/n) y
 Sending build context to Docker daemon  11.26kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/enterprise/v0.12/02_develop/02_customize-image.md
+++ b/enterprise/v0.12/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM astronomerinc/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
 RUN ls
 ```
 
@@ -264,7 +264,7 @@ If you haven't initialized an Airflow Project on Astronomer (by running `astro d
 If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, this would be:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
+FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
 For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/v0.12/customize-airflow/manage-airflow-versions/).
@@ -320,7 +320,7 @@ Run the following in your terminal:
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-<airflow-image> .
 ```
 
-If you have `astronomerinc/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
+If you have `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
 
 ```
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-ap-airflow:1.10.10-alpine3.10 .
@@ -334,7 +334,7 @@ Now that we've built your custom image, let's reference that custom image in you
 FROM custom-<airflow-image>
 ```
 
-If you're running `astronomerinc/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
+If you're running `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
 
 ```
 FROM custom-ap-airflow:1.10.10-alpine3.10

--- a/enterprise/v0.12/02_develop/02_customize-image.md
+++ b/enterprise/v0.12/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild
 RUN ls
 ```
 

--- a/enterprise/v0.12/02_develop/04_cli-install-windows-10.md
+++ b/enterprise/v0.12/02_develop/04_cli-install-windows-10.md
@@ -123,7 +123,7 @@ As a Windows user, you might see the following error when trying to call `astro 
 
 ```
 Sending build context to Docker daemon  8.192kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/enterprise/v0.12/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.12/04_deploy/05_environment-variables.md
@@ -107,7 +107,7 @@ If you're working on an Airflow project locally but intend to deploy to Astronom
 To add Environment Variables, insert the value and key in your `Dockerfile` beginning with `ENV`, ensuring all-caps for all characters. With your Airflow image commonly referenced as a "FROM" statement at the top, your Dockerfile might look like this:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild
 
 ENV AIRFLOW__CORE__MAX_ACTIVE_RUNS_PER_DAG=1
 ENV AIRFLOW__CORE__DAG_CONCURRENCY=5

--- a/enterprise/v0.12/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.12/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  astronomerio/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-build:0.0.7
     steps:
       - checkout
       - setup_remote_docker:
@@ -281,7 +281,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: astronomerio/ap-build:0.0.7
+image: quay.io/astronomer/ap-build:0.0.7
 
 pipelines:
   branches:

--- a/enterprise/v0.12/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.12/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.10-buster
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.10-buster
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  quay.io/astronomer/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-airflow:1.10.10-buster
     steps:
       - checkout
       - setup_remote_docker:
@@ -281,7 +281,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: quay.io/astronomer/ap-build:0.0.7
+image: quay.io/astronomer/ap-airflow:1.10.10-buster
 
 pipelines:
   branches:

--- a/enterprise/v0.12/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.12/05_customize-airflow/01_manage-airflow-versions.md
@@ -49,13 +49,13 @@ Depending on the version of Airflow and OS distribution you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, Debian is often more appropriate.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|
-| [v1.10.5](https://github.com/apache/airflow/releases/tag/1.10.5)         | FROM astronomerinc/ap-airflow:1.10.5-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.5-buster-onbuild |
-| [v1.10.7](https://github.com/apache/airflow/releases/tag/1.10.7)         | FROM astronomerinc/ap-airflow:1.10.7-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild |
-| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.10-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.10-buster-onbuild |
+| [v1.10.5](https://github.com/apache/airflow/releases/tag/1.10.5)         | FROM quay.io/astronomer/ap-airflow:1.10.5-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.5-buster-onbuild |
+| [v1.10.7](https://github.com/apache/airflow/releases/tag/1.10.7)         | FROM quay.io/astronomer/ap-airflow:1.10.7-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild |
+| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild |
 
 > **Note:** Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
 

--- a/enterprise/v0.12/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.12/05_customize-airflow/01_manage-airflow-versions.md
@@ -49,7 +49,7 @@ Depending on the version of Airflow and OS distribution you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, Debian is often more appropriate.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/enterprise/v0.12/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.12/05_customize-airflow/01_manage-airflow-versions.md
@@ -49,7 +49,7 @@ Depending on the version of Airflow and OS distribution you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, Debian is often more appropriate.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/enterprise/v0.13/01_get-started/01_quickstart.md
+++ b/enterprise/v0.13/01_get-started/01_quickstart.md
@@ -140,7 +140,7 @@ dags                   include     plugins
 $ astro dev start
 Env file ".env" found. Loading...
 Sending build context to Docker daemon  11.26kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache
@@ -195,7 +195,7 @@ WARNING! You are about to push an image using the 'latest-onbuild' tag. This is 
 Please use one of the following tags: 1.10.7-alpine3.10-onbuild.
 Are you sure you want to continue? (y/n) y
 Sending build context to Docker daemon  11.26kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/enterprise/v0.13/02_develop/02_customize-image.md
+++ b/enterprise/v0.13/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild
 RUN ls
 ```
 

--- a/enterprise/v0.13/02_develop/02_customize-image.md
+++ b/enterprise/v0.13/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM astronomerinc/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
 RUN ls
 ```
 
@@ -264,7 +264,7 @@ If you haven't initialized an Airflow Project on Astronomer (by running `astro d
 If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, this would be:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
+FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
 For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/v0.13/customize-airflow/manage-airflow-versions/).
@@ -320,7 +320,7 @@ Run the following in your terminal:
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-<airflow-image> .
 ```
 
-If you have `astronomerinc/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
+If you have `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
 
 ```
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-ap-airflow:1.10.10-alpine3.10 .
@@ -334,7 +334,7 @@ Now that we've built your custom image, let's reference that custom image in you
 FROM custom-<airflow-image>
 ```
 
-If you're running `astronomerinc/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
+If you're running `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
 
 ```
 FROM custom-ap-airflow:1.10.10-alpine3.10

--- a/enterprise/v0.13/02_develop/04_cli-install-windows-10.md
+++ b/enterprise/v0.13/02_develop/04_cli-install-windows-10.md
@@ -123,7 +123,7 @@ As a Windows user, you might see the following error when trying to call `astro 
 
 ```
 Sending build context to Docker daemon  8.192kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/enterprise/v0.13/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.13/04_deploy/05_environment-variables.md
@@ -107,7 +107,7 @@ If you're working on an Airflow project locally but intend to deploy to Astronom
 To add Environment Variables, insert the value and key in your `Dockerfile` beginning with `ENV`, ensuring all-caps for all characters. With your Airflow image commonly referenced as a "FROM" statement at the top, your Dockerfile might look like this:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild
 
 ENV AIRFLOW__CORE__MAX_ACTIVE_RUNS_PER_DAG=1
 ENV AIRFLOW__CORE__DAG_CONCURRENCY=5

--- a/enterprise/v0.13/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.13/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  astronomerio/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-build:0.0.7
     steps:
       - checkout
       - setup_remote_docker:
@@ -281,7 +281,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: astronomerio/ap-build:0.0.7
+image: quay.io/astronomer/ap-build:0.0.7
 
 pipelines:
   branches:

--- a/enterprise/v0.13/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.13/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.10-buster
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.10-buster
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  quay.io/astronomer/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-airflow:1.10.10-buster
     steps:
       - checkout
       - setup_remote_docker:
@@ -281,7 +281,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: quay.io/astronomer/ap-build:0.0.7
+image: quay.io/astronomer/ap-airflow:1.10.10-buster
 
 pipelines:
   branches:

--- a/enterprise/v0.13/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.13/05_customize-airflow/01_manage-airflow-versions.md
@@ -49,13 +49,13 @@ Depending on the version of Airflow and OS distribution you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, Debian is often more appropriate.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|
-| [v1.10.5](https://github.com/apache/airflow/releases/tag/1.10.5)         | FROM astronomerinc/ap-airflow:1.10.5-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.5-buster-onbuild |
-| [v1.10.7](https://github.com/apache/airflow/releases/tag/1.10.7)         | FROM astronomerinc/ap-airflow:1.10.7-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild |
-| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.10-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.10-buster-onbuild |
+| [v1.10.5](https://github.com/apache/airflow/releases/tag/1.10.5)         | FROM quay.io/astronomer/ap-airflow:1.10.5-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.5-buster-onbuild |
+| [v1.10.7](https://github.com/apache/airflow/releases/tag/1.10.7)         | FROM quay.io/astronomer/ap-airflow:1.10.7-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild |
+| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild |
 
 > **Note:** Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
 

--- a/enterprise/v0.13/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.13/05_customize-airflow/01_manage-airflow-versions.md
@@ -49,7 +49,7 @@ Depending on the version of Airflow and OS distribution you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, Debian is often more appropriate.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/enterprise/v0.13/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.13/05_customize-airflow/01_manage-airflow-versions.md
@@ -49,7 +49,7 @@ Depending on the version of Airflow and OS distribution you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, Debian is often more appropriate.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/enterprise/v0.14/01_get-started/01_quickstart.md
+++ b/enterprise/v0.14/01_get-started/01_quickstart.md
@@ -140,7 +140,7 @@ dags                   include     plugins
 $ astro dev start
 Env file ".env" found. Loading...
 Sending build context to Docker daemon  11.26kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache
@@ -195,7 +195,7 @@ WARNING! You are about to push an image using the 'latest-onbuild' tag. This is 
 Please use one of the following tags: 1.10.7-alpine3.10-onbuild.
 Are you sure you want to continue? (y/n) y
 Sending build context to Docker daemon  11.26kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/enterprise/v0.14/02_develop/02_customize-image.md
+++ b/enterprise/v0.14/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM astronomerinc/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
 RUN ls
 ```
 
@@ -264,7 +264,7 @@ If you haven't initialized an Airflow Project on Astronomer (by running `astro d
 If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, this would be:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
+FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
 For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/v0.14/customize-airflow/manage-airflow-versions/).
@@ -320,7 +320,7 @@ Run the following in your terminal:
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-<airflow-image> .
 ```
 
-If you have `astronomerinc/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
+If you have `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
 
 ```
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-ap-airflow:1.10.10-alpine3.10 .
@@ -334,7 +334,7 @@ Now that we've built your custom image, let's reference that custom image in you
 FROM custom-<airflow-image>
 ```
 
-If you're running `astronomerinc/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
+If you're running `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
 
 ```
 FROM custom-ap-airflow:1.10.10-alpine3.10

--- a/enterprise/v0.14/02_develop/02_customize-image.md
+++ b/enterprise/v0.14/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild
 RUN ls
 ```
 

--- a/enterprise/v0.14/02_develop/04_cli-install-windows-10.md
+++ b/enterprise/v0.14/02_develop/04_cli-install-windows-10.md
@@ -123,7 +123,7 @@ As a Windows user, you might see the following error when trying to call `astro 
 
 ```
 Sending build context to Docker daemon  8.192kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/enterprise/v0.14/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.14/04_deploy/05_environment-variables.md
@@ -107,7 +107,7 @@ If you're working on an Airflow project locally but intend to deploy to Astronom
 To add Environment Variables, insert the value and key in your `Dockerfile` beginning with `ENV`, ensuring all-caps for all characters. With your Airflow image commonly referenced as a "FROM" statement at the top, your Dockerfile might look like this:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild
 
 ENV AIRFLOW__CORE__MAX_ACTIVE_RUNS_PER_DAG=1
 ENV AIRFLOW__CORE__DAG_CONCURRENCY=5

--- a/enterprise/v0.14/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.14/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  astronomerio/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-build:0.0.7
     steps:
       - checkout
       - setup_remote_docker:
@@ -281,7 +281,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: astronomerio/ap-build:0.0.7
+image: quay.io/astronomer/ap-build:0.0.7
 
 pipelines:
   branches:

--- a/enterprise/v0.14/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.14/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.10-buster
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.10-buster
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  quay.io/astronomer/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-airflow:1.10.10-buster
     steps:
       - checkout
       - setup_remote_docker:
@@ -281,7 +281,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: quay.io/astronomer/ap-build:0.0.7
+image: quay.io/astronomer/ap-airflow:1.10.10-buster
 
 pipelines:
   branches:

--- a/enterprise/v0.14/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.14/05_customize-airflow/01_manage-airflow-versions.md
@@ -49,13 +49,13 @@ Depending on the version of Airflow and OS distribution you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, Debian is often more appropriate.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|
-| [v1.10.5](https://github.com/apache/airflow/releases/tag/1.10.5)         | FROM astronomerinc/ap-airflow:1.10.5-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.5-buster-onbuild |
-| [v1.10.7](https://github.com/apache/airflow/releases/tag/1.10.7)         | FROM astronomerinc/ap-airflow:1.10.7-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild |
-| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.10-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.10-buster-onbuild |
+| [v1.10.5](https://github.com/apache/airflow/releases/tag/1.10.5)         | FROM quay.io/astronomer/ap-airflow:1.10.5-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.5-buster-onbuild |
+| [v1.10.7](https://github.com/apache/airflow/releases/tag/1.10.7)         | FROM quay.io/astronomer/ap-airflow:1.10.7-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild |
+| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild |
 
 > **Note:** Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
 

--- a/enterprise/v0.14/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.14/05_customize-airflow/01_manage-airflow-versions.md
@@ -49,7 +49,7 @@ Depending on the version of Airflow and OS distribution you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, Debian is often more appropriate.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/enterprise/v0.14/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.14/05_customize-airflow/01_manage-airflow-versions.md
@@ -49,7 +49,7 @@ Depending on the version of Airflow and OS distribution you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, Debian is often more appropriate.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/enterprise/v0.15/01_get-started/01_quickstart.md
+++ b/enterprise/v0.15/01_get-started/01_quickstart.md
@@ -140,7 +140,7 @@ dags                   include     plugins
 $ astro dev start
 Env file ".env" found. Loading...
 Sending build context to Docker daemon  11.26kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache
@@ -195,7 +195,7 @@ WARNING! You are about to push an image using the 'latest-onbuild' tag. This is 
 Please use one of the following tags: 1.10.7-alpine3.10-onbuild.
 Are you sure you want to continue? (y/n) y
 Sending build context to Docker daemon  11.26kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/enterprise/v0.15/02_develop/02_customize-image.md
+++ b/enterprise/v0.15/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild
 RUN ls
 ```
 

--- a/enterprise/v0.15/02_develop/02_customize-image.md
+++ b/enterprise/v0.15/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM astronomerinc/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
 RUN ls
 ```
 
@@ -264,7 +264,7 @@ If you haven't initialized an Airflow Project on Astronomer (by running `astro d
 If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, this would be:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
+FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
 For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/v0.15/customize-airflow/manage-airflow-versions/).
@@ -320,7 +320,7 @@ Run the following in your terminal:
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-<airflow-image> .
 ```
 
-If you have `astronomerinc/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
+If you have `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
 
 ```
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-ap-airflow:1.10.10-alpine3.10 .
@@ -334,7 +334,7 @@ Now that we've built your custom image, let's reference that custom image in you
 FROM custom-<airflow-image>
 ```
 
-If you're running `astronomerinc/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
+If you're running `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
 
 ```
 FROM custom-ap-airflow:1.10.10-alpine3.10

--- a/enterprise/v0.15/02_develop/04_cli-install-windows-10.md
+++ b/enterprise/v0.15/02_develop/04_cli-install-windows-10.md
@@ -123,7 +123,7 @@ As a Windows user, you might see the following error when trying to call `astro 
 
 ```
 Sending build context to Docker daemon  8.192kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/enterprise/v0.15/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.15/04_deploy/05_environment-variables.md
@@ -107,7 +107,7 @@ If you're working on an Airflow project locally but intend to deploy to Astronom
 To add Environment Variables, insert the value and key in your `Dockerfile` beginning with `ENV`, ensuring all-caps for all characters. With your Airflow image commonly referenced as a "FROM" statement at the top, your Dockerfile might look like this:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild
 
 ENV AIRFLOW__CORE__MAX_ACTIVE_RUNS_PER_DAG=1
 ENV AIRFLOW__CORE__DAG_CONCURRENCY=5

--- a/enterprise/v0.15/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.15/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  astronomerio/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-build:0.0.7
     steps:
       - checkout
       - setup_remote_docker:
@@ -281,7 +281,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: astronomerio/ap-build:0.0.7
+image: quay.io/astronomer/ap-build:0.0.7
 
 pipelines:
   branches:

--- a/enterprise/v0.15/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.15/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.10-buster
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.10-buster
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  quay.io/astronomer/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-airflow:1.10.10-buster
     steps:
       - checkout
       - setup_remote_docker:
@@ -281,7 +281,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: quay.io/astronomer/ap-build:0.0.7
+image: quay.io/astronomer/ap-airflow:1.10.10-buster
 
 pipelines:
   branches:

--- a/enterprise/v0.15/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.15/05_customize-airflow/01_manage-airflow-versions.md
@@ -49,13 +49,13 @@ Depending on the version of Airflow and OS distribution you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, Debian is often more appropriate.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|
-| [v1.10.5](https://github.com/apache/airflow/releases/tag/1.10.5)         | FROM astronomerinc/ap-airflow:1.10.5-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.5-buster-onbuild |
-| [v1.10.7](https://github.com/apache/airflow/releases/tag/1.10.7)         | FROM astronomerinc/ap-airflow:1.10.7-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild |
-| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.10-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.10-buster-onbuild |
+| [v1.10.5](https://github.com/apache/airflow/releases/tag/1.10.5)         | FROM quay.io/astronomer/ap-airflow:1.10.5-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.5-buster-onbuild |
+| [v1.10.7](https://github.com/apache/airflow/releases/tag/1.10.7)         | FROM quay.io/astronomer/ap-airflow:1.10.7-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild |
+| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild |
 
 > **Note:** Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
 

--- a/enterprise/v0.15/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.15/05_customize-airflow/01_manage-airflow-versions.md
@@ -49,7 +49,7 @@ Depending on the version of Airflow and OS distribution you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, Debian is often more appropriate.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/enterprise/v0.15/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.15/05_customize-airflow/01_manage-airflow-versions.md
@@ -49,7 +49,7 @@ Depending on the version of Airflow and OS distribution you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, Debian is often more appropriate.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/enterprise/v0.16/01_get-started/01_quickstart.md
+++ b/enterprise/v0.16/01_get-started/01_quickstart.md
@@ -140,7 +140,7 @@ dags                   include     plugins
 $ astro dev start
 Env file ".env" found. Loading...
 Sending build context to Docker daemon  11.26kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache
@@ -195,7 +195,7 @@ WARNING! You are about to push an image using the 'latest-onbuild' tag. This is 
 Please use one of the following tags: 1.10.7-alpine3.10-onbuild.
 Are you sure you want to continue? (y/n) y
 Sending build context to Docker daemon  11.26kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/enterprise/v0.16/02_develop/02_customize-image.md
+++ b/enterprise/v0.16/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM astronomerinc/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
 RUN ls
 ```
 
@@ -264,7 +264,7 @@ If you haven't initialized an Airflow Project on Astronomer (by running `astro d
 If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, this would be:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.10-alpine3.10 AS stage1
+FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10 AS stage1
 ```
 
 For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/).
@@ -320,7 +320,7 @@ Run the following in your terminal:
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-<airflow-image> .
 ```
 
-If you have `astronomerinc/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
+If you have `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
 
 ```
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-ap-airflow:1.10.10-alpine3.10 .
@@ -334,7 +334,7 @@ Now that we've built your custom image, let's reference that custom image in you
 FROM custom-<airflow-image>
 ```
 
-If you're running `astronomerinc/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
+If you're running `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
 
 ```
 FROM custom-ap-airflow:1.10.10-alpine3.10

--- a/enterprise/v0.16/02_develop/02_customize-image.md
+++ b/enterprise/v0.16/02_develop/02_customize-image.md
@@ -169,7 +169,7 @@ If you're interested in running any extra commands when your Airflow Image build
 For example, if you wanted to run `ls` when your image builds, your `Dockerfile` would look like this:
 
 ```
-FROM quay.io/astronomer/ap-airflow:0.8.2-1.10.3-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild
 RUN ls
 ```
 

--- a/enterprise/v0.16/02_develop/04_cli-install-windows-10.md
+++ b/enterprise/v0.16/02_develop/04_cli-install-windows-10.md
@@ -123,7 +123,7 @@ As a Windows user, you might see the following error when trying to call `astro 
 
 ```
 Sending build context to Docker daemon  8.192kB
-Step 1/1 : FROM astronomerinc/ap-airflow:latest-onbuild
+Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
 # Executing 5 build triggers
  ---> Using cache
  ---> Using cache

--- a/enterprise/v0.16/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.16/04_deploy/05_environment-variables.md
@@ -107,7 +107,7 @@ If you're working on an Airflow project locally but intend to deploy to Astronom
 To add Environment Variables, insert the value and key in your `Dockerfile` beginning with `ENV`, ensuring all-caps for all characters. With your Airflow image commonly referenced as a "FROM" statement at the top, your Dockerfile might look like this:
 
 ```
-FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild
 ENV AIRFLOW__CORE__MAX_ACTIVE_RUNS_PER_DAG=1
 ENV AIRFLOW__CORE__DAG_CONCURRENCY=5
 ENV AIRFLOW__CORE__PARALLELISM=25

--- a/enterprise/v0.16/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.16/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.12-buster
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: quay.io/astronomer/ap-build:0.0.7
+    image: quay.io/astronomer/ap-airflow:1.10.12-buster
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  quay.io/astronomer/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-airflow:1.10.12-buster
     steps:
       - checkout
       - setup_remote_docker:
@@ -280,7 +280,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: quay.io/astronomer/ap-build:0.0.7
+image: quay.io/astronomer/ap-airflow:1.10.12-buster
 
 pipelines:
   branches:

--- a/enterprise/v0.16/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.16/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: astronomerio/ap-build:0.0.7
+    image: quay.io/astronomer/ap-build:0.0.7
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  astronomerio/ap-build:0.0.7
+      - image:  quay.io/astronomer/ap-build:0.0.7
     steps:
       - checkout
       - setup_remote_docker:
@@ -280,7 +280,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: astronomerio/ap-build:0.0.7
+image: quay.io/astronomer/ap-build:0.0.7
 
 pipelines:
   branches:

--- a/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
@@ -46,14 +46,14 @@ Depending on the OS distribution and version of Airflow you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|
-| [v1.10.5](https://github.com/astronomer/ap-airflow/blob/master/1.10.5/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.5-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.5-buster-onbuild |
-| [v1.10.7](https://github.com/astronomer/ap-airflow/blob/master/1.10.7/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.7-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.7-buster-onbuild |
-| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.10-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.10-buster-onbuild |
-| [v1.10.12](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md)         | FROM astronomerinc/ap-airflow:1.10.12-alpine3.10-onbuild | FROM astronomerinc/ap-airflow:1.10.12-buster-onbuild |
+| [v1.10.5](https://github.com/astronomer/ap-airflow/blob/master/1.10.5/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.5-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.5-buster-onbuild |
+| [v1.10.7](https://github.com/astronomer/ap-airflow/blob/master/1.10.7/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.7-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild |
+| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild |
+| [v1.10.12](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md)         | FROM quay.io/astronomer/ap-airflow:1.10.12-alpine3.10-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild |
 
 To upgrade an Airflow Deployment to Astronomer Certified 1.10.12 you _must_ be running  [v0.16.9](https://www.astronomer.io/docs/enterprise/v0.16/resources/release-notes/)+ of the Astronomer Platform. For instructions on how to upgrade the platform, refer to ["Upgrade Astronomer"](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer/) or [reach out to us](https://support.astronomer.io).
 
@@ -127,7 +127,7 @@ If you're looking for the latest Astronomer Certified 1.10.10, for example, you 
 2. Identify the latest patch (e.g. `1.10.10-5`)
 3. Pin the Astronomer Certified Image in your Dockerfile to that patch version
 
-In this case, that would be: `FROM astronomerinc/ap-airflow:1.10.10-5-buster-onbuild` (Debian).
+In this case, that would be: `FROM quay.io/astronomer/ap-airflow:1.10.10-5-buster-onbuild` (Debian).
 
 > **Note:** If you're pushing code to an Airflow Deployment via the Astronomer CLI and install a new Astronomer Certified image for the first time _without_ pinning a specific patch, the latest version available will automatically be pulled.
 > 

--- a/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
@@ -50,11 +50,7 @@ Astronomer supports both [Alpine Linux](https://alpinelinux.org/) and [Debian](h
 
 For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
 
-<<<<<<< HEAD
 > **Note:** AC 1.10.12 will be the _last_ version to support an Alpine-based image. In an effort to standardize our offering and optimize for reliability, we'll exclusively build, test and support Debian-based images starting with AC 1.10.13. A guide for how to migrate from Alpine to Debian coming soon.
-=======
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
->>>>>>> ec488057bb28f5eacc77987809c66930ff7e9668
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
@@ -42,11 +42,15 @@ First, open the `Dockerfile` within your Astronomer directory. When you initiali
 
 Depending on the OS distribution and version of Airflow you want to run, you'll want to reference the corresponding Astronomer Certified image in the FROM statement of your Dockerfile.
 
+> **Note:** Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow Metadata Database structurally changes with each release, making for backwards incompatibility across versions.
+
 #### Alpine and Debian-based Images
 
-Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
+Astronomer supports both [Alpine Linux](https://alpinelinux.org/) and [Debian](https://www.debian.org/)-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/astronomer/ap-airflow/tags).
+For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
+
+> **Note:** AC 1.10.12 will be the _last_ version to support an Alpine-based image. In an effort to standardize our offering and optimize for reliability, we'll exclusively build, test and support Debian-based images starting with AC 1.10.13. A guide for how to migrate from Alpine to Debian coming soon.
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|
@@ -57,7 +61,7 @@ Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widel
 
 To upgrade an Airflow Deployment to Astronomer Certified 1.10.12 you _must_ be running  [v0.16.9](https://www.astronomer.io/docs/enterprise/v0.16/resources/release-notes/)+ of the Astronomer Platform. For instructions on how to upgrade the platform, refer to ["Upgrade Astronomer"](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer/) or [reach out to us](https://support.astronomer.io).
 
-> **Note:** Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
+> **Note:** We recently migrated from [DockerHub](https://hub.docker.com/r/astronomerinc/ap-airflow) to Quay.io as our Docker Registry due to a [recent change]((https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/)) in DockerHub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer or otherwise pull a Platform  Docker Image (e.g. `toomanyrequests: You have reached your pull rate limit`).
 
 ### 3. Re-Build your Image
 

--- a/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
@@ -46,7 +46,7 @@ Depending on the OS distribution and version of Airflow you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
@@ -46,7 +46,7 @@ Depending on the OS distribution and version of Airflow you want to run, you'll 
 
 Astronomer supports both Alpine Linux and Debian-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
 
-> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Docker Hub](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
+> **Note:** For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://hub.docker.com/r/quay.io/astronomer/ap-airflow/tags).
 
 | Airflow Version | Alpine-based Image                          | Debian-based Image
 |-----------------|-----------------------------------------------------|-----------------------------------------------------|


### PR DESCRIPTION
Astronomer recently migrated Docker images hosted in DockerHub to Quay in light of Docker's new rate-limit policy:  https://docs.docker.com/docker-hub/download-rate-limit/ 

Given that change, we need to update our docs to:
- [x] Reflect change from DockerHub to Quay as our primary Docker Registry
- [x] Replace all Docker Images to Quay from `astronomerinc` (e.g. `astronomerinc/ap-airflow` > `quay.io/astronomer/ap-airflow`)