### PR TITLE
Rewrote the Manage Workspaces doc to be more focused

### DIFF
--- a/cloud/stable/03_deploy/01_manage-workspaces.md
+++ b/cloud/stable/03_deploy/01_manage-workspaces.md
@@ -1,77 +1,52 @@
 ---
 title: "Manage Workspaces and Deployments on Astronomer"
-navTitle: "Manage Workspaces"
+navTitle: "Create a Workspace"
 description: "Manage Astronomer Workspaces and Airflow Deployments via the Astronomer UI."
 ---
 
-We've designed the Astronomer UI as a place for you to easily manage users, Airflow Deployments and resources.
+## Overview
 
-## Dashboard
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
 
-Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
+This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
 
-1. Create a new Workspace
-2. View the Workspaces you have access to in the left-hand navigation
-3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
-
-![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
-
-## Workspaces
-
-**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow Deployments. User access to Deployments is managed at the Workspace level on Astronomer.
-
-A **Workspace** is an Astronomer-specific term. You can think of your Workspaces the same way you'd think of teams - they're just collections of Airflow Deployments that specific user groups have access to. When you create an account on Astronomer, a default personal Workspace is automatically created. Airflow Deployments are hierarchically lower - from a Workspace, you can create one or more Airflow Deployments, and grant or restrict user access to those Deployments accordingly.
-
-If you were a solo agent, you could have multiple Airflow Deployments within that single Workspace and have no need for additional Workspaces. Teams, however, often share one or more Workspaces labeled as such, and have multiple Airflow Deployments from there.
-
-Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one Workspace to another once deployed.
-
-Once you click into a Workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
-
-![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
-
-Here, you have a high-level overview of all of the active Airflow Deployments you have running in that given Workspace. In this case, we only have one cluster spun up.
-
-From this screen, you can:
-
-1. Create new Airflow Deployments
-2. Manage user access to the Workspace
-3. Generate tokens for CI/CD systems via service accounts.
-4. Rename your Workspace
-
-Since all of our app activity is routed through a GraphQL API, you're free to create Deployments, switch Workspaces, and add users via our [CLI](/docs/cloud/stable/develop/cli-quickstart/) if you prefer staying in your terminal.
-
-> **Note:** The concept of a "Workspace" only exists at the API level to support role-based access control and user permissions. It will not affect Airflow task execution.
+* Deployments
+* Settings
+* Users
+* Service Accounts
 
 ## Deployments
 
-An [Apache Airflow](https://airflow.apache.org/) Deployment is made up of a Scheduler, a Webserver and, if you're running the Celery or Kubernetes Executors, one or more Workers. An Airflow Deployment within a Workspace has the capacity to host a collection of DAGs.
+The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/cloud/stable/develop/cli-quickstart/) as part of a Workspace. Under the hood, each Airflow Deployment gets its own Kubernetes namespace and has a reserved set of dedicated resources and an underlying Postgres Metadata Database.
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/stable/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
 
-You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
+The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
-From the Workspace dashboard, navigate back to the "Deployments" tab.
+![Deployment Tab](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
-If you click into one of your Airflow Deployments, you'll land on a page that looks like this:
+Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow Deployment from one Workspace to another once created.
 
-![Deployments](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-deployment.png)
+## Settings
 
-From here, you'll be able to access:
+Use the **Settings** tab to rename your Workspace or rewrite its description. While these fields have no effect on how tasks are executed, we recommend configuring them to give users an idea of the Workspace's purpose and scope.
 
-1. Airflow UI (DAG Dashboard)
-2. Flower Dashboard (if you are running the Celery executor)
+## Users
 
-The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
-
-For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui/).
-
-> **Note:** All Airflow Deployments run in an isolated Kubernetes namespace, which means resources will be provisioned independently and data will be kept isolated from the rest. You can assume that each Airflow Deployment is unaware of the others, even within the same Workspace.
-
-## User Management
-
-If you go to the **Users** tab of your Workspace Dashboard, you'll see who has access to the Workspace.
+You can see who has access to the Workspace in the **Users** tab.
 
 If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
 
-An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on Astronomer Cloud](/docs/cloud/stable/manage-astronomer/workspace-permissions/).
+An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/stable/manage-astronomer/workspace-permissions/).
+
+In addition, Enterprise System Admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/manage-platform-users#customize-permissions).
+
+## Service Accounts
+
+Use the **Service Accounts** tab to create Service Accounts. Service Accounts can push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
+
+A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/stable/deploy/ci-cd).
+
+## Billing
+
+Use the **Billing** tab to configure your organization's billing information. You can specify a billable name, a billing email, and a credit card to use for future payments. For more information on billing, read [Cloud Pricing](https://www.astronomer.io/docs/cloud/stable/resources/pricing).

--- a/cloud/stable/03_deploy/01_manage-workspaces.md
+++ b/cloud/stable/03_deploy/01_manage-workspaces.md
@@ -6,14 +6,19 @@ description: "Manage Astronomer Workspaces and Airflow Deployments via the Astro
 
 ## Overview
 
-A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments.
 
-This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
+If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
+
+This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 5 tabs you can access from a Workspace's menu in the Astronomer UI:
 
 * Deployments
 * Settings
 * Users
 * Service Accounts
+* Billing
+
+![Workspace configuration tab location](https://assets2.astronomer.io/main/docs/astronomer-ui/cloud-workspace.png)
 
 ## Deployments
 

--- a/cloud/stable/03_deploy/01_manage-workspaces.md
+++ b/cloud/stable/03_deploy/01_manage-workspaces.md
@@ -19,7 +19,7 @@ This guide walks through the best practices for creating and managing Workspaces
 
 The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
 
-To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/stable/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in [CLI Quickstart](/docs/cloud/stable/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/cloud/v0.23/deploy/configure-deployment).
 
 The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
@@ -35,18 +35,18 @@ Use the **Settings** tab to rename your Workspace or rewrite its description. Wh
 
 You can see who has access to the Workspace in the **Users** tab.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace admins can grant them varying levels of access to the entire Workspace.
 
-An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/stable/manage-astronomer/workspace-permissions/).
+An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/cloud/stable/manage-astronomer/workspace-permissions/).
 
-In addition, Enterprise System Admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/manage-platform-users#customize-permissions).
+In addition, Enterprise system admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/cloud/stable/manage-astronomer/manage-platform-users#customize-permissions).
 
 ## Service Accounts
 
 Use the **Service Accounts** tab to create Service Accounts. Service Accounts can push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
 
-A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/stable/deploy/ci-cd).
+A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/cloud/stable/deploy/ci-cd).
 
 ## Billing
 
-Use the **Billing** tab to configure your organization's billing information. You can specify a billable name, a billing email, and a credit card to use for future payments. For more information on billing, read [Cloud Pricing](https://www.astronomer.io/docs/cloud/stable/resources/pricing).
+Billing for Astronomer Cloud is managed at the Workspace level. Use the **Billing** tab to add or configure your team's payment method. You can specify a billable name, a billing email, and a credit card to use for future payments. The email address you specify here will receive a monthly invoice for resource usage associated with all Airflow Deployments within your Workspace. If you'd like to receive invoices at more than one email address, reach out to [Astronomer Support](https://support.astronomer.io). For more information on billing, read [Cloud Pricing](https://www.astronomer.io/docs/cloud/stable/resources/pricing).

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -19,7 +19,7 @@ This guide walks through the best practices for creating and managing Workspaces
 
 The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
 
-To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/stable/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in [CLI Quickstart](/docs/enterprise/stable/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
 
 The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
@@ -35,14 +35,14 @@ In the **Settings** tab, you can rename your Workspace or rewrite its descriptio
 
 In the **Users** tab, you'll see who has access to the Workspace.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace admins can grant them varying levels of access to the entire Workspace.
 
 An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/stable/manage-astronomer/workspace-permissions/).
 
-In addition, Enterprise System Admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/manage-platform-users#customize-permissions).
+In addition, Enterprise system admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/manage-platform-users#customize-permissions).
 
 ## Service Accounts
 
-You can create and manage Service Accounts in the **Service Account** tab. Service Accounts push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
+Use the **Service Accounts** tab to create a Workspace-level Service Account. Service Accounts generate a permanent API key that you can use automate any action at the Workspace level, such as deploying to your Workspace's Airflow Deployments via a CI/CD tool of your choice.
 
-A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/stable/deploy/ci-cd).
+To automate actions at the Deployment level, create a Deployment Service Account. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/stable/deploy/ci-cd).

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -1,74 +1,35 @@
 ---
 title: "Manage Workspaces and Deployments on Astronomer"
-navTitle: "Manage Workspaces"
+navTitle: "Create a Workspace"
 description: "Manage Astronomer Workspaces and Airflow Deployments via the Astronomer UI."
 ---
 
-We've designed the Astronomer UI as a place for you to easily manage users, Airflow Deployments and resources.
+## Overview
 
-## Dashboard
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and manage other users' access to those Deployments. New Workspaces can be created using the **New Workspace** button on in the sidebar of the Astronomer UI.  
 
-Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
+This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
 
-1. Create a new Workspace
-2. View the Workspaces you have access to in the left-hand navigation
-3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
-
-![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
-
-## Workspaces
-
-**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow Deployments. User access to Deployments is managed at the Workspace level on Astronomer.
-
-A **Workspace** is an Astronomer-specific term. You can think of your Workspaces the same way you'd think of teams - they're just collections of Airflow Deployments that specific user groups have access to. When you create an account on Astronomer, a default personal Workspace is automatically created. Airflow Deployments are hierarchically lower - from a Workspace, you can create one or more Airflow Deployments, and grant or restrict user access to those Deployments accordingly.
-
-If you were a solo agent, you could have multiple Airflow Deployments within that single Workspace and have no need for additional Workspaces. Teams, however, often share one or more Workspaces labeled as such, and have multiple Airflow Deployments from there.
-
-Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one Workspace to another once deployed.
-
-Once you click into a Workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
-
-![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
-
-Here, you have a high-level overview of all of the active Airflow Deployments you have running in that given Workspace. In this case, we only have one cluster spun up.
-
-From this screen, you can:
-
-1. Create new Airflow Deployments
-2. Manage user access to the Workspace
-3. Generate tokens for CI/CD systems via service accounts
-4. Rename your Workspace
-
-Since all of our app activity is routed through a GraphQL API, you're free to create Deployments, switch Workspaces, and add users via our [CLI](/docs/enterprise/stable/develop/cli-quickstart/) if you prefer staying in your terminal.
-
-> **Note:** The concept of a "Workspace" only exists at the API level to support role-based access control and user permissions. It will not affect Airflow task execution.
+* Deployments
+* Settings
+* Users
+* Service Accounts
 
 ## Deployments
 
-An [Apache Airflow](https://airflow.apache.org/) Deployment is made up of a Scheduler, a Webserver and, if you're running the Celery or Kubernetes Executors, one or more Workers. An Airflow Deployment within a Workspace has the capacity to host a collection of DAGs.
+The most important function of Workspaces is creating and managing access to Airflow Deployments: instances of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/stable/develop/cli-quickstart/). To create a new Deployment, simply click the **New Deployment** button in the **Deployments** tab and configure its settings. For more information on configuring Deployment settings, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/stable/develop/cli-quickstart/) as part of a Workspace. Under the hood, each Airflow Deployment gets its own Kubernetes namespace and has a reserved set of dedicated resources and an underlying Postgres Metadata Database.
+The **Deployments** tab also contains information on all of your existing Deployments, including names, Executor types, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
-You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
+![Deployment Tab](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
-From the Workspace dashboard, navigate back to the "Deployments" tab.
+Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one Workspace to another once deployed.
 
-If you click into one of your Airflow Deployments, you'll land on a page that looks like this:
+## Settings
 
-![Deployments](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-deployment.png)
+You can use the **Settings** tab to rename your Workspace or rewrite its description. While these fields have no effect on how tasks are executed, we recommend configuring them to give users an idea of the Workspace's purpose and scope.
 
-From here, you'll be able to access:
-
-1. Airflow UI (DAG Dashboard)
-2. Flower Dashboard (if you are running the Celery executor)
-
-The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
-
-For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui/).
-
-> **Note:** All Airflow Deployments run in an isolated Kubernetes namespace, which means resources will be provisioned independently and data will be kept isolated from the rest. You can assume that each Airflow Deployment is unaware of the others, even within the same Workspace.
-
-## User Management
+## Users
 
 If you go to the **Users** tab of your Workspace Dashboard, you'll see who has access to the Workspace.
 
@@ -77,3 +38,9 @@ If you'd like to share access to other members of your organization, invite them
 An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/stable/manage-astronomer/workspace-permissions/).
 
 In addition, Enterprise admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/manage-platform-users#customize-permissions).
+
+## Service Accounts
+
+In the **Service Accounts** tab, you can create a new Service Account to push code and deploy to your Workspace's Airflow Deployments via a Continuous Integration/Continuous Delivery (CI/CD) tool of your choice.
+
+Creating a Service Account at the Workspace level allows you to deploy to multiple Airflow deployments with one code push, while creating them at the Deployment level ensures that your CI/CD pipeline only deploys to one particular deployment on Astronomer. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.23/deploy/ci-cd).

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -17,7 +17,7 @@ This guide walks through the best practices for creating and managing Workspaces
 
 ## Deployments
 
-The most important function of Workspaces is creating and managing access to Airflow Deployments: instances of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/stable/develop/cli-quickstart/). To create a new Deployment, simply click the **New Deployment** button in the **Deployments** tab and configure its settings. For more information on configuring Deployment settings, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
+The most important function of Workspaces is creating and managing access to Airflow Deployments: instances of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/stable/develop/cli-quickstart/). To create a new Deployment, click the **New Deployment** button in the **Deployments** tab and configure its settings. For more information on configuring Deployment settings, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
 
 The **Deployments** tab also contains information on all of your existing Deployments, including names, Executor types, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -17,7 +17,7 @@ This guide walks through the best practices for creating and managing Workspaces
 
 ## Deployments
 
-The most important function of Workspaces is creating and managing access to Airflow Deployments: instances of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/stable/develop/cli-quickstart/). To create a new Deployment, click the **New Deployment** button in the **Deployments** tab and configure its settings. For more information on configuring Deployment settings, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
+The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors. To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/stable/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
 
 The **Deployments** tab also contains information on all of your existing Deployments, including names, Executor types, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 

--- a/enterprise/next/04_deploy/01_manage-workspaces.md
+++ b/enterprise/next/04_deploy/01_manage-workspaces.md
@@ -6,7 +6,7 @@ description: "Manage Astronomer Workspaces and Airflow Deployments via the Astro
 
 ## Overview
 
-A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI. 
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
 
 This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
 
@@ -17,7 +17,9 @@ This guide walks through the best practices for creating and managing Workspaces
 
 ## Deployments
 
-The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors. To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/stable/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
+The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
+
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/stable/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
 
 The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
@@ -27,11 +29,11 @@ Deployments cannot be used or shared across Workspaces. While you’re free to p
 
 ## Settings
 
-You can use the **Settings** tab to rename your Workspace or rewrite its description. While these fields have no effect on how tasks are executed, we recommend configuring them to give users an idea of the Workspace's purpose and scope.
+In the **Settings** tab, you can rename your Workspace or rewrite its description. While these fields have no effect on how tasks are executed, we recommend configuring them to give users an idea of the Workspace's purpose and scope.
 
 ## Users
 
-If you go to the **Users** tab of your Workspace Dashboard, you'll see who has access to the Workspace.
+In the **Users** tab, you'll see who has access to the Workspace.
 
 If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
 
@@ -41,6 +43,6 @@ In addition, Enterprise System Admins can add or remove specific permissions for
 
 ## Service Accounts
 
-In the **Service Accounts** tab, you can create a new Service Account to push code and deploy to your Workspace's Airflow Deployments via a Continuous Integration/Continuous Delivery (CI/CD) tool of your choice.
+You can create and manage Service Accounts in the **Service Account** tab. Service Accounts push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
 
-Creating a Service Account at the Workspace level allows you to deploy to multiple Airflow Deployments with one code push, while creating them at the Deployment level ensures that your CI/CD pipeline only deploys to a single Airflow Deployment on Astronomer. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.23/deploy/ci-cd).
+A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/stable/deploy/ci-cd).

--- a/enterprise/v0.12/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.12/04_deploy/01_manage-workspaces.md
@@ -6,14 +6,18 @@ description: "Manage Astronomer Workspaces and Airflow Deployments via the Astro
 
 ## Overview
 
-A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments.
 
-This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
+If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
+
+This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from a Workspace's menu in the Astronomer UI:
 
 * Deployments
 * Settings
 * Users
 * Service Accounts
+
+![Workspace configuration tab location](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.23-workspace.png)
 
 ## Deployments
 

--- a/enterprise/v0.12/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.12/04_deploy/01_manage-workspaces.md
@@ -19,7 +19,7 @@ This guide walks through the best practices for creating and managing Workspaces
 
 The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
 
-To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/v0.12/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.12/deploy/configure-deployment).
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in [CLI Quickstart](/docs/enterprise/v0.12/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.12/deploy/configure-deployment).
 
 The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
@@ -35,14 +35,14 @@ You can rename your Workspace or rewrite its description in the **Settings** tab
 
 You can see who has access to the Workspace in the **Users** tab.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace admins can grant them varying levels of access to the entire Workspace.
 
 An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/v0.12/manage-astronomer/workspace-permissions/).
 
-In addition, Enterprise System Admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.12/manage-astronomer/manage-platform-users#customize-permissions).
+In addition, Enterprise system admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.12/manage-astronomer/manage-platform-users#customize-permissions).
 
 ## Service Accounts
 
-Use the **Service Accounts** tab to create Service Accounts. Service Accounts push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
+Use the **Service Accounts** tab to create a Workspace-level Service Account. Service Accounts generate a permanent API key that you can use automate any action at the Workspace level, such as deploying to your Workspace's Airflow Deployments via a CI/CD tool of your choice.
 
-A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.12/deploy/ci-cd).
+To automate actions at the Deployment level, create a Deployment Service Account. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.12/deploy/ci-cd).

--- a/enterprise/v0.12/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.12/04_deploy/01_manage-workspaces.md
@@ -1,78 +1,48 @@
 ---
 title: "Manage Workspaces and Deployments on Astronomer"
-navTitle: "Manage Workspaces"
+navTitle: "Create a Workspace"
 description: "Manage Astronomer Workspaces and Airflow Deployments via the Astronomer UI."
 ---
 
-We've designed the Astronomer UI as a place for you to easily and effectively manage users, deployments and resources.
+## Overview
 
-## Dashboard
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
 
-Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
+This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
 
-1. Create a new Workspace
-2. View the Workspaces you have access to in the left-hand navigation
-3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
-
-![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
-
-## Workspaces
-
-**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the workspace level on Astronomer.
-
-A **Workspace** is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
-
-If you were a solo agent, you could have multiple Airflow deployments within that single workspace and have no need for additional workspaces. Teams, however, often share one or more workspaces labeled as such, and have multiple Airflow deployments from there.
-
-Deployments cannot be used or shared across workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one workspace to another once deployed.
-
-Once you click into a workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
-
-![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
-
-Here, you have a high-level overview of all of the active Airflow deployments you have running in that given workspace. In this case, we only have one cluster spun up.
-
-From this screen, you can:
-
-1. Create new Airflow deployments
-2. Manage user access to the workspace
-3. Generate tokens for CI/CD systems via service accounts.
-4. Rename your Workspace
-
-Since all of our app activity is routed through a GraphQL API, you're free to create deployments, switch workspaces, and add users via our [CLI](/docs/enterprise/v0.12/develop/cli-quickstart/) if you prefer staying in your terminal.
-
-**Note:** The concept of a "workspace" only exists at the API level to help with permissions. It does **not** have anything to do with how Airflow will run jobs.
+* Deployments
+* Settings
+* Users
+* Service Accounts
 
 ## Deployments
 
-A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
+The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/v0.12/develop/cli-quickstart/) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/v0.12/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.12/deploy/configure-deployment).
 
-You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
+The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
+![Deployment Tab](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
-From the Workspace dashboard, navigate back to the "Deployments" tab.
+Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow Deployment from one Workspace to another once created.
 
-If you click into one of your Airflow deployments, you'll land on a page that looks like this:
+## Settings
 
-![Deployments](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-deployment.png)
+You can rename your Workspace or rewrite its description in the **Settings** tab. While these fields have no effect on how tasks are executed, we recommend configuring them to give users an idea of the Workspace's purpose and scope.
 
-From here, you'll be able to access:
+## Users
 
-1. Airflow UI (DAG Dashboard)
-2. Flower Dashboard (if you are running the Celery executor)
+You can see who has access to the Workspace in the **Users** tab.
 
-The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
 
-For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui/).
+An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/v0.12/manage-astronomer/workspace-permissions/).
 
-**Each deployment will run in a separate Kubernetes namespace, so they'll all get resources and maintain metadata independently. You should assume that each deployment is unaware of the others.**
+In addition, Enterprise System Admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.12/manage-astronomer/manage-platform-users#customize-permissions).
 
-## User Management
+## Service Accounts
 
-If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
+Use the **Service Accounts** tab to create Service Accounts. Service Accounts push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
 
-## Workspace Permissions
-
-Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in the [User Roles and Permissions](/docs/enterprise/v0.12/manage-astronomer/workspace-permissions/) section. Astronomer Enterprise admins can [configure the exact permissions](/docs/enterprise/v0.12/manage-astronomer/manage-platform-users/) for each Astronomer role.
+A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.12/deploy/ci-cd).

--- a/enterprise/v0.13/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.13/04_deploy/01_manage-workspaces.md
@@ -6,14 +6,18 @@ description: "Manage Astronomer Workspaces and Airflow Deployments via the Astro
 
 ## Overview
 
-A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments.
 
-This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
+If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
+
+This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from a Workspace's menu in the Astronomer UI:
 
 * Deployments
 * Settings
 * Users
 * Service Accounts
+
+![Workspace configuration tab location](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.23-workspace.png)
 
 ## Deployments
 

--- a/enterprise/v0.13/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.13/04_deploy/01_manage-workspaces.md
@@ -1,78 +1,48 @@
 ---
 title: "Manage Workspaces and Deployments on Astronomer"
-navTitle: "Manage Workspaces"
+navTitle: "Create a Workspace"
 description: "Manage Astronomer Workspaces and Airflow Deployments via the Astronomer UI."
 ---
 
-We've designed the Astronomer UI as a place for you to easily and effectively manage users, deployments and resources.
+## Overview
 
-## Dashboard
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
 
-Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
+This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
 
-1. Create a new Workspace
-2. View the Workspaces you have access to in the left-hand navigation
-3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
-
-![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
-
-## Workspaces
-
-**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the workspace level on Astronomer.
-
-A **Workspace** is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
-
-If you were a solo agent, you could have multiple Airflow deployments within that single workspace and have no need for additional workspaces. Teams, however, often share one or more workspaces labeled as such, and have multiple Airflow deployments from there.
-
-Deployments cannot be used or shared across workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one workspace to another once deployed.
-
-Once you click into a workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
-
-![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
-
-Here, you have a high-level overview of all of the active Airflow deployments you have running in that given workspace. In this case, we only have one cluster spun up.
-
-From this screen, you can:
-
-1. Create new Airflow deployments
-2. Manage user access to the workspace
-3. Generate tokens for CI/CD systems via service accounts.
-4. Rename your Workspace
-
-Since all of our app activity is routed through a GraphQL API, you're free to create deployments, switch workspaces, and add users via our [CLI](/docs/enterprise/v0.13/develop/cli-quickstart/) if you prefer staying in your terminal.
-
-**Note:** The concept of a "workspace" only exists at the API level to help with permissions. It does **not** have anything to do with how Airflow will run jobs.
+* Deployments
+* Settings
+* Users
+* Service Accounts
 
 ## Deployments
 
-A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
+The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/v0.13/develop/cli-quickstart/) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/v0.13/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.13/deploy/configure-deployment).
 
-You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
+The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
+![Deployment Tab](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
-From the Workspace dashboard, navigate back to the "Deployments" tab.
+Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow Deployment from one Workspace to another once created.
 
-If you click into one of your Airflow deployments, you'll land on a page that looks like this:
+## Settings
 
-![Deployments](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-deployment.png)
+You can rename your Workspace or rewrite its description in the **Settings** tab. While these fields have no effect on how tasks are executed, we recommend configuring them to give users an idea of the Workspace's purpose and scope.
 
-From here, you'll be able to access:
+## Users
 
-1. Airflow UI (DAG Dashboard)
-2. Flower Dashboard (if you are running the Celery executor)
+You can see who has access to the Workspace in the **Users** tab.
 
-The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
 
-For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui/).
+An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/v0.13/manage-astronomer/workspace-permissions/).
 
-**Each deployment will run in a separate Kubernetes namespace, so they'll all get resources and maintain metadata independently. You should assume that each deployment is unaware of the others.**
+In addition, Enterprise System Admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.13/manage-astronomer/manage-platform-users#customize-permissions).
 
-## User Management
+## Service Accounts
 
-If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
+Use the **Service Accounts** tab to create Service Accounts. Service Accounts push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
 
-## Workspace Permissions
-
-Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in the [User Roles and Permissions](/docs/enterprise/v0.13/manage-astronomer/workspace-permissions/) section. Astronomer Enterprise admins can [configure the exact permissions](/docs/enterprise/v0.13/manage-astronomer/manage-platform-users/) for each Astronomer role.
+A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.13/deploy/ci-cd).

--- a/enterprise/v0.13/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.13/04_deploy/01_manage-workspaces.md
@@ -19,7 +19,7 @@ This guide walks through the best practices for creating and managing Workspaces
 
 The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
 
-To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/v0.13/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.13/deploy/configure-deployment).
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in [CLI Quickstart](/docs/enterprise/v0.13/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.13/deploy/configure-deployment).
 
 The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
@@ -35,14 +35,14 @@ You can rename your Workspace or rewrite its description in the **Settings** tab
 
 You can see who has access to the Workspace in the **Users** tab.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace admins can grant them varying levels of access to the entire Workspace.
 
 An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/v0.13/manage-astronomer/workspace-permissions/).
 
-In addition, Enterprise System Admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.13/manage-astronomer/manage-platform-users#customize-permissions).
+In addition, Enterprise system admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.13/manage-astronomer/manage-platform-users#customize-permissions).
 
 ## Service Accounts
 
-Use the **Service Accounts** tab to create Service Accounts. Service Accounts push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
+Use the **Service Accounts** tab to create a Workspace-level Service Account. Service Accounts generate a permanent API key that you can use automate any action at the Workspace level, such as deploying to your Workspace's Airflow Deployments via a CI/CD tool of your choice.
 
-A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.13/deploy/ci-cd).
+To automate actions at the Deployment level, create a Deployment Service Account. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.13/deploy/ci-cd).

--- a/enterprise/v0.15/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.15/04_deploy/01_manage-workspaces.md
@@ -6,14 +6,18 @@ description: "Manage Astronomer Workspaces and Airflow Deployments via the Astro
 
 ## Overview
 
-A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments.
 
-This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
+If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
+
+This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from a Workspace's menu in the Astronomer UI:
 
 * Deployments
 * Settings
 * Users
 * Service Accounts
+
+![Workspace configuration tab location](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.23-workspace.png)
 
 ## Deployments
 
@@ -43,6 +47,6 @@ In addition, Enterprise system admins can add or remove specific permissions for
 
 ## Service Accounts
 
-Use the **Service Accounts** tab to create a Workspace-level Service Account. Service Accounts generate a permanent API key that you can use automate any action at the Workspace level, such as deploying to your Workspace's Airflow Deployments via a CI/CD tool of your choice. 
+Use the **Service Accounts** tab to create a Workspace-level Service Account. Service Accounts generate a permanent API key that you can use automate any action at the Workspace level, such as deploying to your Workspace's Airflow Deployments via a CI/CD tool of your choice.
 
 To automate actions at the Deployment level, create a Deployment Service Account. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.15/deploy/ci-cd).

--- a/enterprise/v0.15/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.15/04_deploy/01_manage-workspaces.md
@@ -1,80 +1,48 @@
 ---
 title: "Manage Workspaces and Deployments on Astronomer"
-navTitle: "Manage Workspaces"
+navTitle: "Create a Workspace"
 description: "Manage Astronomer Workspaces and Airflow Deployments via the Astronomer UI."
 ---
 
-We've designed the Astronomer UI as a place for you to easily and effectively manage users, deployments and resources.
+## Overview
 
-## Dashboard
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
 
-Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
+This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
 
-![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
-
-From this dashboard, you can:
-
-1. Create a new Workspace
-2. View the Workspaces you have access to in the left-hand navigation
-3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
-
-## Workspaces
-
-**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow deployments. User access to deployments is managed at the workspace level on Astronomer.
-
-A **Workspace** is an Astronomer-specific term. You can think of your workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal workspace is automatically created. Airflow deployments are hierarchically lower - from a workspace, you can create one or more Airflow deployments, and grant or restrict user access to those deployments accordingly.
-
-If you were a solo agent, you could have multiple Airflow deployments within that single workspace and have no need for additional workspaces. Teams, however, often share one or more workspaces labeled as such, and have multiple Airflow deployments from there.
-
-Deployments cannot be used or shared across workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one workspace to another once deployed.
-
-Once you click into a workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
-
-![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
-
-Here, you have a high-level overview of all of the active Airflow deployments you have running in that given workspace. In this case, we only have one cluster spun up.
-
-From this screen, you can:
-
-1. Create new Airflow deployments
-2. Manage user access to the workspace
-3. Generate tokens for CI/CD systems via service accounts.
-4. Rename your Workspace
-
-Since all of our app activity is routed through a GraphQL API, you're free to create deployments, switch workspaces, and add users via our [CLI](/docs/enterprise/v0.15/develop/cli-quickstart/) if you prefer staying in your terminal.
-
-**Note:** The concept of a "workspace" only exists at the API level to help with permissions. It does **not** have anything to do with how Airflow will run jobs.
+* Deployments
+* Settings
+* Users
+* Service Accounts
 
 ## Deployments
 
-A single instance of [Apache Airflow](https://airflow.apache.org/) made up of a scheduler, a webserver, and one or more workers. A deployment has the capacity to host a collection of DAGs.
+The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/v0.15/develop/cli-quickstart/) as part of a workspace. Under the hood, each deployment gets its own Kubernetes namespace and has a set isolated resources reserved for itself.
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/v0.15/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.15/deploy/configure-deployment).
 
-You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
+The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
+![Deployment Tab](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
-From the Workspace dashboard, navigate back to the "Deployments" tab.
+Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow Deployment from one Workspace to another once created.
 
-If you click into one of your Airflow deployments, you'll land on a page that looks like this:
+## Settings
 
-![Deployments](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-deployment.png)
+You can rename your Workspace or rewrite its description in the **Settings** tab. While these fields have no effect on how tasks are executed, we recommend configuring them to give users an idea of the Workspace's purpose and scope.
 
-From here, you'll be able to access:
+## Users
 
-1. Airflow UI (DAG Dashboard)
-2. Flower Dashboard (if you are running the Celery executor)
+You can see who has access to the Workspace in the **Users** tab.
 
-The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
 
-For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui/).
+An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/v0.15/manage-astronomer/workspace-permissions/).
 
-**Each deployment will run in a separate Kubernetes namespace, so they'll all get resources and maintain metadata independently. You should assume that each deployment is unaware of the others.**
+In addition, Enterprise System Admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.15/manage-astronomer/manage-platform-users#customize-permissions).
 
-## User Management
+## Service Accounts
 
-If you navigate over to the "Users" tab of your Workspace Dashboard, you'll be able to see who has access to the Workspace. If you'd like to share access to other members of your organization, invite them to a workspace you're a part of. Once members, they'll have access to _all_ Airflow deployments under that workspace.
+Use the **Service Accounts** tab to create Service Accounts. Service Accounts push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
 
-## Workspace Permissions
-
-Users in a Workspace can be given the role of a **Viewer**, **Editor**, or **Admin***. An exact breakdown of these roles can be found in the [User Roles and Permissions](/docs/enterprise/v0.15/manage-astronomer/workspace-permissions/) section. Astronomer Enterprise admins can [configure the exact permissions](/docs/enterprise/v0.15/manage-astronomer/manage-platform-users/) for each Astronomer role.
+A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.15/deploy/ci-cd).

--- a/enterprise/v0.15/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.15/04_deploy/01_manage-workspaces.md
@@ -19,7 +19,7 @@ This guide walks through the best practices for creating and managing Workspaces
 
 The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
 
-To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/v0.15/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.15/deploy/configure-deployment).
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in [CLI Quickstart](/docs/enterprise/v0.15/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.15/deploy/configure-deployment).
 
 The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
@@ -35,14 +35,14 @@ You can rename your Workspace or rewrite its description in the **Settings** tab
 
 You can see who has access to the Workspace in the **Users** tab.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace admins can grant them varying levels of access to the entire Workspace.
 
 An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/v0.15/manage-astronomer/workspace-permissions/).
 
-In addition, Enterprise System Admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.15/manage-astronomer/manage-platform-users#customize-permissions).
+In addition, Enterprise system admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.15/manage-astronomer/manage-platform-users#customize-permissions).
 
 ## Service Accounts
 
-Use the **Service Accounts** tab to create Service Accounts. Service Accounts push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
+Use the **Service Accounts** tab to create a Workspace-level Service Account. Service Accounts generate a permanent API key that you can use automate any action at the Workspace level, such as deploying to your Workspace's Airflow Deployments via a CI/CD tool of your choice. 
 
-A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.15/deploy/ci-cd).
+To automate actions at the Deployment level, create a Deployment Service Account. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.15/deploy/ci-cd).

--- a/enterprise/v0.16/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.16/04_deploy/01_manage-workspaces.md
@@ -6,14 +6,18 @@ description: "Manage Astronomer Workspaces and Airflow Deployments via the Astro
 
 ## Overview
 
-A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments.
 
-This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
+If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
+
+This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from a Workspace's menu in the Astronomer UI:
 
 * Deployments
 * Settings
 * Users
 * Service Accounts
+
+![Workspace configuration tab location](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.23-workspace.png)
 
 ## Deployments
 

--- a/enterprise/v0.16/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.16/04_deploy/01_manage-workspaces.md
@@ -1,79 +1,48 @@
 ---
 title: "Manage Workspaces and Deployments on Astronomer"
-navTitle: "Manage Workspaces"
+navTitle: "Create a Workspace"
 description: "Manage Astronomer Workspaces and Airflow Deployments via the Astronomer UI."
 ---
 
-We've designed the Astronomer UI as a place for you to easily manage users, Airflow Deployments and resources.
+## Overview
 
-## Dashboard
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
 
-Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
+This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
 
-1. Create a new Workspace
-2. View the Workspaces you have access to in the left-hand navigation
-3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
-
-![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
-
-## Workspaces
-
-**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow Deployments. User access to Deployments is managed at the Workspace level on Astronomer.
-
-A **Workspace** is an Astronomer-specific term. You can think of your Workspaces the same way you'd think of teams - they're just collections of Airflow deployments that specific user groups have access to. When you create an account on Astronomer, a default personal Workspace is automatically created. Airflow Deployments are hierarchically lower - from a Workspace, you can create one or more Airflow Deployments, and grant or restrict user access to those Deployments accordingly.
-
-If you were a solo agent, you could have multiple Airflow Deployments within that single Workspace and have no need for additional Workspaces. Teams, however, often share one or more Workspaces labeled as such, and have multiple Airflow Deployments from there.
-
-Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one Workspace to another once deployed.
-
-Once you click into a Workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
-
-![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
-
-Here, you have a high-level overview of all of the active Airflow Deployments you have running in that given Workspace. In this case, we only have one cluster spun up.
-
-From this screen, you can:
-
-1. Create new Airflow Deployments
-2. Manage user access to the Workspace
-3. Generate tokens for CI/CD systems via service accounts
-4. Rename your Workspace
-
-Since all of our app activity is routed through a GraphQL API, you're free to create Deployments, switch Workspaces, and add users via our [CLI](/docs/enterprise/v0.16/develop/cli-quickstart/) if you prefer staying in your terminal.
-
-> **Note:** The concept of a "Workspace" only exists at the API level to support role-based access control and user permissions. It will not affect Airflow task execution.
+* Deployments
+* Settings
+* Users
+* Service Accounts
 
 ## Deployments
 
-An [Apache Airflow](https://airflow.apache.org/) Deployment is made up of a Scheduler, a Webserver and, if you're running the Celery or Kubernetes Executors, one or more Workers. An Airflow Deployment within a Workspace has the capacity to host a collection of DAGs.
+The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/v0.16/develop/cli-quickstart/) as part of a Workspace. Under the hood, each Airflow Deployment gets its own Kubernetes namespace and has a reserved set of dedicated resources and an underlying Postgres Metadata Database.
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/v0.16/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.16/deploy/configure-deployment).
 
-You're able to adjust the resources given to your Airflow Deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
+The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
-From the Workspace dashboard, navigate back to the "Deployments" tab.
+![Deployment Tab](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
-If you click into one of your Airflow Deployments, you'll land on a page that looks like this:
+Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow Deployment from one Workspace to another once created.
 
-![Deployments](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-deployment.png)
+## Settings
 
-From here, you'll be able to access:
+You can rename your Workspace or rewrite its description in the **Settings** tab. While these fields have no effect on how tasks are executed, we recommend configuring them to give users an idea of the Workspace's purpose and scope.
 
-1. Airflow UI (DAG Dashboard)
-2. Flower Dashboard (if you are running the Celery executor)
+## Users
 
-The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
+You can see who has access to the Workspace in the **Users** tab.
 
-For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui/).
-
-> **Note:** All Airflow Deployments run in an isolated Kubernetes namespace, which means resources will be provisioned independently and data will be kept isolated from the rest. You can assume that each Airflow Deployment is unaware of the others, even within the same Workspace.
-
-## User Management
-
-If you go to the **Users** tab of your Workspace Dashboard, you'll see who has access to the Workspace.
-
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Workspace Admins can then grant them varying levels of access to the entire Workspace.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
 
 An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/v0.16/manage-astronomer/workspace-permissions/).
 
-In addition, Enterprise admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/manage-platform-users#customize-permissions).
+In addition, Enterprise System Admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/manage-platform-users#customize-permissions).
+
+## Service Accounts
+
+Use the **Service Accounts** tab to create Service Accounts. Service Accounts push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
+
+A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.16/deploy/ci-cd).

--- a/enterprise/v0.16/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.16/04_deploy/01_manage-workspaces.md
@@ -19,7 +19,7 @@ This guide walks through the best practices for creating and managing Workspaces
 
 The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
 
-To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/v0.16/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.16/deploy/configure-deployment).
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in [CLI Quickstart](/docs/enterprise/v0.16/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.16/deploy/configure-deployment).
 
 The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
@@ -35,14 +35,14 @@ You can rename your Workspace or rewrite its description in the **Settings** tab
 
 You can see who has access to the Workspace in the **Users** tab.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace admins can grant them varying levels of access to the entire Workspace.
 
 An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/v0.16/manage-astronomer/workspace-permissions/).
 
-In addition, Enterprise System Admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/manage-platform-users#customize-permissions).
+In addition, Enterprise system admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/manage-platform-users#customize-permissions).
 
 ## Service Accounts
 
-Use the **Service Accounts** tab to create Service Accounts. Service Accounts push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
+Use the **Service Accounts** tab to create a Workspace-level Service Account. Service Accounts generate a permanent API key that you can use automate any action at the Workspace level, such as deploying to your Workspace's Airflow Deployments via a CI/CD tool of your choice.
 
-A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.16/deploy/ci-cd).
+To automate actions at the Deployment level, create a Deployment Service Account. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.16/deploy/ci-cd).

--- a/enterprise/v0.23/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.23/04_deploy/01_manage-workspaces.md
@@ -6,14 +6,18 @@ description: "Manage Astronomer Workspaces and Airflow Deployments via the Astro
 
 ## Overview
 
-A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments.
 
-This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
+If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
+
+This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from a Workspace's menu in the Astronomer UI:
 
 * Deployments
 * Settings
 * Users
 * Service Accounts
+
+![Workspace configuration tab location](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.23-workspace.png)
 
 ## Deployments
 

--- a/enterprise/v0.23/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.23/04_deploy/01_manage-workspaces.md
@@ -1,79 +1,48 @@
 ---
 title: "Manage Workspaces and Deployments on Astronomer"
-navTitle: "Manage Workspaces"
+navTitle: "Create a Workspace"
 description: "Manage Astronomer Workspaces and Airflow Deployments via the Astronomer UI."
 ---
 
-We've designed the Astronomer UI as a place for you to easily manage users, Airflow Deployments and resources.
+## Overview
 
-## Dashboard
+A Workspace is the highest level of organization on Astronomer. From a Workspace, you can manage a collection of Airflow Deployments and a set of users with varying levels of access to those Deployments. If you're not a member of any Workspaces already, you'll be prompted to create one as soon as you log in to the Astronomer UI. If you already have access to at least 1 Workspace, you can create a new one using the **New Workspace** button in the sidebar of the Astronomer UI.
 
-Once logged in, you'll land on a view that will direct you to create a new **Workspace**. From this view, you can:
+This guide walks through the best practices for creating and managing Workspaces as a Workspace admin. It's organized by the 4 tabs you can access from the Workspace menu in the Astronomer UI:
 
-1. Create a new Workspace
-2. View the Workspaces you have access to in the left-hand navigation
-3. Access "Documentation," "Account Settings" and more in the Account drop-down menu
-
-![Account Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-empty-dashboard.png)
-
-## Workspaces
-
-**The Astronomer Workspace:** A personal or shared space that is home to a collection of Airflow Deployments. User access to Deployments is managed at the Workspace level on Astronomer.
-
-A **Workspace** is an Astronomer-specific term. You can think of your Workspaces the same way you'd think of teams - they're just collections of Airflow Deployments that specific user groups have access to. When you create an account on Astronomer, a default personal Workspace is automatically created. Airflow Deployments are hierarchically lower - from a Workspace, you can create one or more Airflow Deployments, and grant or restrict user access to those Deployments accordingly.
-
-If you were a solo agent, you could have multiple Airflow Deployments within that single Workspace and have no need for additional Workspaces. Teams, however, often share one or more Workspaces labeled as such, and have multiple Airflow Deployments from there.
-
-Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow instance from one Workspace to another once deployed.
-
-Once you click into a Workspace, you'll land on another dashboard that we'll call the **Workspace Dashboard**:
-
-![Workspace Dashboard](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
-
-Here, you have a high-level overview of all of the active Airflow Deployments you have running in that given Workspace. In this case, we only have one cluster spun up.
-
-From this screen, you can:
-
-1. Create new Airflow Deployments
-2. Manage user access to the Workspace
-3. Generate tokens for CI/CD systems via service accounts
-4. Rename your Workspace
-
-Since all of our app activity is routed through a GraphQL API, you're free to create Deployments, switch Workspaces, and add users via our [CLI](/docs/enterprise/v0.23/develop/cli-quickstart/) if you prefer staying in your terminal.
-
-> **Note:** The concept of a "Workspace" only exists at the API level to support role-based access control and user permissions. It will not affect Airflow task execution.
+* Deployments
+* Settings
+* Users
+* Service Accounts
 
 ## Deployments
 
-An [Apache Airflow](https://airflow.apache.org/) Deployment is made up of a Scheduler, a Webserver and, if you're running the Celery or Kubernetes Executors, one or more Workers. An Airflow Deployment within a Workspace has the capacity to host a collection of DAGs.
+The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
 
-In the context of Astronomer, the term **Airflow Deployment** is used to describe an instance of Airflow that you've spun up either via the Astronomer UI or [CLI](/docs/enterprise/v0.23/develop/cli-quickstart/) as part of a Workspace. Under the hood, each Airflow Deployment gets its own Kubernetes namespace and has a reserved set of dedicated resources and an underlying Postgres Metadata Database.
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/v0.23/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
 
-You're able to adjust the resources given to your Airflow deployment directly from the UI. This functionality allows you to choose executor (local or celery) and easily provision additional resources as you scale up.
+The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
-From the Workspace dashboard, navigate back to the "Deployments" tab.
+![Deployment Tab](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.12-deployments.png)
 
-If you click into one of your Airflow Deployments, you'll land on a page that looks like this:
+Deployments cannot be used or shared across Workspaces. While you’re free to push local DAGs and code anywhere you wish at any time, there is currently no way to move an existing Airflow Deployment from one Workspace to another once created.
 
-![Deployments](https://assets2.astronomer.io/main/docs/astronomer-ui/v0.15-deployment.png)
+## Settings
 
-From here, you'll be able to access:
+You can rename your Workspace or rewrite its description in the **Settings** tab. While these fields have no effect on how tasks are executed, we recommend configuring them to give users an idea of the Workspace's purpose and scope.
 
-1. Airflow UI (DAG Dashboard)
-2. Flower Dashboard (if you are running the Celery executor)
+## Users
 
-The former will link you directly to your DAG Dashboard on Airflow itself. Your Flower Dashboard is your go-to spot to monitor your Celery Workers.
-
-For a breakdown the Airflow UI itself, check out [this guide](/guides/airflow-ui/).
-
-> **Note:** All Airflow Deployments run in an isolated Kubernetes namespace, which means resources will be provisioned independently and data will be kept isolated from the rest. You can assume that each Airflow Deployment is unaware of the others, even within the same Workspace.
-
-## User Management
-
-If you go to the **Users** tab of your Workspace Dashboard, you'll see who has access to the Workspace.
+You can see who has access to the Workspace in the **Users** tab.
 
 If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
 
 An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/v0.23/manage-astronomer/workspace-permissions/).
 
-In addition, Enterprise admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.23/manage-astronomer/manage-platform-users#customize-permissions).
+In addition, Enterprise System Admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.23/manage-astronomer/manage-platform-users#customize-permissions).
+
+## Service Accounts
+
+Use the **Service Accounts** tab to create Service Accounts. Service Accounts push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
+
+A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.23/deploy/ci-cd).

--- a/enterprise/v0.23/04_deploy/01_manage-workspaces.md
+++ b/enterprise/v0.23/04_deploy/01_manage-workspaces.md
@@ -19,7 +19,7 @@ This guide walks through the best practices for creating and managing Workspaces
 
 The most important function of Workspaces is creating and managing access to one or more Airflow Deployments. An Airflow Deployment is an instance of Apache Airflow that consists of a Scheduler, Webserver, and one or more Workers if you're running the Celery or Kubernetes Executors.
 
-To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in the [CLI Quickstart](/docs/enterprise/v0.23/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
+To create a new Deployment, click the **New Deployment** button in the **Deployments** tab or use the Astronomer CLI as described in [CLI Quickstart](/docs/enterprise/v0.23/develop/cli-quickstart/). For more information on configuring Deployment settings and resources, read [Configure a Deployment](https://www.astronomer.io/docs/enterprise/v0.23/deploy/configure-deployment).
 
 The **Deployments** tab also contains information on all of your existing Deployments, including name, Executor type, and Deployment status. A blue dot next to a Deployment's name indicates that the Deployment is still spinning up, while a green dot indicates that the Deployment is fully operational:
 
@@ -35,14 +35,14 @@ You can rename your Workspace or rewrite its description in the **Settings** tab
 
 You can see who has access to the Workspace in the **Users** tab.
 
-If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment Admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace Admins can grant them varying levels of access to the entire Workspace.
+If you'd like to share access to other members of your organization, invite them to a Workspace you're a part of. Once your team members are part of your Workspace, Deployment admins can grant them varying levels of access to Airflow Deployments within the Workspace. Likewise, Workspace admins can grant them varying levels of access to the entire Workspace.
 
 An exact breakdown of user roles and their respective levels of access can be found in [Manage User Permissions on an Astronomer Workspace](/docs/enterprise/v0.23/manage-astronomer/workspace-permissions/).
 
-In addition, Enterprise System Admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.23/manage-astronomer/manage-platform-users#customize-permissions).
+In addition, Enterprise system admins can add or remove specific permissions for each type of user role. For more information on this feature, read [Customize Permissions](https://www.astronomer.io/docs/enterprise/v0.23/manage-astronomer/manage-platform-users#customize-permissions).
 
 ## Service Accounts
 
-Use the **Service Accounts** tab to create Service Accounts. Service Accounts push code and deploy to your Workspace's Airflow Deployments via the CI/CD tool of your choice.
+Use the **Service Accounts** tab to create a Workspace-level Service Account. Service Accounts generate a permanent API key that you can use automate any action at the Workspace level, such as deploying to your Workspace's Airflow Deployments via a CI/CD tool of your choice.
 
-A Service Account created at the Workspace level can deploy to multiple Deployments with one code push, whereas a Service Account at the Deployment level can deploy only to a single Deployment. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.23/deploy/ci-cd).
+To automate actions at the Deployment level, create a Deployment Service Account. For more information on this feature, read [Deploy via CI/CD](https://www.astronomer.io/docs/enterprise/v0.23/deploy/ci-cd).


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/182

For this guide renovation, I ended up going for a less extreme reimagining than what's proposed in the original issue. Instead, I  opted for a more simple overview of everything you can manage at the Workspace level with links to all relevant documentation. This significantly shortened the document.

Because each Workspace process is either super simple (changing Workspace name) or described in other docs, I organized this doc by menu items rather than processes. If this is approved, I'll push the changes to other Enterprise versions and Cloud (making sure to include Billing info for Cloud).