### PR TITLE
Updated link checker to limit 429 errors

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -12,3 +12,4 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://astronomer.io
+          cmd_params: "--rate-limit=1" # Limiting rate for requests to GitHub pages


### PR DESCRIPTION
Thanks to the work from @danielhoherd and the [Muffet](https://github.com/raviqqe/muffet/pull/154) team, we can now specify a rate limit for accessing links in our docs. This should result in less false flag 429 errors in our GH reports.

I referenced GitHub's docs to determine the rate limit. According to [this doc](https://docs.github.com/en/developers/apps/rate-limits-for-github-apps), the minimum rate limit for GH is 5,000 requests per hour (or about 1 request per second, which is the unit this flag uses).