### PR TITLE
Added Azure config defaults into the Azure installation guide

### DIFF
--- a/enterprise/next/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/next/03_install/03_azure/01_install-azure-standard.md
@@ -160,7 +160,7 @@ Depending on your organization, you may receive either a globally trusted certif
 To confirm that your certificate has the proper certificate order, first run the following command using the `openssl` CLI:
 
 ```sh
-$ openssl crl2pkcs7 -nocrl -certfile <your-certificate-filepath> | openssl pkcs7 -print_certs -noout 
+$ openssl crl2pkcs7 -nocrl -certfile <your-certificate-filepath> | openssl pkcs7 -print_certs -noout
 ```
 
 This command will generate a report of all certificates included. Verify that the order of these certificates is as follows:
@@ -213,6 +213,10 @@ In the newly created file, copy the example below and replace `baseDomain`, `pri
 ### Astronomer global configuration
 #################################
 global:
+  # Enables default values for Azure installations
+  azure:
+    enabled: true
+
   # Base domain for all subdomains exposed through ingress
   baseDomain: astro.mydomain.com
 

--- a/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
@@ -212,7 +212,11 @@ In the newly created file, copy the example below and replace `baseDomain`, `pri
 ### Astronomer global configuration
 #################################
 global:
-  # Base domain for all subdomains exposed through ingress
+
+  azure:
+    enabled: true
+
+  # Base domain for all subdomains exposed through ingress
   baseDomain: astro.mydomain.com
 
   # Name of secret containing TLS certificate

--- a/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
@@ -212,7 +212,7 @@ In the newly created file, copy the example below and replace `baseDomain`, `pri
 ### Astronomer global configuration
 #################################
 global:
-
+  # Enables default values for Azure installations
   azure:
     enabled: true
 


### PR DESCRIPTION
We never added the `azure.enabled` value from our default `config.yaml` file in the Azure install guide. This PR adds that back to 0.23 and `next`, since those are the only versions people would still install. 