### PR TITLE
Fixed indentation in TLS guides

### DIFF
--- a/enterprise/next/06_manage-astronomer/09_renew-tls-cert.md
+++ b/enterprise/next/06_manage-astronomer/09_renew-tls-cert.md
@@ -18,95 +18,105 @@ Once you set up a TLS certificate for Astronomer, you'll need to establish a pro
 1. Install the Kubernetes Cert Manager by following [the official installation guide](https://cert-manager.io/docs/installation/kubernetes/).
 
 2. If you're running Astronomer on AWS, grant your nodes access to Route 53 by adding the following CloudFormation snippet to your nodes' Instance Profile (if you don't use AWS, complete whatever setup is necessary to authenticate Cert Manager to your DNS):
-```yaml
-Type: "AWS::IAM::Role"
-Properties:
-  RoleName: instance-profile-role
-  Policies:
-    - PolicyName: instance-profile-policy
-      PolicyDocument:
-        Version: '2012-10-17'
+
+    ```yaml
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: instance-profile-role
+      Policies:
+        - PolicyName: instance-profile-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: route53:GetChange
+                Resource: arn:aws:route53:::change/*
+              - Effect: Allow
+                Action:
+                  - route53:ChangeResourceRecordSets
+                  - route53:ListResourceRecordSets
+                # Use the second Resource format if you're updating this through the AWS UI
+                Resource: !Sub arn:aws:route53:::hostedzone/${HostedZoneIdLookup.HostedZoneId}
+              - Effect: Allow
+                Action: route53:ListHostedZonesByName
+                Resource: '*'
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
         Statement:
-          - Effect: Allow
-            Action: route53:GetChange
-            Resource: arn:aws:route53:::change/*
-          - Effect: Allow
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "ec2.amazonaws.com"
             Action:
-              - route53:ChangeResourceRecordSets
-              - route53:ListResourceRecordSets
-            # Use the second Resource format if you're updating this through the AWS UI
-            Resource: !Sub arn:aws:route53:::hostedzone/${HostedZoneIdLookup.HostedZoneId}
-          - Effect: Allow
-            Action: route53:ListHostedZonesByName
-            Resource: '*'
-  AssumeRolePolicyDocument:
-    Version: "2012-10-17"
-    Statement:
-      - Effect: "Allow"
-        Principal:
-          Service:
-            - "ec2.amazonaws.com"
-        Action:
-          - "sts:AssumeRole"
-```
-For more information on how to complete this setup, refer to [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html).
+              - "sts:AssumeRole"
+    ```
+
+    For more information on how to complete this setup, refer to [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html).
 
 3. Create a "ClusterIssuer" resource that declares how requests for certificates will be fulfilled. To do so, first create a `clusterissuer.yaml` file with the following values:
-```yaml
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-    name: letsencrypt-prod
-spec:
-    acme:
-        email: <your-email>
-        server: https://acme-v02.api.letsencrypt.org/directory
-        privateKeySecretRef:
-            name: cert-manager-issuer-secret-key
-        solvers:
-        - selector: {}
-          dns01:
-            route53:
-                region: <your-server-region>
-```
-Then, create the ClusterIssuer by running the following command:
-```sh
-$ kubectl apply -f clusterissuer.yaml
-```
+
+    ```yaml
+    apiVersion: cert-manager.io/v1
+    kind: ClusterIssuer
+    metadata:
+        name: letsencrypt-prod
+    spec:
+        acme:
+            email: <your-email>
+            server: https://acme-v02.api.letsencrypt.org/directory
+            privateKeySecretRef:
+                name: cert-manager-issuer-secret-key
+            solvers:
+            - selector: {}
+              dns01:
+                 route53:
+                    region: <your-server-region>
+    ```
+
+    Then, create the ClusterIssuer by running the following command:
+
+    ```sh
+    $ kubectl apply -f clusterissuer.yaml
+    ```
 
 4. Create a "Certificate" resource that declares the type of certificate you'll request from Let's Encrypt. To do so, first create a `certificate.yaml` file, replacing `BASE_DOMAIN` with yours:
-```yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-    name: acme-crt
-spec:
-    secretName: astronomer-tls
-    dnsNames:
-        - BASE_DOMAIN
-        - app.BASE_DOMAIN
-        - deployments.BASE_DOMAIN
-        - registry.BASE_DOMAIN
-        - houston.BASE_DOMAIN
-        - grafana.BASE_DOMAIN
-        - kibana.BASE_DOMAIN
-        - install.BASE_DOMAIN
-        - prometheus.BASE_DOMAIN
-        - alertmanager.BASE_DOMAIN
-    issuerRef:
-        name: letsencrypt-prod
-        kind: ClusterIssuer
-        group: cert-manager.io
-```
-Then, create the certificate by running the following command and waiting a few minutes:
-```sh
-$ kubectl apply -f certificate.yaml
-```
+
+    ```yaml
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+        name: acme-crt
+    spec:
+        secretName: astronomer-tls
+        dnsNames:
+            - BASE_DOMAIN
+            - app.BASE_DOMAIN
+            - deployments.BASE_DOMAIN
+            - registry.BASE_DOMAIN
+            - houston.BASE_DOMAIN
+            - grafana.BASE_DOMAIN
+            - kibana.BASE_DOMAIN
+            - install.BASE_DOMAIN
+            - prometheus.BASE_DOMAIN
+            - alertmanager.BASE_DOMAIN
+        issuerRef:
+            name: letsencrypt-prod
+            kind: ClusterIssuer
+            group: cert-manager.io
+    ```
+
+    Then, create the certificate by running the following command and waiting a few minutes:
+
+    ```sh
+    $ kubectl apply -f certificate.yaml
+    ```
 
 5. Ensure that the certificate was created by running:
 ```sh
 $ kubectl get certificates
 ```
+
+6. Note your certificate name for when you create a Kubernetes TLS secret and push it to your Enterprise configuration as described in the Enterprise installation guide ([AWS](https://www.astronomer.io/docs/enterprise/stable/install/aws/install-aws-standard#step-5-create-a-kubernetes-tls-secret)/[GCP](https://www.astronomer.io/docs/enterprise/stable/install/gcp/install-gcp-standard#step-5-create-a-kubernetes-tls-secret)/[AKS](https://www.astronomer.io/docs/enterprise/stable/install/azure/install-azure-standard#step-5-create-a-kubernetes-tls-secret)).
 
 ## Manually Renew TLS Certificates
 

--- a/enterprise/v0.16/06_manage-astronomer/09_renew-tls-cert.md
+++ b/enterprise/v0.16/06_manage-astronomer/09_renew-tls-cert.md
@@ -65,12 +65,12 @@ Once you set up a TLS certificate for Astronomer, you'll need to establish a pro
             email: <your-email>
             server: https://acme-v02.api.letsencrypt.org/directory
             privateKeySecretRef:
-               name: cert-manager-issuer-secret-key
+                name: cert-manager-issuer-secret-key
             solvers:
             - selector: {}
-            dns01:
-                route53:
-                     region: <your-server-region>
+              dns01:
+                 route53:
+                    region: <your-server-region>
     ```
 
     Then, create the ClusterIssuer by running the following command:
@@ -112,10 +112,9 @@ Once you set up a TLS certificate for Astronomer, you'll need to establish a pro
     ```
 
 5. Ensure that the certificate was created by running:
-
-    ```sh
-    $ kubectl get certificates
-    ```
+```sh
+$ kubectl get certificates
+```
 
 ## Manually Renew TLS Certificates
 

--- a/enterprise/v0.16/06_manage-astronomer/09_renew-tls-cert.md
+++ b/enterprise/v0.16/06_manage-astronomer/09_renew-tls-cert.md
@@ -18,109 +18,120 @@ Once you set up a TLS certificate for Astronomer, you'll need to establish a pro
 1. Install the Kubernetes Cert Manager by following [the official installation guide](https://cert-manager.io/docs/installation/kubernetes/).
 
 2. If you're running Astronomer on AWS, grant your nodes access to Route 53 by adding the following CloudFormation snippet to your nodes' Instance Profile (if you don't use AWS, complete whatever setup is necessary to authenticate Cert Manager to your DNS):
-```yaml
-Type: "AWS::IAM::Role"
-Properties:
-  RoleName: instance-profile-role
-  Policies:
-    - PolicyName: instance-profile-policy
-      PolicyDocument:
-        Version: '2012-10-17'
+
+    ```yaml
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: instance-profile-role
+      Policies:
+        - PolicyName: instance-profile-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: route53:GetChange
+                Resource: arn:aws:route53:::change/*
+              - Effect: Allow
+                Action:
+                  - route53:ChangeResourceRecordSets
+                  - route53:ListResourceRecordSets
+                # Use the second Resource format if you're updating this through the AWS UI
+                Resource: !Sub arn:aws:route53:::hostedzone/${HostedZoneIdLookup.HostedZoneId}
+              - Effect: Allow
+                Action: route53:ListHostedZonesByName
+                Resource: '*'
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
         Statement:
-          - Effect: Allow
-            Action: route53:GetChange
-            Resource: arn:aws:route53:::change/*
-          - Effect: Allow
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "ec2.amazonaws.com"
             Action:
-              - route53:ChangeResourceRecordSets
-              - route53:ListResourceRecordSets
-            # Use the second Resource format if you're updating this through the AWS UI
-            Resource: !Sub arn:aws:route53:::hostedzone/${HostedZoneIdLookup.HostedZoneId}
-          - Effect: Allow
-            Action: route53:ListHostedZonesByName
-            Resource: '*'
-  AssumeRolePolicyDocument:
-    Version: "2012-10-17"
-    Statement:
-      - Effect: "Allow"
-        Principal:
-          Service:
-            - "ec2.amazonaws.com"
-        Action:
-          - "sts:AssumeRole"
-```
-For more information on how to complete this setup, refer to [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html).
+              - "sts:AssumeRole"
+    ```
+
+    For more information on how to complete this setup, refer to [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html).
 
 3. Create a "ClusterIssuer" resource that declares how requests for certificates will be fulfilled. To do so, first create a `clusterissuer.yaml` file with the following values:
-```yaml
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-    name: letsencrypt-prod
-spec:
-    acme:
-        email: <your-email>
-        server: https://acme-v02.api.letsencrypt.org/directory
-        privateKeySecretRef:
-            name: cert-manager-issuer-secret-key
-        solvers:
-        - selector: {}
-          dns01:
-            route53:
-                region: <your-server-region>
-```
-Then, create the ClusterIssuer by running the following command:
-```sh
-$ kubectl apply -f clusterissuer.yaml
-```
+
+    ```yaml
+    apiVersion: cert-manager.io/v1
+    kind: ClusterIssuer
+    metadata:
+        name: letsencrypt-prod
+    spec:
+        acme:
+            email: <your-email>
+            server: https://acme-v02.api.letsencrypt.org/directory
+            privateKeySecretRef:
+               name: cert-manager-issuer-secret-key
+            solvers:
+            - selector: {}
+            dns01:
+                route53:
+                     region: <your-server-region>
+    ```
+
+    Then, create the ClusterIssuer by running the following command:
+
+    ```sh
+    $ kubectl apply -f clusterissuer.yaml
+    ```
 
 4. Create a "Certificate" resource that declares the type of certificate you'll request from Let's Encrypt. To do so, first create a `certificate.yaml` file, replacing `BASE_DOMAIN` with yours:
-```yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-    name: acme-crt
-spec:
-    secretName: astronomer-tls
-    dnsNames:
-        - BASE_DOMAIN
-        - app.BASE_DOMAIN
-        - deployments.BASE_DOMAIN
-        - registry.BASE_DOMAIN
-        - houston.BASE_DOMAIN
-        - grafana.BASE_DOMAIN
-        - kibana.BASE_DOMAIN
-        - install.BASE_DOMAIN
-        - prometheus.BASE_DOMAIN
-        - alertmanager.BASE_DOMAIN
-    issuerRef:
-        name: letsencrypt-prod
-        kind: ClusterIssuer
-        group: cert-manager.io
-```
-Then, create the certificate by running the following command and waiting a few minutes:
-```sh
-$ kubectl apply -f certificate.yaml
-```
+
+    ```yaml
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+        name: acme-crt
+    spec:
+        secretName: astronomer-tls
+        dnsNames:
+            - BASE_DOMAIN
+            - app.BASE_DOMAIN
+            - deployments.BASE_DOMAIN
+            - registry.BASE_DOMAIN
+            - houston.BASE_DOMAIN
+            - grafana.BASE_DOMAIN
+            - kibana.BASE_DOMAIN
+            - install.BASE_DOMAIN
+            - prometheus.BASE_DOMAIN
+            - alertmanager.BASE_DOMAIN
+        issuerRef:
+            name: letsencrypt-prod
+            kind: ClusterIssuer
+            group: cert-manager.io
+    ```
+
+    Then, create the certificate by running the following command and waiting a few minutes:
+
+    ```sh
+    $ kubectl apply -f certificate.yaml
+    ```
 
 5. Ensure that the certificate was created by running:
-```sh
-$ kubectl get certificates
-```
+
+    ```sh
+    $ kubectl get certificates
+    ```
 
 ## Manually Renew TLS Certificates
 
 Larger organizations with dedicated security teams will likely have their own processes for requesting and renewing TLS certificates. Regardless, there are specific steps you have to complete for Astronomer when renewing TLS certificates:
 
 1. Delete your current TLS certificate by running the following command:
-```sh
-$ kubectl delete secret astronomer-tls
-```
+
+    ```sh
+    $ kubectl delete secret astronomer-tls
+    ```
 
 2. Follow the instructions for requesting a TLS certificate from your organization's security team as described in [Configure SSL](https://www.astronomer.io/docs/enterprise/v0.16/install/aws/install-aws-standard#4-configure-ssl). The linked guide is written for users installing Astronomer on AWS, but this step is the same regardless of which service you use.
 
 3. Restart your Houston, nginx, and registry pods to begin using the new certificate by running the following commands:
-```sh
-$ kubectl rollout restart deployments -n <your-namespace>
-$ kubectl rollout restart statefulsets -n <your-namespace>
-```
+
+    ```sh
+    $ kubectl rollout restart deployments -n <your-namespace>
+    $ kubectl rollout restart statefulsets -n <your-namespace>
+    ```

--- a/enterprise/v0.23/06_manage-astronomer/10_renew-tls-cert.md
+++ b/enterprise/v0.23/06_manage-astronomer/10_renew-tls-cert.md
@@ -18,90 +18,98 @@ Once you set up a TLS certificate for Astronomer, you'll need to establish a pro
 1. Install the Kubernetes Cert Manager by following [the official installation guide](https://cert-manager.io/docs/installation/kubernetes/).
 
 2. If you're running Astronomer on AWS, grant your nodes access to Route 53 by adding the following CloudFormation snippet to your nodes' Instance Profile (if you don't use AWS, complete whatever setup is necessary to authenticate Cert Manager to your DNS):
-```yaml
-Type: "AWS::IAM::Role"
-Properties:
-  RoleName: instance-profile-role
-  Policies:
-    - PolicyName: instance-profile-policy
-      PolicyDocument:
-        Version: '2012-10-17'
+
+    ```yaml
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: instance-profile-role
+      Policies:
+        - PolicyName: instance-profile-policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: route53:GetChange
+                Resource: arn:aws:route53:::change/*
+              - Effect: Allow
+                Action:
+                  - route53:ChangeResourceRecordSets
+                  - route53:ListResourceRecordSets
+                # Use the second Resource format if you're updating this through the AWS UI
+                Resource: !Sub arn:aws:route53:::hostedzone/${HostedZoneIdLookup.HostedZoneId}
+              - Effect: Allow
+                Action: route53:ListHostedZonesByName
+                Resource: '*'
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
         Statement:
-          - Effect: Allow
-            Action: route53:GetChange
-            Resource: arn:aws:route53:::change/*
-          - Effect: Allow
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "ec2.amazonaws.com"
             Action:
-              - route53:ChangeResourceRecordSets
-              - route53:ListResourceRecordSets
-            # Use the second Resource format if you're updating this through the AWS UI
-            Resource: !Sub arn:aws:route53:::hostedzone/${HostedZoneIdLookup.HostedZoneId}
-          - Effect: Allow
-            Action: route53:ListHostedZonesByName
-            Resource: '*'
-  AssumeRolePolicyDocument:
-    Version: "2012-10-17"
-    Statement:
-      - Effect: "Allow"
-        Principal:
-          Service:
-            - "ec2.amazonaws.com"
-        Action:
-          - "sts:AssumeRole"
-```
-For more information on how to complete this setup, refer to [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html).
+              - "sts:AssumeRole"
+    ```
+
+    For more information on how to complete this setup, refer to [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html).
 
 3. Create a "ClusterIssuer" resource that declares how requests for certificates will be fulfilled. To do so, first create a `clusterissuer.yaml` file with the following values:
-```yaml
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-    name: letsencrypt-prod
-spec:
-    acme:
-        email: <your-email>
-        server: https://acme-v02.api.letsencrypt.org/directory
-        privateKeySecretRef:
-            name: cert-manager-issuer-secret-key
-        solvers:
-        - selector: {}
-          dns01:
-            route53:
-                region: <your-server-region>
-```
-Then, create the ClusterIssuer by running the following command:
-```sh
-$ kubectl apply -f clusterissuer.yaml
-```
 
-4. Create a "Certificate" resource that declares the type of certificate you'll request from Let's Encrypt. To do so, first create a `certificate.yaml` file, replacing `BASE_DOMAIN` with your own value:
-```yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-    name: acme-crt
-spec:
-    secretName: astronomer-tls
-    dnsNames:
-        - BASE_DOMAIN
-        - app.BASE_DOMAIN
-        - deployments.BASE_DOMAIN
-        - registry.BASE_DOMAIN
-        - houston.BASE_DOMAIN
-        - grafana.BASE_DOMAIN
-        - kibana.BASE_DOMAIN
-        - install.BASE_DOMAIN
-        - prometheus.BASE_DOMAIN
-        - alertmanager.BASE_DOMAIN
-    issuerRef:
+    ```yaml
+    apiVersion: cert-manager.io/v1
+    kind: ClusterIssuer
+    metadata:
         name: letsencrypt-prod
-        kind: ClusterIssuer
-        group: cert-manager.io
-```
-Then, create the certificate by running the following command and waiting a few minutes:
-```sh
-$ kubectl apply -f certificate.yaml
-```
+    spec:
+        acme:
+            email: <your-email>
+            server: https://acme-v02.api.letsencrypt.org/directory
+            privateKeySecretRef:
+               name: cert-manager-issuer-secret-key
+            solvers:
+            - selector: {}
+            dns01:
+                route53:
+                     region: <your-server-region>
+    ```
+
+    Then, create the ClusterIssuer by running the following command:
+
+    ```sh
+    $ kubectl apply -f clusterissuer.yaml
+    ```
+
+4. Create a "Certificate" resource that declares the type of certificate you'll request from Let's Encrypt. To do so, first create a `certificate.yaml` file, replacing `BASE_DOMAIN` with yours:
+
+    ```yaml
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+        name: acme-crt
+    spec:
+        secretName: astronomer-tls
+        dnsNames:
+            - BASE_DOMAIN
+            - app.BASE_DOMAIN
+            - deployments.BASE_DOMAIN
+            - registry.BASE_DOMAIN
+            - houston.BASE_DOMAIN
+            - grafana.BASE_DOMAIN
+            - kibana.BASE_DOMAIN
+            - install.BASE_DOMAIN
+            - prometheus.BASE_DOMAIN
+            - alertmanager.BASE_DOMAIN
+        issuerRef:
+            name: letsencrypt-prod
+            kind: ClusterIssuer
+            group: cert-manager.io
+    ```
+
+    Then, create the certificate by running the following command and waiting a few minutes:
+
+    ```sh
+    $ kubectl apply -f certificate.yaml
+    ```
 
 5. Ensure that the certificate was created by running:
 ```sh

--- a/enterprise/v0.23/06_manage-astronomer/10_renew-tls-cert.md
+++ b/enterprise/v0.23/06_manage-astronomer/10_renew-tls-cert.md
@@ -65,12 +65,12 @@ Once you set up a TLS certificate for Astronomer, you'll need to establish a pro
             email: <your-email>
             server: https://acme-v02.api.letsencrypt.org/directory
             privateKeySecretRef:
-               name: cert-manager-issuer-secret-key
+                name: cert-manager-issuer-secret-key
             solvers:
             - selector: {}
-            dns01:
-                route53:
-                     region: <your-server-region>
+              dns01:
+                 route53:
+                    region: <your-server-region>
     ```
 
     Then, create the ClusterIssuer by running the following command:


### PR DESCRIPTION
Closes https://github.com/astronomer/docs/issues/243

For step 3, the indentation was fully incorrect (both in the raw Markdown and on the site). For Step 4, it turned out that while our indented code in the raw Markdown was correct, the website was incorrectly rendering it due to the way I wrote the code fence in line with steps. This change should both keep the code in line with steps and properly indented. 