### PR TITLE
Replaced every instance of 'open-source' with 'open source'

### DIFF
--- a/ac/README.md
+++ b/ac/README.md
@@ -4,4 +4,4 @@ navTitle: "Astronomer Certified Overview"
 description: "An overview of Astronomer Certified."
 ---
 
-Astronomer Certifed is a distribution of Apache Airflow ready for enterprise scale. It is completely feature-parallel to the open-source project, but with each release, the Astronomer team puts the distribution through a series of rigorous security scans, end-to-end manual QA, and proprietary automated unit and system tests. It is currently used by hundreds of Airflow users in production.
+Astronomer Certifed is a distribution of Apache Airflow ready for enterprise scale. It is completely feature-parallel to the open source project, but with each release, the Astronomer team puts the distribution through a series of rigorous security scans, end-to-end manual QA, and proprietary automated unit and system tests. It is currently used by hundreds of Airflow users in production.

--- a/ac/next/01_local.md
+++ b/ac/next/01_local.md
@@ -31,7 +31,7 @@ Once you have the pre-reqs installed, follow the below instructions to get the A
 
 ### Via Docker
 
-The preferred way to install Astronomer Astronomer Certified is to download our latest Astronomer-hosted Docker image, each of which will generally correspond with an open-source Airflow release.
+The preferred way to install Astronomer Astronomer Certified is to download our latest Astronomer-hosted Docker image, each of which will generally correspond with an open source Airflow release.
 
 For Astronomer's full collection of Docker Images, reference our public [Quay.io repository](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
 
@@ -126,7 +126,7 @@ By default, the above will run Airflow on your machine using the Local Executor.
 
 ### Via Python Wheel
 
-We also distribute Astronomer Certified as a python wheel available on PyPi. This distribution can be run locally via the same mechanisms used to run the open-source Airflow package.
+We also distribute Astronomer Certified as a python wheel available on PyPi. This distribution can be run locally via the same mechanisms used to run the open source Airflow package.
 
 1. Run `export AIRFLOW_HOME=~/airflow` to give Astronomer Certified Airflow a home root directory on your machine.
 2. Run the following command to get the latest version of the distribution on your machine:

--- a/ac/v1.10.10/01_get-started/01_local.md
+++ b/ac/v1.10.10/01_get-started/01_local.md
@@ -31,7 +31,7 @@ Once you have the pre-reqs installed, follow the below instructions to get the A
 
 ### Via Docker
 
-The preferred way to install Astronomer Astronomer Certified is to download our latest Astronomer-hosted Docker image, each of which will generally correspond with an open-source Airflow release.
+The preferred way to install Astronomer Astronomer Certified is to download our latest Astronomer-hosted Docker image, each of which will generally correspond with an open source Airflow release.
 
 For Astronomer's full collection of Docker Images, reference our public [Quay.io repository](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
 
@@ -128,7 +128,7 @@ By default, the above will run Airflow on your machine using the Local Executor.
 
 ### Via Python Wheel
 
-We also distribute Astronomer Certified as a python wheel available on PyPi. This distribution can be run locally via the same mechanisms used to run the open-source Airflow package.
+We also distribute Astronomer Certified as a python wheel available on PyPi. This distribution can be run locally via the same mechanisms used to run the open source Airflow package.
 
 1. Run `export AIRFLOW_HOME=~/airflow` to give Astronomer Certified Airflow a home root directory on your machine.
 2. Run the following command to get the latest version of the distribution on your machine:

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -6,7 +6,7 @@ description: "An overview of Astronomer Cloud."
 
 ## Overview
 
-Astronomer Cloud is the easiest way for any organization to adopt [Apache Airflow](https://airflow.apache.org/), an open-source tool designed to programmatically author, schedule and monitor data workflows.
+Astronomer Cloud is the easiest way for any organization to adopt [Apache Airflow](https://airflow.apache.org/), an open source tool designed to programmatically author, schedule and monitor data workflows.
 
 Astronomer Cloud runs on a Kubernetes cluster hosted and managed by the Astronomer team. Our managed offering abstracts the everyday data engineer from the infrastructure management layer otherwise required to adopt, maintain and grow with Airflow.
 

--- a/cloud/stable/01_get-started/01_quickstart.md
+++ b/cloud/stable/01_get-started/01_quickstart.md
@@ -40,7 +40,7 @@ If you're new to Astronomer but someone else on your team has an existing Worksp
 
 ## Start with the Astronomer CLI
 
-Astronomer's [open-source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
+Astronomer's [open source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
 
 From the CLI, you can establish a local testing environment and deploy to Astronomer Cloud whenever you're ready.
 

--- a/cloud/stable/02_develop/01_cli-quickstart.md
+++ b/cloud/stable/02_develop/01_cli-quickstart.md
@@ -6,7 +6,7 @@ description: "Establish a local testing environment and deploy to Astronomer fro
 
 ## Overview
 
-Astronomer's [open-source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
+Astronomer's [open source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
 
 From the CLI, both Astronomer and non-Astronomer users can provision a local Apache Airflow instance with a dedicated Webserver, Scheduler and Postgres Database. Once you initialize a project on Astronomer, you can easily customize your image (e.g. add Python or OS-level packages, plugins etc.) and push that image to run on your local machine.
 

--- a/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/01_manage-airflow-versions.md
@@ -8,7 +8,7 @@ description: "How to adjust and upgrade Airflow versions on Astronomer."
 
 On Astronomer, the process of pushing up your code to an individual Airflow Deployment involves customizing a locally built Docker image —— with your DAG code, Python Packages, plugins, and so on —— that's then bundled, tagged, and pushed to Astronomer Cloud's Docker Registry.
 
-Included in that build is your `Dockerfile`, a file that is automatically generated when you initialize an Airflow project on Astronomer via our CLI. Every successful build on Astronomer must include a `Dockerfile` that references an Astronomer Certified Docker Image. Astronomer Certified (AC) is a production-ready distribution of Apache Airflow that mirrors the open-source project and undergoes additional levels of rigorous testing conducted by our team.
+Included in that build is your `Dockerfile`, a file that is automatically generated when you initialize an Airflow project on Astronomer via our CLI. Every successful build on Astronomer must include a `Dockerfile` that references an Astronomer Certified Docker Image. Astronomer Certified (AC) is a production-ready distribution of Apache Airflow that mirrors the open source project and undergoes additional levels of rigorous testing conducted by our team.
 
 To upgrade your Airflow Deployment to a higher version of Airflow, there are three steps:
 
@@ -210,7 +210,7 @@ If you're on Astronomer Cloud, navigate to your Airflow Deployment via Astronome
 
 ### Patch Versions of Astronomer Certified
 
-In addition to supporting the latest versions of open-source Airflow on Astronomer Certified (AC), our team regularly ships bug and security fixes to AC images as _patch_ releases.
+In addition to supporting the latest versions of open source Airflow on Astronomer Certified (AC), our team regularly ships bug and security fixes to AC images as _patch_ releases.
 
 For example, Astronomer Certified 1.10.10 has been enhanced with 4 additional patches since its initial release: 
 
@@ -218,7 +218,7 @@ For example, Astronomer Certified 1.10.10 has been enhanced with 4 additional pa
 - 1.10.10-3
 - 1.10.10-4 etc.
 
-All generally available patch releases are listed in a corresponding changelog, which specifies the date the patch was released and all individual changes made to it. Bugs that are reported by the wider Airflow community are often backported by our team and made available prior to the subsequent open-source release.
+All generally available patch releases are listed in a corresponding changelog, which specifies the date the patch was released and all individual changes made to it. Bugs that are reported by the wider Airflow community are often backported by our team and made available prior to the subsequent open source release.
 
 #### Upgrade to an Astronomer Certified Patch Version
 

--- a/cloud/stable/05_manage-astronomer/02_houston-api.md
+++ b/cloud/stable/05_manage-astronomer/02_houston-api.md
@@ -22,7 +22,7 @@ Anything you can do via the Astronomer UI, you can do programmatically via Astro
 
 ## Getting Started
 
-Astronomer's Houston API is made available via a [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/), "a graphical, interative, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphiQL." [GraphQL](https://graphql.org/) itself is an open-source query language for APIs that makes for an easy and simple way to manage data.
+Astronomer's Houston API is made available via a [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/), "a graphical, interative, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphiQL." [GraphQL](https://graphql.org/) itself is an open source query language for APIs that makes for an easy and simple way to manage data.
 
 In short, the Playground is a portal that allows you to write GraphQL queries directly against the API within your browser.
 

--- a/cloud/stable/06_resources/01_release-notes.md
+++ b/cloud/stable/06_resources/01_release-notes.md
@@ -236,7 +236,7 @@ This has been resolved in 0.17.
 
 As reported [here](https://forum.astronomer.io/t/error-http-do-failed-i-o-timeout/706/2) and [here](https://forum.astronomer.io/t/local-airflow-instance-using-astro-cli-on-linux/711/6), v0.16.1 of the Astronomer CLI introduced a bug that blocked users from running `$ astro dev init` and `$ astro version` commands if not authenticated to Astronomer.
 
-The Astronomer CLI is open-source and open to _all_ developers looking to run Apache Airflow locally, so we've made sure to patch this up in v0.17 and will backport changes to 0.16.2 of the CLI.
+The Astronomer CLI is open source and open to _all_ developers looking to run Apache Airflow locally, so we've made sure to patch this up in v0.17 and will backport changes to 0.16.2 of the CLI.
 
 #### Bug Fixes & Improvements
 

--- a/enterprise/next/02_develop/01_cli-quickstart.md
+++ b/enterprise/next/02_develop/01_cli-quickstart.md
@@ -6,7 +6,7 @@ description: "Establish a local testing environment and deploy to Astronomer fro
 
 ## Overview
 
-Astronomer's [open-source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
+Astronomer's [open source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
 
 From the CLI, both Astronomer and non-Astronomer users can provision a local Apache Airflow instance with a dedicated Webserver, Scheduler and Postgres Database. Once you initialize a project on Astronomer, you can easily customize your image (e.g. add Python or OS-level packages, plugins etc.) and push that image to run on your local machine.
 

--- a/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/next/05_customize-airflow/01_manage-airflow-versions.md
@@ -107,7 +107,7 @@ If you're on Astronomer Enterprise, navigate to your Airflow Deployment page on 
 
 ### Patch Versions of Astronomer Certified
 
-In addition to supporting the latest versions of open-source Airflow on Astronomer Certified (AC), our team regularly ships bug and security fixes to AC images as _patch_ releases.
+In addition to supporting the latest versions of open source Airflow on Astronomer Certified (AC), our team regularly ships bug and security fixes to AC images as _patch_ releases.
 
 For example, Astronomer Certified 1.10.10 has been enhanced with 4 additional patches since its initial release:
 
@@ -116,7 +116,7 @@ For example, Astronomer Certified 1.10.10 has been enhanced with 4 additional pa
 - 1.10.10-4
 - 1.10.10-5
 
-All generally available patch releases are listed in a corresponding changelog, which specifies the date the patch was released and all individual changes made to it. Bugs that are reported by the wider Airflow community are often backported by our team and made available prior to the subsequent open-source release.
+All generally available patch releases are listed in a corresponding changelog, which specifies the date the patch was released and all individual changes made to it. Bugs that are reported by the wider Airflow community are often backported by our team and made available prior to the subsequent open source release.
 
 > **Note:** Not all versions of the Astronomer Platform support all versions of Astronomer Certified. If you're not running the latest version of Astronomer and want to upgrade to the latest AC patch, [reach out to us](https://support.astronomer.io).
 

--- a/enterprise/next/06_manage-astronomer/04_houston-api.md
+++ b/enterprise/next/06_manage-astronomer/04_houston-api.md
@@ -24,7 +24,7 @@ Anything you can do via the Astronomer UI, you can do programmatically via Astro
 
 ## Getting Started
 
-Astronomer's Houston API is made available via a [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/), "a graphical, interative, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphiQL." [GraphQL](https://graphql.org/) itself is an open-source query language for APIs that makes for an easy and simple way to manage data.
+Astronomer's Houston API is made available via a [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/), "a graphical, interative, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphiQL." [GraphQL](https://graphql.org/) itself is an open source query language for APIs that makes for an easy and simple way to manage data.
 
 In short, the Playground is a portal that allows you to write GraphQL queries directly against the API within your browser.
 

--- a/enterprise/next/09_resources/01_release-notes.md
+++ b/enterprise/next/09_resources/01_release-notes.md
@@ -244,7 +244,7 @@ Release Date: June 8, 2020
 
 #### Support for Airflow 1.10.10
 
-As of v0.15, Astronomer users are free to run our [Astronomer Certified (AC) 1.10.10 image](/downloads/ac/v1-10-10/), which is based on the [Airflow 1.10.10](https://airflow.apache.org/blog/airflow-1.10.10/) open-source version released in early April.
+As of v0.15, Astronomer users are free to run our [Astronomer Certified (AC) 1.10.10 image](/downloads/ac/v1-10-10/), which is based on the [Airflow 1.10.10](https://airflow.apache.org/blog/airflow-1.10.10/) open source version released in early April.
 
 Airflow 1.10.10 notably includes the ability to choose a timezone in the Airflow UI, DAG Serialization functionality for improved Webserver performance, and the [ability to sync Airflow Connections and Variables](https://forum.astronomer.io/t/aws-parameter-store-as-secrets-backend-airflow-1-10-10/606) with a Secret Backend tool (e.g. AWS Secret Manager, Hashicorp Vault, etc.)
 

--- a/enterprise/v0.12/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.12/02_develop/01_cli-quickstart.md
@@ -6,7 +6,7 @@ description: "Establish a local testing environment and deploy to Astronomer fro
 
 ## Overview
 
-Astronomer's [open-source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
+Astronomer's [open source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
 
 From the CLI, both Astronomer and non-Astronomer users can provision a local Apache Airflow instance with a dedicated Webserver, Scheduler and Postgres Database. Once you initialize a project on Astronomer, you can easily customize your image (e.g. add Python or OS-level packages, plugins etc.) and push that image to run on your local machine.
 

--- a/enterprise/v0.12/06_manage-astronomer/04_houston-api.md
+++ b/enterprise/v0.12/06_manage-astronomer/04_houston-api.md
@@ -24,7 +24,7 @@ Anything you can do via the Astronomer UI, you can do programmatically via Astro
 
 ## Getting Started
 
-Astronomer's Houston API is made available via a [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/), "a graphical, interative, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphiQL." [GraphQL](https://graphql.org/) itself is an open-source query language for APIs that makes for an easy and simple way to manage data.
+Astronomer's Houston API is made available via a [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/), "a graphical, interative, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphiQL." [GraphQL](https://graphql.org/) itself is an open source query language for APIs that makes for an easy and simple way to manage data.
 
 In short, the Playground is a portal that allows you to write GraphQL queries directly against the API within your browser.
 

--- a/enterprise/v0.12/09_resources/01_release-notes.md
+++ b/enterprise/v0.12/09_resources/01_release-notes.md
@@ -48,7 +48,7 @@ Release Date: June 8, 2020
 
 ### Support for Airflow 1.10.10
 
-As of v0.15, Astronomer users are free to run our [Astronomer Certified (AC) 1.10.10 image](/downloads/ac/v1-10-10/), which is based on the [Airflow 1.10.10](https://airflow.apache.org/blog/airflow-1.10.10/) open-source version released in early April.
+As of v0.15, Astronomer users are free to run our [Astronomer Certified (AC) 1.10.10 image](/downloads/ac/v1-10-10/), which is based on the [Airflow 1.10.10](https://airflow.apache.org/blog/airflow-1.10.10/) open source version released in early April.
 
 Airflow 1.10.10 notably includes the ability to choose a timezone in the Airflow UI, DAG Serialization functionality for improved Webserver performance, and the [ability to sync Airflow Connections and Variables](https://forum.astronomer.io/t/aws-parameter-store-as-secrets-backend-airflow-1-10-10/606) with a Secret Backend tool (e.g. AWS Secret Manager, Hashicorp Vault, etc.)
 

--- a/enterprise/v0.13/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.13/02_develop/01_cli-quickstart.md
@@ -6,7 +6,7 @@ description: "Establish a local testing environment and deploy to Astronomer fro
 
 ## Overview
 
-Astronomer's [open-source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
+Astronomer's [open source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
 
 From the CLI, both Astronomer and non-Astronomer users can provision a local Apache Airflow instance with a dedicated Webserver, Scheduler and Postgres Database. Once you initialize a project on Astronomer, you can easily customize your image (e.g. add Python or OS-level packages, plugins etc.) and push that image to run on your local machine.
 

--- a/enterprise/v0.13/06_manage-astronomer/04_houston-api.md
+++ b/enterprise/v0.13/06_manage-astronomer/04_houston-api.md
@@ -24,7 +24,7 @@ Anything you can do via the Astronomer UI, you can do programmatically via Astro
 
 ## Getting Started
 
-Astronomer's Houston API is made available via a [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/), "a graphical, interative, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphiQL." [GraphQL](https://graphql.org/) itself is an open-source query language for APIs that makes for an easy and simple way to manage data.
+Astronomer's Houston API is made available via a [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/), "a graphical, interative, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphiQL." [GraphQL](https://graphql.org/) itself is an open source query language for APIs that makes for an easy and simple way to manage data.
 
 In short, the Playground is a portal that allows you to write GraphQL queries directly against the API within your browser.
 

--- a/enterprise/v0.13/09_resources/01_release-notes.md
+++ b/enterprise/v0.13/09_resources/01_release-notes.md
@@ -48,7 +48,7 @@ Release Date: June 8, 2020
 
 ### Support for Airflow 1.10.10
 
-As of v0.15, Astronomer users are free to run our [Astronomer Certified (AC) 1.10.10 image](/downloads/ac/v1-10-10/), which is based on the [Airflow 1.10.10](https://airflow.apache.org/blog/airflow-1.10.10/) open-source version released in early April.
+As of v0.15, Astronomer users are free to run our [Astronomer Certified (AC) 1.10.10 image](/downloads/ac/v1-10-10/), which is based on the [Airflow 1.10.10](https://airflow.apache.org/blog/airflow-1.10.10/) open source version released in early April.
 
 Airflow 1.10.10 notably includes the ability to choose a timezone in the Airflow UI, DAG Serialization functionality for improved Webserver performance, and the [ability to sync Airflow Connections and Variables](https://forum.astronomer.io/t/aws-parameter-store-as-secrets-backend-airflow-1-10-10/606) with a Secret Backend tool (e.g. AWS Secret Manager, Hashicorp Vault, etc.)
 

--- a/enterprise/v0.15/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.15/02_develop/01_cli-quickstart.md
@@ -6,7 +6,7 @@ description: "Establish a local testing environment and deploy to Astronomer fro
 
 ## Overview
 
-Astronomer's [open-source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
+Astronomer's [open source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
 
 From the CLI, both Astronomer and non-Astronomer users can provision a local Apache Airflow instance with a dedicated Webserver, Scheduler and Postgres Database. Once you initialize a project on Astronomer, you can easily customize your image (e.g. add Python or OS-level packages, plugins etc.) and push that image to run on your local machine.
 

--- a/enterprise/v0.15/06_manage-astronomer/04_houston-api.md
+++ b/enterprise/v0.15/06_manage-astronomer/04_houston-api.md
@@ -24,7 +24,7 @@ Anything you can do via the Astronomer UI, you can do programmatically via Astro
 
 ## Getting Started
 
-Astronomer's Houston API is made available via a [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/), "a graphical, interative, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphiQL." [GraphQL](https://graphql.org/) itself is an open-source query language for APIs that makes for an easy and simple way to manage data.
+Astronomer's Houston API is made available via a [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/), "a graphical, interative, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphiQL." [GraphQL](https://graphql.org/) itself is an open source query language for APIs that makes for an easy and simple way to manage data.
 
 In short, the Playground is a portal that allows you to write GraphQL queries directly against the API within your browser.
 

--- a/enterprise/v0.15/09_resources/01_release-notes.md
+++ b/enterprise/v0.15/09_resources/01_release-notes.md
@@ -48,7 +48,7 @@ Release Date: June 8, 2020
 
 ### Support for Airflow 1.10.10
 
-As of v0.15, Astronomer users are free to run our [Astronomer Certified (AC) 1.10.10 image](/downloads/ac/v1-10-10/), which is based on the [Airflow 1.10.10](https://airflow.apache.org/blog/airflow-1.10.10/) open-source version released in early April.
+As of v0.15, Astronomer users are free to run our [Astronomer Certified (AC) 1.10.10 image](/downloads/ac/v1-10-10/), which is based on the [Airflow 1.10.10](https://airflow.apache.org/blog/airflow-1.10.10/) open source version released in early April.
 
 Airflow 1.10.10 notably includes the ability to choose a timezone in the Airflow UI, DAG Serialization functionality for improved Webserver performance, and the [ability to sync Airflow Connections and Variables](https://forum.astronomer.io/t/aws-parameter-store-as-secrets-backend-airflow-1-10-10/606) with a Secret Backend tool (e.g. AWS Secret Manager, Hashicorp Vault, etc.)
 

--- a/enterprise/v0.16/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.16/02_develop/01_cli-quickstart.md
@@ -6,7 +6,7 @@ description: "Establish a local testing environment and deploy to Astronomer fro
 
 ## Overview
 
-Astronomer's [open-source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
+Astronomer's [open source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
 
 From the CLI, both Astronomer and non-Astronomer users can provision a local Apache Airflow instance with a dedicated Webserver, Scheduler and Postgres Database. Once you initialize a project on Astronomer, you can easily customize your image (e.g. add Python or OS-level packages, plugins etc.) and push that image to run on your local machine.
 

--- a/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.16/05_customize-airflow/01_manage-airflow-versions.md
@@ -108,7 +108,7 @@ If you're on Astronomer Enterprise, navigate to your Airflow Deployment page on 
 
 ### Patch Versions of Astronomer Certified
 
-In addition to supporting the latest versions of open-source Airflow on Astronomer Certified (AC), our team regularly ships bug and security fixes to AC images as _patch_ releases.
+In addition to supporting the latest versions of open source Airflow on Astronomer Certified (AC), our team regularly ships bug and security fixes to AC images as _patch_ releases.
 
 For example, Astronomer Certified 1.10.10 has been enhanced with 4 additional patches since its initial release:
 
@@ -117,7 +117,7 @@ For example, Astronomer Certified 1.10.10 has been enhanced with 4 additional pa
 - 1.10.10-4
 - 1.10.10-5
 
-All generally available patch releases are listed in a corresponding changelog, which specifies the date the patch was released and all individual changes made to it. Bugs that are reported by the wider Airflow community are often backported by our team and made available prior to the subsequent open-source release.
+All generally available patch releases are listed in a corresponding changelog, which specifies the date the patch was released and all individual changes made to it. Bugs that are reported by the wider Airflow community are often backported by our team and made available prior to the subsequent open source release.
 
 > **Note:** Not all versions of the Astronomer Platform support all versions of Astronomer Certified. If you're not running the latest version of Astronomer and want to upgrade to the latest AC patch, [reach out to us](https://support.astronomer.io).
 

--- a/enterprise/v0.16/06_manage-astronomer/04_houston-api.md
+++ b/enterprise/v0.16/06_manage-astronomer/04_houston-api.md
@@ -24,7 +24,7 @@ Anything you can do via the Astronomer UI, you can do programmatically via Astro
 
 ## Getting Started
 
-Astronomer's Houston API is made available via a [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/), "a graphical, interative, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphiQL." [GraphQL](https://graphql.org/) itself is an open-source query language for APIs that makes for an easy and simple way to manage data.
+Astronomer's Houston API is made available via a [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/), "a graphical, interative, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphiQL." [GraphQL](https://graphql.org/) itself is an open source query language for APIs that makes for an easy and simple way to manage data.
 
 In short, the Playground is a portal that allows you to write GraphQL queries directly against the API within your browser.
 

--- a/enterprise/v0.16/09_resources/01_release-notes.md
+++ b/enterprise/v0.16/09_resources/01_release-notes.md
@@ -244,7 +244,7 @@ Release Date: June 8, 2020
 
 #### Support for Airflow 1.10.10
 
-As of v0.15, Astronomer users are free to run our [Astronomer Certified (AC) 1.10.10 image](/downloads/ac/v1-10-10/), which is based on the [Airflow 1.10.10](https://airflow.apache.org/blog/airflow-1.10.10/) open-source version released in early April.
+As of v0.15, Astronomer users are free to run our [Astronomer Certified (AC) 1.10.10 image](/downloads/ac/v1-10-10/), which is based on the [Airflow 1.10.10](https://airflow.apache.org/blog/airflow-1.10.10/) open source version released in early April.
 
 Airflow 1.10.10 notably includes the ability to choose a timezone in the Airflow UI, DAG Serialization functionality for improved Webserver performance, and the [ability to sync Airflow Connections and Variables](https://forum.astronomer.io/t/aws-parameter-store-as-secrets-backend-airflow-1-10-10/606) with a Secret Backend tool (e.g. AWS Secret Manager, Hashicorp Vault, etc.)
 


### PR DESCRIPTION
Closes https://github.com/astronomer/issues/issues/2296. Per discussion on Slack, agreement was reached that it's OK to refrain from hyphenation across all uses of open source. This is both how it's done in IBM's developer style guide, the AP style guide, and Google's open source documents. 