### PR TITLE
Moved Customizing Images changes from Cloud to Enterprise

### DIFF
--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -14,7 +14,7 @@ More specifically, this doc includes instructions for how to:
 - Add dependencies
 - Run commands on build
 - Access the Airflow CLI
-- Add Environment Variables locally
+- Add Environment Variables Locally
 - Build from a Private Repository
 
 > **Note:** The guidelines below assume that you've initialized a project on Astronomer via `$ astro dev init`. If you haven't done so already, refer to our ["CLI Quickstart" doc](/docs/enterprise/stable/develop/cli-quickstart/).
@@ -75,9 +75,9 @@ pymongo==3.7.2
 
 ## Add Other Dependencies
 
-In the same way you can add Python and OS-level Packages, you're free to build additional dependencies and files for your DAGs to use into your image.
+In the same way you can build Python and OS-level Packages into your image, you're free to build additional dependencies and files for your DAGs to use.
 
-In the example below, we'll add a folder of `helper_functions` with a file (or set of files) that our Airflow DAGs can then call.
+In the example below, we'll add a folder of `helper_functions` with a file (or set of files) that our Airflow DAGs can then use.
 
 ### Add the folder into your project directory
 
@@ -118,7 +118,7 @@ airflow.cfg  dags  include  packages.txt  requirements.txt
 
 Notice that `helper_functions` folder has been built into your image.
 
-## Configure `airflow_settings.yaml`
+## Configure airflow_settings.yaml
 
 When you first initialize a new Airflow project on Astronomer, a file titled `airflow_settings.yaml` will be automatically generated. With this file you can configure and programmatically generate Airflow Connections, Pools, and Variables when you're developing locally.
 
@@ -225,8 +225,6 @@ docker exec -it SCHEDULER_CONTAINER bash -c "airflow connections -a --conn_id te
 
 Refer to the native [Airflow CLI](https://airflow.apache.org/cli.html) for a list of all commands.
 
-> **Note:** If you're interested in running the Airflow CLI to interact with an Airflow Deployment running on Astronomer, [reach out to us](support.astronomer.io).
-
 ## Add Environment Variables Locally
 
 The Astronomer CLI comes with the ability to  bring in Environment Variables from a specified file by running `$ astro dev start` with an `--env` flag as seen below:
@@ -241,35 +239,33 @@ $ astro dev start --env .env
 
 ## Build from a Private Repository
 
-If you're interested in bringing in custom Python Packages stored in a Private GitHub Repo, you're free to do that on Astronomer.
+If you're interested in bringing in custom Python Packages stored in a Private GitHub repo, you're free to do that on Astronomer.
 
 Read below for guidelines.
 
-### Pre-Requisites
+### Prerequisites
 
 - The Astronomer CLI
 - An intialized Astronomer Airflow project and corresponding directory
-- An [SSH Key](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to your Private GitHub Repo
+- An [SSH Key](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to your Private GitHub repo
 
-If you haven't initialized an Airflow Project on Astronomer (by running `astro dev init`), reference our [CLI Quickstart Guide](/docs/enterprise/stable/develop/cli-quickstart/).
+If you haven't initialized an Airflow Project on Astronomer (by running `$ astro dev init`), reference our [CLI Quickstart Guide](/docs/enterprise/stable/develop/cli-quickstart/).
 
-### Building your Image
-
-### Create a file called `Dockerfile.build`
+### Step 1. Create a file called Dockerfile.build
 
 1. In your directory, create a file called `Dockerfile.build` that's parallel to your `Dockerfile`.
 
 2. To the first line of that file, add a "FROM" statement that specifies the Airflow Image you want to run on Astronomer and ends with `AS stage`.
 
-If you're running the Alpine-based, Airflow 1.10.10 Astronomer Certified image, this would be:
+If you're running the Debian-based Astronomer Certified image for Airflow 1.10.12, this would be:
 
 ```
-FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10 AS stage1
+FROM quay.io/astronomer/ap-airflow:1.10.12-buster AS stage1
 ```
 
-For a list of all Airflow Images supported on Astronomer, refer to our ["Manage Airflow Versions" doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/).
+For a list of all Airflow Images supported on Astronomer, refer to [Upgrade Apache Airflow on Astronomer](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/).
 
-> **Note:**  Do NOT include `on-build` at the end of your Airflow Image as you typically would in your Dockerfile.
+> **Note:** Do NOT include `-onbuild` at the end of your Airflow Image as you typically would in your `Dockerfile`.
 
 3. Immediately below the `FROM...` line specified above, add the folllowing:
 
@@ -310,7 +306,7 @@ A few notes:
 - Make sure your custom OS-Level packages are in `packages.txt` and your Python packages in `requirements.txt` within your repo
 - If you're running Python 3.7 on your machine, replace the reference to Python 3.6 under `# Copy requirements directory` with `/usr/lib/python3.7/site-packages/` above
 
-### 2. Build your Image
+### Step 2. Build your Image
 
 Now, let's build a Docker image based on the requirements above that we'll then reference in your Dockerfile, tag, and push to Astronomer.
 
@@ -320,13 +316,13 @@ Run the following in your terminal:
 $ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-<airflow-image> .
 ```
 
-If you have `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` in your `Dockerfile.build`, for example, this command would be:
+If you have `quay.io/astronomer/ap-airflow:1.10.12-buster` in your `Dockerfile.build`, for example, this command would be:
 
 ```
-$ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-ap-airflow:1.10.10-alpine3.10 .
+$ docker build -f Dockerfile.build --build-arg PRIVATE_RSA_KEY="$(cat ~/.ssh/id_rsa)" -t custom-ap-airflow:1.10.12-buster .
 ```
 
-### 3. Replace your Dockerfile
+### Step 3. Replace your Dockerfile
 
 Now that we've built your custom image, let's reference that custom image in your `Dockerfile`. Replace the current contents of your `Dockerfile` with the following:
 
@@ -337,14 +333,14 @@ FROM custom-<airflow-image>
 If you're running `quay.io/astronomer/ap-airflow:1.10.10-alpine3.10` as specified above, this line would read:
 
 ```
-FROM custom-ap-airflow:1.10.10-alpine3.10
+FROM custom-ap-airflow:1.10.12-buster
 ```
 
-### 4. Push your Custom Image to Astronomer
+### Step 4. Push your Custom Image to Astronomer
 
 Now, let's push your new image to Astronomer.
 
 - If you're developing locally, run `$ astro dev stop` > `$ astro dev start`
 - If you're pushing up to Astronomer, you're free to deploy by running `$ astro deploy` or by triggering your CI/CD pipeline
 
-For more detail on the Astronomer deployment process, refer to our [Code Deployment doc](/docs/enterprise/stable/deploy/deploy-code/).
+For more detail on the Astronomer deployment process, refer to [Deploy to Astronomer via the CLI](/docs/enterprise/stable/deploy/deploy-cli/).


### PR DESCRIPTION
Final part of https://github.com/astronomer/docs/issues/179 !

The only differences I could find between the Cloud and Enterprise versions of these docs seems to come from this PR: https://github.com/astronomer/docs/pull/171/files

The only change I made was to update links and to remove the note stating that direct access to the Airflow CLI was an Enterprise-only feature. Once this change is approved, I'll push this back to v0.16 (or earlier, assuming the functionality is still supported. 