### PR TITLE
Modify Enterprise Helm Install Command to Assume Latest Patch

### DIFF
--- a/enterprise/next/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/next/03_install/01_aws/01_install-aws-standard.md
@@ -255,7 +255,7 @@ $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespac
 
 This command will install the latest available patch version of Astronomer Enterprise v0.23. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).
 
-Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI and Houston API.
 
 ## Step 8: Verify Pods are Up
 

--- a/enterprise/next/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/next/03_install/01_aws/01_install-aws-standard.md
@@ -244,12 +244,12 @@ $ helm repo add astronomer https://helm.astronomer.io/
 Then, run:
 
 ```sh
-$ helm install astronomer -f config.yaml --version=<platform-version> astronomer/astronomer --namespace astronomer
+$ helm install astronomer -f config.yaml --version=0.23 astronomer/astronomer --namespace astronomer
 ```
 
-Replace `<platform-version>` above with the version of the Astronomer platform you want to install in the format of `0.23.x`. For the latest version of Astronomer made generally available to Enterprise customers, refer to our ["Enterprise Release Notes"](/docs/enterprise/stable/resources/release-notes/). We recommend installing our latest as we regularly ship patch releases with bug and security fixes incorporated.
+This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).
 
-Running the commands above will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 ## Step 8: Verify Pods are Up
 

--- a/enterprise/next/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/next/03_install/01_aws/01_install-aws-standard.md
@@ -244,7 +244,13 @@ $ helm repo add astronomer https://helm.astronomer.io/
 Then, run:
 
 ```sh
-$ helm install astronomer -f config.yaml --version=0.23 astronomer/astronomer --namespace astronomer
+$ helm repo update
+```
+
+This will ensure you're pulling the latest from our Helm repository. Finally, run:
+
+```sh
+$ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
 This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).

--- a/enterprise/next/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/next/03_install/01_aws/01_install-aws-standard.md
@@ -247,7 +247,7 @@ Then, run:
 $ helm repo update
 ```
 
-This will ensure you're pulling the latest from our Helm repository. Finally, run:
+This will ensure that you pull the latest from our Helm repository. Finally, run:
 
 ```sh
 $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer

--- a/enterprise/next/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/next/03_install/01_aws/01_install-aws-standard.md
@@ -253,7 +253,7 @@ This will ensure you're pulling the latest from our Helm repository. Finally, ru
 $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
-This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).
+This command will install the latest available patch version of Astronomer Enterprise v0.23. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).
 
 Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 

--- a/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
@@ -291,7 +291,13 @@ $ helm repo add astronomer https://helm.astronomer.io/
 Then, run:
 
 ```sh
-$ helm install astronomer -f config.yaml --version=0.23 astronomer/astronomer --namespace astronomer
+$ helm repo update
+```
+
+This will ensure you're pulling the latest from our Helm repository. Finally, run:
+
+```sh
+$ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
 This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).

--- a/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
@@ -288,16 +288,15 @@ First, run:
 $ helm repo add astronomer https://helm.astronomer.io/
 ```
 
-Now, run:
+Then, run:
 
-
+```sh
+$ helm install astronomer -f config.yaml --version=0.23 astronomer/astronomer --namespace astronomer
 ```
-$ helm install astronomer -f config.yaml --version=<platform-version> astronomer/astronomer --namespace astronomer
-```
 
-Replace <platform-version> above with the version of the Astronomer platform you want to install in the format of `0.23.x`. For the latest version of Astronomer made generally available to Enterprise customers, refer to our ["Enterprise Release Notes"](/docs/enterprise/stable/resources/release-notes/). We recommend installing our latest as we regularly ship patch releases with bug and security fixes incorporated.
+This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).
 
-Running the commands above will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 ## Step 8: Verify That All Pods Are Up
 

--- a/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
@@ -300,7 +300,7 @@ This will ensure you're pulling the latest from our Helm repository. Finally, ru
 $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
-This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).
+This command will install the latest available patch version of Astronomer Enterprise v0.23. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).
 
 Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 

--- a/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
@@ -302,7 +302,7 @@ $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespac
 
 This command will install the latest available patch version of Astronomer Enterprise v0.23. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).
 
-Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI and Houston API.
 
 ## Step 8: Verify That All Pods Are Up
 

--- a/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
@@ -294,7 +294,7 @@ Then, run:
 $ helm repo update
 ```
 
-This will ensure you're pulling the latest from our Helm repository. Finally, run:
+This will ensure that you pull the latest from our Helm repository. Finally, run:
 
 ```sh
 $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer

--- a/enterprise/next/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/next/03_install/03_azure/01_install-azure-standard.md
@@ -285,7 +285,7 @@ $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespac
 
 This command will install the latest available patch version of Astronomer Enterprise v0.23. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).
 
-Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI and Houston API.
 
 ## Step 8: Verify all pods are up
 

--- a/enterprise/next/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/next/03_install/03_azure/01_install-azure-standard.md
@@ -271,15 +271,15 @@ First, run:
 $ helm repo add astronomer https://helm.astronomer.io/
 ```
 
-Now, run:
+Then, run:
 
+```sh
+$ helm install astronomer -f config.yaml --version=0.23 astronomer/astronomer --namespace astronomer
 ```
-$ helm install astronomer -f config.yaml --version=<platform-version> astronomer/astronomer --namespace astronomer
-```
 
-Replace `<platform-version>` above with the version of the Astronomer platform you want to install in the format of `0.23.x`. For the latest version of Astronomer made generally available to Enterprise customers, refer to our ["Enterprise Release Notes"](/docs/enterprise/stable/resources/release-notes/). We recommend installing our latest as we regularly ship patch releases with bug and security fixes incorporated.
+This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).
 
-Running the commands above will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 ## Step 8: Verify all pods are up
 

--- a/enterprise/next/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/next/03_install/03_azure/01_install-azure-standard.md
@@ -274,7 +274,13 @@ $ helm repo add astronomer https://helm.astronomer.io/
 Then, run:
 
 ```sh
-$ helm install astronomer -f config.yaml --version=0.23 astronomer/astronomer --namespace astronomer
+$ helm repo update
+```
+
+This will ensure you're pulling the latest from our Helm repository. Finally, run:
+
+```sh
+$ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
 This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).

--- a/enterprise/next/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/next/03_install/03_azure/01_install-azure-standard.md
@@ -283,7 +283,7 @@ This will ensure you're pulling the latest from our Helm repository. Finally, ru
 $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
-This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).
+This command will install the latest available patch version of Astronomer Enterprise v0.23. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/stable/resources/release-notes/).
 
 Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 

--- a/enterprise/next/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/next/03_install/03_azure/01_install-azure-standard.md
@@ -277,7 +277,7 @@ Then, run:
 $ helm repo update
 ```
 
-This will ensure you're pulling the latest from our Helm repository. Finally, run:
+This will ensure that you pull the latest from our Helm repository. Finally, run:
 
 ```sh
 $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer

--- a/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
@@ -233,7 +233,7 @@ This will ensure you're pulling the latest from our Helm repository. Finally, ru
 $ helm install -f config.yaml --version=0.16 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
-This command will install the latest available patch version of Astronomer Enterprise v0.16. To specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).
+This command will install the latest available patch version of Astronomer Enterprise v0.16. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).
 
 Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 

--- a/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
@@ -224,7 +224,13 @@ $ helm repo add astronomer https://helm.astronomer.io/
 Then, run:
 
 ```sh
-$ helm install astronomer -f config.yaml --version=0.16 astronomer/astronomer --namespace astronomer
+$ helm repo update
+```
+
+This will ensure you're pulling the latest from our Helm repository. Finally, run:
+
+```sh
+$ helm install -f config.yaml --version=0.16 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
 This command will install the latest available patch version of Astronomer Enterprise v0.16. To specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).

--- a/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
@@ -235,7 +235,7 @@ $ helm install -f config.yaml --version=0.16 --namespace=<your-platform-namespac
 
 This command will install the latest available patch version of Astronomer Enterprise v0.16. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).
 
-Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI and Houston API.
 
 ## 8. Verify Pods are Up
 

--- a/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
@@ -227,7 +227,7 @@ Then, run:
 $ helm repo update
 ```
 
-This will ensure you're pulling the latest from our Helm repository. Finally, run:
+This will ensure that you pull the latest from our Helm repository. Finally, run:
 
 ```sh
 $ helm install -f config.yaml --version=0.16 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer

--- a/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.16/03_install/01_aws/01_install-aws-standard.md
@@ -221,15 +221,15 @@ First, run:
 $ helm repo add astronomer https://helm.astronomer.io/
 ```
 
-Now, run:
+Then, run:
 
+```sh
+$ helm install astronomer -f config.yaml --version=0.16 astronomer/astronomer --namespace astronomer
 ```
-$ helm install astronomer -f config.yaml --version=<platform-version> astronomer/astronomer --namespace astronomer
-```
 
-Replace `<platform-version>` above with the version of the Astronomer platform you want to install in the format of `0.16.x`. For the latest version of Astronomer made generally available to Enterprise customers, refer to our ["Enterprise Release Notes"](/docs/enterprise/stable/resources/release-notes/). We recommend installing our latest as we regularly ship patch releases with bug and security fixes incorporated.
+This command will install the latest available patch version of Astronomer Enterprise v0.16. To specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).
 
-Running the commands above will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 ## 8. Verify Pods are Up
 

--- a/enterprise/v0.16/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.16/03_install/02_gcp/01_install-gcp-standard.md
@@ -292,7 +292,13 @@ $ helm repo add astronomer https://helm.astronomer.io/
 Then, run:
 
 ```sh
-$ helm install astronomer -f config.yaml --version=0.16 astronomer/astronomer --namespace astronomer
+$ helm repo update
+```
+
+This will ensure you're pulling the latest from our Helm repository. Finally, run:
+
+```sh
+$ helm install -f config.yaml --version=0.16 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
 This command will install the latest available patch version of Astronomer Enterprise v0.16. To specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).

--- a/enterprise/v0.16/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.16/03_install/02_gcp/01_install-gcp-standard.md
@@ -295,7 +295,7 @@ Then, run:
 $ helm repo update
 ```
 
-This will ensure you're pulling the latest from our Helm repository. Finally, run:
+This will ensure that you pull the latest from our Helm repository. Finally, run:
 
 ```sh
 $ helm install -f config.yaml --version=0.16 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer

--- a/enterprise/v0.16/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.16/03_install/02_gcp/01_install-gcp-standard.md
@@ -301,7 +301,7 @@ This will ensure you're pulling the latest from our Helm repository. Finally, ru
 $ helm install -f config.yaml --version=0.16 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
-This command will install the latest available patch version of Astronomer Enterprise v0.16. To specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).
+This command will install the latest available patch version of Astronomer Enterprise v0.16. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).
 
 Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 

--- a/enterprise/v0.16/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.16/03_install/02_gcp/01_install-gcp-standard.md
@@ -303,7 +303,7 @@ $ helm install -f config.yaml --version=0.16 --namespace=<your-platform-namespac
 
 This command will install the latest available patch version of Astronomer Enterprise v0.16. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).
 
-Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI and Houston API.
 
 ## 9. Verify all pods are up
 

--- a/enterprise/v0.16/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.16/03_install/02_gcp/01_install-gcp-standard.md
@@ -289,16 +289,15 @@ First, run:
 $ helm repo add astronomer https://helm.astronomer.io/
 ```
 
-Now, run:
+Then, run:
 
-
+```sh
+$ helm install astronomer -f config.yaml --version=0.16 astronomer/astronomer --namespace astronomer
 ```
-$ helm install astronomer -f config.yaml --version=<platform-version> astronomer/astronomer --namespace astronomer
-```
 
-Replace <platform-version> above with the version of the Astronomer platform you want to install in the format of `0.16.x`. For the latest version of Astronomer made generally available to Enterprise customers, refer to our ["Enterprise Release Notes"](/docs/enterprise/v0.16/resources/release-notes/). We recommend installing our latest as we regularly ship patch releases with bug and security fixes incorporated.
+This command will install the latest available patch version of Astronomer Enterprise v0.16. To specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).
 
-Running the commands above will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 ## 9. Verify all pods are up
 

--- a/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
@@ -266,7 +266,13 @@ $ helm repo add astronomer https://helm.astronomer.io/
 Then, run:
 
 ```sh
-$ helm install astronomer -f config.yaml --version=0.16 astronomer/astronomer --namespace astronomer
+$ helm repo update
+```
+
+This will ensure you're pulling the latest from our Helm repository. Finally, run:
+
+```sh
+$ helm install -f config.yaml --version=0.16 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
 This command will install the latest available patch version of Astronomer Enterprise v0.16. To specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).

--- a/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
@@ -263,15 +263,15 @@ First, run:
 $ helm repo add astronomer https://helm.astronomer.io/
 ```
 
-Now, run:
+Then, run:
 
+```sh
+$ helm install astronomer -f config.yaml --version=0.16 astronomer/astronomer --namespace astronomer
 ```
-$ helm install astronomer -f config.yaml --version=<platform-version> astronomer/astronomer --namespace astronomer
-```
 
-Replace `<platform-version>` above with the version of the Astronomer platform you want to install in the format of `0.16.x`. For the latest version of Astronomer made generally available to Enterprise customers, refer to our ["Enterprise Release Notes"](/docs/enterprise/stable/resources/release-notes/). We recommend installing our latest as we regularly ship patch releases with bug and security fixes incorporated.
+This command will install the latest available patch version of Astronomer Enterprise v0.16. To specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).
 
-Running the commands above will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 ## 8. Verify all pods are up
 

--- a/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
@@ -269,7 +269,7 @@ Then, run:
 $ helm repo update
 ```
 
-This will ensure you're pulling the latest from our Helm repository. Finally, run:
+This will ensure that you pull the latest from our Helm repository. Finally, run:
 
 ```sh
 $ helm install -f config.yaml --version=0.16 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer

--- a/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
@@ -275,7 +275,7 @@ This will ensure you're pulling the latest from our Helm repository. Finally, ru
 $ helm install -f config.yaml --version=0.16 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
-This command will install the latest available patch version of Astronomer Enterprise v0.16. To specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).
+This command will install the latest available patch version of Astronomer Enterprise v0.16. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).
 
 Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 

--- a/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.16/03_install/03_azure/01_install-azure-standard.md
@@ -277,7 +277,7 @@ $ helm install -f config.yaml --version=0.16 --namespace=<your-platform-namespac
 
 This command will install the latest available patch version of Astronomer Enterprise v0.16. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.16.x`. To install Astronomer Enterprise v0.16.9, for example, specify `--version=0.16.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.16/resources/release-notes/).
 
-Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI and Houston API.
 
 ## 8. Verify all pods are up
 

--- a/enterprise/v0.23/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.23/03_install/01_aws/01_install-aws-standard.md
@@ -244,7 +244,13 @@ $ helm repo add astronomer https://helm.astronomer.io/
 Then, run:
 
 ```sh
-$ helm install astronomer -f config.yaml --version=0.23 astronomer/astronomer --namespace astronomer
+$ helm repo update
+```
+
+This will ensure you're pulling the latest from our Helm repository. Finally, run:
+
+```sh
+$ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
 This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).

--- a/enterprise/v0.23/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.23/03_install/01_aws/01_install-aws-standard.md
@@ -255,7 +255,7 @@ $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespac
 
 This command will install the latest available patch version of Astronomer Enterprise v0.23. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).
 
-Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI and Houston API.
 
 ## Step 8: Verify Pods are Up
 

--- a/enterprise/v0.23/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.23/03_install/01_aws/01_install-aws-standard.md
@@ -247,7 +247,7 @@ Then, run:
 $ helm repo update
 ```
 
-This will ensure you're pulling the latest from our Helm repository. Finally, run:
+This will ensure that you pull the latest from our Helm repository. Finally, run:
 
 ```sh
 $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer

--- a/enterprise/v0.23/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.23/03_install/01_aws/01_install-aws-standard.md
@@ -253,7 +253,7 @@ This will ensure you're pulling the latest from our Helm repository. Finally, ru
 $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
-This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).
+This command will install the latest available patch version of Astronomer Enterprise v0.23. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).
 
 Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 

--- a/enterprise/v0.23/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.23/03_install/01_aws/01_install-aws-standard.md
@@ -244,12 +244,12 @@ $ helm repo add astronomer https://helm.astronomer.io/
 Then, run:
 
 ```sh
-$ helm install astronomer -f config.yaml --version=<platform-version> astronomer/astronomer --namespace astronomer
+$ helm install astronomer -f config.yaml --version=0.23 astronomer/astronomer --namespace astronomer
 ```
 
-Replace `<platform-version>` above with the version of the Astronomer platform you want to install in the format of `0.23.x`. For the latest version of Astronomer made generally available to Enterprise customers, refer to our ["Enterprise Release Notes"](/docs/enterprise/v0.23/resources/release-notes/). We recommend installing our latest as we regularly ship patch releases with bug and security fixes incorporated.
+This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).
 
-Running the commands above will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 ## Step 8: Verify Pods are Up
 

--- a/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
@@ -291,7 +291,13 @@ $ helm repo add astronomer https://helm.astronomer.io/
 Then, run:
 
 ```sh
-$ helm install astronomer -f config.yaml --version=0.23 astronomer/astronomer --namespace astronomer
+$ helm repo update
+```
+
+This will ensure you're pulling the latest from our Helm repository. Finally, run:
+
+```sh
+$ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
 This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).

--- a/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
@@ -294,7 +294,7 @@ Then, run:
 $ helm repo update
 ```
 
-This will ensure you're pulling the latest from our Helm repository. Finally, run:
+This will ensure that you pull the latest from our Helm repository. Finally, run:
 
 ```sh
 $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer

--- a/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
@@ -288,16 +288,15 @@ First, run:
 $ helm repo add astronomer https://helm.astronomer.io/
 ```
 
-Now, run:
+Then, run:
 
-
+```sh
+$ helm install astronomer -f config.yaml --version=0.23 astronomer/astronomer --namespace astronomer
 ```
-$ helm install astronomer -f config.yaml --version=<platform-version> astronomer/astronomer --namespace astronomer
-```
 
-Replace <platform-version> above with the version of the Astronomer platform you want to install in the format of `0.23.x`. For the latest version of Astronomer made generally available to Enterprise customers, refer to our ["Enterprise Release Notes"](/docs/enterprise/v0.23/resources/release-notes/). We recommend installing our latest as we regularly ship patch releases with bug and security fixes incorporated.
+This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).
 
-Running the commands above will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 ## Step 8: Verify That All Pods Are Up
 

--- a/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
@@ -302,7 +302,7 @@ $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespac
 
 This command will install the latest available patch version of Astronomer Enterprise v0.23. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).
 
-Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI and Houston API.
 
 ## Step 8: Verify That All Pods Are Up
 

--- a/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
@@ -300,7 +300,7 @@ This will ensure you're pulling the latest from our Helm repository. Finally, ru
 $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
-This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).
+This command will install the latest available patch version of Astronomer Enterprise v0.23. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).
 
 Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 

--- a/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
@@ -274,7 +274,13 @@ $ helm repo add astronomer https://helm.astronomer.io/
 Then, run:
 
 ```sh
-$ helm install astronomer -f config.yaml --version=0.23 astronomer/astronomer --namespace astronomer
+$ helm repo update
+```
+
+This will ensure you're pulling the latest from our Helm repository. Finally, run:
+
+```sh
+$ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
 This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).

--- a/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
@@ -283,7 +283,7 @@ This will ensure you're pulling the latest from our Helm repository. Finally, ru
 $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer
 ```
 
-This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).
+This command will install the latest available patch version of Astronomer Enterprise v0.23. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).
 
 Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 

--- a/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
@@ -285,7 +285,7 @@ $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespac
 
 This command will install the latest available patch version of Astronomer Enterprise v0.23. To override latest and specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).
 
-Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI and Houston API.
 
 ## Step 8: Verify all pods are up
 

--- a/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
@@ -277,7 +277,7 @@ Then, run:
 $ helm repo update
 ```
 
-This will ensure you're pulling the latest from our Helm repository. Finally, run:
+This will ensure that you pull the latest from our Helm repository. Finally, run:
 
 ```sh
 $ helm install -f config.yaml --version=0.23 --namespace=<your-platform-namespace> <your-platform-release-name> astronomer/astronomer

--- a/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
@@ -271,15 +271,15 @@ First, run:
 $ helm repo add astronomer https://helm.astronomer.io/
 ```
 
-Now, run:
+Then, run:
 
+```sh
+$ helm install astronomer -f config.yaml --version=0.23 astronomer/astronomer --namespace astronomer
 ```
-$ helm install astronomer -f config.yaml --version=<platform-version> astronomer/astronomer --namespace astronomer
-```
 
-Replace `<platform-version>` above with the version of the Astronomer platform you want to install in the format of `0.23.x`. For the latest version of Astronomer made generally available to Enterprise customers, refer to our ["Enterprise Release Notes"](/docs/enterprise/v0.23/resources/release-notes/). We recommend installing our latest as we regularly ship patch releases with bug and security fixes incorporated.
+This command will install the latest available patch version of Astronomer Enterprise v0.23. To specify a patch, add it to the `--version=` flag in the format of `0.23.x`. To install Astronomer Enterprise v0.23.9, for example, specify `--version=0.23.9`. For information on all available patch versions, refer to [Enterprise Release Notes](/docs/enterprise/v0.23/resources/release-notes/).
 
-Running the commands above will generate a set of Kubernetes pods that will power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
+Once you run the commands above, a set of Kubernetes pods will be generated in your namespace. These pods power the individual services required to run our platform, including the Astronomer UI, our Houston API, etc.
 
 ## Step 8: Verify all pods are up
 


### PR DESCRIPTION
Submitting a PR here that instructs users to run a modified `$ helm install` command that assumes latest patch, such that they're not required to:

- Look up what the latest patch is in our release notes
- Specify that patch in `$ helm install`

I included instructions on how to specify a patch in this command if a user wants to override that. @sjmiller609 This is something you recently told me was possible, so I finally have it documented! Can you take a quick look at this?

The changes I made applies to install docs for all providers in v0.16, v0.23 and 'next'.

Related ProductBoard feedback: https://astronomer.productboard.com/feature-board/2193567-step-1-feature-backlog/features/6612989/detail