### PR TITLE
correcting the experimental api url

### DIFF
--- a/cloud/stable/04_customize-airflow/06_airflow_api.md
+++ b/cloud/stable/04_customize-airflow/06_airflow_api.md
@@ -82,14 +82,14 @@ You can make requests via the method of your choosing. Below, we'll walk through
 If you'd like to externally trigger a DAG run, you can start with a generic cURL command to Airflow's POST endpoint: 
 
 ```
-POST /api/experimental/dags/<DAG_ID>/dag_runs
+POST /airflow/api/experimental/dags/<DAG_ID>/dag_runs
 ```
 
 This command would look like this:
 
 ```
 curl -v -X POST
-https://AIRFLOW_DOMAIN/api/experimental/dags/<DAG_ID>/dag_runs
+https://AIRFLOW_DOMAIN/airflow/api/experimental/dags/<DAG_ID>/dag_runs
 -H 'Authorization: <API_Key> ’
 -H ‘Cache-Control: no-cache’
 -H ‘content-type: application/json’ -d ‘{}’

--- a/enterprise/next/05_customize-airflow/07_airflow-api.md
+++ b/enterprise/next/05_customize-airflow/07_airflow-api.md
@@ -79,17 +79,17 @@ You can make requests via the method of your choosing. Below, we'll walk through
 
 ### Trigger DAG
 
-If you'd like to externally trigger a DAG run, you can start with a generic cURL command to Airflow's POST endpoint: 
+If you'd like to externally trigger a DAG run, you can start with a generic cURL command to Airflow's POST endpoint:
 
 ```
-POST /api/experimental/dags/<DAG_ID>/dag_runs
+POST /airflow/api/experimental/dags/<DAG_ID>/dag_runs
 ```
 
 This command would look like this:
 
 ```
 curl -v -X POST
-https://AIRFLOW_DOMAIN/api/experimental/dags/<DAG_ID>/dag_runs
+https://AIRFLOW_DOMAIN/airflow/api/experimental/dags/<DAG_ID>/dag_runs
 -H 'Authorization: <API_Key> ’
 -H ‘Cache-Control: no-cache’
 -H ‘content-type: application/json’ -d ‘{}’
@@ -133,7 +133,7 @@ https://AIRFLOW_DOMAIN/api/experimental/dags/customer_health_score/dag_runs
 
 ### Get all Pools
 
-If you'd like to get all existing Pools from your Airflow Deployment, you can start with a generic Python command to Airflow's GET endpoint: 
+If you'd like to get all existing Pools from your Airflow Deployment, you can start with a generic Python command to Airflow's GET endpoint:
 
 ```
 GET /api/experimental/pools

--- a/enterprise/v0.16/05_customize-airflow/07_airflow-api.md
+++ b/enterprise/v0.16/05_customize-airflow/07_airflow-api.md
@@ -82,14 +82,14 @@ You can make requests via the method of your choosing. Below, we'll walk through
 If you'd like to externally trigger a DAG run, you can start with a generic cURL command to Airflow's POST endpoint: 
 
 ```
-POST /api/experimental/dags/<DAG_ID>/dag_runs
+POST /airflow/api/experimental/dags/<DAG_ID>/dag_runs
 ```
 
 This command would look like this:
 
 ```
 curl -v -X POST
-https://AIRFLOW_DOMAIN/api/experimental/dags/<DAG_ID>/dag_runs
+https://AIRFLOW_DOMAIN/airflow/api/experimental/dags/<DAG_ID>/dag_runs
 -H 'Authorization: <API_Key> ’
 -H ‘Cache-Control: no-cache’
 -H ‘content-type: application/json’ -d ‘{}’


### PR DESCRIPTION
we omitted "/airflow/" from the url on two docs