### PR TITLE
Update 02_customize-image.md

### DIFF
--- a/cloud/stable/02_develop/02_customize-image.md
+++ b/cloud/stable/02_develop/02_customize-image.md
@@ -298,7 +298,7 @@ RUN pip install --no-cache-dir -q -r requirements.txt
 FROM stage1 AS stage3
 # Copy requirements directory
 COPY --from=stage2 /usr/lib/python3.6/site-packages/ /usr/lib/python3.6/site-packages/
-ONBUILD COPY . .
+COPY . .
 ```
 
 In 3 stages, this file is bundling up your SSH keys, OS-Level packages in `packages.txt` and Python Packages in `requirements.txt` from your private directory into a Docker image.

--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -298,7 +298,7 @@ RUN pip install --no-cache-dir -q -r requirements.txt
 FROM stage1 AS stage3
 # Copy requirements directory
 COPY --from=stage2 /usr/lib/python3.6/site-packages/ /usr/lib/python3.6/site-packages/
-ONBUILD COPY . .
+COPY . .
 ```
 
 In 3 stages, this file is bundling up your SSH keys, OS-Level packages in `packages.txt` and Python Packages in `requirements.txt` from your private directory into a Docker image.

--- a/enterprise/v0.12/02_develop/02_customize-image.md
+++ b/enterprise/v0.12/02_develop/02_customize-image.md
@@ -298,7 +298,7 @@ RUN pip install --no-cache-dir -q -r requirements.txt
 FROM stage1 AS stage3
 # Copy requirements directory
 COPY --from=stage2 /usr/lib/python3.6/site-packages/ /usr/lib/python3.6/site-packages/
-ONBUILD COPY . .
+COPY . .
 ```
 
 In 3 stages, this file is bundling up your SSH keys, OS-Level packages in `packages.txt` and Python Packages in `requirements.txt` from your private directory into a Docker image.

--- a/enterprise/v0.13/02_develop/02_customize-image.md
+++ b/enterprise/v0.13/02_develop/02_customize-image.md
@@ -298,7 +298,7 @@ RUN pip install --no-cache-dir -q -r requirements.txt
 FROM stage1 AS stage3
 # Copy requirements directory
 COPY --from=stage2 /usr/lib/python3.6/site-packages/ /usr/lib/python3.6/site-packages/
-ONBUILD COPY . .
+COPY . .
 ```
 
 In 3 stages, this file is bundling up your SSH keys, OS-Level packages in `packages.txt` and Python Packages in `requirements.txt` from your private directory into a Docker image.

--- a/enterprise/v0.15/02_develop/02_customize-image.md
+++ b/enterprise/v0.15/02_develop/02_customize-image.md
@@ -298,7 +298,7 @@ RUN pip install --no-cache-dir -q -r requirements.txt
 FROM stage1 AS stage3
 # Copy requirements directory
 COPY --from=stage2 /usr/lib/python3.6/site-packages/ /usr/lib/python3.6/site-packages/
-ONBUILD COPY . .
+COPY . .
 ```
 
 In 3 stages, this file is bundling up your SSH keys, OS-Level packages in `packages.txt` and Python Packages in `requirements.txt` from your private directory into a Docker image.

--- a/enterprise/v0.16/02_develop/02_customize-image.md
+++ b/enterprise/v0.16/02_develop/02_customize-image.md
@@ -298,7 +298,7 @@ RUN pip install --no-cache-dir -q -r requirements.txt
 FROM stage1 AS stage3
 # Copy requirements directory
 COPY --from=stage2 /usr/lib/python3.6/site-packages/ /usr/lib/python3.6/site-packages/
-ONBUILD COPY . .
+COPY . .
 ```
 
 In 3 stages, this file is bundling up your SSH keys, OS-Level packages in `packages.txt` and Python Packages in `requirements.txt` from your private directory into a Docker image.


### PR DESCRIPTION
Modified ONBUILD COPY . . to COPY . .

`ONBUILD COPY . .` causes airflow to not detect dags and files when user changes work directory in docker.build file post this command as the files are copied over to changed work directory instead of `/usr/local/airflow `