### PR TITLE
Ported Cloud version of the Manage Workspaces doc to Enterprise

### DIFF
--- a/cloud/stable/03_deploy/01_manage-workspaces.md
+++ b/cloud/stable/03_deploy/01_manage-workspaces.md
@@ -18,11 +18,11 @@ Once logged in, you'll land on a view that will direct you to create a new **Wor
 
 ## Workspaces
 
-**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the Workspace level on Astronomer.
+**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow Deployments. User access to Deployments is managed at the Workspace level on Astronomer.
 
-A **Workspace** is an Astronomer-specific term. You can think of your Workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal Workspace is automatically created. Airflow deployments are hierarchically lower - from a Workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
+A **Workspace** is an Astronomer-specific term. You can think of your Workspaces the same way you'd think of teams - they're just collections of Airflow Deployments that specific user groups have access to. When you create an account on Astronomer, a default personal Workspace is automatically created. Airflow Deployments are hierarchically lower - from a Workspace, you can create one or more Airflow Deployments, and grant or restrict user access to those Deployments accordingly.
 
-If you were a solo agent, you could have multiple Airflow deployments within that single Workspace and have no need for additional Workspaces. Teams, however, often share one or more Workspaces labeled as such, and have multiple Airflow deployments from there.
+If you were a solo agent, you could have multiple Airflow Deployments within that single Workspace and have no need for additional Workspaces. Teams, however, often share one or more Workspaces labeled as such, and have multiple Airflow Deployments from there.
 
 Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one Workspace to another once deployed.
 
@@ -30,16 +30,16 @@ Once you click into a Workspace, you'll land on another dashboard that we'll cal
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
-Here, you have a high-level overview of all of the active Airflow deployments you have running in that given Workspace. In this case, we only have one cluster spun up.
+Here, you have a high-level overview of all of the active Airflow Deployments you have running in that given Workspace. In this case, we only have one cluster spun up.
 
 From this screen, you can:
 
-1. Create new Airflow deployments
+1. Create new Airflow Deployments
 2. Manage user access to the Workspace
 3. Generate tokens for CI/CD systems via service accounts.
 4. Rename your Workspace
 
-Since all of our app activity is routed through a GraphQL API, you're free to create deployments, switch Workspaces, and add users via our [CLI](/docs/cloud/stable/develop/cli-quickstart/) if you prefer staying in your terminal.
+Since all of our app activity is routed through a GraphQL API, you're free to create Deployments, switch Workspaces, and add users via our [CLI](/docs/cloud/stable/develop/cli-quickstart/) if you prefer staying in your terminal.
 
 > **Note:** The concept of a "Workspace" only exists at the API level to support role-based access control and user permissions. It will not affect Airflow task execution.
 
@@ -53,7 +53,7 @@ You're able to adjust the resources given to your Airflow deployment directly fr
 
 From the Workspace dashboard, navigate back to the "Deployments" tab.
 
-If you click into one of your Airflow deployments, you'll land on a page that looks like this:
+If you click into one of your Airflow Deployments, you'll land on a page that looks like this:
 
 ![Deployments](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-deployment.png)
 
@@ -72,7 +72,7 @@ For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui
 
 If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that Workspace with varying permissions.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once members, they'll have access to _all_ Airflow Deployments under that Workspace with varying permissions.
 
 ### Workspace Permissions
 

--- a/cloud/stable/03_deploy/01_manage-workspaces.md
+++ b/cloud/stable/03_deploy/01_manage-workspaces.md
@@ -70,10 +70,8 @@ For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui
 
 ## User Management
 
-If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
+If you go to the **Users** tab of your Workspace Dashboard, you'll see who has access to the Workspace.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. For more information, read [Manage User Permissions on Astronomer Cloud](/docs/cloud/stable/manage-astronomer/workspace-permissions/).
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
 
-### Workspace Permissions
-
-Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in [Manage User Permissions on Astronomer Cloud](/docs/cloud/stable/manage-astronomer/workspace-permissions/).
+An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on Astronomer Cloud](/docs/cloud/stable/manage-astronomer/workspace-permissions/).

--- a/cloud/stable/03_deploy/01_manage-workspaces.md
+++ b/cloud/stable/03_deploy/01_manage-workspaces.md
@@ -72,7 +72,7 @@ For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui
 
 If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once members, they'll have access to _all_ Airflow Deployments under that Workspace with varying permissions.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once they are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace.
 
 ### Workspace Permissions
 

--- a/cloud/stable/03_deploy/01_manage-workspaces.md
+++ b/cloud/stable/03_deploy/01_manage-workspaces.md
@@ -18,34 +18,34 @@ Once logged in, you'll land on a view that will direct you to create a new **Wor
 
 ## Workspaces
 
-**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the workspace level on Astronomer.
+**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the Workspace level on Astronomer.
 
-A **Workspace** is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
+A **Workspace** is an Astronomer-specific term. You can think of your Workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal Workspace is automatically created. Airflow deployments are hierarchically lower - from a Workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
 
-If you were a solo agent, you could have multiple Airflow deployments within that single workspace and have no need for additional workspaces. Teams, however, often share one or more workspaces labeled as such, and have multiple Airflow deployments from there.
+If you were a solo agent, you could have multiple Airflow deployments within that single Workspace and have no need for additional Workspaces. Teams, however, often share one or more Workspaces labeled as such, and have multiple Airflow deployments from there.
 
-Deployments cannot be used or shared across workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one workspace to another once deployed.
+Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one Workspace to another once deployed.
 
-Once you click into a workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
+Once you click into a Workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
-Here, you have a high-level overview of all of the active Airflow deployments you have running in that given workspace. In this case, we only have one cluster spun up.
+Here, you have a high-level overview of all of the active Airflow deployments you have running in that given Workspace. In this case, we only have one cluster spun up.
 
 From this screen, you can:
 
 1. Create new Airflow deployments
-2. Manage user access to the workspace
+2. Manage user access to the Workspace
 3. Generate tokens for CI/CD systems via service accounts.
 4. Rename your Workspace
 
-Since all of our app activity is routed through a GraphQL API, you're free to create deployments, switch workspaces, and add users via our [CLI](/docs/cloud/stable/develop/cli-quickstart/) if you prefer staying in your terminal.
+Since all of our app activity is routed through a GraphQL API, you're free to create deployments, switch Workspaces, and add users via our [CLI](/docs/cloud/stable/develop/cli-quickstart/) if you prefer staying in your terminal.
 
 > **Note:** The concept of a "Workspace" only exists at the API level to support role-based access control and user permissions. It will not affect Airflow task execution.
 
 ## Deployments
 
-An [Apache Airflow](https://airflow.apache.org/) Deployment is made up of a Scheduler, a Webserver and, if you're running the Celery or Kubernetes Executors, one or more Workers. An Airflow Deployment within a Workspce has the capacity to host a collection of DAGs.
+An [Apache Airflow](https://airflow.apache.org/) Deployment is made up of a Scheduler, a Webserver and, if you're running the Celery or Kubernetes Executors, one or more Workers. An Airflow Deployment within a Workspace has the capacity to host a collection of DAGs.
 
 In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/cloud/stable/develop/cli-quickstart/) as part of a Workspace. Under the hood, each Airflow Deployment gets its own Kubernetes namespace and has a reserved set of dedicated resources and an underlying Postgres Metadata Database.
 
@@ -72,7 +72,7 @@ For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui
 
 If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace with varying permissions.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that Workspace with varying permissions.
 
 ### Workspace Permissions
 

--- a/cloud/stable/03_deploy/01_manage-workspaces.md
+++ b/cloud/stable/03_deploy/01_manage-workspaces.md
@@ -72,7 +72,7 @@ For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui
 
 If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once they are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. For more information, read [Manage User Permissions on Astronomer Cloud](/docs/cloud/stable/manage-astronomer/workspace-permissions/).
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. For more information, read [Manage User Permissions on Astronomer Cloud](/docs/cloud/stable/manage-astronomer/workspace-permissions/).
 
 ### Workspace Permissions
 

--- a/cloud/stable/03_deploy/01_manage-workspaces.md
+++ b/cloud/stable/03_deploy/01_manage-workspaces.md
@@ -72,8 +72,8 @@ For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui
 
 If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once they are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once they are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. For more information, read [Manage User Permissions on Astronomer Cloud](/docs/cloud/stable/manage-astronomer/workspace-permissions/).
 
 ### Workspace Permissions
 
-Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in the [User Roles and Permissions](/docs/cloud/stable/manage-astronomer/workspace-permissions/) section.
+Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in [Manage User Permissions on Astronomer Cloud](/docs/cloud/stable/manage-astronomer/workspace-permissions/).

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -70,10 +70,10 @@ For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui
 
 ## User Management
 
-If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
+If you go to the **Users** tab of your Workspace Dashboard, you'll see who has access to the Workspace.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. For more information, read [Manage User Permissions on Astronomer Enterprise](/docs/enterprise/stable/manage-astronomer/workspace-permissions/).
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
 
-### Workspace Permissions
+An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on Astronomer Cloud](/docs/cloud/stable/manage-astronomer/workspace-permissions/).
 
-Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. For an exact breakdown of these roles, refer to [Manage User Permissions on Astronomer Enterprise](/docs/enterprise/stable/manage-astronomer/workspace-permissions/). In addition, Enterprise admins can add or remove specific permissions for each of these roles. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/manage-platform-users#customize-permissions).
+In addition, Enterprise admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/manage-platform-users#customize-permissions).

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -4,55 +4,52 @@ navTitle: "Manage Workspaces"
 description: "Manage Astronomer Workspaces and Airflow Deployments via the Astronomer UI."
 ---
 
-We've designed the Astronomer UI as a place for you to easily and effectively manage users, deployments and resources.
+We've designed the Astronomer UI as a place for you to easily manage users, Airflow Deployments and resources.
 
 ## Dashboard
 
 Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
 
-![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
-
-From this dashboard, you can:
-
 1. Create a new Workspace
 2. View the Workspaces you have access to in the left-hand navigation
 3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
 
+![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
+
 ## Workspaces
 
-**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the workspace level on Astronomer.
+**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the Workspace level on Astronomer.
 
-A **Workspace** is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
+A **Workspace** is an Astronomer-specific term. You can think of your Workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal Workspace is automatically created. Airflow deployments are hierarchically lower - from a Workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
 
-If you were a solo agent, you could have multiple Airflow deployments within that single workspace and have no need for additional workspaces. Teams, however, often share one or more workspaces labeled as such, and have multiple Airflow deployments from there.
+If you were a solo agent, you could have multiple Airflow deployments within that single Workspace and have no need for additional Workspaces. Teams, however, often share one or more Workspaces labeled as such, and have multiple Airflow deployments from there.
 
-Deployments cannot be used or shared across workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one workspace to another once deployed.
+Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one Workspace to another once deployed.
 
-Once you click into a workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
+Once you click into a Workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
-Here, you have a high-level overview of all of the active Airflow deployments you have running in that given workspace. In this case, we only have one cluster spun up.
+Here, you have a high-level overview of all of the active Airflow deployments you have running in that given Workspace. In this case, we only have one cluster spun up.
 
 From this screen, you can:
 
 1. Create new Airflow deployments
-2. Manage user access to the workspace
+2. Manage user access to the Workspace
 3. Generate tokens for CI/CD systems via service accounts.
 4. Rename your Workspace
 
-Since all of our app activity is routed through a GraphQL API, you're free to create deployments, switch workspaces, and add users via our [CLI](/docs/enterprise/stable/develop/cli-quickstart/) if you prefer staying in your terminal.
+Since all of our app activity is routed through a GraphQL API, you're free to create deployments, switch Workspaces, and add users via our [CLI](/docs/enterprise/stable/develop/cli-quickstart/) if you prefer staying in your terminal.
 
-**Note:** The concept of a "workspace" only exists at the API level to help with permissions. It does **not** have anything to do with how Airflow will run jobs.
+> **Note:** The concept of a "Workspace" only exists at the API level to support role-based access control and user permissions. It will not affect Airflow task execution.
 
 ## Deployments
 
-A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
+An [Apache Airflow](https://airflow.apache.org/) Deployment is made up of a Scheduler, a Webserver and, if you're running the Celery or Kubernetes Executors, one or more Workers. An Airflow Deployment within a Workspace has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/stable/develop/cli-quickstart/) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/stable/develop/cli-quickstart/) as part of a Workspace. Under the hood, each Airflow Deployment gets its own Kubernetes namespace and has a reserved set of dedicated resources and an underlying Postgres Metadata Database.
 
 You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
-
 
 From the Workspace dashboard, navigate back to the "Deployments" tab.
 
@@ -69,12 +66,14 @@ The former will link you directly to your DAG Dashboard on Airflow itself. Your 
 
 For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui/).
 
-**Each deployment will run in a separate Kubernetes namespace, so they'll all get resources and maintain metadata independently. You should assume that each deployment is unaware of the others.**
+> **Note:** All Airflow Deployments run in an isolated Kubernetes namespace, which means resources will be provisioned independently and data will be kept isolated from the rest. You can assume that each Airflow Deployment is unaware of the others, even within the same Workspace.
 
 ## User Management
 
-If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
+If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
 
-## Workspace Permissions
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that Workspace with varying permissions.
 
-Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in the [User Roles and Permissions](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) section. Astronomer Enterprise admins can [configure the exact permissions](/docs/enterprise/stable/manage-astronomer/manage-platform-users/) for each Astronomer role.
+### Workspace Permissions
+
+Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. For an exact breakdown of these roles, refer to [User Roles and Permissions](/docs/enterprise/stable/manage-astronomer/workspace-permissions/). In addition, Enterprise admins can add or remove specific permissions for each of these roles. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/manage-platform-users#customize-permissions).

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -72,7 +72,7 @@ For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui
 
 If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once members, they'll have access to _all_ Airflow Deployments under that Workspace with varying permissions.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once they are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace.
 
 ### Workspace Permissions
 

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -72,7 +72,7 @@ For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui
 
 If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once they are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. For more information, read [Manage User Permissions on Astronomer Enterprise](/docs/enterprise/stable/manage-astronomer/workspace-permissions/).
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. For more information, read [Manage User Permissions on Astronomer Enterprise](/docs/enterprise/stable/manage-astronomer/workspace-permissions/).
 
 ### Workspace Permissions
 

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -20,7 +20,7 @@ Once logged in, you'll land on a view that will direct you to create a new **Wor
 
 **The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow Deployments. User access to Deployments is managed at the Workspace level on Astronomer.
 
-A **Workspace** is an Astronomer-specific term. You can think of your Workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal Workspace is automatically created. Airflow Deployments are hierarchically lower - from a Workspace, you can create one or more Airflow Deployments, and grant or restrict user access to those Deployments accordingly.
+A **Workspace** is an Astronomer-specific term. You can think of your Workspaces the same way you'd think of teams - they're just collections of Airflow Deployments that specific user groups have access to. When you create an account on Astronomer, a default personal Workspace is automatically created. Airflow Deployments are hierarchically lower - from a Workspace, you can create one or more Airflow Deployments, and grant or restrict user access to those Deployments accordingly.
 
 If you were a solo agent, you could have multiple Airflow Deployments within that single Workspace and have no need for additional Workspaces. Teams, however, often share one or more Workspaces labeled as such, and have multiple Airflow Deployments from there.
 
@@ -36,7 +36,7 @@ From this screen, you can:
 
 1. Create new Airflow Deployments
 2. Manage user access to the Workspace
-3. Generate tokens for CI/CD systems via service accounts.
+3. Generate tokens for CI/CD systems via service accounts
 4. Rename your Workspace
 
 Since all of our app activity is routed through a GraphQL API, you're free to create Deployments, switch Workspaces, and add users via our [CLI](/docs/enterprise/stable/develop/cli-quickstart/) if you prefer staying in your terminal.
@@ -74,6 +74,6 @@ If you go to the **Users** tab of your Workspace Dashboard, you'll see who has a
 
 If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
 
-An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on Astronomer Cloud](/docs/cloud/stable/manage-astronomer/workspace-permissions/).
+An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/stable/manage-astronomer/workspace-permissions/).
 
 In addition, Enterprise admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/manage-platform-users#customize-permissions).

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -18,11 +18,11 @@ Once logged in, you'll land on a view that will direct you to create a new **Wor
 
 ## Workspaces
 
-**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the Workspace level on Astronomer.
+**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow Deployments. User access to Deployments is managed at the Workspace level on Astronomer.
 
-A **Workspace** is an Astronomer-specific term. You can think of your Workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal Workspace is automatically created. Airflow deployments are hierarchically lower - from a Workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
+A **Workspace** is an Astronomer-specific term. You can think of your Workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal Workspace is automatically created. Airflow Deployments are hierarchically lower - from a Workspace, you can create one or more Airflow Deployments, and grant or restrict user access to those Deployments accordingly.
 
-If you were a solo agent, you could have multiple Airflow deployments within that single Workspace and have no need for additional Workspaces. Teams, however, often share one or more Workspaces labeled as such, and have multiple Airflow deployments from there.
+If you were a solo agent, you could have multiple Airflow Deployments within that single Workspace and have no need for additional Workspaces. Teams, however, often share one or more Workspaces labeled as such, and have multiple Airflow Deployments from there.
 
 Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one Workspace to another once deployed.
 
@@ -30,16 +30,16 @@ Once you click into a Workspace, you'll land on another dashboard that we'll cal
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
-Here, you have a high-level overview of all of the active Airflow deployments you have running in that given Workspace. In this case, we only have one cluster spun up.
+Here, you have a high-level overview of all of the active Airflow Deployments you have running in that given Workspace. In this case, we only have one cluster spun up.
 
 From this screen, you can:
 
-1. Create new Airflow deployments
+1. Create new Airflow Deployments
 2. Manage user access to the Workspace
 3. Generate tokens for CI/CD systems via service accounts.
 4. Rename your Workspace
 
-Since all of our app activity is routed through a GraphQL API, you're free to create deployments, switch Workspaces, and add users via our [CLI](/docs/enterprise/stable/develop/cli-quickstart/) if you prefer staying in your terminal.
+Since all of our app activity is routed through a GraphQL API, you're free to create Deployments, switch Workspaces, and add users via our [CLI](/docs/enterprise/stable/develop/cli-quickstart/) if you prefer staying in your terminal.
 
 > **Note:** The concept of a "Workspace" only exists at the API level to support role-based access control and user permissions. It will not affect Airflow task execution.
 
@@ -53,7 +53,7 @@ You're able to adjust the resources given to your Airflow deployment directly fr
 
 From the Workspace dashboard, navigate back to the "Deployments" tab.
 
-If you click into one of your Airflow deployments, you'll land on a page that looks like this:
+If you click into one of your Airflow Deployments, you'll land on a page that looks like this:
 
 ![Deployments](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-deployment.png)
 
@@ -72,7 +72,7 @@ For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui
 
 If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that Workspace with varying permissions.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once members, they'll have access to _all_ Airflow Deployments under that Workspace with varying permissions.
 
 ### Workspace Permissions
 

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -72,8 +72,8 @@ For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui
 
 If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once they are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once they are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. For more information, read [Manage User Permissions on Astronomer Enterprise](/docs/enterprise/stable/manage-astronomer/workspace-permissions/).
 
 ### Workspace Permissions
 
-Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. For an exact breakdown of these roles, refer to [User Roles and Permissions](/docs/enterprise/stable/manage-astronomer/workspace-permissions/). In addition, Enterprise admins can add or remove specific permissions for each of these roles. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/manage-platform-users#customize-permissions).
+Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. For an exact breakdown of these roles, refer to [Manage User Permissions on Astronomer Enterprise](/docs/enterprise/stable/manage-astronomer/workspace-permissions/). In addition, Enterprise admins can add or remove specific permissions for each of these roles. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/manage-platform-users#customize-permissions).

--- a/enterprise/v0.16/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.16/04_deploy/01_manage-workspaces.md
@@ -4,59 +4,56 @@ navTitle: "Manage Workspaces"
 description: "Manage Astronomer Workspaces and Airflow Deployments via the Astronomer UI."
 ---
 
-We've designed the Astronomer UI as a place for you to easily and effectively manage users, deployments and resources.
+We've designed the Astronomer UI as a place for you to easily manage users, Airflow Deployments and resources.
 
 ## Dashboard
 
 Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
 
-![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
-
-From this dashboard, you can:
-
 1. Create a new Workspace
 2. View the Workspaces you have access to in the left-hand navigation
 3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
 
+![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
+
 ## Workspaces
 
-**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the workspace level on Astronomer.
+**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow Deployments. User access to Deployments is managed at the Workspace level on Astronomer.
 
-A **Workspace** is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
+A **Workspace** is an Astronomer-specific term. You can think of your Workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal Workspace is automatically created. Airflow Deployments are hierarchically lower - from a Workspace, you can create one or more Airflow Deployments, and grant or restrict user access to those Deployments accordingly.
 
-If you were a solo agent, you could have multiple Airflow deployments within that single workspace and have no need for additional workspaces. Teams, however, often share one or more workspaces labeled as such, and have multiple Airflow deployments from there.
+If you were a solo agent, you could have multiple Airflow Deployments within that single Workspace and have no need for additional Workspaces. Teams, however, often share one or more Workspaces labeled as such, and have multiple Airflow Deployments from there.
 
-Deployments cannot be used or shared across workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one workspace to another once deployed.
+Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one Workspace to another once deployed.
 
-Once you click into a workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
+Once you click into a Workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
 
 ![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
-Here, you have a high-level overview of all of the active Airflow deployments you have running in that given workspace. In this case, we only have one cluster spun up.
+Here, you have a high-level overview of all of the active Airflow Deployments you have running in that given Workspace. In this case, we only have one cluster spun up.
 
 From this screen, you can:
 
-1. Create new Airflow deployments
-2. Manage user access to the workspace
-3. Generate tokens for CI/CD systems via service accounts.
+1. Create new Airflow Deployments
+2. Manage user access to the Workspace
+3. Generate tokens for CI/CD systems via service accounts
 4. Rename your Workspace
 
-Since all of our app activity is routed through a GraphQL API, you're free to create deployments, switch workspaces, and add users via our [CLI](/docs/enterprise/v0.16/develop/cli-quickstart/) if you prefer staying in your terminal.
+Since all of our app activity is routed through a GraphQL API, you're free to create Deployments, switch Workspaces, and add users via our [CLI](/docs/enterprise/v0.16/develop/cli-quickstart/) if you prefer staying in your terminal.
 
-**Note:** The concept of a "workspace" only exists at the API level to help with permissions. It does **not** have anything to do with how Airflow will run jobs.
+> **Note:** The concept of a "Workspace" only exists at the API level to support role-based access control and user permissions. It will not affect Airflow task execution.
 
 ## Deployments
 
-A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
+An [Apache Airflow](https://airflow.apache.org/) Deployment is made up of a Scheduler, a Webserver and, if you're running the Celery or Kubernetes Executors, one or more Workers. An Airflow Deployment within a Workspace has the capacity to host a collection of DAGs.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/v0.16/develop/cli-quickstart/) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/v0.16/develop/cli-quickstart/) as part of a Workspace. Under the hood, each Airflow Deployment gets its own Kubernetes namespace and has a reserved set of dedicated resources and an underlying Postgres Metadata Database.
 
-You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
-
+You're able to adjust the resources given to your Airflow Deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
 
 From the Workspace dashboard, navigate back to the "Deployments" tab.
 
-If you click into one of your Airflow deployments, you'll land on a page that looks like this:
+If you click into one of your Airflow Deployments, you'll land on a page that looks like this:
 
 ![Deployments](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-deployment.png)
 
@@ -69,12 +66,14 @@ The former will link you directly to your DAG Dashboard on Airflow itself. Your 
 
 For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui/).
 
-**Each deployment will run in a separate Kubernetes namespace, so they'll all get resources and maintain metadata independently. You should assume that each deployment is unaware of the others.**
+> **Note:** All Airflow Deployments run in an isolated Kubernetes namespace, which means resources will be provisioned independently and data will be kept isolated from the rest. You can assume that each Airflow Deployment is unaware of the others, even within the same Workspace.
 
 ## User Management
 
-If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
+If you go to the **Users** tab of your Workspace Dashboard, you'll see who has access to the Workspace.
 
-## Workspace Permissions
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Workspace Admins can then grant them varying levels of access to the entire Workspace.
 
-Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in the [User Roles and Permissions](/docs/enterprise/v0.16/manage-astronomer/workspace-permissions/) section. Astronomer Enterprise admins can [configure the exact permissions](/docs/enterprise/v0.16/manage-astronomer/manage-platform-users/) for each Astronomer role.
+An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/v0.16/manage-astronomer/workspace-permissions/).
+
+In addition, Enterprise admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/manage-platform-users#customize-permissions).


### PR DESCRIPTION
Part 4 of this Issue: https://github.com/astronomer/docs/issues/179

While the Managing Workspaces doc has a long ways to go, this PR brings some of the vital fixes from the Cloud doc over to Enterprise. I also updated some references to Astronomer terms per our style guide across both Cloud and Enterprise versions.

The only new content here is a rewording of the last sentence in the Enterprise "Workspace Permissions" section. 