### PR TITLE
Use consistent naming convention across packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "docs",
+  "name": "astro-docs",
   "version": "0.0.1",
   "scripts": {}
 }


### PR DESCRIPTION
This is repo is a dependency of astronomer/astro-site. As depicted below it is one of three content dependencies, each with different package naming conventions. This will be one of a series of PRs to update to a common naming convention. I'll just be updating the package names, not the repo names.

![image](https://user-images.githubusercontent.com/3267/101791857-04065880-3ad2-11eb-8aa7-b70b334e4b7b.png)

New naming convention:
```json
"dependencies": {
    "astro-guides": "astronomer/airflow-guides",
    "astro-blog": "astronomer/astro-blog",
    "astro-docs": "astronomer/docs",
}
```