### PR TITLE
Updated Cloud and Enterprise CLI quickstart guides

### DIFF
--- a/cloud/stable/02_develop/01_cli-quickstart.md
+++ b/cloud/stable/02_develop/01_cli-quickstart.md
@@ -184,7 +184,7 @@ If you created your account with a username and password, you'll be prompted to 
 
 If you do not yet have an account on Astronomer, ask a Workspace Admin on your team to send you an invitation or [reach out to us](/get-astronomer?ref=docs) to start a free 14-day trial on Astronomer Cloud.
 
-> **Note:** Once you run this command once, it should stay cached and allow you to just run `astro auth login` to authenticate more easily in the future.
+> **Note:** Once you run this command once, it should stay cached and allow you to just run `$ astro auth login` to authenticate more easily in the future.
 
 ## Next Steps: Apply Changes using the CLI
 

--- a/cloud/stable/02_develop/01_cli-quickstart.md
+++ b/cloud/stable/02_develop/01_cli-quickstart.md
@@ -17,7 +17,7 @@ If you're an Astronomer user, you might use the Astronomer CLI to do the followi
 - Deploy to an Airflow Deployment on Astronomer
 - Create Astronomer Service Accounts, Users and Deployments
 
-The guidelines belows will walk you through how to install the CLI, initialize an Astronomer project, and deploy to an Airflow instance on your local machine.
+The guidelines below will walk you through how to install the CLI, initialize an Astronomer project, and deploy to an Airflow instance on your local machine.
 
 ## Step 1: Install the Astronomer CLI
 
@@ -118,26 +118,18 @@ Use "astro [command] --help" for more information about a command.
 
 ## Step 3: Initialize an Airflow Project
 
-Once the Astronomer CLI is installed, the next step is to initialize an Airflow project on Astronomer. Follow the guidelines below.
+Once the Astronomer CLI is installed, the next step is to initialize an Airflow project on Astronomer. To do so:
 
-### a. Create a New Directory on Your Machine
-
-To do this in a single command, run:
-
-```
+1. Create a new directory on your machine by running the following command:
+```sh
 $ mkdir <directory-name> && cd <directory-name>
 ```
 
-### b. Create the Necessary Project Files
-
-Once you're in that project directory, run:
-
-```
+2. Create the necessary project files in your new directory by running the following command:
+```sh
 $ astro dev init
 ```
-
 This will generate the following files in that directory:
-
 ```py
 .
 ├── dags # Where your DAGs go
@@ -149,75 +141,36 @@ This will generate the following files in that directory:
 ├──packages.txt # For OS-level packages
 └── requirements.txt # For any Python packages
 ```
-
-These files make up the Docker image you'll then push to the Airflow instance on your local machine or to an Airflow Deployment on Astronomer Cloud.
+These files make up the Docker image you'll then push to the Airflow instance on your local machine or to an Airflow Deployment on Astronomer Enterprise.
 
 ## Step 4: Start Airflow Locally
 
-### a. Start Airflow
+You can now push your project to a local instance of Airflow. To do so:
 
-To start Airflow on your local machine, run:
-
+1. Start Airflow on your local machine by running the following command in your project directory:
 ```
 $ astro dev start
 ```
+This command will spin up 3 Docker containers on your machine, each for a different Airflow component:
+ - **Postgres:** Airflow's Metadata Database
+ - **Webserver:** The Airflow component responsible for rendering the Airflow UI
+ - **Scheduler:** The Airflow component responsible for monitoring and triggering tasks
 
-This command will spin up 3 Docker containers on your machine, each for a different Airflow component.
+ For guidelines on accessing your Postgres database both locally and on Astronomer, read [Access the Airflow Database](/docs/cloud/stable/customize-airflow/access-airflow-database/).
 
-- **Postgres:** Airflow's Metadata Database
-- **Webserver:** The Airflow component responsible for rendering the Airflow UI
-- **Scheduler:** The Airflow component responsible for monitoring and triggering tasks
-
-The image might take some time to build the first time you run this command on your machine. After that, it will build from cached layers.
-
-As your image builds, you should see the following output:
-
-```
-$ astro dev start
-Env file ".env" found. Loading...
-Sending build context to Docker daemon  10.75kB
-Step 1/1 : FROM quay.io/astronomer/ap-airflow:latest-onbuild
-# Executing 5 build triggers
- ---> Using cache
- ---> Using cache
- ---> Using cache
- ---> Using cache
- ---> Using cache
- ---> 5160cfd00623
-Successfully built 5160cfd00623
-Successfully tagged astro-trial_705330/airflow:latest
-INFO[0000] [0/3] [postgres]: Starting
-INFO[0002] [1/3] [postgres]: Started
-INFO[0002] [1/3] [scheduler]: Starting
-INFO[0003] [2/3] [scheduler]: Started
-INFO[0003] [2/3] [webserver]: Starting
-INFO[0004] [3/3] [webserver]: Started
-Airflow Webserver: http://localhost:8080
-Postgres Database: localhost:5432/postgres
-The default credentials are admin:admin
-```
-
-For guidelines on accessing your Postgres database both locally and on Astronomer, read [Access the Airflow Database](/docs/cloud/stable/customize-airflow/access-airflow-database/).
-
-### b. Verify Docker Containers
-
-To verify that all 3 Docker containers were created, run:
-
+2. Verify that all 3 Docker containers were created by running:
 ```
 $ docker ps
 ```
-
 > **Note**: Running `$ astro dev start` will start your project with the Airflow Webserver exposed at port 8080 and Postgres exposed at port 5432.
 >
 > If you already have either of those ports allocated, you can either [stop existing docker containers](https://forum.astronomer.io/t/docker-error-in-cli-bind-for-0-0-0-0-5432-failed-port-is-already-allocated/151) or [change the port](https://forum.astronomer.io/t/i-already-have-the-ports-that-the-cli-is-trying-to-use-8080-5432-occupied-can-i-change-the-ports-when-starting-a-project/48).
 
-### c. Open the Airflow UI
+3. Access the Airflow UI for your local Airflow project. To do so, go to http://localhost:8080/ and log in with `admin` for both your Username and Password.
 
-To access the Airflow UI of your local Airflow project, go to http://localhost:8080/ and log in with `admin` as both your Username and Password.
+ You should also be able to access your Postgres Database at: `localhost:5432/postgres`.
 
-You should also be able to access your Postgres Database at: `localhost:5432/postgres`.
-
-For guidelines on accessing your Postgres database both locally and on Astronomer, refer to the [Access Airflow Database](/docs/cloud/stable/customize-airflow/access-airflow-database/) guide.
+ For guidelines on accessing your Postgres database both locally and on Astronomer, refer to the [Access Airflow Database](/docs/cloud/stable/customize-airflow/access-airflow-database/) guide.
 
 ## Step 5: Authenticate to Astronomer
 

--- a/enterprise/next/02_develop/01_cli-quickstart.md
+++ b/enterprise/next/02_develop/01_cli-quickstart.md
@@ -1,14 +1,14 @@
 ---
 title: "CLI Quickstart"
 navTitle: "CLI Quickstart"
-description: "Establish a local testing environment and deploy to Astronomer from your CLI."
+description: "Establish a local testing environment and deploy to Astronomer from the CLI."
 ---
 
 ## Overview
 
 Astronomer's [open source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
 
-From the CLI, both Astronomer and non-Astronomer users can provision a local Apache Airflow instance with a dedicated Webserver, Scheduler and Postgres Database. Once you initialize a project on Astronomer, you can easily customize your image (e.g. add Python or OS-level packages, plugins etc.) and push that image to run on your local machine.
+From the CLI, both Astronomer and non-Astronomer users can create a local Apache Airflow instance with a dedicated Webserver, Scheduler and Postgres Database. Once you initialize a project on Astronomer, you can easily customize your image (e.g. add Python or OS-level packages, plugins etc.) and push that image to run on your local machine.
 
 If you're an Astronomer user, you might use the Astronomer CLI to do the following:
 
@@ -16,26 +16,25 @@ If you're an Astronomer user, you might use the Astronomer CLI to do the followi
 - List Astronomer Workspaces and Deployments you have access to
 - Deploy to an Airflow Deployment on Astronomer
 - Create Astronomer Service Accounts, Users and Deployments
-- Append annotations to your Deployment's Pods (_Enterprise only_)
+- Append annotations to your Deployment's Pods (Enterprise only)
 
-This guide will walk you through how to install the CLI, initalize an Astronomer project, and deploy to an Airflow instance on your local machine.
 
-## Pre-Requisites
+The guidelines below will walk you through how to install the CLI, initialize an Astronomer project, and deploy to an Airflow instance on your local machine.
 
-To install the CLI, make sure you've installed:
-
-- [Docker](https://www.docker.com/) (v18.09 or higher)
-
-## Installation
+## Step 1: Install the Astronomer CLI
 
 There are two ways to install any version of the Astronomer CLI:
 
-1. via [Homebrew](https://brew.sh/)
-2. via a simple cURL command
+- [Homebrew](https://brew.sh/)
+- cURL
 
 > **Note:** Both methods only work for Unix (Linux+Mac) based systems. If you're running on Windows 10, follow [this guide](/docs/enterprise/stable/develop/cli-install-windows-10/) to get set up with Docker for WSL.
 
-### via Homebrew
+### Prerequisites
+
+The Astronomer CLI installation process requires [Docker](https://www.docker.com/) (v18.09 or higher).
+
+### Install with Homebrew
 
 If you have Homebrew installed, run:
 
@@ -43,27 +42,27 @@ If you have Homebrew installed, run:
 $ brew install astronomer/tap/astro
 ```
 
-To install a specific version of the Astro CLI, you'll have to specify `@major.minor.patch`. To install v0.13.1, for example, run:
+To install a specific version of the Astro CLI, you'll have to specify `@major.minor.patch`. To install v0.16.1, for example, run:
 
 ```sh
-$ brew install astronomer/tap/astro@0.13.1
+$ brew install astronomer/tap/astro@0.16.1
 ```
 
-### via cURL
+### Install with cURL
 
-To install the latest version of our CLI, run:
+To install the latest version of the Astronomer CLI, run:
 
 ```
 $ curl -sSL https://install.astronomer.io | sudo bash
 ```
 
-To install a specific version of the Astro CLI, specify `-s -- major.minor.patch` as a flag at the end of the curl command. To install v0.13.1, for example, run:
+To install a specific version of the Astronomer CLI, specify `-s -- major.minor.patch` as a flag at the end of the cURL command. To install v0.16.1, for example, run:
 
 ```
-$ curl -sSL https://install.astronomer.io | sudo bash -s -- v0.13.1
+$ curl -sSL https://install.astronomer.io | sudo bash -s -- v0.16.1
 ```
 
-#### MacOS Catalina Users
+#### Note for MacOS Catalina Users:
 
 As of macOS Catalina, Apple [replaced bash with ZSH](https://www.theverge.com/2019/6/4/18651872/apple-macos-catalina-zsh-bash-shell-replacement-features) as the default shell. Our CLI install cURL command currently presents an incompatibility error with ZSH, sudo and the pipe syntax.
 
@@ -76,22 +75,22 @@ If you're running macOS Catalina and beyond, do the following:
 $ curl -sSL https://install.astronomer.io | sudo bash -s < /dev/null
 ```
 
-### Confirm the Install
+## Step 2: Confirm the Install
 
-To make sure that you have the Astro CLI installed on your machine and have a project to work from, run:
+To make sure that you have the Astronomer CLI installed on your machine, run:
 
 ```bash
 $ astro version
 ```
 
-If you're set up properly, you should see the version of the CLI you installed in the output:
+If the installation was successful, you should see the version of the CLI that you installed in the output:
 
 ```
 Astro CLI Version: 0.15.0
 Git Commit: c4fdeda96501ac9b1f3526c97a1c5c9b3f890d71
 ```
 
-For a breakdown of subcommands and corresponding descriptions, you can always run `astro` or `astro --help`.
+For a breakdown of subcommands and corresponding descriptions, you can always run `$ astro` or `$ astro --help`.
 
 ```
 astro is a command line interface for working with the Astronomer Platform.
@@ -119,77 +118,89 @@ Flags:
 Use "astro [command] --help" for more information about a command.
 ```
 
-## Initialize an Airflow Project
+## Step 3: Initialize an Airflow Project
 
-Once the Astronomer CLI is installed, the next step is to initialize an Airflow project on Astronomer. Follow the guidelines below.
+Once the Astronomer CLI is installed, the next step is to initialize an Airflow project on Astronomer. To do so:
 
-#### 1. Create a new directory on your machine
-
-```
+1. Create a new directory on your machine by running the following command:
+```sh
 $ mkdir <directory-name> && cd <directory-name>
 ```
 
-This is what you should check into your version control tool.
-
-#### 2. Once you're in that project directory, run:
-
-```
+2. Create the necessary project files in your new directory by running the following command:
+```sh
 $ astro dev init
 ```
-
-This will generate a collection of files within your directory:
-
+This will generate the following files in that directory:
 ```py
 .
 ├── dags # Where your DAGs go
 │   ├── example-dag.py # An example dag that comes with the initialized project
 ├── Dockerfile # For Astronomer's Docker image and runtime overrides
 ├── include # For any other files you'd like to include
-├── packages.txt # For OS-level packages
 ├── plugins # For any custom or community Airflow plugins
+├──airflow_settings.yaml #For your Airflow Connections, Variables and Pools (local only)
+├──packages.txt # For OS-level packages
 └── requirements.txt # For any Python packages
 ```
+These files make up the Docker image you'll then push to the Airflow instance on your local machine or to an Airflow Deployment on Astronomer Enterprise.
 
-These files collectively make up the Docker image you'll then push to the Airflow instance on your local machine or to a Deployment on Astronomer Enterprise.
+## Step 4: Start Airflow Locally
 
-## Start Airflow Locally
+You can now push your project to a local instance of Airflow. To do so:
 
-To spin up a local Airflow Deployment on your machine, run:
-
+1. Start Airflow on your local machine by running the following command in your project directory:
 ```
 $ astro dev start
 ```
+This command will spin up 3 Docker containers on your machine, each for a different Airflow component:
+ - **Postgres:** Airflow's Metadata Database
+ - **Webserver:** The Airflow component responsible for rendering the Airflow UI
+ - **Scheduler:** The Airflow component responsible for monitoring and triggering tasks
 
-This command will spin up 3 Docker containers on your machine, each for a different Airflow component.
+ For guidelines on accessing your Postgres database both locally and on Astronomer, read [Access the Airflow Database](/docs/enterprise/stable/customize-airflow/access-airflow-database/).
 
-- **Postgres:** [Airflow's Metadata Database](/docs/enterprise/stable/customize-airflow/access-airflow-database/)
-- **Webserver:** The Airflow component responsible for rendering the Airflow UI
-- **Scheduler:** The Airflow component responsible for monitoring and triggering tasks
+2. Verify that all 3 Docker containers were created by running:
+```
+$ docker ps
+```
+> **Note**: Running `$ astro dev start` will start your project with the Airflow Webserver exposed at port 8080 and Postgres exposed at port 5432.
+>
+> If you already have either of those ports allocated, you can either [stop existing docker containers](https://forum.astronomer.io/t/docker-error-in-cli-bind-for-0-0-0-0-5432-failed-port-is-already-allocated/151) or [change the port](https://forum.astronomer.io/t/i-already-have-the-ports-that-the-cli-is-trying-to-use-8080-5432-occupied-can-i-change-the-ports-when-starting-a-project/48).
 
-Run `docker ps` to verify that these containers were created. Once you've run `astro dev start`, you'll be able to access the following components locally:
+3. Access the Airflow UI for your local Airflow project. To do so, go to http://localhost:8080/ and log in with `admin` for both your Username and Password.
 
-- Airflow Webserver: http://localhost:8080/admin/ (Credentials are `admin:admin` by default)
-- Postgres Database: localhost:5432/postgres
+ You should also be able to access your Postgres Database at: `localhost:5432/postgres`.
 
-For guidelines on accessing your Postgres database both locally and on Astronomer, refer to our ["Airflow Database" doc](/docs/enterprise/stable/customize-airflow/access-airflow-database/).
+ For guidelines on accessing your Postgres database both locally and on Astronomer, refer to the [Access Airflow Database](/docs/enterprise/stable/customize-airflow/access-airflow-database/) guide.
 
-> **Note:** The image might take some time to build the first time. After that, it will build from cached layers.
+## Step 5: Authenticate to Astronomer
 
-## Applying Changes
+To authenticate to Astronomer Cloud via the Astronomer CLI, run:
+
+```
+$ astro auth login BASEDOMAIN
+```
+
+If you created your account with a username and password, you'll be prompted to enter them directly in your terminal. If you did so via Google or GitHub, you'll be prompted to grab a temporary token from the Astronomer UI in your browser.
+
+If you do not yet have an account on Astronomer, ask a Workspace Admin on your team to send you an invitation or [reach out to us](/get-astronomer?ref=docs) to start a free 14-day trial on Astronomer Cloud.
+
+> **Note:** Once you run this command once, it should stay cached and allow you to just run `astro auth login` to authenticate more easily in the future.
+
+## Next Steps: Apply Changes using the CLI
 
 As you develop locally, it's worth noting that some changes made to your image are automatically applied, while other changes made to a certain set of files require rebuilding your image in order for them to render.
 
-Read below for guidelines on both.
-
 ### Code Changes
 
-All changes made to the following files will be picked up automatically:
+All changes made to the following files will be picked up as soon as they're saved to your code editor:
 
 - `dags`
 - `plugins`
 - `include`
 
-Make sure to save changes in your code editor and refresh the Airflow Webserver in your browser to see them render.
+Once you save your changes, refresh the Airflow Webserver in your browser to see them render.
 
 ### Other Changes
 
@@ -200,48 +211,32 @@ All changes made to the following files require rebuilding your image:
 - `requirements.txt`
 - `airflow_settings.yaml`
 
-This includes changing the Airflow image in your `Dockerfile`, adding Python Packages to `requirements.txt` or OS-level packages to `packages.txt`, etc. To rebuild your image, follow the guidelines below.
-
-#### 1. Stop your running Docker containers:
+This includes changing the Airflow image in your `Dockerfile`, adding Python Packages to `requirements.txt` or OS-level packages to `packages.txt`, etc. To rebuild your image, first run the following command:
 
 ```
 $ astro dev stop
 ```
 
-#### 2. Restart those Docker containers:
+Then, restart the Docker containers by running:
 
 ```
 $ astro dev start
 ```
 
-## Access to the Airflow CLI
-
-You're free to use native Airflow CLI commands with the Astro CLI when developing locally by wrapping them around docker commands.
-
-### Adding a Connection
-
-For example, an Airflow Connection can be added with:
-
-```bash
-docker exec -it SCHEDULER_CONTAINER bash -c "airflow connections -a --conn_id test_three  --conn_type ' ' --conn_login etl --conn_password pw --conn_extra {"account":"blah"}"
-```
-
-Refer to the native [Airflow CLI](https://airflow.apache.org/cli.html) for a list of all commands.
-
 ## Additional Resources
 
-For more information on our CLI specifically, feel free to reference:
+For more information on the Astronomer CLI, feel free to reference:
 
 * [CLI Release Changelog](https://github.com/astronomer/astro-cli/releases)
 * [CLI README on GitHub](https://github.com/astronomer/astro-cli#astronomer-cli----)
 
-### Beyond the CLI
+## Beyond the CLI
 
-If you're looking for guidance beyond the Astronomer CLI, we'd encourage you to reference some of the resources below:
+Looking for additional next steps after installing the Astronomer CLI? We recommend reading through the following guides:
 
-* [Deploying to Astronomer](/docs/enterprise/stable/deploy/deploy-code/)
-* [Customizing your Image](/docs/enterprise/stable/develop/customize-image/)
+* [Deploying to Astronomer](/docs/enterprise/stable/deploy/deploy-cli/)
+* [Customizing Your Image](/docs/enterprise/stable/develop/customize-image/)
 * [Manage Airflow Versions](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/)
-* [CI/CD](/docs/enterprise/stable/deploy/ci-cd/)
+* [Deploy to Astronomer via CI/CD](/docs/enterprise/stable/deploy/ci-cd/)
 
-As always, don't hesitate to reach out to the [Astronomer Support Portal](https://support.astronomer.io/hc/en-us) for additional questions or reference the [Astronomer Forum](https://forum.astronomer.io/).
+As always, don't hesitate to reach out to [Astronomer Support](https://support.astronomer.io/hc/en-us) or post in our [Astronomer Forum](https://forum.astronomer.io/) for additional questions.

--- a/enterprise/next/02_develop/01_cli-quickstart.md
+++ b/enterprise/next/02_develop/01_cli-quickstart.md
@@ -183,7 +183,7 @@ If you created your account with a username and password, you'll be prompted to 
 
 If you do not yet have an account on Astronomer, ask a Workspace Admin on your team to send you an invitation.
 
-> **Note:** Once you run this command once, it should stay cached and allow you to just run `astro auth login` to authenticate more easily in the future.
+> **Note:** Once you run this command once, it should stay cached and allow you to just run `$ astro auth login` to authenticate more easily in the future.
 
 ## Next Steps: Apply Changes using the CLI
 

--- a/enterprise/next/02_develop/01_cli-quickstart.md
+++ b/enterprise/next/02_develop/01_cli-quickstart.md
@@ -10,13 +10,13 @@ Astronomer's [open source CLI](https://github.com/astronomer/astro-cli) is the e
 
 From the CLI, both Astronomer and non-Astronomer users can create a local Apache Airflow instance with a dedicated Webserver, Scheduler and Postgres Database. Once you initialize a project on Astronomer, you can easily customize your image (e.g. add Python or OS-level packages, plugins etc.) and push that image to run on your local machine.
 
-If you're an Astronomer user, you might use the Astronomer CLI to do the following:
+If you're an Astronomer Enterprise user, you might use the Astronomer CLI to do the following:
 
 - Authenticate to Astronomer
 - List Astronomer Workspaces and Deployments you have access to
 - Deploy to an Airflow Deployment on Astronomer
 - Create Astronomer Service Accounts, Users and Deployments
-- Append annotations to your Deployment's Pods (Enterprise only)
+- Append annotations to your Deployment's Pods
 
 
 The guidelines below will walk you through how to install the CLI, initialize an Astronomer project, and deploy to an Airflow instance on your local machine.
@@ -158,21 +158,18 @@ This command will spin up 3 Docker containers on your machine, each for a differ
  - **Webserver:** The Airflow component responsible for rendering the Airflow UI
  - **Scheduler:** The Airflow component responsible for monitoring and triggering tasks
 
- For guidelines on accessing your Postgres database both locally and on Astronomer, read [Access the Airflow Database](/docs/enterprise/stable/customize-airflow/access-airflow-database/).
-
 2. Verify that all 3 Docker containers were created by running:
 ```
 $ docker ps
 ```
-> **Note**: Running `$ astro dev start` will start your project with the Airflow Webserver exposed at port 8080 and Postgres exposed at port 5432.
->
-> If you already have either of those ports allocated, you can either [stop existing docker containers](https://forum.astronomer.io/t/docker-error-in-cli-bind-for-0-0-0-0-5432-failed-port-is-already-allocated/151) or [change the port](https://forum.astronomer.io/t/i-already-have-the-ports-that-the-cli-is-trying-to-use-8080-5432-occupied-can-i-change-the-ports-when-starting-a-project/48).
 
 3. Access the Airflow UI for your local Airflow project. To do so, go to http://localhost:8080/ and log in with `admin` for both your Username and Password.
 
- You should also be able to access your Postgres Database at: `localhost:5432/postgres`.
+    You should also be able to access your Postgres Database at: `localhost:5432/postgres`. For guidelines on accessing your Postgres database both locally and on Astronomer, refer to the [Access Airflow Database](/docs/enterprise/stable/customize-airflow/access-airflow-database/) guide.
 
- For guidelines on accessing your Postgres database both locally and on Astronomer, refer to the [Access Airflow Database](/docs/enterprise/stable/customize-airflow/access-airflow-database/) guide.
+    > **Note**: Running `$ astro dev start` will start your project with the Airflow Webserver exposed at port 8080 and Postgres exposed at port 5432.
+    >
+    > If you already have either of those ports allocated, you can either [stop existing docker containers](https://forum.astronomer.io/t/docker-error-in-cli-bind-for-0-0-0-0-5432-failed-port-is-already-allocated/151) or [change the port](https://forum.astronomer.io/t/i-already-have-the-ports-that-the-cli-is-trying-to-use-8080-5432-occupied-can-i-change-the-ports-when-starting-a-project/48).
 
 ## Step 5: Authenticate to Astronomer
 
@@ -184,7 +181,7 @@ $ astro auth login BASEDOMAIN
 
 If you created your account with a username and password, you'll be prompted to enter them directly in your terminal. If you did so via Google or GitHub, you'll be prompted to grab a temporary token from the Astronomer UI in your browser.
 
-If you do not yet have an account on Astronomer, ask a Workspace Admin on your team to send you an invitation or [reach out to us](/get-astronomer?ref=docs) to start a free 14-day trial on Astronomer Cloud.
+If you do not yet have an account on Astronomer, ask a Workspace Admin on your team to send you an invitation.
 
 > **Note:** Once you run this command once, it should stay cached and allow you to just run `astro auth login` to authenticate more easily in the future.
 

--- a/enterprise/next/02_develop/01_cli-quickstart.md
+++ b/enterprise/next/02_develop/01_cli-quickstart.md
@@ -165,11 +165,11 @@ $ docker ps
 
 3. Access the Airflow UI for your local Airflow project. To do so, go to http://localhost:8080/ and log in with `admin` for both your Username and Password.
 
-    You should also be able to access your Postgres Database at: `localhost:5432/postgres`. For guidelines on accessing your Postgres database both locally and on Astronomer, refer to the [Access Airflow Database](/docs/enterprise/stable/customize-airflow/access-airflow-database/) guide.
+   You should also be able to access your Postgres Database at: `localhost:5432/postgres`. For guidelines on accessing your Postgres database both locally and on Astronomer, refer to the [Access Airflow Database](/docs/enterprise/stable/customize-airflow/access-airflow-database/) guide.
 
-    > **Note**: Running `$ astro dev start` will start your project with the Airflow Webserver exposed at port 8080 and Postgres exposed at port 5432.
-    >
-    > If you already have either of those ports allocated, you can either [stop existing docker containers](https://forum.astronomer.io/t/docker-error-in-cli-bind-for-0-0-0-0-5432-failed-port-is-already-allocated/151) or [change the port](https://forum.astronomer.io/t/i-already-have-the-ports-that-the-cli-is-trying-to-use-8080-5432-occupied-can-i-change-the-ports-when-starting-a-project/48).
+   > **Note**: Running `$ astro dev start` will start your project with the Airflow Webserver exposed at port 8080 and Postgres exposed at port 5432.
+   >
+   > If you already have either of those ports allocated, you can either [stop existing docker containers](https://forum.astronomer.io/t/docker-error-in-cli-bind-for-0-0-0-0-5432-failed-port-is-already-allocated/151) or [change the port](https://forum.astronomer.io/t/i-already-have-the-ports-that-the-cli-is-trying-to-use-8080-5432-occupied-can-i-change-the-ports-when-starting-a-project/48).
 
 ## Step 5: Authenticate to Astronomer
 

--- a/enterprise/v0.16/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.16/02_develop/01_cli-quickstart.md
@@ -183,7 +183,7 @@ If you created your account with a username and password, you'll be prompted to 
 
 If you do not yet have an account on Astronomer, ask a Workspace Admin on your team to send you an invitation.
 
-> **Note:** Once you run this command once, it should stay cached and allow you to just run `astro auth login` to authenticate more easily in the future.
+> **Note:** Once you run this command once, it should stay cached and allow you to just run `$ astro auth login` to authenticate more easily in the future.
 
 ## Next Steps: Apply Changes using the CLI
 

--- a/enterprise/v0.16/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.16/02_develop/01_cli-quickstart.md
@@ -1,41 +1,40 @@
 ---
 title: "CLI Quickstart"
 navTitle: "CLI Quickstart"
-description: "Establish a local testing environment and deploy to Astronomer from your CLI."
+description: "Establish a local testing environment and deploy to Astronomer from the CLI."
 ---
 
 ## Overview
 
 Astronomer's [open source CLI](https://github.com/astronomer/astro-cli) is the easiest way to run Apache Airflow on your machine.
 
-From the CLI, both Astronomer and non-Astronomer users can provision a local Apache Airflow instance with a dedicated Webserver, Scheduler and Postgres Database. Once you initialize a project on Astronomer, you can easily customize your image (e.g. add Python or OS-level packages, plugins etc.) and push that image to run on your local machine.
+From the CLI, both Astronomer and non-Astronomer users can create a local Apache Airflow instance with a dedicated Webserver, Scheduler and Postgres Database. Once you initialize a project on Astronomer, you can easily customize your image (e.g. add Python or OS-level packages, plugins etc.) and push that image to run on your local machine.
 
-If you're an Astronomer user, you might use the Astronomer CLI to do the following:
+If you're an Astronomer Enterprise user, you might use the Astronomer CLI to do the following:
 
 - Authenticate to Astronomer
 - List Astronomer Workspaces and Deployments you have access to
 - Deploy to an Airflow Deployment on Astronomer
 - Create Astronomer Service Accounts, Users and Deployments
-- Append annotations to your Deployment's Pods (_Enterprise only_)
+- Append annotations to your Deployment's Pods
 
-This guide will walk you through how to install the CLI, initalize an Astronomer project, and deploy to an Airflow instance on your local machine.
 
-## Pre-Requisites
+The guidelines below will walk you through how to install the CLI, initialize an Astronomer project, and deploy to an Airflow instance on your local machine.
 
-To install the CLI, make sure you've installed:
-
-- [Docker](https://www.docker.com/) (v18.09 or higher)
-
-## Installation
+## Step 1: Install the Astronomer CLI
 
 There are two ways to install any version of the Astronomer CLI:
 
-1. via [Homebrew](https://brew.sh/)
-2. via a simple cURL command
+- [Homebrew](https://brew.sh/)
+- cURL
 
 > **Note:** Both methods only work for Unix (Linux+Mac) based systems. If you're running on Windows 10, follow [this guide](/docs/enterprise/v0.16/develop/cli-install-windows-10/) to get set up with Docker for WSL.
 
-### via Homebrew
+### Prerequisites
+
+The Astronomer CLI installation process requires [Docker](https://www.docker.com/) (v18.09 or higher).
+
+### Install with Homebrew
 
 If you have Homebrew installed, run:
 
@@ -43,27 +42,27 @@ If you have Homebrew installed, run:
 $ brew install astronomer/tap/astro
 ```
 
-To install a specific version of the Astro CLI, you'll have to specify `@major.minor.patch`. To install v0.13.1, for example, run:
+To install a specific version of the Astro CLI, you'll have to specify `@major.minor.patch`. To install v0.16.1, for example, run:
 
 ```sh
-$ brew install astronomer/tap/astro@0.13.1
+$ brew install astronomer/tap/astro@0.16.1
 ```
 
-### via cURL
+### Install with cURL
 
-To install the latest version of our CLI, run:
+To install the latest version of the Astronomer CLI, run:
 
 ```
 $ curl -sSL https://install.astronomer.io | sudo bash
 ```
 
-To install a specific version of the Astro CLI, specify `-s -- major.minor.patch` as a flag at the end of the curl command. To install v0.13.1, for example, run:
+To install a specific version of the Astronomer CLI, specify `-s -- major.minor.patch` as a flag at the end of the cURL command. To install v0.16.1, for example, run:
 
 ```
-$ curl -sSL https://install.astronomer.io | sudo bash -s -- v0.13.1
+$ curl -sSL https://install.astronomer.io | sudo bash -s -- v0.16.1
 ```
 
-#### MacOS Catalina Users
+#### Note for MacOS Catalina Users:
 
 As of macOS Catalina, Apple [replaced bash with ZSH](https://www.theverge.com/2019/6/4/18651872/apple-macos-catalina-zsh-bash-shell-replacement-features) as the default shell. Our CLI install cURL command currently presents an incompatibility error with ZSH, sudo and the pipe syntax.
 
@@ -76,22 +75,22 @@ If you're running macOS Catalina and beyond, do the following:
 $ curl -sSL https://install.astronomer.io | sudo bash -s < /dev/null
 ```
 
-### Confirm the Install
+## Step 2: Confirm the Install
 
-To make sure that you have the Astro CLI installed on your machine and have a project to work from, run:
+To make sure that you have the Astronomer CLI installed on your machine, run:
 
 ```bash
 $ astro version
 ```
 
-If you're set up properly, you should see the version of the CLI you installed in the output:
+If the installation was successful, you should see the version of the CLI that you installed in the output:
 
 ```
 Astro CLI Version: 0.15.0
 Git Commit: c4fdeda96501ac9b1f3526c97a1c5c9b3f890d71
 ```
 
-For a breakdown of subcommands and corresponding descriptions, you can always run `astro` or `astro --help`.
+For a breakdown of subcommands and corresponding descriptions, you can always run `$ astro` or `$ astro --help`.
 
 ```
 astro is a command line interface for working with the Astronomer Platform.
@@ -119,77 +118,86 @@ Flags:
 Use "astro [command] --help" for more information about a command.
 ```
 
-## Initialize an Airflow Project
+## Step 3: Initialize an Airflow Project
 
-Once the Astronomer CLI is installed, the next step is to initialize an Airflow project on Astronomer. Follow the guidelines below.
+Once the Astronomer CLI is installed, the next step is to initialize an Airflow project on Astronomer. To do so:
 
-#### 1. Create a new directory on your machine
-
-```
+1. Create a new directory on your machine by running the following command:
+```sh
 $ mkdir <directory-name> && cd <directory-name>
 ```
 
-This is what you should check into your version control tool.
-
-#### 2. Once you're in that project directory, run:
-
-```
+2. Create the necessary project files in your new directory by running the following command:
+```sh
 $ astro dev init
 ```
-
-This will generate a collection of files within your directory:
-
+This will generate the following files in that directory:
 ```py
 .
 ├── dags # Where your DAGs go
 │   ├── example-dag.py # An example dag that comes with the initialized project
 ├── Dockerfile # For Astronomer's Docker image and runtime overrides
 ├── include # For any other files you'd like to include
-├── packages.txt # For OS-level packages
 ├── plugins # For any custom or community Airflow plugins
+├──airflow_settings.yaml #For your Airflow Connections, Variables and Pools (local only)
+├──packages.txt # For OS-level packages
 └── requirements.txt # For any Python packages
 ```
+These files make up the Docker image you'll then push to the Airflow instance on your local machine or to an Airflow Deployment on Astronomer Enterprise.
 
-These files collectively make up the Docker image you'll then push to the Airflow instance on your local machine or to a Deployment on Astronomer Enterprise.
+## Step 4: Start Airflow Locally
 
-## Start Airflow Locally
+You can now push your project to a local instance of Airflow. To do so:
 
-To spin up a local Airflow Deployment on your machine, run:
-
+1. Start Airflow on your local machine by running the following command in your project directory:
 ```
 $ astro dev start
 ```
+This command will spin up 3 Docker containers on your machine, each for a different Airflow component:
+ - **Postgres:** Airflow's Metadata Database
+ - **Webserver:** The Airflow component responsible for rendering the Airflow UI
+ - **Scheduler:** The Airflow component responsible for monitoring and triggering tasks
 
-This command will spin up 3 Docker containers on your machine, each for a different Airflow component.
+2. Verify that all 3 Docker containers were created by running:
+```
+$ docker ps
+```
 
-- **Postgres:** [Airflow's Metadata Database](/docs/enterprise/v0.16/customize-airflow/access-airflow-database/)
-- **Webserver:** The Airflow component responsible for rendering the Airflow UI
-- **Scheduler:** The Airflow component responsible for monitoring and triggering tasks
+3. Access the Airflow UI for your local Airflow project. To do so, go to http://localhost:8080/ and log in with `admin` for both your Username and Password.
 
-Run `docker ps` to verify that these containers were created. Once you've run `astro dev start`, you'll be able to access the following components locally:
+   You should also be able to access your Postgres Database at: `localhost:5432/postgres`. For guidelines on accessing your Postgres database both locally and on Astronomer, refer to the [Access Airflow Database](/docs/enterprise/v0.16/customize-airflow/access-airflow-database/) guide.
 
-- Airflow Webserver: http://localhost:8080/admin/ (Credentials are `admin:admin` by default)
-- Postgres Database: localhost:5432/postgres
+   > **Note**: Running `$ astro dev start` will start your project with the Airflow Webserver exposed at port 8080 and Postgres exposed at port 5432.
+   >
+   > If you already have either of those ports allocated, you can either [stop existing docker containers](https://forum.astronomer.io/t/docker-error-in-cli-bind-for-0-0-0-0-5432-failed-port-is-already-allocated/151) or [change the port](https://forum.astronomer.io/t/i-already-have-the-ports-that-the-cli-is-trying-to-use-8080-5432-occupied-can-i-change-the-ports-when-starting-a-project/48).
 
-For guidelines on accessing your Postgres database both locally and on Astronomer, refer to our ["Airflow Database" doc](/docs/enterprise/v0.16/customize-airflow/access-airflow-database/).
+## Step 5: Authenticate to Astronomer
 
-> **Note:** The image might take some time to build the first time. After that, it will build from cached layers.
+To authenticate to Astronomer Cloud via the Astronomer CLI, run:
 
-## Applying Changes
+```
+$ astro auth login BASEDOMAIN
+```
+
+If you created your account with a username and password, you'll be prompted to enter them directly in your terminal. If you did so via Google or GitHub, you'll be prompted to grab a temporary token from the Astronomer UI in your browser.
+
+If you do not yet have an account on Astronomer, ask a Workspace Admin on your team to send you an invitation.
+
+> **Note:** Once you run this command once, it should stay cached and allow you to just run `astro auth login` to authenticate more easily in the future.
+
+## Next Steps: Apply Changes using the CLI
 
 As you develop locally, it's worth noting that some changes made to your image are automatically applied, while other changes made to a certain set of files require rebuilding your image in order for them to render.
 
-Read below for guidelines on both.
-
 ### Code Changes
 
-All changes made to the following files will be picked up automatically:
+All changes made to the following files will be picked up as soon as they're saved to your code editor:
 
 - `dags`
 - `plugins`
 - `include`
 
-Make sure to save changes in your code editor and refresh the Airflow Webserver in your browser to see them render.
+Once you save your changes, refresh the Airflow Webserver in your browser to see them render.
 
 ### Other Changes
 
@@ -200,48 +208,32 @@ All changes made to the following files require rebuilding your image:
 - `requirements.txt`
 - `airflow_settings.yaml`
 
-This includes changing the Airflow image in your `Dockerfile`, adding Python Packages to `requirements.txt` or OS-level packages to `packages.txt`, etc. To rebuild your image, follow the guidelines below.
-
-#### 1. Stop your running Docker containers:
+This includes changing the Airflow image in your `Dockerfile`, adding Python Packages to `requirements.txt` or OS-level packages to `packages.txt`, etc. To rebuild your image, first run the following command:
 
 ```
 $ astro dev stop
 ```
 
-#### 2. Restart those Docker containers:
+Then, restart the Docker containers by running:
 
 ```
 $ astro dev start
 ```
 
-## Access to the Airflow CLI
-
-You're free to use native Airflow CLI commands with the Astro CLI when developing locally by wrapping them around docker commands.
-
-### Adding a Connection
-
-For example, an Airflow Connection can be added with:
-
-```bash
-docker exec -it SCHEDULER_CONTAINER bash -c "airflow connections -a --conn_id test_three  --conn_type ' ' --conn_login etl --conn_password pw --conn_extra {"account":"blah"}"
-```
-
-Refer to the native [Airflow CLI](https://airflow.apache.org/cli.html) for a list of all commands.
-
 ## Additional Resources
 
-For more information on our CLI specifically, feel free to reference:
+For more information on the Astronomer CLI, feel free to reference:
 
 * [CLI Release Changelog](https://github.com/astronomer/astro-cli/releases)
 * [CLI README on GitHub](https://github.com/astronomer/astro-cli#astronomer-cli----)
 
-### Beyond the CLI
+## Beyond the CLI
 
-If you're looking for guidance beyond the Astronomer CLI, we'd encourage you to reference some of the resources below:
+Looking for additional next steps after installing the Astronomer CLI? We recommend reading through the following guides:
 
-* [Deploying to Astronomer](/docs/enterprise/v0.16/deploy/deploy-code/)
-* [Customizing your Image](/docs/enterprise/v0.16/develop/customize-image/)
+* [Deploying to Astronomer](/docs/enterprise/v0.16/deploy/deploy-cli/)
+* [Customizing Your Image](/docs/enterprise/v0.16/develop/customize-image/)
 * [Manage Airflow Versions](/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/)
-* [CI/CD](/docs/enterprise/v0.16/deploy/ci-cd/)
+* [Deploy to Astronomer via CI/CD](/docs/enterprise/v0.16/deploy/ci-cd/)
 
-As always, don't hesitate to reach out to the [Astronomer Support Portal](https://support.astronomer.io/hc/en-us) for additional questions or reference the [Astronomer Forum](https://forum.astronomer.io/).
+As always, don't hesitate to reach out to [Astronomer Support](https://support.astronomer.io/hc/en-us) or post in our [Astronomer Forum](https://forum.astronomer.io/) for additional questions.


### PR DESCRIPTION
This PR addresses the CLI Quickstart portion of this issue: https://app.zenhub.com/workspaces/documentation-5fcfce583ed44e0011db3db5/issues/astronomer/docs/179

It does _not_ address the long-term improvements we hope to make to our CLI guides, such as removing content that's redundant with the general CLI. The only new changes here are a slight reorganization from lettered to numbered steps in Step 3 and Step 4. Otherwise, this was a fairly straightforward port from Cloud to Enterprise. 

Once I receive written approval of the changes here, I'll push them to Enterprise v0.16 as well. 