### PR TITLE
Issue template creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -36,6 +36,6 @@ _What is the purpose of the document? Select all that apply:_
   
 #### _Describe your suggestion for the change. In addition, include links to any relevant existing documentation, support tickets, messages, or external content:_
   
-### Context
-Add any context about the problem here.
+### Other Context
+Add any additional context about the problem here.
 

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -30,7 +30,7 @@ _What is the purpose of the document? Select all that apply:_
 #### _Link to affected document:_
   
 #### _How severe is the problem?_
-- [ ] Important to fix: The document has incorrect or missing information that is preventing customers from being successful (Add the `error/itf` label to this issue).
+- [ ] Critical: The document has incorrect or missing information that is preventing customers from being successful (Add the `error/itf` label to this issue).
 - [ ] Useful: The document could benefit from a change, but there's nothing that's currently preventing customers from being successful without it (Add the `error/useful` label to this issue).
 - [ ] Typo: There's a noticeable grammar, spelling, or formatting issue in a document (Add the `error/typo` label to this issue). 
   
@@ -38,4 +38,3 @@ _What is the purpose of the document? Select all that apply:_
   
 ### Other Context
 Add any additional context about the problem here.
-

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,41 @@
+---
+name: Documentation Request
+about: An issue specific to documentation needed
+title: ''
+labels:
+assignees: ''
+
+---
+
+**What kind of documentation change are you requesting?**
+
+* **New document, topic, or other piece of content**: Add the `docs/newcontent` label to this issue. 
+* **Fix to an existing document**: See below for what labels to add
+
+**For new documents, answer the following questions**
+
+_What is the purpose of the document? Select all that apply:_
+- [ ] Setup steps a new feature for an upcoming release (Add the appropriate version label to this issue). 
+- [ ] Information for an existing feature that isn't yet documented.
+- [ ] Additional considerations/ reference material for an existing feature or document.
+
+_Describe the problem that requires documentation:_
+
+
+_Describe the documentation request, making sure to outline what users should be able to achieve with the doc. In addition, include links to any relevant existing documentation, support tickets, messages, or external content:_
+
+_Are you the right person to review a draft of the document for technical accuracy? If not, who is?_
+
+**For fixes, answer the following questions:**
+
+_How severe is the problem?_
+- [ ] Important to fix: The document has incorrect or missing information that is preventing customers from being successful (Add the `docs/error/itf` label to this issue).
+- [ ] Useful: The document could benefit from a change, but there's nothing that's currently preventing customers from being successful without it (Add the `docs/error/useful` label to this issue).
+- [ ] Typo: There's a noticeable grammar, spelling, or formatting issue in a document (Add the `docs/error/typo` label to this issue). 
+
+_Link to affected document:_
+
+_Describe your suggestion for the change. In addition, include links to any relevant existing documentation, support tickets, messages, or external content:_
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -9,7 +9,7 @@ assignees: ''
 
 **What kind of documentation change are you requesting?**
 
-* **New document, topic, or other piece of content**: Add the `docs/newcontent` label to this issue. 
+* **New document, topic, or other piece of content**: Add the `newcontent` label to this issue. 
 * **Fix to an existing document**: See below for what labels to add
 
 **For new documents, answer the following questions**
@@ -29,9 +29,9 @@ _Are you the right person to review a draft of the document for technical accura
 **For fixes, answer the following questions:**
 
 _How severe is the problem?_
-- [ ] Important to fix: The document has incorrect or missing information that is preventing customers from being successful (Add the `docs/error/itf` label to this issue).
-- [ ] Useful: The document could benefit from a change, but there's nothing that's currently preventing customers from being successful without it (Add the `docs/error/useful` label to this issue).
-- [ ] Typo: There's a noticeable grammar, spelling, or formatting issue in a document (Add the `docs/error/typo` label to this issue). 
+- [ ] Important to fix: The document has incorrect or missing information that is preventing customers from being successful (Add the `error/itf` label to this issue).
+- [ ] Useful: The document could benefit from a change, but there's nothing that's currently preventing customers from being successful without it (Add the `error/useful` label to this issue).
+- [ ] Typo: There's a noticeable grammar, spelling, or formatting issue in a document (Add the `error/typo` label to this issue). 
 
 _Link to affected document:_
 

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -7,35 +7,35 @@ assignees: ''
 
 ---
 
-**What kind of documentation change are you requesting?**
+## What kind of documentation change are you requesting?
 
 * **New document, topic, or other piece of content**: Add the `newcontent` label to this issue. 
 * **Fix to an existing document**: See below for what labels to add
-
-**For new documents, answer the following questions**
+  
+### For new documents, answer the following questions**
 
 _What is the purpose of the document? Select all that apply:_
 - [ ] Setup steps a new feature for an upcoming release (Add the appropriate version label to this issue). 
 - [ ] Information for an existing feature that isn't yet documented.
 - [ ] Additional considerations/ reference material for an existing feature or document.
 
-_Describe the problem that requires documentation:_
-
-
-_Describe the documentation request, making sure to outline what users should be able to achieve with the doc. In addition, include links to any relevant existing documentation, support tickets, messages, or external content:_
-
-_Are you the right person to review a draft of the document for technical accuracy? If not, who is?_
-
-**For fixes, answer the following questions:**
-
-_How severe is the problem?_
+#### _Describe the problem/ feature that requires documentation:_
+  
+#### _Describe what should be included in the document, making sure to outline what users should be able to achieve with the doc. In addition, include links to any relevant existing documentation, support tickets, messages, or external content:_
+  
+#### _Are you the right person to review a draft of the document for technical accuracy? If not, who is?_ 
+  
+### For fixes, complete the following sections:
+  
+#### _Link to affected document:_
+  
+#### _How severe is the problem?_
 - [ ] Important to fix: The document has incorrect or missing information that is preventing customers from being successful (Add the `error/itf` label to this issue).
 - [ ] Useful: The document could benefit from a change, but there's nothing that's currently preventing customers from being successful without it (Add the `error/useful` label to this issue).
 - [ ] Typo: There's a noticeable grammar, spelling, or formatting issue in a document (Add the `error/typo` label to this issue). 
+  
+#### _Describe your suggestion for the change. In addition, include links to any relevant existing documentation, support tickets, messages, or external content:_
+  
+### Context
+Add any context about the problem here.
 
-_Link to affected document:_
-
-_Describe your suggestion for the change. In addition, include links to any relevant existing documentation, support tickets, messages, or external content:_
-
-**Additional context**
-Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -10,11 +10,12 @@ assignees: ''
 ## What kind of documentation change are you requesting?
 
 * **New document, topic, or other piece of content**: Add the `newcontent` label to this issue. 
+* **Significant change to an existing document**: Add the `enhancement` label to this issue. 
 * **Fix to an existing document**: See below for what labels to add
   
-### For new documents, answer the following questions**
+### For new documents and enhancements, answer the following questions**
 
-_What is the purpose of the document? Select all that apply:_
+_What is the purpose of the document/enhancement? Select all that apply:_
 - [ ] Setup steps a new feature for an upcoming release (Add the appropriate version label to this issue). 
 - [ ] Information for an existing feature that isn't yet documented.
 - [ ] Additional considerations/ reference material for an existing feature or document.
@@ -31,7 +32,7 @@ _What is the purpose of the document? Select all that apply:_
   
 #### _How severe is the problem?_
 - [ ] Critical: The document has incorrect or missing information that is preventing customers from being successful (Add the `error/itf` label to this issue).
-- [ ] Useful: The document could benefit from a change, but there's nothing that's currently preventing customers from being successful without it (Add the `error/useful` label to this issue).
+- [ ] FYI: The document could benefit from a change, but there's nothing that's currently preventing customers from being successful without it (Add the `error/useful` label to this issue).
 - [ ] Typo: There's a noticeable grammar, spelling, or formatting issue in a document (Add the `error/typo` label to this issue). 
   
 #### _Describe your suggestion for the change. In addition, include links to any relevant existing documentation, support tickets, messages, or external content:_


### PR DESCRIPTION
Added a new issue template to be used for all doc issues going forward. This is the same one that was in the private repo, save for the updated label names.