### PR TITLE
Added a Helm Chart compatibility column to "Version Compatibility Reference"

### DIFF
--- a/enterprise/next/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/next/09_resources/03_version-compatibility-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "Version Compatibility Reference for Astronomer Enterprise"
 navTitle: "Version Compatibility Reference"
-description: "A reference of all adjecent tooling required to run Astronomer Enterprise and corresponding version compatibility."
+description: "A reference of all adjacent tooling required to run Astronomer Enterprise and corresponding version compatibility."
 ---
 
 ## Overview
@@ -12,23 +12,23 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Enterprise
 
-| Astronomer Platform  | Kubernetes        | Helm | Terraform | Postgres | Astronomer Certified                             | Python       |
-|----------------------|------------------|------|-----------|----------|--------------------------------------------------|---------------|
-| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 |
-| v0.23                | 1.16, 1.17, 1.18 | 3    | 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 |
+| Astronomer Platform | Kubernetes       | Helm | Terraform    | Postgres | Astronomer Certified                             | Python        |
+| ------------------- | ---------------- | ---- | ------------ | -------- | ------------------------------------------------ | ------------- |
+| v0.16               | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5 | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 |
+| v0.23               | 1.16, 1.17, 1.18 | 3    | 0.13.5       | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 |
 
 > **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12, and Astronomer v0.16.15+ is required to run Astronomer Certified 1.10.14. For instructions on how to upgrade to an Astronomer v0.16 patch version, read [Upgrade to a Patch Version of Astronomer](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer-patch).
 
 ## Astronomer Certified
 
-| Astronomer Certified    | Postgres | MySQL     | Python        | System Distribution             |
-|-------------------------|----------|-----------|---------------|---------------------------------|
-| 1.10.5                  | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.7                  | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.10                 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.12                 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.14 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
-| 2.0.0 (*Coming Soon*)   | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
+| Astronomer Certified | Postgres | MySQL     | Python        | System Distribution             | Airflow Helm Chart |
+| -------------------- | -------- | --------- | ------------- | ------------------------------- | ------------------ |
+| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | N/A                |
+| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | N/A                |
+| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | N/A                |
+| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | N/A                |
+| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | N/A                |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6             |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/next/customize-airflow/manage-airflow-versions/).
 

--- a/enterprise/v0.16/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/v0.16/09_resources/03_version-compatibility-reference.md
@@ -12,23 +12,23 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Enterprise
 
-| Astronomer Platform  | Kubernetes        | Helm | Terraform | Postgres | Astronomer Certified                             | Python       |
-|----------------------|------------------|------|-----------|----------|--------------------------------------------------|---------------|
-| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 |
-| v0.23 (*Coming Soon*)| 1.16, 1.17, 1.18 | 3    | 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 |
+| Astronomer Platform   | Kubernetes       | Helm | Terraform    | Postgres | Astronomer Certified                             | Python        |
+| --------------------- | ---------------- | ---- | ------------ | -------- | ------------------------------------------------ | ------------- |
+| v0.16                 | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5 | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 |
+| v0.23 (_Coming Soon_) | 1.16, 1.17, 1.18 | 3    | 0.13.5       | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 |
 
 > **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12, and Astronomer v0.16.15+ is required to run Astronomer Certified 1.10.14. For instructions on how to upgrade, read [Upgrade to a Patch Version of Astronomer](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer-patch).
 
 ## Astronomer Certified
 
-| Astronomer Certified    | Postgres | MySQL     | Python        | System Distribution             |
-|-------------------------|----------|-----------|---------------|---------------------------------|
-| 1.10.5                  | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.7                  | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.10                 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.12                 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.14                 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
-| 2.0.0 (*Coming Soon*)   | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
+| Astronomer Certified | Postgres | MySQL     | Python        | System Distribution             | Airflow Helm Chart |
+| -------------------- | -------- | --------- | ------------- | ------------------------------- | ------------------ |
+| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | N/A                |
+| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | N/A                |
+| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | N/A                |
+| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | N/A                |
+| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | N/A                |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6             |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/).
 

--- a/enterprise/v0.23/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/v0.23/09_resources/03_version-compatibility-reference.md
@@ -12,23 +12,23 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Enterprise
 
-| Astronomer Platform  | Kubernetes       | Helm | Terraform   | Postgres | Astronomer Certified                             | Python        |
-|----------------------|------------------|------|-------------|----------|--------------------------------------------------|---------------|
-| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5| 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 |
-| v0.23                | 1.16, 1.17, 1.18 | 3    | 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 |
+| Astronomer Platform | Kubernetes       | Helm | Terraform    | Postgres | Astronomer Certified                             | Python        |
+| ------------------- | ---------------- | ---- | ------------ | -------- | ------------------------------------------------ | ------------- |
+| v0.16               | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5 | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 |
+| v0.23               | 1.16, 1.17, 1.18 | 3    | 0.13.5       | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 |
 
 > **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12, and Astronomer v0.16.15+ is required to run Astronomer Certified 1.10.14. For instructions on how to upgrade to an Astronomer v0.16 patch version, read [Upgrade to a Patch Version of Astronomer](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer-patch).
 
 ## Astronomer Certified
 
-| Astronomer Certified    | Postgres | MySQL     | Python        | System Distribution             |
-|-------------------------|----------|-----------|---------------|---------------------------------|
-| 1.10.5                  | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.7                  | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.10                 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.12                 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) |
-| 1.10.14                 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
-| 2.0.0                   | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
+| Astronomer Certified | Postgres | MySQL     | Python        | System Distribution             | Airflow Helm Chart |
+| -------------------- | -------- | --------- | ------------- | ------------------------------- | ------------------ |
+| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | N/A                |
+| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | N/A                |
+| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | N/A                |
+| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | N/A                |
+| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | N/A                |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6             |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/next/customize-airflow/manage-airflow-versions/).
 


### PR DESCRIPTION
Airflow 2.0 requires your Airflow Helm Chart version to be at least 0.18.6. Because we didn't have a version requirement before, there was no place to document this info.

To fix this, I've added a new version column to the `Astronomer Certified` table that indicates the minimum required version for Airflow Helm Charts. I'm torn whether to say `N/A` or `Any` for the AC versions where it doesn't matter, let me know what you think!