### PR TITLE
Fix HA postgresql example in AKS guide

### DIFF
--- a/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
@@ -222,14 +222,12 @@ global:
   postgresqlEnabled: true # Keep True if deploying a database on your AKS cluster.
 
 # Settings for database deployed on AKS cluster.
-  postgresql:
-    replication:
-      enabled: true
-      slaveReplicas: 2
-      synchronousCommit: on
-      numSynchronousReplicas: 1
-    metrics:
-      enabled: true
+postgresql:
+  replication:
+    enabled: true
+    slaveReplicas: 2
+    synchronousCommit: "on"
+    numSynchronousReplicas: 1
 
 #################################
 ### Nginx configuration


### PR DESCRIPTION
Fixed the following in HA postgresql example:
- Indentation
- `synchronousCommit` value needed quotes
- Removed metrics as it required additional values to be set