### PR TITLE
Updated screenshot hyperlinks to point to new screenshots

### DIFF
--- a/cloud/stable/03_deploy/02_deploy-cli.md
+++ b/cloud/stable/03_deploy/02_deploy-cli.md
@@ -19,7 +19,7 @@ To create a deployment on Astronomer, log into [Astronomer Cloud](https://app.gc
 
 From your Workspace on Astronomer, click "New Deployment".
 
-![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-deployments.png)
+![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.23-deployments.png)
 
 ### Configure your Airflow Deployment
 
@@ -29,7 +29,7 @@ To finish creating your Deployment, you'll have to:
 - Pick an Airflow Executor (Celery or Local)
 - Set Initial Resources
 
-![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/V0.16-new_deployment-config.png)
+![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/V0.23-new_deployment-config.png)
 
 ### Deployment Dashboard
 
@@ -37,7 +37,7 @@ Once you've initialized your deployment, give it a few moments to provision.
 
 You should soon have access to your deployment dashboard:
 
-![New Deployment Celery Dashboard](https://assets2.astronomer.io/main/docs/deploying-code/v0.16-new_deployment-dashboard.png)
+![New Deployment Celery Dashboard](https://assets2.astronomer.io/main/docs/deploying-code/v0.23-new_deployment-dashboard.png)
 
 From this dashboard, you can:
 

--- a/cloud/stable/03_deploy/02_deploy-cli.md
+++ b/cloud/stable/03_deploy/02_deploy-cli.md
@@ -19,7 +19,7 @@ To create a deployment on Astronomer, log into [Astronomer Cloud](https://app.gc
 
 From your Workspace on Astronomer, click "New Deployment".
 
-![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/workspace_dashboard.png)
+![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.16-deployments.png)
 
 ### Configure your Airflow Deployment
 
@@ -29,7 +29,7 @@ To finish creating your Deployment, you'll have to:
 - Pick an Airflow Executor (Celery or Local)
 - Set Initial Resources
 
-![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/V0.15-new_deployment-config.png)
+![New Deployment Config](https://assets2.astronomer.io/main/docs/deploying-code/V0.16-new_deployment-config.png)
 
 ### Deployment Dashboard
 
@@ -37,7 +37,7 @@ Once you've initialized your deployment, give it a few moments to provision.
 
 You should soon have access to your deployment dashboard:
 
-![New Deployment Celery Dashboard](https://assets2.astronomer.io/main/docs/deploying-code/new_deployment_celery_dashboard.png)
+![New Deployment Celery Dashboard](https://assets2.astronomer.io/main/docs/deploying-code/v0.16-new_deployment-dashboard.png)
 
 From this dashboard, you can:
 


### PR DESCRIPTION
**NOTE: Review this pull request and merge it before reviewing this one, or else the screen shots will not appear: https://github.com/astronomer/web-assets/pull/11**

Because the Deploy Code guide uses slightly different screenshot naming conventions, I created new files and linked to those by updating the links in the main guide. This PR simply updates those links to point to the new screenshots. 

