### PR TITLE
Remove support for K8s 1.14 + 1.15 from Enterprise in Docs

### DIFF
--- a/enterprise/next/09_resources/02_version-compatibility-reference.md
+++ b/enterprise/next/09_resources/02_version-compatibility-reference.md
@@ -12,10 +12,10 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Enterprise
 
-| Astronomer Platform  | Kubernetes             | Helm | Terraform | Postgres | Astronomer Certified                             | Python        |
-|----------------------|------------------------|------|-----------|----------|--------------------------------------------------|---------------|
-| v0.16                | 1.14, 1.15, 1.16, 1.17 | 3    | 0.12      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.13        | 3.6, 3.7, 3.8 |
-| v0.22 (*Coming Soon*)| 1.15, 1.16, 1.17       | 3    | 0.12      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.13, 2.0.0 | 3.6, 3.7, 3.8 |
+| Astronomer Platform  | Kubernetes        | Helm | Terraform | Postgres | Astronomer Certified                             | Python       |
+|----------------------|------------------|------|-----------|----------|--------------------------------------------------|---------------|
+| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 |
+| v0.23 (*Coming Soon*)| 1.16, 1.17, 1.18 | 3    | 0.12      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 |
 
 > **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12. For instructions on how to upgrade to the latest version of Astronomer, refer to our ["Enterprise Upgrade Guide"](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer/).
 
@@ -27,7 +27,7 @@ It's worth noting that while the tables below reference the minimum compatible v
 | 1.10.7                  | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
 | 1.10.10                 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
 | 1.10.12                 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.13 (*Coming Soon*) | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
+| 1.10.14 (*Coming Soon*) | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
 | 2.0.0 (*Coming Soon*)   | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/).

--- a/enterprise/v0.16/09_resources/02_version-compatibility-reference.md
+++ b/enterprise/v0.16/09_resources/02_version-compatibility-reference.md
@@ -12,10 +12,10 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Enterprise
 
-| Astronomer Platform  | Kubernetes             | Helm | Terraform | Postgres | Astronomer Certified                             | Python        |
-|----------------------|------------------------|------|-----------|----------|--------------------------------------------------|---------------|
-| v0.16                | 1.14, 1.15, 1.16, 1.17 | 3    | 0.12      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.13        | 3.6, 3.7, 3.8 |
-| v0.22 (*Coming Soon*)| 1.15, 1.16, 1.17       | 3    | 0.12      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.13, 2.0.0 | 3.6, 3.7, 3.8 |
+| Astronomer Platform  | Kubernetes        | Helm | Terraform | Postgres | Astronomer Certified                             | Python       |
+|----------------------|------------------|------|-----------|----------|--------------------------------------------------|---------------|
+| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 |
+| v0.23 (*Coming Soon*)| 1.16, 1.17, 1.18 | 3    | 0.12      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 |
 
 > **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12. For instructions on how to upgrade to the latest version of Astronomer, refer to our ["Enterprise Upgrade Guide"](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer/).
 
@@ -27,7 +27,7 @@ It's worth noting that while the tables below reference the minimum compatible v
 | 1.10.7                  | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
 | 1.10.10                 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
 | 1.10.12                 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.13 (*Coming Soon*) | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
+| 1.10.14 (*Coming Soon*) | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
 | 2.0.0 (*Coming Soon*)   | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/).


### PR DESCRIPTION
Capturing the changes we just discussed in Slack [here](https://astronomerteam.slack.com/archives/CJTN7S938/p1606843331142800).

TL;DR:

- Remove support for K8s 1.14 + 1.15 from 0.16.x
- Add support for K8s 1.18 to both 0.16.x + 0.23

Now, we officially only support 1.16, 1.17 and 1.18 across 0.16 + 0.23 (coming soon).