### PR TITLE
Add Guidelines on Requests to Airflow 2.0 REST API

### DIFF
--- a/cloud/stable/01_get-started/02_cloud-faq.md
+++ b/cloud/stable/01_get-started/02_cloud-faq.md
@@ -17,7 +17,7 @@ Astronomer Cloud is officially compatible with Airflow v1.10.5 and higher. For o
 
 We currently support the Celery, Local and Kubernetes Executors. You can switch between the three freely via the Astronomer UI.
 
-If you're not sure which Executor to use, we generally recommend starting off with the Local Executor and moving up from there once you see your deployment is in need of horizontal scaling. Check out [Airflow Executors: Explained](/guides/airflow-executors-explained/) for a ful analysis on each.
+If you're not sure which Executor to use, we generally recommend starting off with the Local Executor and moving up from there once you see your deployment is in need of horizontal scaling. Check out [Airflow Executors: Explained](/guides/airflow-executors-explained/) for a full analysis on each.
 
 ## Networking
 

--- a/cloud/stable/01_get-started/02_cloud-faq.md
+++ b/cloud/stable/01_get-started/02_cloud-faq.md
@@ -23,19 +23,24 @@ If you're not sure which Executor to use, we generally recommend starting off wi
 
 ### How would I give Astronomer Cloud access to my VPC?
 
-To connect Astronomer Cloud to any database in your VPC, you'll just have to allowlist our Static IP: `35.245.140.149`
+To connect Astronomer Cloud to any database in your VPC, you'll have to allowlist the following Static IP Addresses:
 
-If you're allowlisting that IP on Amazon Redshift, check out [our VPC Access Doc](/docs/cloud/stable/manage-astronomer/vpc-access/).
+- `35.245.140.149`
+- `35.245.44.221`
+- `34.86.203.139`
+- `35.199.31.94`
+
+For more information, read [VPC Access Doc](/docs/cloud/stable/manage-astronomer/vpc-access/).
 
 ## Airflow Metadata Access
 
-### Will I have access to Airflow's underlying database for my deployment?
+### Can I access Airflow's underlying Metadata database for my Airflow Deployment?
 
-Yes! Every Airflow Deployment on Astronomer Cloud has a corresponding Postgres Metadata Database hosted by Astronomer and isolated from all other Airflow Deployments. To access that database both on your local machine and Astronomer, check out our [Query the Airflow Database](/docs/cloud/stable/customize-airflow/access-airflow-database/) doc.
+Yes! Every Airflow Deployment on Astronomer Cloud has a corresponding Postgres Metadata Database hosted by Astronomer and isolated from all other Airflow Deployments. To access that database both on your local machine and Astronomer, check out [Access the Airflow Database](/docs/cloud/stable/customize-airflow/access-airflow-database/).
 
 ## Monitoring
 
-### What are my options for monitoring our deployments?
+### What are my options for monitoring an Airflow Deployment on Astronomer?
 
 Right now, your monitoring options for Cloud are:
 
@@ -63,13 +68,11 @@ As for the code itself, we’ve seen effective organization where external code 
 
 ### What authentication methods does Astronomer Cloud support?
 
-We offer authentication via Google, Github, and Local Username/Password.
-
-Once you've created a Workspace on Astronomer, you'll use that same method to authenticate to the Astronomer CLI.
+We offer authentication via Google, Github, and Local Username/Password. Once you've created a Workspace on Astronomer, you'll use that same method to authenticate to the Astronomer CLI.
 
 ### Where do I log in?
 
-After you [sign up for a trial](/trial/), you can head over to the [Astro UI](https://app.gcp0001.us-east4.astronomer.io/login) to login.
+After you [get in touch with us](https://astronomer.io/get-astronomer) and start a 14-day trial, you can head over to the [Astro UI](https://app.gcp0001.us-east4.astronomer.io/login) to login.
 
 ## Billing
 
@@ -79,4 +82,5 @@ Your first 14 days on Astronomer Cloud are entirely free of cost. When you creat
 
 After your first 14 days, you'll be required to input a payment method to continue usage. From there, we'll charge you based on exact resource usage per Airflow Deployment every 1st of the month, pro-rated for your first few weeks.
 
-If you want to cancel your account or trial and are having trouble accessing your Astronomer account,  please [reach out to us](https://support.astronomer.io).
+For more information, refer to [Cloud Pricing](https://www.astronomer.io/docs/cloud/stable/resources/pricing). If you want to cancel your account or trial and are having trouble accessing your Astronomer account,  please [reach out to us](https://support.astronomer.io).
+

--- a/cloud/stable/01_get-started/02_cloud-faq.md
+++ b/cloud/stable/01_get-started/02_cloud-faq.md
@@ -68,7 +68,7 @@ As for the code itself, we’ve seen effective organization where external code 
 
 ### What authentication methods does Astronomer Cloud support?
 
-We offer authentication via Google, Github, and Local Username/Password. Once you've created a Workspace on Astronomer, you'll use that same method to authenticate to the Astronomer CLI.
+We offer authentication via Google, Github, and local username/password. Once you've created a Workspace on Astronomer with a given authentication method, you'll use that same method to authenticate to the Astronomer CLI.
 
 ### Where do I log in?
 
@@ -83,4 +83,3 @@ Your first 14 days on Astronomer Cloud are entirely free of cost. When you creat
 After your first 14 days, you'll be required to input a payment method to continue usage. From there, we'll charge you based on exact resource usage per Airflow Deployment every 1st of the month, pro-rated for your first few weeks.
 
 For more information, refer to [Cloud Pricing](https://www.astronomer.io/docs/cloud/stable/resources/pricing). If you want to cancel your account or trial and are having trouble accessing your Astronomer account,  please [reach out to us](https://support.astronomer.io).
-

--- a/cloud/stable/04_customize-airflow/06_airflow_api.md
+++ b/cloud/stable/04_customize-airflow/06_airflow_api.md
@@ -109,7 +109,6 @@ The string needs to be in the following format (in UTC):
 
 Where, `YYYY`: Year, `MM`: Month, `DD`: Day, `HH`: Hour, `MM`: Minute, `SS`: Second.
 
-
 For example:
 
 ```

--- a/cloud/stable/04_customize-airflow/06_airflow_api.md
+++ b/cloud/stable/04_customize-airflow/06_airflow_api.md
@@ -16,22 +16,23 @@ To get started, you'll need a Service Account on Astronomer to authenticate. Rea
 
 The first step to calling the Airflow API on Astronomer is to create a Deployment-level Service Account, which will assume a user role and set of permissions and output an API Key that you can use to authenticate with your request.
 
-You can create a Service Account either via the Astronomer UI or the Astronomer CLI.
+You can create a Service Account via either the Astronomer UI or the Astronomer CLI.
 
 > **Note:** If you just need to call the Airflow API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer Cloud in place of a long-lasting Service Account. To do so, simply navigate to: https://app.gcp0001.us-east4.astronomer.io/token and skip to Step 2.
 
 ### Create a Service Account via the Astronomer UI
 
-To create a Service Account via the Astronomer UI, follow the steps below.
+To create a Service Account via the Astronomer UI:
 
 1. Log in to the Astronomer UI.
-2. Navigate to **Deployment** > **Service Accounts**.
+2. Go to **Deployment** > **Service Accounts**.
    ![New Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-new-service-account.png)
-3. Give your Service Account a **Name**, **User Role**, and    **Category** (_Optional_).
+3. Give your Service Account a **Name**, **User Role**, and **Category** (_Optional_).
    > **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the Editor or Admin role. For more information on Workspace roles, refer to [Roles and Permissions](/docs/cloud/stable/manage-astronomer/workspace-permissions/).
    
    ![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
-4. Save the API Key that was generated. Depending on           your use case, you may want to store this key in an       Environment Variable or secret management tool of choice.
+4. Save the API Key that was generated. Depending on your use case, you may want to store this key in an Environment Variable or secret management tool of choice.
+   
    ![Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-api-key.png)
 
 ### Create a Service Account via the Astronomer CLI
@@ -42,7 +43,7 @@ To create a Deployment-level Service account via the Astronomer CLI, follow the 
    ```
    $ astro auth login gcp0001.us-east4.astronomer.io
    ```
-2. Identify your Airflow Deployment's **Deployment ID**. To do so, run:
+2. Identify your Airflow Deployment's Deployment ID. To do so, run:
    ```
    $ astro deployment list
    ```
@@ -51,19 +52,19 @@ To create a Deployment-level Service account via the Astronomer CLI, follow the 
    ```
    $ astro deployment service-account create -d <deployment-id> --label <service-account-label> --role <deployment-role>
    ```
-4.  Save the API Key that was generated. Depending on          your use case, you might want to store this key in an       Environment Variable or secret management tool of choice.
+4.  Save the API Key that was generated. Depending on your use case, you might want to store this key in an Environment Variable or secret management tool of choice.
 
 For more information on the Astronomer CLI, read [CLI Quickstart](https://www.astronomer.io/docs/cloud/stable/develop/cli-quickstart).
 
 ## Step 2: Make an Airflow API Request
 
-Now that you've created a Service Account, you're free to generate both GET or POST requests to any supported endpoints in Airflow's [Rest API Reference](https://airflow.apache.org/docs/stable/rest-api-ref.html) via the following base URL:
+Now that you've created a Service Account, you're free to generate both `GET` or `POST` requests to any supported endpoints in Airflow's [Rest API Reference](https://airflow.apache.org/docs/stable/rest-api-ref.html) via the following base URL:
 
 ```
 https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>
 ```
 
-In the examples below, we'll refer to this URL as the **AIRFLOW-DOMAIN**, where you'll replace `deployment-release-name` with your own (e.g. `galactic-stars-1234`).
+In the examples below, we'll refer to this URL as the `AIRFLOW-DOMAIN`, where you'll replace `deployment-release-name` with your own (e.g. `galactic-stars-1234`).
 
 You can make requests via the method of your choosing. Below, we'll walk through an example request via cURL to Airflow's "Trigger DAG" endpoint and an example request via Python to the "Get all Pools" endpoint.
 
@@ -75,7 +76,7 @@ If you'd like to externally trigger a DAG run, you can start with a generic cURL
 POST /airflow/api/experimental/dags/<DAG_ID>/dag_runs
 ```
 
-The command for your request would look like this:
+The command for your request should look like this:
 
 ```
 curl -v -X POST
@@ -87,7 +88,7 @@ https://<AIRFLOW-DOMAIN>/airflow/api/experimental/dags/<DAG-ID>/dag_runs
 
 To run this, replace:
 
-- **AIRFLOW-DOMAIN**: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
+- `AIRFLOW-DOMAIN`: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
 - **DAG-ID**: Name of your DAG (_case-sensitive_)
 - **API-Key**: API Key from your Service Account
 
@@ -157,9 +158,9 @@ To run this, replace:
 
 ### What's new
 
-As of the momentous [Airflow 2.0 release](https://www.astronomer.io/blog/introducing-airflow-2-0), the Apache Airflow project now supports an official and more robust Stable REST API. Among other things, Airflow's new REST API:
+As of its momentous [2.0 release](https://www.astronomer.io/blog/introducing-airflow-2-0), the Apache Airflow project now supports an official and more robust Stable REST API. Among other things, Airflow's new REST API:
 
-* Makes for easy access by third-parties
+* Makes for easy access by third-parties.
 * Is based on the [Swagger/OpenAPI Spec](https://swagger.io/specification/)
 * Implements CRUD (Create, Update, Delete) operations on *all* Airflow resources
 * Includes authorization capabilities

--- a/cloud/stable/04_customize-airflow/06_airflow_api.md
+++ b/cloud/stable/04_customize-airflow/06_airflow_api.md
@@ -31,13 +31,14 @@ To create a Service Account via the Astronomer UI:
    > **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the Editor or Admin role. For more information on Workspace roles, refer to [Roles and Permissions](/docs/cloud/stable/manage-astronomer/workspace-permissions/).
    
    ![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
+   
 4. Save the API Key that was generated. Depending on your use case, you may want to store this key in an Environment Variable or secret management tool of choice.
    
    ![Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-api-key.png)
 
 ### Create a Service Account via the Astronomer CLI
 
-To create a Deployment-level Service account via the Astronomer CLI, follow the steps below.
+To create a Deployment-level Service Account via the Astronomer CLI:
 
 1. Authenticate to the Astronomer CLI by running:
    ```

--- a/cloud/stable/04_customize-airflow/06_airflow_api.md
+++ b/cloud/stable/04_customize-airflow/06_airflow_api.md
@@ -89,8 +89,8 @@ https://<AIRFLOW-DOMAIN>/airflow/api/experimental/dags/<DAG-ID>/dag_runs
 To run this, replace:
 
 - `AIRFLOW-DOMAIN`: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
-- **DAG-ID**: Name of your DAG (_case-sensitive_)
-- **API-Key**: API Key from your Service Account
+- `DAG-ID`: Name of your DAG (_case-sensitive_)
+- `API-Key`: API Key from your Service Account
 
 This will trigger a DAG run for your desired DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the “Play” button in the main "DAGs" view of the Airflow UI.
 
@@ -151,8 +151,8 @@ print(resp.json())
 
 To run this, replace:
 
-- **API-Key**: API Key from your Service Account
-- **deployment-release-name**: Your Airflow Deployment Release Name
+- `API-Key`: API Key from your Service Account
+- `deployment-release-name`: Your Airflow Deployment Release Name
 
 ## Airflow 2.0 Stable REST API
 
@@ -161,9 +161,9 @@ To run this, replace:
 As of its momentous [2.0 release](https://www.astronomer.io/blog/introducing-airflow-2-0), the Apache Airflow project now supports an official and more robust Stable REST API. Among other things, Airflow's new REST API:
 
 * Makes for easy access by third-parties.
-* Is based on the [Swagger/OpenAPI Spec](https://swagger.io/specification/)
-* Implements CRUD (Create, Update, Delete) operations on *all* Airflow resources
-* Includes authorization capabilities
+* Is based on the [Swagger/OpenAPI Spec](https://swagger.io/specification/).
+* Implements CRUD (Create, Update, Delete) operations on *all* Airflow resources.
+* Includes authorization capabilities.
 
 > **Note:** Astronomer makes it easy to upgrade to Airflow 2.0. For guidelines, read [Upgrade to Airflow 2.0 on Astronomer](https://www.astronomer.io/docs/cloud/stable/customize-airflow/upgrade-to-airflow-2).
 
@@ -188,5 +188,5 @@ https://<AIRFLOW-DOMAIN>/airflow/api/v1/config \
 
 To run this, replace:
 
-- **AIRFLOW-DOMAIN**: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
+- `AIRFLOW-DOMAIN`: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
 - **API-Key**: API Key from your Service Account

--- a/cloud/stable/04_customize-airflow/06_airflow_api.md
+++ b/cloud/stable/04_customize-airflow/06_airflow_api.md
@@ -6,74 +6,64 @@ description: "How to call the Airflow API on Astronomer."
 
 ## Overview
 
-Apache Airflow is an extensible orchestration tool that offers multiple ways to define and orchestrate data workflows. For users looking to automate actions around those workflows, Airflow exposes an ["experimental" REST API](https://airflow.apache.org/docs/stable/rest-api-ref.html) that you're free to leverage on Astronomer.
+Apache Airflow is an extensible orchestration tool that offers multiple ways to define and orchestrate data workflows. For users looking to automate actions around those workflows, Airflow exposes a [stable REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html) in Airflow 2.0, and an ["experimental" REST API](https://airflow.apache.org/docs/stable/rest-api-ref.html) for users running Airflow 1.10. You're free to leverage both on Astronomer.
 
 If you're looking to externally trigger DAG runs without needing to access your Airflow Deployment directly, for example, you can make an HTTP request (in Python, cURL etc.) to the corresponding endpoint in Airflow's API that calls for that exact action.
 
 To get started, you'll need a Service Account on Astronomer to authenticate. Read below for guidelines.
 
-## Create a Service Account on Astronomer
+## Step 1: Create a Service Account on Astronomer
 
 The first step to calling the Airflow API on Astronomer is to create a Deployment-level Service Account, which will assume a user role and set of permissions and output an API Key that you can use to authenticate with your request.
 
-You can create a Service Account either via the Astronomer CLI or the Astronomer UI.
+You can create a Service Account either via the Astronomer UI or the Astronomer CLI.
 
-> **Note:** If you just need to call the Airflow API once, you could create a temporary Authentication Token (_expires in 24 hours_) on Astronomer Cloud in place of a long-lasting Service Account. To do so, navigate to: https://app.gcp0001.us-east4.astronomer.io/token.
-
-### Create a Service Account via the Astronomer CLI
-
-To create a Deployment-level Service account via the CLI, first run:
-
-```
-$ astro deployment list
-```
-
-This will output the list of Airflow Deployments you have access to and their corresponding Deployment ID.
-
-With that Deployment ID, run:
-
-```
-$ astro deployment service-account create -d <deployment-id> --label <service-account-label> --role <deployment-role>
-```
+> **Note:** If you just need to call the Airflow API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer Cloud in place of a long-lasting Service Account. To do so, simply navigate to: https://app.gcp0001.us-east4.astronomer.io/token and skip to Step 2.
 
 ### Create a Service Account via the Astronomer UI
 
-If you prefer to provision a Service Account through the Astronomer UI, start by logging into Astronomer.
+To create a Service Account via the Astronomer UI, follow the steps below.
 
-#### Navigate to your Deployment's "Configure" Page
+1. Log in to the Astronomer UI.
+2. Navigate to **Deployment** > **Service Accounts**.
+   ![New Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-new-service-account.png)
+3. Give your Service Account a **Name**, **User Role**, and    **Category** (_Optional_).
+   > **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the Editor or Admin role. For more information on Workspace roles, refer to [Roles and Permissions](/docs/cloud/stable/manage-astronomer/workspace-permissions/).
+   
+   ![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
+4. Save the API Key that was generated. Depending on           your use case, you may want to store this key in an       Environment Variable or secret management tool of choice.
+   ![Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-api-key.png)
 
-From the Astronomer UI, navigate to: **Deployment** > **Service Accounts**.
+### Create a Service Account via the Astronomer CLI
 
-![New Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-new-service-account.png)
+To create a Deployment-level Service account via the Astronomer CLI, follow the steps below.
 
-#### Configure your Service Account
+1. Authenticate to the Astronomer CLI by running:
+   ```
+   $ astro auth login gcp0001.us-east4.astronomer.io
+   ```
+2. Identify your Airflow Deployment's **Deployment ID**. To do so, run:
+   ```
+   $ astro deployment list
+   ```
+   This will output the list of Airflow Deployments you have access to and their corresponding Deployment ID.
+3. With that Deployment ID, run:
+   ```
+   $ astro deployment service-account create -d <deployment-id> --label <service-account-label> --role <deployment-role>
+   ```
+4.  Save the API Key that was generated. Depending on          your use case, you might want to store this key in an       Environment Variable or secret management tool of choice.
 
-As you're creating a Service Account, you'll be asked to specify its:
+For more information on the Astronomer CLI, read [CLI Quickstart](https://www.astronomer.io/docs/cloud/stable/develop/cli-quickstart).
 
-- Name
-- User Role
-- Category (_optional_)
+## Step 2: Make an Airflow API Request
 
-![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
-
-> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the "Editor" or "Admin" role. For more information on Workspace roles, refer to our ["Roles and Permissions"](/docs/cloud/stable/manage-astronomer/workspace-permissions/) doc.
-
-#### Copy the API Key
-
-Once you've created your new Service Account, grab the API Key that was immediately generated. Depending on your use case, you might want to store this key in an Environment Variable or secret management tool of choice.
-
-![Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-api-key.png)
-
-
-## Test an Airflow API Request
-
-Now that you've created a Service Account, you're free to generate both GET or POST requests to any supported endpoints in Airflow's ["Rest API Reference"](https://airflow.apache.org/docs/stable/rest-api-ref.html) via this URL:
+Now that you've created a Service Account, you're free to generate both GET or POST requests to any supported endpoints in Airflow's [Rest API Reference](https://airflow.apache.org/docs/stable/rest-api-ref.html) via the following base URL:
 
 ```
 https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>
 ```
 
-Make sure to replace the end of the URL above with your own Deployment's release name (e.g. `galactic-stars-1234`).
+In the examples below, we'll refer to this URL as the **AIRFLOW-DOMAIN**, where you'll replace `deployment-release-name` with your own (e.g. `galactic-stars-1234`).
 
 You can make requests via the method of your choosing. Below, we'll walk through an example request via cURL to Airflow's "Trigger DAG" endpoint and an example request via Python to the "Get all Pools" endpoint.
 
@@ -85,35 +75,38 @@ If you'd like to externally trigger a DAG run, you can start with a generic cURL
 POST /airflow/api/experimental/dags/<DAG_ID>/dag_runs
 ```
 
-This command would look like this:
+The command for your request would look like this:
 
 ```
 curl -v -X POST
-https://AIRFLOW_DOMAIN/airflow/api/experimental/dags/<DAG_ID>/dag_runs
--H 'Authorization: <API_Key> ’
+https://<AIRFLOW-DOMAIN>/airflow/api/experimental/dags/<DAG-ID>/dag_runs
+-H 'Authorization: <API-Key> ’
 -H ‘Cache-Control: no-cache’
 -H ‘content-type: application/json’ -d ‘{}’
 ```
 
 To run this, replace:
 
-- **AIRFLOW_DOMAIN**: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
-- **DAG_ID**: Name of your DAG (_case-sensitive_)
-- **API_Key**: API Key from your Service Account
+- **AIRFLOW-DOMAIN**: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
+- **DAG-ID**: Name of your DAG (_case-sensitive_)
+- **API-Key**: API Key from your Service Account
 
-This will successfully kick off a DAG run for your DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the “Play” button in the main "DAGs" view of the Airflow UI (Webserver).
+This will trigger a DAG run for your desired DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the “Play” button in the main "DAGs" view of the Airflow UI.
 
 > **Note:** Your request will have the same permissions as the role of the Service Account you created on Astronomer.
 
 #### Specify Execution Date
 
-If you'd like to choose a specific `execution_date` (i.e. start timestamp) to kick off your DAG on, you can pass that in with the data parameter's JSON value `("-d'{}')`.
+If you'd like to choose a specific `execution_date` (i.e. start timestamp) to trigger your DAG on, you can pass that in with the data parameter's JSON value `("-d'{}')`.
 
 The string needs to be in the following format (in UTC):
 
 ```
-“YYYY-mm-DDTHH:MM:SS”
+“YYYY-MM-DDTHH:MM:SS”
 ```
+
+Where, `YYYY`: Year, `MM`: Month, `DD`: Day, `HH`: Hour, `MM`: Minute, `SS`: Second.
+
 
 For example:
 
@@ -125,8 +118,8 @@ Here, your request becomes:
 
 ```
 curl -v -X POST
-https://AIRFLOW_DOMAIN/api/experimental/dags/customer_health_score/dag_runs
--H ‘Authorization: XXXX’
+https://<AIRFLOW_DOMAIN>/api/experimental/dags/customer_health_score/dag_runs
+-H ‘Authorization: <API-Key>’
 -H ‘Cache-Control: no-cache’
 -H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-03-05T08:30:00”}’
 ```
@@ -144,10 +137,10 @@ Here, your request would look like this:
 ```python
 python
 import requests
-token="<API_KEY>"
+token="<API-Key>"
 base_url="https://deployments.gcp0001.us-east4.astronomer.io/"
 resp = requests.get(
-   url=base_url + "<deployment_release_name>/airflow/api/experimental/pools",
+   url=base_url + "<deployment-release-name>/airflow/api/experimental/pools",
    headers={"Authorization": token},
    data={}
 )
@@ -157,9 +150,42 @@ print(resp.json())
 
 To run this, replace:
 
-- **API_KEY**: API Key from your Service Account
-- **deployment_release_name**: Your Airflow Deployment Release Name
+- **API-Key**: API Key from your Service Account
+- **deployment-release-name**: Your Airflow Deployment Release Name
 
-## New REST API Coming soon
+## Airflow 2.0 Stable REST API
 
-An official REST API for Airflow is coming in the Airflow 2.0 release scheduled for Winter 2020. For more information, check out [AIP-32](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-32%3A+Airflow+REST+API) or [reach out to us](https://support.astronomer.io).
+### What's new
+
+As of the momentous [Airflow 2.0 release](https://www.astronomer.io/blog/introducing-airflow-2-0), the Apache Airflow project now supports an official and more robust Stable REST API. Among other things, Airflow's new REST API:
+
+* Makes for easy access by third-parties
+* Is based on the [Swagger/OpenAPI Spec](https://swagger.io/specification/)
+* Implements CRUD (Create, Update, Delete) operations on *all* Airflow resources
+* Includes authorization capabilities
+
+> **Note:** Astronomer makes it easy to upgrade to Airflow 2.0. For guidelines, read [Upgrade to Airflow 2.0 on Astronomer](https://www.astronomer.io/docs/cloud/stable/customize-airflow/upgrade-to-airflow-2).
+
+### Make a Request
+
+To convert a call from Airflow's experimental API, simply update the URL to use the endpoint specified in Airflow's [Stable REST API reference](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html).
+
+For example, take Airflow's "Get Current Configuration" endpoint:
+
+```
+GET /api/v1/config
+```
+
+Here, your cURL request would look like the following:
+
+```
+curl -X GET \
+https://<AIRFLOW-DOMAIN>/airflow/api/v1/config \
+-H 'Authorization: <API-Key>' \
+-H 'Cache-Control: no-cache'
+```
+
+To run this, replace:
+
+- **AIRFLOW-DOMAIN**: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
+- **API-Key**: API Key from your Service Account

--- a/cloud/stable/04_customize-airflow/06_airflow_api.md
+++ b/cloud/stable/04_customize-airflow/06_airflow_api.md
@@ -87,9 +87,9 @@ https://<AIRFLOW-DOMAIN>/airflow/api/experimental/dags/<DAG-ID>/dag_runs
 -H ‘content-type: application/json’ -d ‘{}’
 ```
 
-To run this, replace:
+To run this, replace the following placeholder values:
 
-- `<AIRFLOW-DOMAIN>`: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
+- `<AIRFLOW-DOMAIN>`: Use `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
 - `<DAG-ID>`: Name of your DAG (_case-sensitive_)
 - `<API-Key>`: API Key from your Service Account
 
@@ -150,7 +150,7 @@ print(resp.json())
 >>>>  [{'description': 'Default pool', 'id': 1, 'pool': 'default_pool', 'slots': 128}]
 ```
 
-To run this, replace:
+To run this, replace the following placeholder values:
 
 - `<API-Key>`: API Key from your Service Account
 - `<deployment-release-name>`: Your Airflow Deployment Release Name
@@ -187,7 +187,7 @@ https://<AIRFLOW-DOMAIN>/airflow/api/v1/config \
 -H 'Cache-Control: no-cache'
 ```
 
-To run this, replace:
+To run this, replace the following placeholder values:
 
-- `<AIRFLOW-DOMAIN>`: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
+- `<AIRFLOW-DOMAIN>`: Use `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
 - `<API-Key>`: API Key from your Service Account

--- a/cloud/stable/04_customize-airflow/06_airflow_api.md
+++ b/cloud/stable/04_customize-airflow/06_airflow_api.md
@@ -64,7 +64,7 @@ Now that you've created a Service Account, you're free to generate both `GET` or
 https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>
 ```
 
-In the examples below, we'll refer to this URL as the `AIRFLOW-DOMAIN`, where you'll replace `deployment-release-name` with your own (e.g. `galactic-stars-1234`).
+In the examples below, we'll refer to this URL as the `AIRFLOW-DOMAIN`, where you'll replace `<deployment-release-name>` with your own (e.g. `galactic-stars-1234`).
 
 You can make requests via the method of your choosing. Below, we'll walk through an example request via cURL to Airflow's "Trigger DAG" endpoint and an example request via Python to the "Get all Pools" endpoint.
 
@@ -88,9 +88,9 @@ https://<AIRFLOW-DOMAIN>/airflow/api/experimental/dags/<DAG-ID>/dag_runs
 
 To run this, replace:
 
-- `AIRFLOW-DOMAIN`: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
-- `DAG-ID`: Name of your DAG (_case-sensitive_)
-- `API-Key`: API Key from your Service Account
+- `<AIRFLOW-DOMAIN>`: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
+- `<DAG-ID>`: Name of your DAG (_case-sensitive_)
+- `<API-Key>`: API Key from your Service Account
 
 This will trigger a DAG run for your desired DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the “Play” button in the main "DAGs" view of the Airflow UI.
 
@@ -112,7 +112,7 @@ Where, `YYYY`: Year, `MM`: Month, `DD`: Day, `HH`: Hour, `MM`: Minute, `SS`: Sec
 For example:
 
 ```
-“2016-11-16T11:34:15”
+“2019-11-16T11:34:00”
 ```
 
 Here, your request becomes:
@@ -122,12 +122,12 @@ curl -v -X POST
 https://<AIRFLOW_DOMAIN>/api/experimental/dags/customer_health_score/dag_runs
 -H ‘Authorization: <API-Key>’
 -H ‘Cache-Control: no-cache’
--H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-03-05T08:30:00”}’
+-H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-11-16T11:34:00”}’
 ```
 
 ### Get all Pools
 
-If you'd like to get all existing Pools from your Airflow Deployment, you can start with a generic Python command to Airflow's GET endpoint: 
+If you'd like to get all existing Pools from your Airflow Deployment, you can start with a generic Python command to Airflow's `GET` endpoint: 
 
 ```
 GET /api/experimental/pools
@@ -151,8 +151,8 @@ print(resp.json())
 
 To run this, replace:
 
-- `API-Key`: API Key from your Service Account
-- `deployment-release-name`: Your Airflow Deployment Release Name
+- `<API-Key>`: API Key from your Service Account
+- `<deployment-release-name>`: Your Airflow Deployment Release Name
 
 ## Airflow 2.0 Stable REST API
 
@@ -188,5 +188,5 @@ https://<AIRFLOW-DOMAIN>/airflow/api/v1/config \
 
 To run this, replace:
 
-- `AIRFLOW-DOMAIN`: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
-- **API-Key**: API Key from your Service Account
+- `<AIRFLOW-DOMAIN>`: `https://deployments.gcp0001.us-east4.astronomer.io/<deployment-release-name>`
+- `<API-Key>`: API Key from your Service Account

--- a/enterprise/next/05_customize-airflow/07_airflow-api.md
+++ b/enterprise/next/05_customize-airflow/07_airflow-api.md
@@ -86,9 +86,9 @@ https://<AIRFLOW-DOMAIN>/airflow/api/experimental/dags/<DAG-ID>/dag_runs
 -H ‘content-type: application/json’ -d ‘{}’
 ```
 
-To run this, replace:
+To run this, replace the following placeholder values:
 
-- `<AIRFLOW-DOMAIN>`: `https://<your-base-domain>/<deployment-release-name>`
+- `<AIRFLOW-DOMAIN>`: Use `https://<your-base-domain>/<deployment-release-name>`
 - `<DAG-ID>`: Name of your DAG (_case-sensitive_)
 - `<API-Key>`: API Key from your Service Account
 
@@ -149,7 +149,7 @@ print(resp.json())
 >>>>  [{'description': 'Default pool', 'id': 1, 'pool': 'default_pool', 'slots': 128}]
 ```
 
-To run this, replace:
+To run this, replace the following placeholder values:
 
 - `<your-base-domain>`: Your Astronomer Enterprise base domain
 - `<API-Key>`: API Key from your Service Account
@@ -187,7 +187,7 @@ https://<AIRFLOW-DOMAIN>/airflow/api/v1/config \
 -H 'Cache-Control: no-cache'
 ```
 
-To run this, replace:
+To run this, replace the following placeholder values:
 
-- `<AIRFLOW-DOMAIN>`: `https://<your-base-domain>/<deployment-release-name>`
+- `<AIRFLOW-DOMAIN>`: Use `https://<your-base-domain>/<deployment-release-name>`
 - `<API-Key>`: API Key from your Service Account

--- a/enterprise/next/05_customize-airflow/07_airflow-api.md
+++ b/enterprise/next/05_customize-airflow/07_airflow-api.md
@@ -108,7 +108,6 @@ The string needs to be in the following format (in UTC):
 
 Where, `YYYY`: Year, `MM`: Month, `DD`: Day, `HH`: Hour, `MM`: Minute, `SS`: Second.
 
-
 For example:
 
 ```

--- a/enterprise/next/05_customize-airflow/07_airflow-api.md
+++ b/enterprise/next/05_customize-airflow/07_airflow-api.md
@@ -6,134 +6,128 @@ description: "How to call the Airflow API on Astronomer."
 
 ## Overview
 
-Apache Airflow is an extensible orchestration tool that offers multiple ways to define and orchestrate data workflows. For users looking to automate actions around those workflows, Airflow exposes an ["experimental" REST API](https://airflow.apache.org/docs/stable/rest-api-ref.html) that you're free to leverage on Astronomer.
+Apache Airflow is an extensible orchestration tool that offers multiple ways to define and orchestrate data workflows. For users looking to automate actions around those workflows, Airflow exposes a [stable REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html) in Airflow 2.0, and an ["experimental" REST API](https://airflow.apache.org/docs/stable/rest-api-ref.html) for users running Airflow 1.10. You're free to leverage both on Astronomer.
 
 If you're looking to externally trigger DAG runs without needing to access your Airflow Deployment directly, for example, you can make an HTTP request (in Python, cURL etc.) to the corresponding endpoint in Airflow's API that calls for that exact action.
 
 To get started, you'll need a Service Account on Astronomer to authenticate. Read below for guidelines.
 
-## Create a Service Account on Astronomer
+## Step 1: Create a Service Account on Astronomer
 
 The first step to calling the Airflow API on Astronomer is to create a Deployment-level Service Account, which will assume a user role and set of permissions and output an API Key that you can use to authenticate with your request.
 
-You can create a Service Account either via the Astronomer CLI or the Astronomer UI.
+You can create a Service Account via either the Astronomer UI or the Astronomer CLI.
 
-> **Note:** If you just need to call the Airflow API once, you could create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service Account. To do so, navigate to: https://app.BASEDOMAIN/token.
-
-### Create a Service Account via the Astronomer CLI
-
-To create a Deployment-level Service account via the CLI, first run:
-
-```
-$ astro deployment list
-```
-
-This will output the list of Airflow Deployments you have access to and their corresponding Deployment ID.
-
-With that Deployment ID, run:
-
-```
-$ astro deployment service-account create -d <deployment-id> --label <service-account-label> --role <deployment-role>
-```
+> **Note:** If you just need to call the Airflow API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service Account. To do so, simply navigate to: `https://<your-base-domain>/token` and skip to Step 2.
 
 ### Create a Service Account via the Astronomer UI
 
-If you prefer to provision a Service Account through the Astronomer UI, start by logging into Astronomer.
+To create a Service Account via the Astronomer UI:
 
-#### Navigate to your Deployment's "Configure" Page
+1. Log in to the Astronomer UI.
+2. Go to **Deployment** > **Service Accounts**.
+   ![New Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-new-service-account.png)
+3. Give your Service Account a **Name**, **User Role**, and **Category** (_Optional_).
+   > **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the Editor or Admin role. For more information on Workspace roles, refer to [Roles and Permissions](/docs/enterprise/stable/manage-astronomer/workspace-permissions/).
+   
+   ![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
+4. Save the API Key that was generated. Depending on your use case, you may want to store this key in an Environment Variable or secret management tool of choice.
+   
+   ![Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-api-key.png)
 
-From the Astronomer UI, navigate to: **Deployment** > **Service Accounts**.
+### Create a Service Account via the Astronomer CLI
 
-![New Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-new-service-account.png)
+To create a Deployment-level Service account via the Astronomer CLI, follow the steps below.
 
-#### Configure your Service Account
+1. Authenticate to the Astronomer CLI by running:
+   ```
+   $ astro auth login gcp0001.us-east4.astronomer.io
+   ```
+2. Identify your Airflow Deployment's Deployment ID. To do so, run:
+   ```
+   $ astro deployment list
+   ```
+   This will output the list of Airflow Deployments you have access to and their corresponding Deployment ID.
+3. With that Deployment ID, run:
+   ```
+   $ astro deployment service-account create -d <deployment-id> --label <service-account-label> --role <deployment-role>
+   ```
+4.  Save the API Key that was generated. Depending on your use case, you might want to store this key in an Environment Variable or secret management tool of choice.
 
-As you're creating a Service Account, you'll be asked to specify its:
+For more information on the Astronomer CLI, read [CLI Quickstart](https://www.astronomer.io/docs/enterprise/stable/develop/cli-quickstart).
 
-- Name
-- User Role
-- Category (_optional_)
+## Step 2: Make an Airflow API Request
 
-![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
-
-> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the "Editor" or "Admin" role. For more information on Workspace roles, refer to our ["Roles and Permissions"](/docs/enterprise/stable/manage-astronomer/workspace-permissions/) doc.
-
-#### Copy the API Key
-
-Once you've created your new Service Account, grab the API Key that was immediately generated. Depending on your use case, you might want to store this key in an Environment Variable or secret management tool of choice.
-
-![Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-api-key.png)
-
-
-## Test an Airflow API Request
-
-Now that you've created a Service Account, you're free to generate both GET or POST requests to any supported endpoints in Airflow's ["Rest API Reference"](https://airflow.apache.org/docs/stable/rest-api-ref.html) via this URL:
+Now that you've created a Service Account, you're free to generate both `GET` or `POST` requests to any supported endpoints in Airflow's [Rest API Reference](https://airflow.apache.org/docs/stable/rest-api-ref.html) via the following base URL:
 
 ```
-https://deployments.<BASEDOMAIN>/<deployment-release-name>
+https://<your-base-domain>/<deployment-release-name>
 ```
 
-Make sure to replace the end of the URL above with your platform's basedomain and your Deployment's release name (e.g. `galactic-stars-1234`).
+In the examples below, we'll refer to this URL as the `AIRFLOW-DOMAIN`, where you'll replace `<your-base-domain>` (e.g. `mycompany.astronomer.io`) and `<deployment-release-name>` (e.g. `galactic-stars-1234`) with your own.
 
 You can make requests via the method of your choosing. Below, we'll walk through an example request via cURL to Airflow's "Trigger DAG" endpoint and an example request via Python to the "Get all Pools" endpoint.
 
 ### Trigger DAG
 
-If you'd like to externally trigger a DAG run, you can start with a generic cURL command to Airflow's POST endpoint:
+If you'd like to externally trigger a DAG run, you can start with a generic cURL command to Airflow's POST endpoint: 
 
 ```
 POST /airflow/api/experimental/dags/<DAG_ID>/dag_runs
 ```
 
-This command would look like this:
+The command for your request should look like this:
 
 ```
 curl -v -X POST
-https://AIRFLOW_DOMAIN/airflow/api/experimental/dags/<DAG_ID>/dag_runs
--H 'Authorization: <API_Key> ’
+https://<AIRFLOW-DOMAIN>/airflow/api/experimental/dags/<DAG-ID>/dag_runs
+-H 'Authorization: <API-Key> ’
 -H ‘Cache-Control: no-cache’
 -H ‘content-type: application/json’ -d ‘{}’
 ```
 
 To run this, replace:
 
-- **AIRFLOW_DOMAIN**: `https://deployments.BASEDOMAIN/<deployment-release-name>`
-- **DAG_ID**: Name of your DAG (_case-sensitive_)
-- **API_Key**: API Key from your Service Account
+- `<AIRFLOW-DOMAIN>`: `https://<your-base-domain>/<deployment-release-name>`
+- `<DAG-ID>`: Name of your DAG (_case-sensitive_)
+- `<API-Key>`: API Key from your Service Account
 
-This will successfully kick off a DAG run for your DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the “Play” button in the main "DAGs" view of the Airflow UI (Webserver).
+This will trigger a DAG run for your desired DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the “Play” button in the main "DAGs" view of the Airflow UI.
 
 > **Note:** Your request will have the same permissions as the role of the Service Account you created on Astronomer.
 
 #### Specify Execution Date
 
-If you'd like to choose a specific `execution_date` (i.e. start timestamp) to kick off your DAG on, you can pass that in with the data parameter's JSON value `("-d'{}')`.
+If you'd like to choose a specific `execution_date` (i.e. start timestamp) to trigger your DAG on, you can pass that in with the data parameter's JSON value `("-d'{}')`.
 
 The string needs to be in the following format (in UTC):
 
 ```
-“YYYY-mm-DDTHH:MM:SS”
+“YYYY-MM-DDTHH:MM:SS”
 ```
+
+Where, `YYYY`: Year, `MM`: Month, `DD`: Day, `HH`: Hour, `MM`: Minute, `SS`: Second.
+
 
 For example:
 
 ```
-“2016-11-16T11:34:15”
+“2019-11-16T11:34:00”
 ```
 
 Here, your request becomes:
 
 ```
 curl -v -X POST
-https://AIRFLOW_DOMAIN/api/experimental/dags/customer_health_score/dag_runs
--H ‘Authorization: XXXX’
+https://<AIRFLOW_DOMAIN>/api/experimental/dags/customer_health_score/dag_runs
+-H ‘Authorization: <API-Key>’
 -H ‘Cache-Control: no-cache’
--H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-03-05T08:30:00”}’
+-H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-11-16T11:34:00”}’
 ```
 
 ### Get all Pools
 
-If you'd like to get all existing Pools from your Airflow Deployment, you can start with a generic Python command to Airflow's GET endpoint:
+If you'd like to get all existing Pools from your Airflow Deployment, you can start with a generic Python command to Airflow's `GET` endpoint: 
 
 ```
 GET /api/experimental/pools
@@ -144,10 +138,10 @@ Here, your request would look like this:
 ```python
 python
 import requests
-token="<API_KEY>"
-base_url="<BASE_DOMAIN>"
+token="<API-Key>"
+base_url="https://<your-base-domain/"
 resp = requests.get(
-   url=base_url + "<deployment_release_name>/airflow/api/experimental/pools",
+   url=base_url + "<deployment-release-name>/airflow/api/experimental/pools",
    headers={"Authorization": token},
    data={}
 )
@@ -157,10 +151,43 @@ print(resp.json())
 
 To run this, replace:
 
-- **BASE_DOMAIN**: Your platform's base domain (e.g. `mycompany.astronomer.com`)
-- **API_KEY**: API Key from your Service Account
-- **deployment_release_name**: Your Airflow Deployment Release Name
+- `<your-base-domain>`: Your Astronomer Enterprise base domain
+- `<API-Key>`: API Key from your Service Account
+- `<deployment-release-name>`: Your Airflow Deployment Release Name
 
-## New REST API Coming soon
+## Airflow 2.0 Stable REST API
 
-An official REST API for Airflow is coming in the Airflow 2.0 release scheduled for Winter 2020. For more information, check out [AIP-32](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-32%3A+Airflow+REST+API) or [reach out to us](https://support.astronomer.io).
+### What's new
+
+As of its momentous [2.0 release](https://www.astronomer.io/blog/introducing-airflow-2-0), the Apache Airflow project now supports an official and more robust Stable REST API. Among other things, Airflow's new REST API:
+
+* Makes for easy access by third-parties.
+* Is based on the [Swagger/OpenAPI Spec](https://swagger.io/specification/).
+* Implements CRUD (Create, Update, Delete) operations on *all* Airflow resources.
+* Includes authorization capabilities.
+
+> **Note:** To get started with Airflow 2.0 locally, read [Get Started with Apache Airflow 2.0](https://www.astronomer.io/guides/get-started-airflow-2). To upgrade an Airflow Deployment on Astronomer to 2.0, make sure you've first upgraded to both [Astronomer Enterprise v0.23](https://www.astronomer.io/docs/enterprise/v0.23/manage-astronomer/upgrade-to-0-23) and Airflow 1.10.14. For questions, reach out to [Astronomer Support](https://support.astronomer.io). 
+
+### Make a Request
+
+To convert a call from Airflow's experimental API, simply update the URL to use the endpoint specified in Airflow's [Stable REST API reference](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html).
+
+For example, take Airflow's "Get Current Configuration" endpoint:
+
+```
+GET /api/v1/config
+```
+
+Here, your cURL request would look like the following:
+
+```
+curl -X GET \
+https://<AIRFLOW-DOMAIN>/airflow/api/v1/config \
+-H 'Authorization: <API-Key>' \
+-H 'Cache-Control: no-cache'
+```
+
+To run this, replace:
+
+- `<AIRFLOW-DOMAIN>`: `https://<your-base-domain>/<deployment-release-name>`
+- `<API-Key>`: API Key from your Service Account

--- a/enterprise/next/05_customize-airflow/07_airflow-api.md
+++ b/enterprise/next/05_customize-airflow/07_airflow-api.md
@@ -37,7 +37,7 @@ To create a Service Account via the Astronomer UI:
 
 ### Create a Service Account via the Astronomer CLI
 
-To create a Deployment-level Service account via the Astronomer CLI, follow the steps below.
+To create a Deployment-level Service Account via the Astronomer CLI:
 
 1. Authenticate to the Astronomer CLI by running:
    ```

--- a/enterprise/v0.23/05_customize-airflow/07_airflow-api.md
+++ b/enterprise/v0.23/05_customize-airflow/07_airflow-api.md
@@ -6,134 +6,128 @@ description: "How to call the Airflow API on Astronomer."
 
 ## Overview
 
-Apache Airflow is an extensible orchestration tool that offers multiple ways to define and orchestrate data workflows. For users looking to automate actions around those workflows, Airflow exposes an ["experimental" REST API](https://airflow.apache.org/docs/stable/rest-api-ref.html) that you're free to leverage on Astronomer.
+Apache Airflow is an extensible orchestration tool that offers multiple ways to define and orchestrate data workflows. For users looking to automate actions around those workflows, Airflow exposes a [stable REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html) in Airflow 2.0, and an ["experimental" REST API](https://airflow.apache.org/docs/stable/rest-api-ref.html) for users running Airflow 1.10. You're free to leverage both on Astronomer.
 
 If you're looking to externally trigger DAG runs without needing to access your Airflow Deployment directly, for example, you can make an HTTP request (in Python, cURL etc.) to the corresponding endpoint in Airflow's API that calls for that exact action.
 
 To get started, you'll need a Service Account on Astronomer to authenticate. Read below for guidelines.
 
-## Create a Service Account on Astronomer
+## Step 1: Create a Service Account on Astronomer
 
 The first step to calling the Airflow API on Astronomer is to create a Deployment-level Service Account, which will assume a user role and set of permissions and output an API Key that you can use to authenticate with your request.
 
-You can create a Service Account either via the Astronomer CLI or the Astronomer UI.
+You can create a Service Account via either the Astronomer UI or the Astronomer CLI.
 
-> **Note:** If you just need to call the Airflow API once, you could create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service Account. To do so, navigate to: https://app.BASEDOMAIN/token.
-
-### Create a Service Account via the Astronomer CLI
-
-To create a Deployment-level Service account via the CLI, first run:
-
-```
-$ astro deployment list
-```
-
-This will output the list of Airflow Deployments you have access to and their corresponding Deployment ID.
-
-With that Deployment ID, run:
-
-```
-$ astro deployment service-account create -d <deployment-id> --label <service-account-label> --role <deployment-role>
-```
+> **Note:** If you just need to call the Airflow API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service Account. To do so, simply navigate to: `https://<your-base-domain>/token` and skip to Step 2.
 
 ### Create a Service Account via the Astronomer UI
 
-If you prefer to provision a Service Account through the Astronomer UI, start by logging into Astronomer.
+To create a Service Account via the Astronomer UI:
 
-#### Navigate to your Deployment's "Configure" Page
+1. Log in to the Astronomer UI.
+2. Go to **Deployment** > **Service Accounts**.
+   ![New Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-new-service-account.png)
+3. Give your Service Account a **Name**, **User Role**, and **Category** (_Optional_).
+   > **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the Editor or Admin role. For more information on Workspace roles, refer to [Roles and Permissions](/docs/enterprise/v0.23/manage-astronomer/workspace-permissions/).
+   
+   ![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
+4. Save the API Key that was generated. Depending on your use case, you may want to store this key in an Environment Variable or secret management tool of choice.
+   
+   ![Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-api-key.png)
 
-From the Astronomer UI, navigate to: **Deployment** > **Service Accounts**.
+### Create a Service Account via the Astronomer CLI
 
-![New Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-new-service-account.png)
+To create a Deployment-level Service account via the Astronomer CLI, follow the steps below.
 
-#### Configure your Service Account
+1. Authenticate to the Astronomer CLI by running:
+   ```
+   $ astro auth login gcp0001.us-east4.astronomer.io
+   ```
+2. Identify your Airflow Deployment's Deployment ID. To do so, run:
+   ```
+   $ astro deployment list
+   ```
+   This will output the list of Airflow Deployments you have access to and their corresponding Deployment ID.
+3. With that Deployment ID, run:
+   ```
+   $ astro deployment service-account create -d <deployment-id> --label <service-account-label> --role <deployment-role>
+   ```
+4.  Save the API Key that was generated. Depending on your use case, you might want to store this key in an Environment Variable or secret management tool of choice.
 
-As you're creating a Service Account, you'll be asked to specify its:
+For more information on the Astronomer CLI, read [CLI Quickstart](https://www.astronomer.io/docs/enterprise/v0.23/develop/cli-quickstart).
 
-- Name
-- User Role
-- Category (_optional_)
+## Step 2: Make an Airflow API Request
 
-![Name Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-name-service-account.png)
-
-> **Note:** In order for a Service Account to have permission to push code to your Airflow Deployment, it must have either the "Editor" or "Admin" role. For more information on Workspace roles, refer to our ["Roles and Permissions"](/docs/enterprise/v0.23/manage-astronomer/workspace-permissions/) doc.
-
-#### Copy the API Key
-
-Once you've created your new Service Account, grab the API Key that was immediately generated. Depending on your use case, you might want to store this key in an Environment Variable or secret management tool of choice.
-
-![Service Account](https://assets2.astronomer.io/main/docs/ci-cd/ci-cd-api-key.png)
-
-
-## Test an Airflow API Request
-
-Now that you've created a Service Account, you're free to generate both GET or POST requests to any supported endpoints in Airflow's ["Rest API Reference"](https://airflow.apache.org/docs/stable/rest-api-ref.html) via this URL:
+Now that you've created a Service Account, you're free to generate both `GET` or `POST` requests to any supported endpoints in Airflow's [Rest API Reference](https://airflow.apache.org/docs/stable/rest-api-ref.html) via the following base URL:
 
 ```
-https://deployments.<BASEDOMAIN>/<deployment-release-name>
+https://<your-base-domain>/<deployment-release-name>
 ```
 
-Make sure to replace the end of the URL above with your platform's basedomain and your Deployment's release name (e.g. `galactic-stars-1234`).
+In the examples below, we'll refer to this URL as the `AIRFLOW-DOMAIN`, where you'll replace `<your-base-domain>` (e.g. `mycompany.astronomer.io`) and `<deployment-release-name>` (e.g. `galactic-stars-1234`) with your own.
 
 You can make requests via the method of your choosing. Below, we'll walk through an example request via cURL to Airflow's "Trigger DAG" endpoint and an example request via Python to the "Get all Pools" endpoint.
 
 ### Trigger DAG
 
-If you'd like to externally trigger a DAG run, you can start with a generic cURL command to Airflow's POST endpoint:
+If you'd like to externally trigger a DAG run, you can start with a generic cURL command to Airflow's POST endpoint: 
 
 ```
 POST /airflow/api/experimental/dags/<DAG_ID>/dag_runs
 ```
 
-This command would look like this:
+The command for your request should look like this:
 
 ```
 curl -v -X POST
-https://AIRFLOW_DOMAIN/airflow/api/experimental/dags/<DAG_ID>/dag_runs
--H 'Authorization: <API_Key> ’
+https://<AIRFLOW-DOMAIN>/airflow/api/experimental/dags/<DAG-ID>/dag_runs
+-H 'Authorization: <API-Key> ’
 -H ‘Cache-Control: no-cache’
 -H ‘content-type: application/json’ -d ‘{}’
 ```
 
 To run this, replace:
 
-- **AIRFLOW_DOMAIN**: `https://deployments.BASEDOMAIN/<deployment-release-name>`
-- **DAG_ID**: Name of your DAG (_case-sensitive_)
-- **API_Key**: API Key from your Service Account
+- `<AIRFLOW-DOMAIN>`: `https://<your-base-domain>/<deployment-release-name>`
+- `<DAG-ID>`: Name of your DAG (_case-sensitive_)
+- `<API-Key>`: API Key from your Service Account
 
-This will successfully kick off a DAG run for your DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the “Play” button in the main "DAGs" view of the Airflow UI (Webserver).
+This will trigger a DAG run for your desired DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the “Play” button in the main "DAGs" view of the Airflow UI.
 
 > **Note:** Your request will have the same permissions as the role of the Service Account you created on Astronomer.
 
 #### Specify Execution Date
 
-If you'd like to choose a specific `execution_date` (i.e. start timestamp) to kick off your DAG on, you can pass that in with the data parameter's JSON value `("-d'{}')`.
+If you'd like to choose a specific `execution_date` (i.e. start timestamp) to trigger your DAG on, you can pass that in with the data parameter's JSON value `("-d'{}')`.
 
 The string needs to be in the following format (in UTC):
 
 ```
-“YYYY-mm-DDTHH:MM:SS”
+“YYYY-MM-DDTHH:MM:SS”
 ```
+
+Where, `YYYY`: Year, `MM`: Month, `DD`: Day, `HH`: Hour, `MM`: Minute, `SS`: Second.
+
 
 For example:
 
 ```
-“2016-11-16T11:34:15”
+“2019-11-16T11:34:00”
 ```
 
 Here, your request becomes:
 
 ```
 curl -v -X POST
-https://AIRFLOW_DOMAIN/api/experimental/dags/customer_health_score/dag_runs
--H ‘Authorization: XXXX’
+https://<AIRFLOW_DOMAIN>/api/experimental/dags/customer_health_score/dag_runs
+-H ‘Authorization: <API-Key>’
 -H ‘Cache-Control: no-cache’
--H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-03-05T08:30:00”}’
+-H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-11-16T11:34:00”}’
 ```
 
 ### Get all Pools
 
-If you'd like to get all existing Pools from your Airflow Deployment, you can start with a generic Python command to Airflow's GET endpoint:
+If you'd like to get all existing Pools from your Airflow Deployment, you can start with a generic Python command to Airflow's `GET` endpoint: 
 
 ```
 GET /api/experimental/pools
@@ -144,10 +138,10 @@ Here, your request would look like this:
 ```python
 python
 import requests
-token="<API_KEY>"
-base_url="<BASE_DOMAIN>"
+token="<API-Key>"
+base_url="https://<your-base-domain/"
 resp = requests.get(
-   url=base_url + "<deployment_release_name>/airflow/api/experimental/pools",
+   url=base_url + "<deployment-release-name>/airflow/api/experimental/pools",
    headers={"Authorization": token},
    data={}
 )
@@ -157,10 +151,43 @@ print(resp.json())
 
 To run this, replace:
 
-- **BASE_DOMAIN**: Your platform's base domain (e.g. `mycompany.astronomer.com`)
-- **API_KEY**: API Key from your Service Account
-- **deployment_release_name**: Your Airflow Deployment Release Name
+- `<your-base-domain>`: Your Astronomer Enterprise base domain
+- `<API-Key>`: API Key from your Service Account
+- `<deployment-release-name>`: Your Airflow Deployment Release Name
 
-## New REST API Coming soon
+## Airflow 2.0 Stable REST API
 
-An official REST API for Airflow is coming in the Airflow 2.0 release scheduled for Winter 2020. For more information, check out [AIP-32](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-32%3A+Airflow+REST+API) or [reach out to us](https://support.astronomer.io).
+### What's new
+
+As of its momentous [2.0 release](https://www.astronomer.io/blog/introducing-airflow-2-0), the Apache Airflow project now supports an official and more robust Stable REST API. Among other things, Airflow's new REST API:
+
+* Makes for easy access by third-parties.
+* Is based on the [Swagger/OpenAPI Spec](https://swagger.io/specification/).
+* Implements CRUD (Create, Update, Delete) operations on *all* Airflow resources.
+* Includes authorization capabilities.
+
+> **Note:** To get started with Airflow 2.0 locally, read [Get Started with Apache Airflow 2.0](https://www.astronomer.io/guides/get-started-airflow-2). To upgrade an Airflow Deployment on Astronomer to 2.0, make sure you've first upgraded to both [Astronomer Enterprise v0.23](https://www.astronomer.io/docs/enterprise/v0.23/manage-astronomer/upgrade-to-0-23) and Airflow 1.10.14. For questions, reach out to [Astronomer Support](https://support.astronomer.io). 
+
+### Make a Request
+
+To convert a call from Airflow's experimental API, simply update the URL to use the endpoint specified in Airflow's [Stable REST API reference](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html).
+
+For example, take Airflow's "Get Current Configuration" endpoint:
+
+```
+GET /api/v1/config
+```
+
+Here, your cURL request would look like the following:
+
+```
+curl -X GET \
+https://<AIRFLOW-DOMAIN>/airflow/api/v1/config \
+-H 'Authorization: <API-Key>' \
+-H 'Cache-Control: no-cache'
+```
+
+To run this, replace:
+
+- `<AIRFLOW-DOMAIN>`: `https://<your-base-domain>/<deployment-release-name>`
+- `<API-Key>`: API Key from your Service Account

--- a/enterprise/v0.23/05_customize-airflow/07_airflow-api.md
+++ b/enterprise/v0.23/05_customize-airflow/07_airflow-api.md
@@ -86,9 +86,9 @@ https://<AIRFLOW-DOMAIN>/airflow/api/experimental/dags/<DAG-ID>/dag_runs
 -H ‘content-type: application/json’ -d ‘{}’
 ```
 
-To run this, replace:
+To run this, replace the following placeholder values:
 
-- `<AIRFLOW-DOMAIN>`: `https://<your-base-domain>/<deployment-release-name>`
+- `<AIRFLOW-DOMAIN>`: Use `https://<your-base-domain>/<deployment-release-name>`
 - `<DAG-ID>`: Name of your DAG (_case-sensitive_)
 - `<API-Key>`: API Key from your Service Account
 
@@ -107,7 +107,6 @@ The string needs to be in the following format (in UTC):
 ```
 
 Where, `YYYY`: Year, `MM`: Month, `DD`: Day, `HH`: Hour, `MM`: Minute, `SS`: Second.
-
 
 For example:
 
@@ -149,7 +148,7 @@ print(resp.json())
 >>>>  [{'description': 'Default pool', 'id': 1, 'pool': 'default_pool', 'slots': 128}]
 ```
 
-To run this, replace:
+To run this, replace the following placeholder values:
 
 - `<your-base-domain>`: Your Astronomer Enterprise base domain
 - `<API-Key>`: API Key from your Service Account
@@ -190,4 +189,4 @@ https://<AIRFLOW-DOMAIN>/airflow/api/v1/config \
 To run this, update the following placeholder values:
 
 - `<AIRFLOW-DOMAIN>`: Use `https://<your-base-domain>/<deployment-release-name>`
-- `<API-Key>`: Use the API Key from your Service Account
+- `<API-Key>`: API Key from your Service Account

--- a/enterprise/v0.23/05_customize-airflow/07_airflow-api.md
+++ b/enterprise/v0.23/05_customize-airflow/07_airflow-api.md
@@ -37,7 +37,7 @@ To create a Service Account via the Astronomer UI:
 
 ### Create a Service Account via the Astronomer CLI
 
-To create a Deployment-level Service account via the Astronomer CLI, follow the steps below.
+To create a Deployment-level Service Account via the Astronomer CLI:
 
 1. Authenticate to the Astronomer CLI by running:
    ```
@@ -187,7 +187,7 @@ https://<AIRFLOW-DOMAIN>/airflow/api/v1/config \
 -H 'Cache-Control: no-cache'
 ```
 
-To run this, replace:
+To run this, update the following placeholder values:
 
-- `<AIRFLOW-DOMAIN>`: `https://<your-base-domain>/<deployment-release-name>`
-- `<API-Key>`: API Key from your Service Account
+- `<AIRFLOW-DOMAIN>`: Use `https://<your-base-domain>/<deployment-release-name>`
+- `<API-Key>`: Use the API Key from your Service Account


### PR DESCRIPTION
Resolves: https://github.com/astronomer/docs/issues/248

This PR does a few things:
- Adds information to our existing "Airflow API" doc around Airflow's new REST API
- Reformats headers slightly to match our new "Step" framework and format

Based on feedback from customers + internal folks, and a popular forum post: https://forum.astronomer.io/t/can-i-use-the-airflow-rest-api-to-externally-trigger-a-dag/162/14