### PR TITLE
Add Astro CLI <> Platform Versioning guidelines to CLI Quickstart + Versioning Matrix

### DIFF
--- a/cloud/stable/02_develop/01_cli-quickstart.md
+++ b/cloud/stable/02_develop/01_cli-quickstart.md
@@ -186,6 +186,43 @@ If you do not yet have an account on Astronomer, ask a Workspace Admin on your t
 
 > **Note:** Once you run this command once, it should stay cached and allow you to just run `$ astro auth login` to authenticate more easily in the future.
 
+## Apply Changes to your Airflow Project
+
+As you develop locally, it's worth noting that some changes made to your image are automatically applied, while other changes made to a certain set of files require rebuilding your image in order for them to render.
+
+### Code Changes
+
+All changes made to the following files will be picked up as soon as they're saved to your code editor:
+
+- `dags`
+- `plugins`
+- `include`
+
+Once you save your changes, refresh the Airflow Webserver in your browser to see them render.
+
+### Other Changes
+
+All changes made to the following files require rebuilding your image:
+
+- `packages.txt`
+- `Dockerfile`
+- `requirements.txt`
+- `airflow_settings.yaml`
+
+This includes changing the Airflow image in your `Dockerfile` and adding Python Packages to `requirements.txt` or OS-level packages to `packages.txt`.
+
+To rebuild your image after making a change to any of these files, first run the following command:
+
+```
+$ astro dev stop
+```
+
+Then, restart the Docker containers by running:
+
+```
+$ astro dev start
+```
+
 ## Astronomer CLI and Platform Versioning
 
 For every minor version of Astronomer, a corresponding minor version of the Astronomer CLI is made available. To ensure that you can continue to develop locally and deploy successfully, you should always upgrade to the corresponding minor version of the Astronomer CLI when a new minor version is released to Astronomer Cloud. When v0.23.1 is released to Astronomer Cloud, for instance, v0.23+ of the Astronomer CLI is recommended.

--- a/cloud/stable/02_develop/01_cli-quickstart.md
+++ b/cloud/stable/02_develop/01_cli-quickstart.md
@@ -186,55 +186,43 @@ If you do not yet have an account on Astronomer, ask a Workspace Admin on your t
 
 > **Note:** Once you run this command once, it should stay cached and allow you to just run `$ astro auth login` to authenticate more easily in the future.
 
-## Next Steps: Apply Changes using the CLI
+## Astronomer CLI and Platform Versioning
 
-As you develop locally, it's worth noting that some changes made to your image are automatically applied, while other changes made to a certain set of files require rebuilding your image in order for them to render.
+For every minor version of Astronomer, a corresponding minor version of the Astronomer CLI is made available. To ensure that you can continue to develop locally and deploy successfully, you should always upgrade to the corresponding minor version of the Astronomer CLI when a new minor version is released to Astronomer Cloud. When v0.23.1 is released to Astronomer Cloud, for instance, v0.23+ of the Astronomer CLI is recommended.
 
-### Code Changes
+While a new minor version of Astronomer requires upgrading the Astronomer CLI, subsequent patch versions will remain compatible. For instance, consider a system where Astronomer is on v0.23.9 and the Astronomer CLI is on v0.23.2. While we encourage users to always run the latest available version of all components, these patch versions of Astronomer and the Astronomer CLI remain compatible because they're both in the v0.23 series.
 
-All changes made to the following files will be picked up as soon as they're saved to your code editor:
+### Check Running Versions of Astronomer and the Astronomer CLI
 
-- `dags`
-- `plugins`
-- `include`
+To check your working versions of Astronomer (`Astro Server Version`) and the Astronomer CLI (`Astro CLI`), run:
 
-Once you save your changes, refresh the Airflow Webserver in your browser to see them render.
-
-### Other Changes
-
-All changes made to the following files require rebuilding your image:
-
-- `packages.txt`
-- `Dockerfile`
-- `requirements.txt`
-- `airflow_settings.yaml`
-
-This includes changing the Airflow image in your `Dockerfile`, adding Python Packages to `requirements.txt` or OS-level packages to `packages.txt`, etc. To rebuild your image, first run the following command:
-
-```
-$ astro dev stop
+```sh
+$ astro version
 ```
 
-Then, restart the Docker containers by running:
+This command will output something like the following:
 
+```sh
+$ astro version
+Astro CLI Version: 0.23.2
+Astro Server Version: 0.23.9
+Git Commit: 748ca2e9de1e51e9f48f9d85eb8315b023debc2f
 ```
-$ astro dev start
-```
 
-## Additional Resources
+Here, the listed versions of Astronomer and the Astronomer CLI are compatible because they're both in the v0.23 series. If you're on a version of the Astronomer CLI that's behind the current running minor version of Astronomer, you'll receive an error message in your command line with instructions to upgrade the Astronomer CLI.
 
-For more information on the Astronomer CLI, feel free to reference:
+For more information on Astronomer and Astronomer CLI releases, refer to:
 
 * [CLI Release Changelog](https://github.com/astronomer/astro-cli/releases)
-* [CLI README on GitHub](https://github.com/astronomer/astro-cli#astronomer-cli----)
+* [Astronomer Release Notes](https://www.astronomer.io/docs/cloud/stable/resources/release-notes)
 
-## Beyond the CLI
+## Beyond the Astronomer CLI
 
 Looking for additional next steps after installing the Astronomer CLI? We recommend reading through the following guides:
 
-* [Deploying to Astronomer](/docs/cloud/stable/deploy/deploy-cli/)
-* [Customizing Your Image](/docs/cloud/stable/develop/customize-image/)
-* [Manage Airflow Versions](/docs/cloud/stable/customize-airflow/manage-airflow-versions/)
+* [Deploy to Astronomer](/docs/cloud/stable/deploy/deploy-cli/)
+* [Customize Your Image](/docs/cloud/stable/customize-airflow/customize-image/)
+* [Upgrade Apache Airflow on Astronomer](/docs/cloud/stable/customize-airflow/manage-airflow-versions/)
 * [Deploy to Astronomer via CI/CD](/docs/cloud/stable/deploy/ci-cd/)
 
 As always, don't hesitate to reach out to [Astronomer Support](https://support.astronomer.io/hc/en-us) or post in our [Astronomer Forum](https://forum.astronomer.io/) for additional questions.

--- a/enterprise/next/02_develop/01_cli-quickstart.md
+++ b/enterprise/next/02_develop/01_cli-quickstart.md
@@ -250,15 +250,15 @@ If the minor versions for the two components do not match, you'll receive an err
 For more information on Astronomer and Astronomer CLI releases, refer to:
 
 * [CLI Release Changelog](https://github.com/astronomer/astro-cli/releases)
-* [Astronomer Release Notes](https://www.astronomer.io/docs/enterprise/v0.23/resources/release-notes)
+* [Astronomer Release Notes](https://www.astronomer.io/docs/enterprise/stable/resources/release-notes)
 
 ## Beyond the Astronomer CLI
 
 Looking for additional next steps after installing the Astronomer CLI? We recommend reading through the following guides:
 
-* [Deploy to Astronomer](/docs/enterprise/v0.23/deploy/deploy-cli/)
-* [Customize Your Image](/docs/enterprise/v0.23/develop/customize-image/)
-* [Upgrade Apache Airflow on Astronomer](/docs/enterprise/v0.23/customize-airflow/manage-airflow-versions/)
-* [Deploy to Astronomer via CI/CD](/docs/enterprise/v0.23/deploy/ci-cd/)
+* [Deploy to Astronomer](/docs/enterprise/stable/deploy/deploy-cli/)
+* [Customize Your Image](/docs/enterprise/stable/develop/customize-image/)
+* [Upgrade Apache Airflow on Astronomer](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/)
+* [Deploy to Astronomer via CI/CD](/docs/enterprise/stable/deploy/ci-cd/)
 
 As always, don't hesitate to reach out to [Astronomer Support](https://support.astronomer.io/hc/en-us) or post in our [Astronomer Forum](https://forum.astronomer.io/) for additional questions.

--- a/enterprise/next/02_develop/01_cli-quickstart.md
+++ b/enterprise/next/02_develop/01_cli-quickstart.md
@@ -185,7 +185,7 @@ If you do not yet have an account on Astronomer, ask a Workspace Admin on your t
 
 > **Note:** Once you run this command once, it should stay cached and allow you to just run `$ astro auth login` to authenticate more easily in the future.
 
-## Next Steps: Apply Changes using the CLI
+## Apply Changes to your Airflow Project
 
 As you develop locally, it's worth noting that some changes made to your image are automatically applied, while other changes made to a certain set of files require rebuilding your image in order for them to render.
 
@@ -208,7 +208,9 @@ All changes made to the following files require rebuilding your image:
 - `requirements.txt`
 - `airflow_settings.yaml`
 
-This includes changing the Airflow image in your `Dockerfile`, adding Python Packages to `requirements.txt` or OS-level packages to `packages.txt`, etc. To rebuild your image, first run the following command:
+This includes changing the Airflow image in your `Dockerfile` and adding Python Packages to `requirements.txt` or OS-level packages to `packages.txt`.
+
+To rebuild your image after making a change to any of these files, first run the following command:
 
 ```
 $ astro dev stop
@@ -220,20 +222,43 @@ Then, restart the Docker containers by running:
 $ astro dev start
 ```
 
-## Additional Resources
+## Astronomer CLI and Platform Versioning
 
-For more information on the Astronomer CLI, feel free to reference:
+For every minor version of Astronomer, a corresponding minor version of the Astronomer CLI is made available. To ensure that you can continue to develop locally and deploy successfully, you should always upgrade to the corresponding minor version of the Astronomer CLI when you upgrade to a new minor version of Astronomer. If you're on Astronomer v0.23+, for example, Astronomer CLI v0.23+ is required.
+
+While upgrading to a new minor version of Astronomer requires upgrading the Astronomer CLI, subsequent patch versions will remain compatible. For instance, consider a system where Astronomer is on v0.23.9 and the Astronomer CLI is on v0.23.2. While we encourage users to always run the latest available version of all components, these patch versions of Astronomer and the Astronomer CLI remain compatible because they're both in the v0.23 series.
+
+### Check Running Versions of Astronomer and the Astronomer CLI
+
+To check your working versions of Astronomer (`Astro Server Version`) and the Astronomer CLI (`Astro CLI`), run:
+
+```sh
+$ astro version
+```
+
+This command will output something like the following:
+
+```sh
+$ astro version
+Astro CLI Version: 0.23.2
+Astro Server Version: 0.23.9
+Git Commit: 748ca2e9de1e51e9f48f9d85eb8315b023debc2f
+```
+
+If the minor versions for the two components do not match, you'll receive an error message in your command line with instructions to either upgrade or downgrade the Astronomer CLI accordingly. Here, the listed versions of Astronomer and the Astronomer CLI are compatible because they're both in the v0.23 series. If you're running v0.16.10 of Astronomer and v0.23.2 of the Astronomer CLI, for example, you'll be instructed to downgrade the CLI to the latest in the v0.16 series. If you have access to more than one Astronomer Enterprise installation, `Astro Server Version` will correspond to the `<base-domain>` that you're currently authenticated into.
+
+For more information on Astronomer and Astronomer CLI releases, refer to:
 
 * [CLI Release Changelog](https://github.com/astronomer/astro-cli/releases)
-* [CLI README on GitHub](https://github.com/astronomer/astro-cli#astronomer-cli----)
+* [Astronomer Release Notes](https://www.astronomer.io/docs/enterprise/v0.23/resources/release-notes)
 
-## Beyond the CLI
+## Beyond the Astronomer CLI
 
 Looking for additional next steps after installing the Astronomer CLI? We recommend reading through the following guides:
 
-* [Deploying to Astronomer](/docs/enterprise/stable/deploy/deploy-cli/)
-* [Customizing Your Image](/docs/enterprise/stable/develop/customize-image/)
-* [Manage Airflow Versions](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/)
-* [Deploy to Astronomer via CI/CD](/docs/enterprise/stable/deploy/ci-cd/)
+* [Deploy to Astronomer](/docs/enterprise/v0.23/deploy/deploy-cli/)
+* [Customize Your Image](/docs/enterprise/v0.23/develop/customize-image/)
+* [Upgrade Apache Airflow on Astronomer](/docs/enterprise/v0.23/customize-airflow/manage-airflow-versions/)
+* [Deploy to Astronomer via CI/CD](/docs/enterprise/v0.23/deploy/ci-cd/)
 
 As always, don't hesitate to reach out to [Astronomer Support](https://support.astronomer.io/hc/en-us) or post in our [Astronomer Forum](https://forum.astronomer.io/) for additional questions.

--- a/enterprise/next/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/next/09_resources/03_version-compatibility-reference.md
@@ -12,10 +12,10 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Enterprise
 
-| Astronomer Platform  | Kubernetes        | Helm | Terraform | Postgres | Astronomer Certified                             | Python       |
-|----------------------|------------------|------|-----------|----------|--------------------------------------------------|---------------|
-| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 |
-| v0.23                | 1.16, 1.17, 1.18 | 3    | 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 |
+| Astronomer Platform  | Kubernetes       | Helm | Terraform   | Postgres | Astronomer Certified                             | Python        | Astronomer CLI |
+|----------------------|------------------|------|-------------|----------|--------------------------------------------------|---------------|----------------|
+| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5| 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 | 0.16           |
+| v0.23                | 1.16, 1.17, 1.18 | 3    | 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 | 0.23           |
 
 > **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12, and Astronomer v0.16.15+ is required to run Astronomer Certified 1.10.14. For instructions on how to upgrade to an Astronomer v0.16 patch version, read [Upgrade to a Patch Version of Astronomer](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer-patch).
 

--- a/enterprise/v0.16/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.16/02_develop/01_cli-quickstart.md
@@ -185,7 +185,7 @@ If you do not yet have an account on Astronomer, ask a Workspace Admin on your t
 
 > **Note:** Once you run this command once, it should stay cached and allow you to just run `$ astro auth login` to authenticate more easily in the future.
 
-## Next Steps: Apply Changes using the CLI
+## Apply Changes to your Airflow Project
 
 As you develop locally, it's worth noting that some changes made to your image are automatically applied, while other changes made to a certain set of files require rebuilding your image in order for them to render.
 
@@ -208,7 +208,9 @@ All changes made to the following files require rebuilding your image:
 - `requirements.txt`
 - `airflow_settings.yaml`
 
-This includes changing the Airflow image in your `Dockerfile`, adding Python Packages to `requirements.txt` or OS-level packages to `packages.txt`, etc. To rebuild your image, first run the following command:
+This includes changing the Airflow image in your `Dockerfile` and adding Python Packages to `requirements.txt` or OS-level packages to `packages.txt`.
+
+To rebuild your image after making a change to any of these files, first run the following command:
 
 ```
 $ astro dev stop
@@ -220,20 +222,43 @@ Then, restart the Docker containers by running:
 $ astro dev start
 ```
 
-## Additional Resources
+## Astronomer CLI and Platform Versioning
 
-For more information on the Astronomer CLI, feel free to reference:
+For every minor version of Astronomer, a corresponding minor version of the Astronomer CLI is made available. To ensure that you can continue to develop locally and deploy successfully, you should always upgrade to the corresponding minor version of the Astronomer CLI when you upgrade to a new minor version of Astronomer. If you're on Astronomer v0.16+, for example, Astronomer CLI v0.16+ is required.
+
+While upgrading to a new minor version of Astronomer requires upgrading the Astronomer CLI, subsequent patch versions will remain compatible. For instance, consider a system where Astronomer is on v0.16.9 and the Astronomer CLI is on v0.16.2. While we encourage users to always run the latest available version of all components, these patch versions of Astronomer and the Astronomer CLI remain compatible because they're both in the v0.16 series.
+
+### Check Running Versions of Astronomer and the Astronomer CLI
+
+To check your working versions of Astronomer (`Astro Server Version`) and the Astronomer CLI (`Astro CLI`), run:
+
+```sh
+$ astro version
+```
+
+This command will output something like the following:
+
+```sh
+$ astro version
+Astro CLI Version: 0.16.2
+Astro Server Version: 0.16.9
+Git Commit: 748ca2e9de1e51e9f48f9d85eb8315b023debc2f
+```
+
+If the minor versions for the two components do not match, you'll receive an error message in your command line with instructions to either upgrade or downgrade the Astronomer CLI accordingly. Here, the listed versions of Astronomer and the Astronomer CLI are compatible because they're both in the v0.16 series. If you are running v0.16.10 of Astronomer and v0.23.1 of the Astronomer CLI, for example, you'll be instructed to downgrade the CLI to the latest in the v0.16 series. If you have access to more than one Astronomer Enterprise installation, `Astro Server Version` will correspond to the `<base-domain>` that you're currently authenticated into.
+
+For more information on Astronomer and Astronomer CLI releases, refer to:
 
 * [CLI Release Changelog](https://github.com/astronomer/astro-cli/releases)
-* [CLI README on GitHub](https://github.com/astronomer/astro-cli#astronomer-cli----)
+* [Astronomer Release Notes](https://www.astronomer.io/docs/enterprise/v0.16/resources/release-notes)
 
-## Beyond the CLI
+## Beyond the Astronomer CLI
 
 Looking for additional next steps after installing the Astronomer CLI? We recommend reading through the following guides:
 
-* [Deploying to Astronomer](/docs/enterprise/v0.16/deploy/deploy-cli/)
-* [Customizing Your Image](/docs/enterprise/v0.16/develop/customize-image/)
-* [Manage Airflow Versions](/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/)
+* [Deploy to Astronomer](/docs/enterprise/v0.16/deploy/deploy-cli/)
+* [Customize Your Image](/docs/enterprise/v0.16/develop/customize-image/)
+* [Upgrade Apache Airflow on Astronomer](/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/)
 * [Deploy to Astronomer via CI/CD](/docs/enterprise/v0.16/deploy/ci-cd/)
 
 As always, don't hesitate to reach out to [Astronomer Support](https://support.astronomer.io/hc/en-us) or post in our [Astronomer Forum](https://forum.astronomer.io/) for additional questions.

--- a/enterprise/v0.16/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.16/02_develop/01_cli-quickstart.md
@@ -245,7 +245,7 @@ Astro Server Version: 0.16.9
 Git Commit: 748ca2e9de1e51e9f48f9d85eb8315b023debc2f
 ```
 
-If the minor versions for the two components do not match, you'll receive an error message in your command line with instructions to either upgrade or downgrade the Astronomer CLI accordingly. Here, the listed versions of Astronomer and the Astronomer CLI are compatible because they're both in the v0.16 series. If you are running v0.16.10 of Astronomer and v0.23.1 of the Astronomer CLI, for example, you'll be instructed to downgrade the CLI to the latest in the v0.16 series. If you have access to more than one Astronomer Enterprise installation, `Astro Server Version` will correspond to the `<base-domain>` that you're currently authenticated into.
+Here, the listed versions of Astronomer and the Astronomer CLI are compatible because they're both in the v0.16 series. If the minor versions for the two components do not match, you'll receive an error message in your command line with instructions to either upgrade or downgrade the Astronomer CLI accordingly. If you are running v0.16.10 of Astronomer and v0.23.1 of the Astronomer CLI, for example, you'll be instructed to downgrade the CLI to the latest in the v0.16 series. If you have access to more than one Astronomer Enterprise installation, `Astro Server Version` will correspond to the `<base-domain>` that you're currently authenticated into.
 
 For more information on Astronomer and Astronomer CLI releases, refer to:
 

--- a/enterprise/v0.16/06_manage-astronomer/06_upgrade-to-0-23.md
+++ b/enterprise/v0.16/06_manage-astronomer/06_upgrade-to-0-23.md
@@ -100,6 +100,24 @@ If the upgrade was successful, you should be able to:
 * Open the Airflow UI for each of your Deployments
 * Access logs for your DAGs in the Airflow UI.
 
+## Step 8: Upgrade the Astronomer CLI to v0.23
+
+To ensure reliability and full access to features included in Astronomer v0.23, all users must upgrade to v0.23 of the Astronomer CLI following an upgrade from v0.16. We recommend the latest available version, though you may choose to install a particular patch release within the v0.23 series.
+
+To upgrade to the latest available v0.23 version of the Astronomer CLI, run:
+
+```sh
+$ curl -sSL https://install.astronomer.io | sudo bash -s -- v0.23
+```
+
+To do so via Homebrew, run:
+
+```sh
+$ brew install astronomer/tap/astro@0.23
+```
+
+All team members within your organization should upgrade the Astronomer CLI individually before taking any further action on the platform or in a local Airflow environment. For a detailed breakdown of CLI changes between versions, refer to [Astronomer CLI releases](https://github.com/astronomer/astro-cli/releases). For detailed install guidelines and more information on the Astronomer CLI, refer to [Astronomer CLI Quickstart](https://www.astronomer.io/docs/enterprise/v0.16/develop/cli-quickstart).
+
 ## Roll Back to Enterprise v0.16
 
 If you encounter an issue during your upgrade that requires you to recover your original platform, you can roll back to Astronomer v0.16. To do so:

--- a/enterprise/v0.16/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/v0.16/09_resources/03_version-compatibility-reference.md
@@ -12,10 +12,10 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Enterprise
 
-| Astronomer Platform  | Kubernetes        | Helm | Terraform | Postgres | Astronomer Certified                             | Python       |
-|----------------------|------------------|------|-----------|----------|--------------------------------------------------|---------------|
-| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 |
-| v0.23 (*Coming Soon*)| 1.16, 1.17, 1.18 | 3    | 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 |
+| Astronomer Platform  | Kubernetes       | Helm | Terraform   | Postgres | Astronomer Certified                             | Python        | Astronomer CLI |
+|----------------------|------------------|------|-------------|----------|--------------------------------------------------|---------------|----------------|
+| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5| 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 | 0.16           |
+| v0.23                | 1.16, 1.17, 1.18 | 3    | 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 | 0.23           |
 
 > **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12, and Astronomer v0.16.15+ is required to run Astronomer Certified 1.10.14. For instructions on how to upgrade, read [Upgrade to a Patch Version of Astronomer](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer-patch).
 

--- a/enterprise/v0.23/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.23/02_develop/01_cli-quickstart.md
@@ -228,6 +228,8 @@ For every minor version of the Astronomer Platform, a corresponding minor versio
 
 While corresponding minor versions of the Astronomer Platform and the Astronomer CLI are required, subsequent patch versions do not need to match and will not introduce breaking changes. The release of Astronomer v0.23.9, for example, does not mean that v0.23.9 of the Astronomer CLI exists or is required.
 
+### Check Running Astronomer CLI and Platform Versions
+
 To check your working version of the Astronomer CLI (`Astro CLI`) and the Astronomer Platform (`Astro Server Version`), run:
 
 ```

--- a/enterprise/v0.23/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.23/02_develop/01_cli-quickstart.md
@@ -245,7 +245,7 @@ Astro Server Version: 0.23.9
 Git Commit: 748ca2e9de1e51e9f48f9d85eb8315b023debc2f
 ```
 
-If the minor versions for the two components do not match, you'll receive an error message in your command line with instructions to either upgrade or downgrade the Astronomer CLI accordingly. Here, the listed versions of Astronomer and the Astronomer CLI are compatible because they're both in the v0.23 series. If you're running v0.16.10 of Astronomer and v0.23.2 of the Astronomer CLI, for example, you'll be instructed to downgrade the CLI to the latest in the v0.16 series. If you have access to more than one Astronomer Enterprise installation, `Astro Server Version` will correspond to the `<base-domain>` that you're currently authenticated into.
+Here, the listed versions of Astronomer and the Astronomer CLI are compatible because they're both in the v0.23 series. If the minor versions for the two components do not match, you'll receive an error message in your command line with instructions to either upgrade or downgrade the Astronomer CLI accordingly. If you're running v0.16.10 of Astronomer and v0.23.2 of the Astronomer CLI, for example, you'll be instructed to downgrade the CLI to the latest in the v0.16 series. If you have access to more than one Astronomer Enterprise installation, `Astro Server Version` will correspond to the `<base-domain>` that you're currently authenticated into.
 
 For more information on Astronomer and Astronomer CLI releases, refer to:
 

--- a/enterprise/v0.23/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.23/02_develop/01_cli-quickstart.md
@@ -224,11 +224,11 @@ $ astro dev start
 
 ## Astronomer CLI and Platform Versioning
 
-For every minor version of the Astronomer Platform, a corresponding minor version of the Astronomer CLI is made available. To ensure reliability, upgrade to the corresponding minor version of the Astronomer CLI. If you're on Astronomer v0.23+, for example, Astronomer CLI v0.23+ is required.
+For every minor version of Astronomer, a corresponding minor version of the Astronomer CLI is made available. To ensure that you can continue to develop locally and deploy successfully, you should always upgrade to the corresponding minor version of the Astronomer CLI when you upgrade to a new minor version of Astronomer. If you're on Astronomer v0.23+, for example, Astronomer CLI v0.23+ is required.
 
-While corresponding minor versions of the Astronomer Platform and the Astronomer CLI are required, subsequent patch versions do not need to match and will not introduce breaking changes. The release of Astronomer v0.23.9, for example, does not mean that v0.23.9 of the Astronomer CLI exists or is required.
+While upgrading to a new minor version of Astronomer requires upgrading the Astronomer CLI, subsequent patch versions will remain compatible. For instance, consider a system where Astronomer is on v0.23.9 and the Astronomer CLI is on v0.23.2. While we encourage users to always run the latest available version of all components, these patch versions of Astronomer and the Astronomer CLI remain compatible because they're both in the v0.23 series.
 
-### Check Running Astronomer CLI and Platform Versions
+### Check Running Versions of Astronomer and the Astronomer CLI
 
 To check your working versions of Astronomer (`Astro Server Version`) and the Astronomer CLI (`Astro CLI`), run:
 
@@ -245,7 +245,7 @@ Astro Server Version: 0.23.9
 Git Commit: 748ca2e9de1e51e9f48f9d85eb8315b023debc2f
 ```
 
-If the minor versions for the two components don't match, you'll receive an error message in your command line with instructions to either upgrade or downgrade the Astronomer CLI accordingly. If you're running v0.16.10 of Astronomer and v0.23.2 of the Astronomer CLI, for example, you'll be instructed to downgrade the CLI to the latest in the v0.16 series. If you have access to more than one Astronomer Enterprise installation, `Astro Server Version` will correspond to the `<base-domain>` that you're currently authenticated into.
+If the minor versions for the two components do not match, you'll receive an error message in your command line with instructions to either upgrade or downgrade the Astronomer CLI accordingly. Here, the listed versions of Astronomer and the Astronomer CLI are compatible because they're both in the v0.23 series. If you're running v0.16.10 of Astronomer and v0.23.2 of the Astronomer CLI, for example, you'll be instructed to downgrade the CLI to the latest in the v0.16 series. If you have access to more than one Astronomer Enterprise installation, `Astro Server Version` will correspond to the `<base-domain>` that you're currently authenticated into.
 
 For more information on Astronomer and Astronomer CLI releases, refer to:
 

--- a/enterprise/v0.23/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.23/02_develop/01_cli-quickstart.md
@@ -252,13 +252,13 @@ For more information on Astronomer Platform and CLI releases, refer to:
 * [CLI Release Changelog](https://github.com/astronomer/astro-cli/releases)
 * [Astronomer Release Notes](https://www.astronomer.io/docs/enterprise/v0.23/resources/release-notes)
 
-### Beyond the Astronomer CLI
+## Beyond the Astronomer CLI
 
 Looking for additional next steps after installing the Astronomer CLI? We recommend reading through the following guides:
 
-* [Deploying to Astronomer](/docs/enterprise/v0.23/deploy/deploy-cli/)
-* [Customizing Your Image](/docs/enterprise/v0.23/develop/customize-image/)
-* [Manage Airflow Versions](/docs/enterprise/v0.23/customize-airflow/manage-airflow-versions/)
+* [Deploy to Astronomer](/docs/enterprise/v0.23/deploy/deploy-cli/)
+* [Customize Your Image](/docs/enterprise/v0.23/develop/customize-image/)
+* [Upgrade Apache Airflow on Astronomer](/docs/enterprise/v0.23/customize-airflow/manage-airflow-versions/)
 * [Deploy to Astronomer via CI/CD](/docs/enterprise/v0.23/deploy/ci-cd/)
 
 As always, don't hesitate to reach out to [Astronomer Support](https://support.astronomer.io/hc/en-us) or post in our [Astronomer Forum](https://forum.astronomer.io/) for additional questions.

--- a/enterprise/v0.23/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.23/02_develop/01_cli-quickstart.md
@@ -230,9 +230,9 @@ While corresponding minor versions of the Astronomer Platform and the Astronomer
 
 ### Check Running Astronomer CLI and Platform Versions
 
-To check your working version of the Astronomer CLI (`Astro CLI`) and the Astronomer Platform (`Astro Server Version`), run:
+To check your working versions of Astronomer (`Astro Server Version`) and the Astronomer CLI (`Astro CLI`), run:
 
-```
+```sh
 $ astro version
 ```
 
@@ -245,9 +245,9 @@ Astro Server Version: 0.23.9
 Git Commit: 748ca2e9de1e51e9f48f9d85eb8315b023debc2f
 ```
 
-If the minor versions between the two don't match, you'll receive an error message in your command line with instructions to either upgrade or downgrade. If you have access to more than one Astronomer Enterprise installation, `Astro Server Version` will correspond to the `<base-domain>` that you're currently authenticated into.
+If the minor versions for the two components don't match, you'll receive an error message in your command line with instructions to either upgrade or downgrade the Astronomer CLI accordingly. If you're running v0.16.10 of Astronomer and v0.23.2 of the Astronomer CLI, for example, you'll be instructed to downgrade the CLI to the latest in the v0.16 series. If you have access to more than one Astronomer Enterprise installation, `Astro Server Version` will correspond to the `<base-domain>` that you're currently authenticated into.
 
-For more information on Astronomer Platform and CLI releases, refer to:
+For more information on Astronomer and Astronomer CLI releases, refer to:
 
 * [CLI Release Changelog](https://github.com/astronomer/astro-cli/releases)
 * [Astronomer Release Notes](https://www.astronomer.io/docs/enterprise/v0.23/resources/release-notes)

--- a/enterprise/v0.23/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.23/02_develop/01_cli-quickstart.md
@@ -224,9 +224,26 @@ $ astro dev start
 
 ## Astronomer CLI and Platform Versioning
 
-For every minor version of the Astronomer Platform, a corresponding minor version of the Astronomer CLI is made available. To ensure reliability and proper access to our latest features, Astronomer users should always upgrade to the corresponding minor version of the Astronomer CLI. If you're on Astronomer v0.23+, for example, Astronomer CLI v0.23+ is required.
+For every minor version of the Astronomer Platform, a corresponding minor version of the Astronomer CLI is made available. To ensure reliability, upgrade to the corresponding minor version of the Astronomer CLI. If you're on Astronomer v0.23+, for example, Astronomer CLI v0.23+ is required.
 
 While corresponding minor versions of the Astronomer Platform and the Astronomer CLI are required, subsequent patch versions do not need to match and will not introduce breaking changes. The release of Astronomer v0.23.9, for example, does not mean that v0.23.9 of the Astronomer CLI exists or is required.
+
+To check your working version of the Astronomer CLI (`Astro CLI`) and the Astronomer Platform (`Astro Server Version`), run:
+
+```
+$ astro version
+```
+
+This command will output something like the following:
+
+```sh
+$ astro version
+Astro CLI Version: 0.23.2
+Astro Server Version: 0.23.9
+Git Commit: 748ca2e9de1e51e9f48f9d85eb8315b023debc2f
+```
+
+If the minor versions between the two don't match, you'll receive an error message in your command line with instructions to either upgrade or downgrade. If you have access to more than one Astronomer Enterprise installation, `Astro Server Version` will correspond to the `<base-domain>` that you're currently authenticated into.
 
 For more information on Astronomer Platform and CLI releases, refer to:
 

--- a/enterprise/v0.23/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.23/02_develop/01_cli-quickstart.md
@@ -185,7 +185,7 @@ If you do not yet have an account on Astronomer, ask a Workspace Admin on your t
 
 > **Note:** Once you run this command once, it should stay cached and allow you to just run `$ astro auth login` to authenticate more easily in the future.
 
-## Next Steps: Apply Changes using the CLI
+## Apply Changes to your Airflow Project
 
 As you develop locally, it's worth noting that some changes made to your image are automatically applied, while other changes made to a certain set of files require rebuilding your image in order for them to render.
 
@@ -208,7 +208,9 @@ All changes made to the following files require rebuilding your image:
 - `requirements.txt`
 - `airflow_settings.yaml`
 
-This includes changing the Airflow image in your `Dockerfile`, adding Python Packages to `requirements.txt` or OS-level packages to `packages.txt`, etc. To rebuild your image, first run the following command:
+This includes changing the Airflow image in your `Dockerfile` and adding Python Packages to `requirements.txt` or OS-level packages to `packages.txt`.
+
+To rebuild your image after making a change to any of these files, first run the following command:
 
 ```
 $ astro dev stop
@@ -220,14 +222,18 @@ Then, restart the Docker containers by running:
 $ astro dev start
 ```
 
-## Additional Resources
+## Astronomer CLI and Platform Versioning
 
-For more information on the Astronomer CLI, feel free to reference:
+For every minor version of the Astronomer Platform, a corresponding minor version of the Astronomer CLI is made available. To ensure reliability and proper access to our latest features, Astronomer users should always upgrade to the corresponding minor version of the Astronomer CLI. If you're on Astronomer v0.23+, for example, Astronomer CLI v0.23+ is required.
+
+While corresponding minor versions of the Astronomer Platform and the Astronomer CLI are required, subsequent patch versions do not need to match and will not introduce breaking changes. The release of Astronomer v0.23.9, for example, does not mean that v0.23.9 of the Astronomer CLI exists or is required.
+
+For more information on Astronomer Platform and CLI releases, refer to:
 
 * [CLI Release Changelog](https://github.com/astronomer/astro-cli/releases)
-* [CLI README on GitHub](https://github.com/astronomer/astro-cli#astronomer-cli----)
+* [Astronomer Release Notes](https://www.astronomer.io/docs/enterprise/v0.23/resources/release-notes)
 
-## Beyond the CLI
+### Beyond the Astronomer CLI
 
 Looking for additional next steps after installing the Astronomer CLI? We recommend reading through the following guides:
 

--- a/enterprise/v0.23/06_manage-astronomer/06_upgrade-to-0-23.md
+++ b/enterprise/v0.23/06_manage-astronomer/06_upgrade-to-0-23.md
@@ -102,7 +102,7 @@ If the upgrade was successful, you should be able to:
 
 ## Step 8: Upgrade the Astronomer CLI to v0.23
 
-To ensure reliability and full access to features included in Astronomer v0.23, all users must upgrade to v0.23 of the Astronomer CLI. We recommend the latest available version, though you may choose to install a particular patch release within the v0.23 series.
+To ensure reliability and full access to features included in Astronomer v0.23, all users must upgrade to v0.23 of the Astronomer CLI following an upgrade from v0.16. We recommend the latest available version, though you may choose to install a particular patch release within the v0.23 series.
 
 To upgrade to the latest available v0.23 version of the Astronomer CLI, run:
 

--- a/enterprise/v0.23/06_manage-astronomer/06_upgrade-to-0-23.md
+++ b/enterprise/v0.23/06_manage-astronomer/06_upgrade-to-0-23.md
@@ -100,7 +100,7 @@ If the upgrade was successful, you should be able to:
 * Open the Airflow UI for each of your Deployments
 * Access logs for your DAGs in the Airflow UI.
 
-## Step 8: Upgrade your Astronomer CLI
+## Step 8: Upgrade the Astronomer CLI to v0.23
 
 To ensure reliability and full access to features included in Astronomer v0.23, all users must upgrade to v0.23 of the Astronomer CLI. We recommend the latest available version, though you may choose to install a particular patch release within the v0.23 series.
 

--- a/enterprise/v0.23/06_manage-astronomer/06_upgrade-to-0-23.md
+++ b/enterprise/v0.23/06_manage-astronomer/06_upgrade-to-0-23.md
@@ -100,6 +100,24 @@ If the upgrade was successful, you should be able to:
 * Open the Airflow UI for each of your Deployments
 * Access logs for your DAGs in the Airflow UI.
 
+## Step 8: Upgrade your Astronomer CLI
+
+To ensure reliability and full access to features included in Astronomer v0.23, all users must upgrade to v0.23 of the Astronomer CLI. We recommend the latest available version, though you may choose to install a particular patch release within the v0.23 series.
+
+To upgrade to the latest available v0.23 version of the Astronomer CLI, run:
+
+```sh
+$ curl -sSL https://install.astronomer.io | sudo bash -s -- v0.23
+```
+
+To do so via Homebrew, run:
+
+```sh
+$ brew install astronomer/tap/astro@0.23
+```
+
+All team members within your organization should upgrade the Astronomer CLI individually before taking any further action on the platform or in a local Airflow environment. For a detailed breakdown of CLI changes between versions, refer to [Astronomer CLI releases](https://github.com/astronomer/astro-cli/releases). For detailed install guidelines and more information on the Astronomer CLI, refer to [Astronomer CLI Quickstart](https://www.astronomer.io/docs/enterprise/v0.23/develop/cli-quickstart).
+
 ## Roll Back to Enterprise v0.16
 
 If you encounter an issue during your upgrade that requires you to recover your original platform, you can roll back to Astronomer v0.16. To do so:

--- a/enterprise/v0.23/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/v0.23/09_resources/03_version-compatibility-reference.md
@@ -12,12 +12,12 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Enterprise
 
-| Astronomer Platform  | Kubernetes       | Helm | Terraform   | Postgres | Astronomer Certified                             | Python        |
-|----------------------|------------------|------|-------------|----------|--------------------------------------------------|---------------|
-| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5| 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 |
-| v0.23                | 1.16, 1.17, 1.18 | 3    | 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 |
+| Astronomer Platform  | Kubernetes       | Helm | Terraform   | Postgres | Astronomer Certified                             | Python        | Astronomer CLI |
+|----------------------|------------------|------|-------------|----------|--------------------------------------------------|---------------|----------------|
+| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5| 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 | 0.16           |
+| v0.23                | 1.16, 1.17, 1.18 | 3    | 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 | 0.23           |         
 
-> **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12, and Astronomer v0.16.15+ is required to run Astronomer Certified 1.10.14. For instructions on how to upgrade to an Astronomer v0.16 patch version, read [Upgrade to a Patch Version of Astronomer](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer-patch).
+> **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12, and Astronomer v0.16.15+ is required to run Astronomer Certified 1.10.14. For instructions on how to upgrade to an Astronomer v0.16 patch version, read [Upgrade to a Patch Version of Astronomer](https://www.astronomer.io/docs/enterprise/v0.23/manage-astronomer/upgrade-astronomer-patch).
 
 ## Astronomer Certified
 
@@ -30,13 +30,13 @@ It's worth noting that while the tables below reference the minimum compatible v
 | 1.10.14                 | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
 | 2.0.0                   | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              |
 
-For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/next/customize-airflow/manage-airflow-versions/).
+For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/v0.23/customize-airflow/manage-airflow-versions/).
 
 > **Note:** MySQL 5.7 is compatible with Airflow and Astronomer Certified 2.0 but it does NOT support the ability to run more than 1 Scheduler and is not recommended. If you'd like to leverage Airflow's new Highly-Available Scheduler, make sure you're running MySQL 8.0+.
 
 ## Additional Resources
 
-The table above lists long-term support (LTS) versions of Astronomer and does not specify _patch_ versions that our engineering team releases on a regular basis. For more detail on changes between patches, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/next/resources/release-notes/).
+The table above lists long-term support (LTS) versions of Astronomer and does not specify _patch_ versions that our engineering team releases on a regular basis. For more detail on changes between patches, refer to [Astronomer Enterprise Release Notes](https://www.astronomer.io/docs/enterprise/v0.23/resources/release-notes/).
 
 > **Note:** If you're running on a legacy version of Astronomer (pre-v0.16), reach out to [Astronomer Support](https://support.astronomer.io) to schedule an upgrade with our team.
 


### PR DESCRIPTION
This PR adds guidelines around Astronomer CLI and Platform versioning policy and recommendations, applicable to both Astronomer Cloud and Enterprise. Changes include:

1. Add CLI versions to Enterprise Versioning Compatibility Matrix
2. Add a step to our "Upgrade to Astronomer v0.23" guide that instructs users to upgrade the CLI
3. Add information around Platform <> CLI minor versioning in "CLI Quickstart"

Adding @jwitz as a reviewer here but @vishwas-astro @astrorfox feel free to take a look at this as well and provide feedback on any of the above. Once we're good with the changes here, I'll port them over to Cloud docs + v0.16/next Enterprise versions.

Related Astro CLI PR: https://github.com/astronomer/astro-cli/pull/339

Resolves: https://github.com/astronomer/docs/issues/162