### PR TITLE
Guidelines on Migration from Alpine to Debian

### DIFF
--- a/cloud/stable/02_develop/02_customize-image.md
+++ b/cloud/stable/02_develop/02_customize-image.md
@@ -335,7 +335,7 @@ FROM custom-<airflow-image>
 If you're running `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
 
 ```
-FROM custom-ap-airflow:1.10.10-alpine3.10
+FROM custom-ap-airflow:1.10.12-buster
 ```
 
 ### Step 4. Push your Custom Image to Astronomer
@@ -345,4 +345,4 @@ Now, let's push your new image to Astronomer.
 - If you're developing locally, run `$ astro dev stop` > `$ astro dev start`
 - If you're pushing up to Astronomer, you're free to deploy by running `$ astro deploy` or by triggering your CI/CD pipeline
 
-For more detail on the Astronomer deployment process, refer to our [Code Deployment doc](/docs/cloud/stable/deploy/deploy-cli/).
+For more detail on the Astronomer deployment process, refer to [Deploy to Astronomer via the CLI](/docs/cloud/stable/deploy/deploy-cli/).

--- a/cloud/stable/02_develop/02_customize-image.md
+++ b/cloud/stable/02_develop/02_customize-image.md
@@ -118,7 +118,7 @@ airflow.cfg  dags  include  packages.txt  requirements.txt
 
 Notice that `helper_functions` folder has been built into your image.
 
-## Configure `airflow_settings.yaml`
+## Configure airflow_settings.yaml
 
 When you first initialize a new Airflow project on Astronomer, a file titled `airflow_settings.yaml` will be automatically generated. With this file you can configure and programmatically generate Airflow Connections, Pools, and Variables when you're developing locally.
 
@@ -241,35 +241,33 @@ $ astro dev start --env .env
 
 ## Build from a Private Repository
 
-If you're interested in bringing in custom Python Packages stored in a Private GitHub Repo, you're free to do that on Astronomer.
+If you're interested in bringing in custom Python Packages stored in a Private GitHub repo, you're free to do that on Astronomer.
 
 Read below for guidelines.
 
-## Pre-Requisites
+### Prerequisites
 
 - The Astronomer CLI
 - An intialized Astronomer Airflow project and corresponding directory
-- An [SSH Key](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to your Private GitHub Repo
+- An [SSH Key](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to your Private GitHub repo
 
 If you haven't initialized an Airflow Project on Astronomer (by running `$ astro dev init`), reference our [CLI Quickstart Guide](/docs/cloud/stable/develop/cli-quickstart/).
 
-## Building your Image
-
-### Create a file called `Dockerfile.build`
+### Step 1. Create a file called Dockerfile.build
 
 1. In your directory, create a file called `Dockerfile.build` that's parallel to your `Dockerfile`.
 
 2. To the first line of that file, add a "FROM" statement that specifies the Airflow Image you want to run on Astronomer and ends with `AS stage`.
 
-If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, this would be:
+If you're running the Debian-based Astronomer Certified image for Airflow 1.10.12, this would be:
 
 ```
-FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10 AS stage1
+FROM quay.io/astronomer/ap-airflow:1.10.12-buster AS stage1
 ```
 
-For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
+For a list of all Airflow Images supported on Astronomer, refer to [Upgrade Apache Airflow on Astronomer](/docs/cloud/stable/customize-airflow/manage-airflow-versions/).
 
-> **Note:**  Do NOT include `on-build` at the end of your Airflow Image as you typically would in your Dockerfile.
+> **Note:** Do NOT include `-onbuild` at the end of your Airflow Image as you typically would in your `Dockerfile`.
 
 3. Immediately below the `FROM...` line specified above, add the folllowing:
 
@@ -310,7 +308,7 @@ A few notes:
 - Make sure your custom OS-Level packages are in `packages.txt` and your Python packages in `requirements.txt` within your repo
 - If you're running Python 3.7 on your machine, replace the reference to Python 3.6 under `# Copy requirements directory` with `/usr/lib/python3.7/site-packages/` above
 
-### 2. Build your Image
+### Step 2. Build your Image
 
 Now, let's build a Docker image based on the requirements above that we'll then reference in your Dockerfile, tag, and push to Astronomer.
 
@@ -320,13 +318,13 @@ Run the following in your terminal:
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-<airflow-image> .
 ```
 
-If you have `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
+If you have `quay.io/astronomer/ap-airflow:1.10.12-buster` in your `Dockerfile.build`, for example, this command would be:
 
 ```
-$ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-ap-airflow:1.10.10-alpine3.10 .
+$ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-ap-airflow:1.10.12-buster .
 ```
 
-### 3. Replace your Dockerfile
+### Step 3. Replace your Dockerfile
 
 Now that we've built your custom image, let's reference that custom image in your `Dockerfile`. Replace the current contents of your `Dockerfile` with the following:
 
@@ -340,7 +338,7 @@ If you're running `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` as specifie
 FROM custom-ap-airflow:1.10.10-alpine3.10
 ```
 
-### 4. Push your Custom Image to Astronomer
+### Step 4. Push your Custom Image to Astronomer
 
 Now, let's push your new image to Astronomer.
 

--- a/cloud/stable/04_customize-airflow/02_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/02_manage-airflow-versions.md
@@ -13,7 +13,7 @@ Included in that build is your `Dockerfile`, a file that is automatically genera
 To upgrade your Airflow Deployment to a higher version of Airflow, there are three steps:
 
 1. Initialize the upgrade by selecting a new Airflow version via the Astronomer UI or CLI
-2. Change the FROM statement in your project's Dockerfile to reference an AC image that corresponds to the Airflow version indicated in Step 1
+2. Change the FROM statement in your project's `Dockerfile` to reference an AC image that corresponds to the Airflow version indicated in Step 1
 3. Deploy to Astronomer
 
 Read below for details.
@@ -94,7 +94,7 @@ The upgrade from Airflow 1.10.5 to 1.10.12 has been started. To complete this pr
 
 As noted above, this action will NOT interrupt or otherwise impact your Airflow Deployment or trigger a code change - it is simply a signal to our platform that you _intend_ to upgrade such that we can guide your experience through the rest of the process.
 
-To complete the upgrade, all you have to do is add a corresponding AC image to your Dockerfile.
+To complete the upgrade, all you have to do is add a corresponding AC image to your `Dockerfile`.
 
 ## Step 2: Deploy a New Astronomer Certified Image
 
@@ -113,7 +113,7 @@ First, open the `Dockerfile` within your Astronomer directory. When you initiali
 └── requirements.txt # For any Python packages
 ```
 
-Depending on the OS distribution and version of Airflow you want to run, you'll want to reference the corresponding Astronomer Certified image in the FROM statement of your Dockerfile.
+Depending on the OS distribution and version of Airflow you want to run, you'll want to reference the corresponding Astronomer Certified image in the FROM statement of your `Dockerfile`.
 
 ### 2. Choose your new Astronomer Certified Image
 
@@ -261,7 +261,7 @@ To do so, trigger your [CI/CD process](https://www.astronomer.io/docs/cloud/stab
 
 ## Cancel Airflow Upgrade Initialization
 
-If you begin the upgrade process for your Airflow Deployment and would like to cancel it, you can do so at any time either via the Astronomer UI or CLI as long as you have NOT changed the Astronomer Certified Image in your Dockerfile and deployed it.
+If you begin the upgrade process for your Airflow Deployment and would like to cancel it, you can do so at any time either via the Astronomer UI or CLI as long as you have NOT changed the Astronomer Certified Image in your `Dockerfile` and deployed it.
 
 Via the Astronomer UI, select **Cancel** next to **Airflow Version**.
 

--- a/cloud/stable/04_customize-airflow/02_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/02_manage-airflow-versions.md
@@ -1,12 +1,12 @@
 ---
-title: "Upgrade Airflow Versions on Astronomer"
+title: "Upgrade Apache Airflow on Astronomer"
 navTitle: "Upgrade Airflow"
 description: "How to adjust and upgrade Airflow versions on Astronomer."
 ---
 
 ## Overview
 
-On Astronomer, the process of pushing up your code to an individual Airflow Deployment involves customizing a locally built Docker image —— with your DAG code, Python Packages, plugins, and so on —— that's then bundled, tagged, and pushed to Astronomer Cloud's Docker Registry.
+On Astronomer, the process of pushing up your code to an individual Airflow Deployment involves customizing a locally built Docker image —— with your DAG code, dependencies, plugins, and so on —— that's then bundled, tagged, and pushed to Astronomer Cloud's Docker Registry.
 
 Included in that build is your `Dockerfile`, a file that is automatically generated when you initialize an Airflow project on Astronomer via our CLI. Every successful build on Astronomer must include a `Dockerfile` that references an Astronomer Certified Docker Image. Astronomer Certified (AC) is a production-ready distribution of Apache Airflow that mirrors the open source project and undergoes additional levels of rigorous testing conducted by our team.
 
@@ -185,28 +185,30 @@ If you're on Astronomer Cloud, navigate to your Airflow Deployment via Astronome
 
 Astronomer exclusively builds [Debian Buster](https://www.debian.org/) Docker images, though we support [Alpine Linux](https://alpinelinux.org/) images for AC versions 1.10.5 - 1.10.12.
 
-In an effort to standardize our offering and optimize for reliability, Debian Buster proved most suitable to handle complex dependencies and integrate well with Machine Learning Python Liberaries that are commonly used with Airflow.
+In an effort to standardize our offering and optimize for reliability, Debian Buster proved most suitable to handle complex dependencies and integrate well with Machine Learning Python Libraries that are commonly used with Airflow.
 
 Aside from the initial Docker image build and deploy process, both base images offer the exact same Apache Airflow experience. For best practices on migrating from Alpine to Debian, read below.
 
 ### Before you Begin
 
-To avoid unexpected impact to your Airflow Deployment, we strongly recommend two things:
+To avoid unexpected impact to your Airflow Deployment, we strongly recommend two things as you prepare to migrate from Alpine to Debian:
 
 1. Do not upgrade Airflow versions simultaneously.
 2. Test your changes locally before you push a new image to Astronomer.
 
 If you're runnning an Alpine-based 1.10.12 image, for example, try the Debian-based AC 1.10.12 image locally *before* you push that image to Astronomer and before you upgrade to a higher version of Airflow.
 
-> **Note:** If your `packages.txt` and `requirements.txt` files are empty, skip to step 3.
+> **Note:** If your `packages.txt` file is empty, skip to step 3.
 
 ### Step 1. Remove Packages.
 
 Debian Buster has many common packages installed by default, which means that you should be able to remove some dependencies.
 
-If you have any Python packages installed primarily *because* they're native to another library  (e.g. `pandas`, `numpy`, `pyarrow`, `scipy`, `sci-kit learn`), we recommend that you remove those additional packages from your `requirements.txt` or `packages.txt` files and see if your image builds successfully.
+If you have any packages installed primarily *because* they're native to another library  (e.g. `pandas`, `numpy`, `pyarrow`, `scipy`, `sci-kit learn`), we recommend that you remove those additional packages from your `requirements.txt` or `packages.txt` files and see if your image builds successfully.
 
 If you test a Debian-based image and encounter an error, you can always add packages back as needed.
+
+> **Note:** If you need a particular version of any package, make sure to pin it in your `requirements.txt` or `packages.txt` files (i.e. `<package-name>==<version>`). For Python packages that are pre-built into Astronomer's Debian image *and* listed in your `requirements.txt` file, the version of the package that's specified in `requirements.txt` will take precedence.
 
 ### Step 2. Rename Existing Packages.
 
@@ -214,11 +216,11 @@ For the dependencies you *do* have installed, a primary concern in migrating fro
 
 To identify a difference in package names, refer to [Debian Buster Packages](https://packages.debian.org/stable/) and [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages) for a full breakdown of both collections.
 
-Modify your `requirements.txt` and `packages.txt` files as needed.
+Modify your `requirements.txt` and `packages.txt` files as needed. If you include a package that does not exist or is named incorrectly, your image will fail to build.
 
 ### Step 3. Modify your Dockerfile.
 
-Now, try to build your Debian-based image via the Astronomer CLI locally. To do so, replace the Alpine image in your `Dockerfile` with an available Debian Image.
+Now, try to build your Debian-based image via the Astronomer CLI locally. To do so, replace the Alpine image in your `Dockerfile` with an available Debian image.
 
 For AC 1.10.12, you would replace:
 
@@ -232,16 +234,16 @@ with:
 FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild
 ```
 
-For all available images, refer to the matrix above or the [Astronomer Docker Registry](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
+For all available images, refer to the matrix above or [Astronomer's Docker Registry](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
 
 ### Step 4. Test your Image Locally.
 
-Now, test your new change locally via the Astronomer CLI by running:
+Now, test your changes locally via the Astronomer CLI by running:
 
 1. `$ astro dev stop`, then
 2. `$ astro dev start`
 
-If your image does not build successfully, it's likely you're missing additional dependencies, Add them as needed.
+If your image does not build successfully, it's likely that you're either missing additional dependencies or one of your packages is not named properly. Add and modify as needed.
 
 For help from our team, reach out to [Astronomer Support](https://support.astronomer.io).
 
@@ -249,11 +251,13 @@ For help from our team, reach out to [Astronomer Support](https://support.astron
 
 If your image *does* build successfully, you're ready to push it to your Airflow Deployment Astronomer.
 
-To do so, simply run:
+To do so, trigger your [CI/CD process](https://www.astronomer.io/docs/cloud/stable/deploy/ci-cd) or simply run:
 
 ```bash
  $ astro deploy
  ```
+
+ For more information on deploying to Astronomer, refer to [Deploy to Astronomer via the CLI](https://www.astronomer.io/docs/cloud/stable/deploy/deploy-cli).
 
 ## Cancel Airflow Upgrade Initialization
 

--- a/cloud/stable/04_customize-airflow/02_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/02_manage-airflow-versions.md
@@ -1,6 +1,6 @@
 ---
-title: "Manage Airflow Versions on Astronomer"
-navTitle: "Manage Airflow Versions"
+title: "Upgrade Airflow Versions on Astronomer"
+navTitle: "Upgrade Airflow"
 description: "How to adjust and upgrade Airflow versions on Astronomer."
 ---
 
@@ -31,15 +31,13 @@ Astronomer Certified offers support for the following versions of Apache Airflow
 - [Airflow 1.10.7](https://github.com/apache/airflow/releases/tag/1.10.7)
 - [Airflow 1.10.5](https://github.com/apache/airflow/releases/tag/1.10.5)
 
-## Upgrade Airflow
-
-### Step 1. Initialize the Upgrade Process
+## Step 1. Initialize the Upgrade Process
 
 The first step to upgrading your Deployment to a higher version of Apache Airflow is to indicate your intent to do so via the Astronomer UI or CLI.
 
 > **Note:** The Astronomer UI and CLI will only make available versions of Airflow that are _higher_ than the version you're currently running in your `Dockerfile`. For example, Airflow `1.10.7` would not be available for an Airflow Deployment running `1.10.10`.
 
-#### via the Astronomer UI
+### via the Astronomer UI
 
 To initialize the Airflow upgrade process via the Astronomer UI, navigate to **Deployment** > **Settings** > **Basics** > **Airflow Version**. Next to **Airflow Version**,
 
@@ -54,7 +52,7 @@ Once you select a version, you can expect to see a banner next to **Airflow Vers
 
 > **Note:** If you'd like to change the version of Airflow you'd like to upgrade to, you can do so at anytime by clicking **Cancel**, re-selecting a new version and once again clicking **Upgrade**. More on that below.
 
-#### via the Astronomer CLI
+### via the Astronomer CLI
 
 To initialize the Airflow upgrade process via the Astronomer CLI, first make sure you're authenticated by running `$ astro auth login gcp0001.us-east4.astronomer.io`.
 
@@ -98,7 +96,164 @@ As noted above, this action will NOT interrupt or otherwise impact your Airflow 
 
 To complete the upgrade, all you have to do is add a corresponding AC image to your Dockerfile.
 
-#### Cancel Airflow Upgrade Initialization
+## Step 2: Deploy a New Astronomer Certified Image
+
+### 1. Locate your Dockerfile in your Project Directory
+
+First, open the `Dockerfile` within your Astronomer directory. When you initialized an Airflow project via the Astronomer CLI, the following files should have been automatially generated:
+
+```
+.
+├── dags # Where your DAGs go
+│   ├── example-dag.py # An example dag that comes with the initialized project
+├── Dockerfile # For Astronomer's Docker image and runtime overrides
+├── include # For any other files you'd like to include
+├── packages.txt # For OS-level packages
+├── plugins # For any custom or community Airflow plugins
+└── requirements.txt # For any Python packages
+```
+
+Depending on the OS distribution and version of Airflow you want to run, you'll want to reference the corresponding Astronomer Certified image in the FROM statement of your Dockerfile.
+
+### 2. Choose your new Astronomer Certified Image
+
+Below you'll find a matrix of all Astronomer Certified images supported on Astronomer. Depending on the Airflow version you'd like to run or upgrade to, copy one of the images below to your `Dockerfile` and proceed to Step 3.
+
+Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
+
+For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags). For more information on Alpine and Debian as distinct system distributions, read the "Migrate from Alpine to Debian" section below.
+
+| Airflow Version                                                                       | Debian-based Image                                        | Alpine-based Image                                            |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------- |
+| [v1.10.5](https://github.com/astronomer/ap-airflow/blob/master/1.10.5/CHANGELOG.md)   | FROM quay.io/astronomer/ap-airflow:1.10.5-buster-onbuild  | FROM quay.io/astronomer/ap-airflow:1.10.5-alpine3.10-onbuild  |
+| [v1.10.7](https://github.com/astronomer/ap-airflow/blob/master/1.10.7/CHANGELOG.md)   | FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild  | FROM quay.io/astronomer/ap-airflow:1.10.7-alpine3.10-onbuild  |
+| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild |
+| [v1.10.12](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.12-alpine3.10-onbuild  |
+| [v1.10.14](https://github.com/astronomer/ap-airflow/blob/master/1.10.14/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.14-buster-onbuild | N/A                                                           |
+| [v2.0.0](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild   | N/A                                                           |
+
+> **Note:** We recently migrated from [DockerHub](https://hub.docker.com/r/astronomerinc/ap-airflow) to Quay.io as our Docker Registry due to a [recent change](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/) in DockerHub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer (e.g. `toomanyrequests: You have reached your pull rate limit`).
+
+## Step 3: Rebuild your Image
+
+### Local Development
+
+If you're developing locally, make sure to save your changes and issue the following from your command line:
+
+1. `$ astro dev stop`
+
+   This will stop all 3 running Docker containers for each of the necessary Airflow components (Webserver, Scheduler, Postgres).
+
+2. `$ astro dev start`
+
+   This will start those 3 Docker containers needed to run Airflow.
+
+### On Astronomer
+
+Once you're ready to push to Astronomer Cloud, you can issue:
+
+```bash
+$ astro deploy
+```
+
+This will bundle your updated directory, re-build your image and push it to your remote Airflow deployment on Astronomer.
+
+## Step 4: Confirm your version in the Airflow UI
+
+Once you've issued that command, navigate to your Airflow UI to confirm that you're now running the correct Airflow version.
+
+### Local Development
+
+If you're developing locally, you can:
+
+1. Head to http://localhost:8080/
+2. Navigate to `About` > `Version`
+
+Once there, you should see your correct Airflow version listed.
+
+> **Note:** The URL listed above assumes your Webserver is at Port 8080 (default). To change that default, read [this forum post](https://forum.astronomer.io/t/i-already-have-the-ports-that-the-cli-is-trying-to-use-8080-5432-occupied-can-i-change-the-ports-when-starting-a-project/48).
+
+### On Astronomer
+
+If you're on Astronomer Cloud, navigate to your Airflow Deployment via Astronomer and navigate to **About** > **Version**.
+
+![Verify Airflow Version in Airflow UI](https://assets2.astronomer.io/main/docs/manage-airflow-versions/airflow-ui-version.png)
+
+> **Note:** In Airflow 2.0, the **Version** page referenced above will be deprecated. Check the footer of the Airflow UI to validate Airflow version instead.
+
+## Migrate from Alpine to Debian
+
+Astronomer exclusively builds [Debian Buster](https://www.debian.org/) Docker images, though we support [Alpine Linux](https://alpinelinux.org/) images for AC versions 1.10.5 - 1.10.12.
+
+In an effort to standardize our offering and optimize for reliability, Debian Buster proved most suitable to handle complex dependencies and integrate well with Machine Learning Python Liberaries that are commonly used with Airflow.
+
+Aside from the initial Docker image build and deploy process, both base images offer the exact same Apache Airflow experience. For best practices on migrating from Alpine to Debian, read below.
+
+### Before you Begin
+
+To avoid unexpected impact to your Airflow Deployment, we strongly recommend two things:
+
+1. Do not upgrade Airflow versions simultaneously.
+2. Test your changes locally before you push a new image to Astronomer.
+
+If you're runnning an Alpine-based 1.10.12 image, for example, try the Debian-based AC 1.10.12 image locally *before* you push that image to Astronomer and before you upgrade to a higher version of Airflow.
+
+> **Note:** If your `packages.txt` and `requirements.txt` files are empty, skip to step 3.
+
+### Step 1. Remove Packages.
+
+Debian Buster has many common packages installed by default, which means that you should be able to remove some dependencies.
+
+If you have any Python packages installed primarily *because* they're native to another library  (e.g. `pandas`, `numpy`, `pyarrow`, `scipy`, `sci-kit learn`), we recommend that you remove those additional packages from your `requirements.txt` or `packages.txt` files and see if your image builds successfully.
+
+If you test a Debian-based image and encounter an error, you can always add packages back as needed.
+
+### Step 2. Rename Existing Packages.
+
+For the dependencies you *do* have installed, a primary concern in migrating from Alpine to Debian is that Python and OS-level packages may be named differently.
+
+To identify a difference in package names, refer to [Debian Buster Packages](https://packages.debian.org/stable/) and [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages) for a full breakdown of both collections.
+
+Modify your `requirements.txt` and `packages.txt` files as needed.
+
+### Step 3. Modify your Dockerfile.
+
+Now, try to build your Debian-based image via the Astronomer CLI locally. To do so, replace the Alpine image in your `Dockerfile` with an available Debian Image.
+
+For AC 1.10.12, you would replace:
+
+```
+FROM quay.io/astronomer/ap-airflow:1.10.12-alpine3.10-onbuild
+```
+
+with:
+
+```
+FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild
+```
+
+For all available images, refer to the matrix above or the [Astronomer Docker Registry](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
+
+### Step 4. Test your Image Locally.
+
+Now, test your new change locally via the Astronomer CLI by running:
+
+1. `$ astro dev stop`, then
+2. `$ astro dev start`
+
+If your image does not build successfully, it's likely you're missing additional dependencies.
+
+### Step 5. Push to Astronomer.
+
+If your image *does* build successfully, you're ready to push it to Astronomer.
+
+To do so, simply run:
+
+```bash
+ $ astro deploy
+ ```
+
+## Cancel Airflow Upgrade Initialization
 
 If you begin the upgrade process for your Airflow Deployment and would like to cancel it, you can do so at any time either via the Astronomer UI or CLI as long as you have NOT changed the Astronomer Certified Image in your Dockerfile and deployed it.
 
@@ -121,95 +276,6 @@ Airflow upgrade process has been successfully canceled. Your Deployment was not 
 ```
 
 Canceling the Airflow upgrade process will NOT interrupt or otherwise impact your Airflow Deployment or code that's running with it. To re-initialize an upgrade, follow the steps above.
-
-### Step 2: Deploy a New Astronomer Certified Image
-
-#### Locate your Dockerfile in your Project Directory
-
-First, open the `Dockerfile` within your Astronomer directory. When you initialized an Airflow project via the Astronomer CLI, the following files should have been automatially generated:
-
-```
-.
-├── dags # Where your DAGs go
-│   ├── example-dag.py # An example dag that comes with the initialized project
-├── Dockerfile # For Astronomer's Docker image and runtime overrides
-├── include # For any other files you'd like to include
-├── packages.txt # For OS-level packages
-├── plugins # For any custom or community Airflow plugins
-└── requirements.txt # For any Python packages
-```
-
-Depending on the OS distribution and version of Airflow you want to run, you'll want to reference the corresponding Astronomer Certified image in the FROM statement of your Dockerfile.
-
-#### Choose your new Astronomer Certified Image
-
-Below you'll find a matrix of all Astronomer Certified images supported on Astronomer. Depending on the Airflow version you'd like to run or upgrade to, copy one of the images below to your `Dockerfile` and proceed to Step 3.
-
-Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
-
-In terms of system distribution, Astronomer supports both [Alpine Linux](https://alpinelinux.org/) and [Debian](https://www.debian.org/)-based images. Alpine is a widely-used lightweight distribution of Linux that keeps our default images slim and performant. For users leveraging Machine Learning Python Libraries or more complex dependencies, we strongly recommend Debian.
-
-For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
-
-> **Note:** AC 1.10.12 will be the _last_ version to support an Alpine-based image. In an effort to standardize our offering and optimize for reliability, we'll exclusively build, test and support Debian-based images starting with AC 1.10.13. A guide for how to migrate from Alpine to Debian coming soon.
-
-| Airflow Version                                                                       | Debian-based Image                                        | Alpine-based Image                                            |
-| ------------------------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------- |
-| [v1.10.5](https://github.com/astronomer/ap-airflow/blob/master/1.10.5/CHANGELOG.md)   | FROM quay.io/astronomer/ap-airflow:1.10.5-buster-onbuild  | FROM quay.io/astronomer/ap-airflow:1.10.5-alpine3.10-onbuild  |
-| [v1.10.7](https://github.com/astronomer/ap-airflow/blob/master/1.10.7/CHANGELOG.md)   | FROM quay.io/astronomer/ap-airflow:1.10.7-buster-onbuild  | FROM quay.io/astronomer/ap-airflow:1.10.7-alpine3.10-onbuild  |
-| [v1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild |
-| [v1.10.12](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild | ROM quay.io/astronomer/ap-airflow:1.10.12-alpine3.10-onbuild  |
-| [v1.10.14](https://github.com/astronomer/ap-airflow/blob/master/1.10.14/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.14-buster-onbuild | N/A                                                           |
-| [v2.0.0](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild   | N/A                                                           |
-
-> **Note:** We recently migrated from [DockerHub](https://hub.docker.com/r/astronomerinc/ap-airflow) to Quay.io as our Docker Registry due to a [recent change](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/) in DockerHub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer (e.g. `toomanyrequests: You have reached your pull rate limit`).
-
-### Step 3: Rebuild your Image
-
-#### Local Development
-
-If you're developing locally, make sure to save your changes and issue the following from your command line:
-
-1. `$ astro dev stop`
-
-   This will stop all 3 running Docker containers for each of the necessary Airflow components (Webserver, Scheduler, Postgres).
-
-2. `$ astro dev start`
-
-   This will start those 3 Docker containers needed to run Airflow.
-
-#### On Astronomer
-
-Once you're ready to push to Astronomer Cloud, you can issue:
-
-```bash
-$ astro deploy
-```
-
-This will bundle your updated directory, re-build your image and push it to your remote Airflow deployment on Astronomer.
-
-### Step 4: Confirm your version in the Airflow UI
-
-Once you've issued that command, navigate to your Airflow UI to confirm that you're now running the correct Airflow version.
-
-#### Local Development
-
-If you're developing locally, you can:
-
-1. Head to http://localhost:8080/
-2. Navigate to `About` > `Version`
-
-Once there, you should see your correct Airflow version listed.
-
-> **Note:** The URL listed above assumes your Webserver is at Port 8080 (default). To change that default, read [this forum post](https://forum.astronomer.io/t/i-already-have-the-ports-that-the-cli-is-trying-to-use-8080-5432-occupied-can-i-change-the-ports-when-starting-a-project/48).
-
-#### On Astronomer
-
-If you're on Astronomer Cloud, navigate to your Airflow Deployment via Astronomer and navigate to **About** > **Version**.
-
-![Verify Airflow Version in Airflow UI](https://assets2.astronomer.io/main/docs/manage-airflow-versions/airflow-ui-version.png)
-
-> **Note:** In Airflow 2.0, the **Version** page referenced above will be deprecated. Check the footer of the Airflow UI to validate Airflow version instead.
 
 ## Patch Versions of Astronomer Certified
 

--- a/cloud/stable/04_customize-airflow/02_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/02_manage-airflow-versions.md
@@ -241,11 +241,13 @@ Now, test your new change locally via the Astronomer CLI by running:
 1. `$ astro dev stop`, then
 2. `$ astro dev start`
 
-If your image does not build successfully, it's likely you're missing additional dependencies.
+If your image does not build successfully, it's likely you're missing additional dependencies, Add them as needed.
+
+For help from our team, reach out to [Astronomer Support](https://support.astronomer.io).
 
 ### Step 5. Push to Astronomer.
 
-If your image *does* build successfully, you're ready to push it to Astronomer.
+If your image *does* build successfully, you're ready to push it to your Airflow Deployment Astronomer.
 
 To do so, simply run:
 


### PR DESCRIPTION
@vparekh94 I drafted some guidelines to help users migration from Alpine to Debian, as Astronomer Certified no longer supports Alpine-based Docker images beginning with AC 1.10.14.

In this PR, I also:
- Renamed this doc from "Manage Airflow Versions" to "Upgrade Airflow"
- Moved headers/section titles up for a cleaner format
- Removed the description of Alpine v Debian to the new section on the topic to keep things simple to start

Can you give this a look and let me know what you think? This doc is generally a bit wordy/packed with information, but hoping it's easy to find/navigate for users nonetheless.