### PR TITLE
Removed our recommendation to use docker:dind in CI/CD GitLab configs

### DIFF
--- a/enterprise/v0.23/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.23/04_deploy/06_ci-cd.md
@@ -305,8 +305,6 @@ pipelines:
 astro_deploy:
   stage: deploy
   image: docker:latest
-  services:
-    - docker:dind
   script:
     - echo "Building container.."
     - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:CI-$CI_PIPELINE_IID .
@@ -376,7 +374,7 @@ trigger:
 
 pool:
   vmImage: 'ubuntu-latest'
- 
+
 variables:
 - group: Variable-Group
 - group: Key-Vault-Group


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/240

Since we haven't tested Kaniko yet, and @danielhoherd said that we can run GitLab on bare metal, I simply removed the `services` configuration. Wasn't sure whether to do that or remove only the `dind` part of the service. 

Adding @danielhoherd  and @wolfier  for review, since they were in the original thread where this issue was reported. If this looks good, I'll push the change to other versions of this doc. 