### PR TITLE
New cron job for checking broken links

### DIFF
--- a/linkchecker.yml
+++ b/linkchecker.yml
@@ -1,0 +1,14 @@
+on:
+  schedule:
+    - cron: '0 8 1 * *'  # Runs on the 1st of every month at 8AM GMT
+
+name: Check markdown links
+jobs:
+  my-broken-link-checker:
+    name: Check broken links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check
+        uses: ruzickap/action-my-broken-link-checker@v1
+        with:
+          url: https://astronomer.io

--- a/linkchecker.yml
+++ b/linkchecker.yml
@@ -2,10 +2,10 @@ on:
   schedule:
     - cron: '0 8 * * 0'  # Runs every Sunday at 8AM GMT
 
-name: Check markdown links
+name: Check for broken Markdown links
 jobs:
   my-broken-link-checker:
-    name: Check broken links
+    name: Astronomer docs, blogs, and guides 
     runs-on: ubuntu-latest
     steps:
       - name: Check

--- a/linkchecker.yml
+++ b/linkchecker.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: '0 8 1 * *'  # Runs on the 1st of every month at 8AM GMT
+    - cron: '0 8 * * 0'  # Runs every Sunday at 8AM GMT
 
 name: Check markdown links
 jobs:


### PR DESCRIPTION
Fixes https://github.com/astronomer/issues/issues/2213#issuecomment-752254937

Created a GitHub action which checks our site for broken links every Sunday at 8am GMT. The results will appear in the `Actions` tab on GitHub. 