### PR TITLE
Updated our recommendations for node sizes in the AWS installation guide

### DIFF
--- a/enterprise/next/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/next/03_install/01_aws/01_install-aws-standard.md
@@ -48,8 +48,7 @@ As you follow the guide linked above, keep in mind:
      * To give more users `kubectl` access, you'll have to do so manually.
      * [This post](https://web.archive.org/web/20190323035848/http://marcinkaszynski.com/2018/07/12/eks-auth.html) goes through how IAM plays with EKS.
 * Expect to see each of your underlying nodes in the EC2 console.
-   * We recommend using 3 [t2.2xlarge](https://aws.amazon.com/ec2/instance-types/) nodes as a starting cluster size.
-   * You're free to use whatever node types you'd like, but Astronomer takes ~11 CPUs and ~40GB of memory as the default overhead. To customize the default resource requests, see step 6.
+   * Given Astronomer's default resource requests of ~11 CPUs and ~40GB of memory, we recommend using 6 [m5.xlarge](https://aws.amazon.com/ec2/instance-types/) nodes for your cluster. To modify Astronomer's default resource requests, see step 6.
 
 > **Note:** If you work with multiple Kubernetes environments, `kubectx` is an incredibly useful tool for quickly switching between Kubernetes clusters. Learn more [here](https://github.com/ahmetb/kubectx).
 

--- a/enterprise/next/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/next/03_install/01_aws/01_install-aws-standard.md
@@ -48,7 +48,7 @@ As you follow the guide linked above, keep in mind:
      * To give more users `kubectl` access, you'll have to do so manually.
      * [This post](https://web.archive.org/web/20190323035848/http://marcinkaszynski.com/2018/07/12/eks-auth.html) goes through how IAM plays with EKS.
 * Expect to see each of your underlying nodes in the EC2 console.
-   * Given Astronomer's default resource request of ~11 CPUs and ~40GB of memory, we recommend using either 6 m5.xlarge or 3 m5.2xlarge [instances](https://aws.amazon.com/ec2/instance-types/) for your cluster. To modify Astronomer's default resource requests, see step 6.
+   * Given Astronomer's default resource request of ~11 CPUs and ~40GB of memory, we recommend using either six m5.xlarge or three m5.2xlarge [instances](https://aws.amazon.com/ec2/instance-types/) for your cluster. To modify Astronomer's default resource requests, see step 6.
 
 > **Note:** If you work with multiple Kubernetes environments, `kubectx` is an incredibly useful tool for quickly switching between Kubernetes clusters. Learn more [here](https://github.com/ahmetb/kubectx).
 

--- a/enterprise/next/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/next/03_install/01_aws/01_install-aws-standard.md
@@ -48,7 +48,7 @@ As you follow the guide linked above, keep in mind:
      * To give more users `kubectl` access, you'll have to do so manually.
      * [This post](https://web.archive.org/web/20190323035848/http://marcinkaszynski.com/2018/07/12/eks-auth.html) goes through how IAM plays with EKS.
 * Expect to see each of your underlying nodes in the EC2 console.
-   * Given Astronomer's default resource requests of ~11 CPUs and ~40GB of memory, we recommend using 6 [m5.xlarge](https://aws.amazon.com/ec2/instance-types/) nodes for your cluster. To modify Astronomer's default resource requests, see step 6.
+   * Given Astronomer's default resource request of ~11 CPUs and ~40GB of memory, we recommend using either 6 m5.xlarge or 3 m5.2xlarge [instances](https://aws.amazon.com/ec2/instance-types/) for your cluster. To modify Astronomer's default resource requests, see step 6.
 
 > **Note:** If you work with multiple Kubernetes environments, `kubectx` is an incredibly useful tool for quickly switching between Kubernetes clusters. Learn more [here](https://github.com/ahmetb/kubectx).
 

--- a/enterprise/v0.12/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.12/03_install/01_aws/01_install-aws-standard.md
@@ -48,8 +48,8 @@ As you follow the guide linked above, keep in mind:
      * To give more users `kubectl` access, you'll have to do so manually.
      * [This post](https://web.archive.org/web/20190323035848/http://marcinkaszynski.com/2018/07/12/eks-auth.html) goes through how IAM plays with EKS.
 * Expect to see each of your underlying nodes in the EC2 console.
-   * We recommend using 3 [t2.2xlarge](https://aws.amazon.com/ec2/instance-types/) nodes as a starting cluster size.
-   * You're free to use whatever node types you'd like, but Astronomer takes ~11 CPUs and ~40GB of memory as the default overhead. To customize the default resource requests, see step 6.
+  * Given Astronomer's default resource request of ~11 CPUs and ~40GB of memory, we recommend using either six m5.xlarge or three m5.2xlarge [instances](https://aws.amazon.com/ec2/instance-types/) for your cluster. To modify Astronomer's default resource requests, see step 6.
+
 
 > **Note:** If you work with multiple Kubernetes environments, `kubectx` is an incredibly useful tool for quickly switching between Kubernetes clusters. Learn more [here](https://github.com/ahmetb/kubectx).
 

--- a/enterprise/v0.13/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.13/03_install/01_aws/01_install-aws-standard.md
@@ -48,8 +48,8 @@ As you follow the guide linked above, keep in mind:
      * To give more users `kubectl` access, you'll have to do so manually.
      * [This post](https://web.archive.org/web/20190323035848/http://marcinkaszynski.com/2018/07/12/eks-auth.html) goes through how IAM plays with EKS.
 * Expect to see each of your underlying nodes in the EC2 console.
-   * We recommend using 3 [t2.2xlarge](https://aws.amazon.com/ec2/instance-types/) nodes as a starting cluster size.
-   * You're free to use whatever node types you'd like, but Astronomer takes ~11 CPUs and ~40GB of memory as the default overhead. To customize the default resource requests, see step 6.
+  * Given Astronomer's default resource request of ~11 CPUs and ~40GB of memory, we recommend using either six m5.xlarge or three m5.2xlarge [instances](https://aws.amazon.com/ec2/instance-types/) for your cluster. To modify Astronomer's default resource requests, see step 6.
+
 
 > **Note:** If you work with multiple Kubernetes environments, `kubectx` is an incredibly useful tool for quickly switching between Kubernetes clusters. Learn more [here](https://github.com/ahmetb/kubectx).
 

--- a/enterprise/v0.15/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.15/03_install/01_aws/01_install-aws-standard.md
@@ -48,8 +48,8 @@ As you follow the guide linked above, keep in mind:
      * To give more users `kubectl` access, you'll have to do so manually.
      * [This post](https://web.archive.org/web/20190323035848/http://marcinkaszynski.com/2018/07/12/eks-auth.html) goes through how IAM plays with EKS.
 * Expect to see each of your underlying nodes in the EC2 console.
-   * We recommend using 3 [t2.2xlarge](https://aws.amazon.com/ec2/instance-types/) nodes as a starting cluster size.
-   * You're free to use whatever node types you'd like, but Astronomer takes ~11 CPUs and ~40GB of memory as the default overhead. To customize the default resource requests, see step 6.
+  * Given Astronomer's default resource request of ~11 CPUs and ~40GB of memory, we recommend using either six m5.xlarge or three m5.2xlarge [instances](https://aws.amazon.com/ec2/instance-types/) for your cluster. To modify Astronomer's default resource requests, see step 6.
+
 
 > **Note:** If you work with multiple Kubernetes environments, `kubectx` is an incredibly useful tool for quickly switching between Kubernetes clusters. Learn more [here](https://github.com/ahmetb/kubectx).
 

--- a/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
@@ -48,8 +48,8 @@ As you follow the guide linked above, keep in mind:
      * To give more users `kubectl` access, you'll have to do so manually.
      * [This post](https://web.archive.org/web/20190323035848/http://marcinkaszynski.com/2018/07/12/eks-auth.html) goes through how IAM plays with EKS.
 * Expect to see each of your underlying nodes in the EC2 console.
-   * We recommend using 3 [t2.2xlarge](https://aws.amazon.com/ec2/instance-types/) nodes as a starting cluster size.
-   * You're free to use whatever node types you'd like, but Astronomer takes ~11 CPUs and ~40GB of memory as the default overhead. To customize the default resource requests, see step 6.
+  * Given Astronomer's default resource request of ~11 CPUs and ~40GB of memory, we recommend using either six m5.xlarge or three m5.2xlarge [instances](https://aws.amazon.com/ec2/instance-types/) for your cluster. To modify Astronomer's default resource requests, see step 6.
+
 
 > **Note:** If you work with multiple Kubernetes environments, `kubectx` is an incredibly useful tool for quickly switching between Kubernetes clusters. Learn more [here](https://github.com/ahmetb/kubectx).
 


### PR DESCRIPTION
This includes both modified recommendations and general changes to wording for this content. The main change that hasn't yet been confirmed by SMEs is switching our references from "nodes" to "resources", which is consistent with Amazon's own wording on the site we link out to. 

When this PR is approved, I'll push the changes here to all other Enterprise versions.