### PR TITLE
Removed Python 3.8 from our compatibility charts

### DIFF
--- a/cloud/stable/02_develop/02_customize-image.md
+++ b/cloud/stable/02_develop/02_customize-image.md
@@ -346,3 +346,34 @@ Now, let's push your new image to Astronomer.
 - If you're pushing up to Astronomer, you're free to deploy by running `$ astro deploy` or by triggering your CI/CD pipeline
 
 For more detail on the Astronomer deployment process, refer to [Deploy to Astronomer via the CLI](/docs/cloud/stable/deploy/deploy-cli/).
+
+
+## Build with a Different Python Version
+
+While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3.7, and 3.8, AC Docker images have been tested and built only for Python 3.7.
+
+To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you need to create a custom version of the image, specify the `PYTHON_MAJOR_MINOR_VERSION` build argument, and push the custom image to an existing Docker registry. To do so:
+
+1. Using `docker build`, build a custom [Astronomer Certified Docker image](https://github.com/astronomer/ap-airflow) and specify `PYTHON_MAJOR_MINOR_VERSION` for the version of Python you'd like to support. For example, the command for building a custom Astronomer Certified image for Airflow 2.0.0 with Python 3.8 would look something like this:
+
+    ```sh
+    $ docker build --build-arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t <your-registry>/ap-airflow:<image-tag> https://github.com/astronomer/ap-airflow.git#master:2.0.0/buster
+    ```
+
+    We recommend using an image tag that indicates the image is using a different Python version, such as `2.0.0-buster-python3.8`.
+
+    > **Note:** To use a different version of Airflow, update the URL to point towards the desired Airflow version. For instance, if you're running Airflow 1.10.14, the GitHub URL here would be: `https://github.com/astronomer/ap-airflow.git#master:1.10.14/buster`
+
+2. Push the custom image to your Docker registry. Based on the example in the previous step, the command to do so would look something like this:
+
+    ```sh
+    $ docker push <your-registry>/ap-airflow:<image-tag>
+    ```
+
+3. Update the `FROM` line of your `Dockerfile` to reference the custom image. Based on the previous example, the line would read:
+
+    ```
+    FROM <your-registry>/ap-airflow:<image-tag>
+    ```
+
+> **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify `alpine3.10` instead of `buster` in the GitHub URL.

--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -362,4 +362,10 @@ To create a custom Astronomer Certified Docker image, with a different Python ve
     $ docker build --build arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t astronomer-certified:python3.8-2.0.0-buster
     ```
 
+4. Update the `FROM` line of your `Dockerfile` to reference the custom image. Based on the previous example, the line would read:
+
+    ```
+    FROM astronomer-certified:python3.8-2.0.0-buster
+    ```
+
 > **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify alpine3.10 instead of buster.

--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -346,17 +346,21 @@ Now, let's push your new image to Astronomer.
 
 For more detail on the Astronomer deployment process, refer to [Deploy to Astronomer via the CLI](/docs/enterprise/stable/deploy/deploy-cli/).
 
-## Change Python Versions
+## Build with a Different Python Version
 
-While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3.7, and 3.8, AC Docker images have been tested and built only for Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you need to create a custom version of the image, specify the `PYTHON_MAJOR_MINOR_VERSION` build argument, and push the custom image to an existing Docker registry. To do so:
+While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3.7, and 3.8, AC Docker images have been tested and built only for Python 3.7.
 
-To create a custom Astronomer Certified Docker image, with a different Python version, you can:
+To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you need to create a custom version of the image, specify the `PYTHON_MAJOR_MINOR_VERSION` build argument, and push the custom image to an existing Docker registry. To do so:
 
-1. Using `docker build`, rebuild an [Astronomer Certified Docker image](https://github.com/astronomer/ap-airflow#master:2.0.0/buster) and specify `PYTHON_MAJOR_MINOR_VERSION` for the version of Python you'd like to support. For example, the command for rebuilding the Astronomer Certified image for Airflow 2.0.0 with Python 3.8 would look something like this:
+1. Using `docker build`, build a custom [Astronomer Certified Docker image](https://github.com/astronomer/ap-airflow) and specify `PYTHON_MAJOR_MINOR_VERSION` for the version of Python you'd like to support. For example, the command for building a custom Astronomer Certified image for Airflow 2.0.0 with Python 3.8 would look something like this:
 
     ```sh
     $ docker build --build-arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t <your-registry>/ap-airflow:<image-tag> https://github.com/astronomer/ap-airflow.git#master:2.0.0/buster
     ```
+
+    We recommend using an image tag that indicates the image is using a different Python version, such as `2.0.0-buster-python3.8`.
+
+    > **Note:** To use a different version of Airflow, update the URL to point towards the desired Airflow version. For instance, if you're running Airflow 1.10.14, the GitHub URL here would be: `https://github.com/astronomer/ap-airflow.git#master:1.10.14/buster`
 
 2. Push the custom image to your Docker registry. Based on the example in the previous step, the command to do so would look something like this:
 
@@ -370,4 +374,4 @@ To create a custom Astronomer Certified Docker image, with a different Python ve
     FROM <your-registry>/ap-airflow:<image-tag>
     ```
 
-> **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify alpine3.10 instead of buster.
+> **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify `alpine3.10` instead of `buster` in the GitHub URL.

--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -355,19 +355,19 @@ To create a custom Astronomer Certified Docker image, with a different Python ve
 1. Using `docker build`, rebuild an [Astronomer Certified Docker image](https://github.com/astronomer/ap-airflow#master:2.0.0/buster) and specify `PYTHON_MAJOR_MINOR_VERSION` for the version of Python you'd like to support. For example, the command for rebuilding the Astronomer Certified image for Airflow 2.0.0 with Python 3.8 would look something like this:
 
     ```sh
-    $ docker build --build-arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t <your-registry>/ap-airflow:python-3.8_2.0.0_custom https://github.com/astronomer/ap-airflow.git#master:2.0.0/buster
+    $ docker build --build-arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t <your-registry>/ap-airflow:<image-tag> https://github.com/astronomer/ap-airflow.git#master:2.0.0/buster
     ```
 
 2. Push the custom image to your Docker registry. Based on the example in the previous step, the command to do so would look something like this:
 
     ```sh
-    $ docker push <your-registry>/ap-airflow:python-3.8_1.10.10_custom
+    $ docker push <your-registry>/ap-airflow:<image-tag>
     ```
 
 3. Update the `FROM` line of your `Dockerfile` to reference the custom image. Based on the previous example, the line would read:
 
     ```
-    FROM <your-registry>/ap-airflow:python-3.8_1.10.10_custom
+    FROM <your-registry>/ap-airflow:<image-tag>
     ```
 
 > **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify alpine3.10 instead of buster.

--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -348,12 +348,18 @@ For more detail on the Astronomer deployment process, refer to [Deploy to Astron
 
 ## Change Python Versions
 
-By default, Astronomer's Docker image has been tested and built only with Python 3.7. However, can also use Python version to 3.6 or 3.8 by specifying the `PYTHON_MAJOR_MINOR_VERSION` variable when building a custom version of the image.
+While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3.7, and 3.8, AC Docker images have been tested and built only for Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you need to create a custom version of the image and specify `PYTHON_MAJOR_MINOR_VERSION`. To do so:
 
-For example, running the following command would build your image with Python 3.6:
+To create a custom Astronomer Certified Docker image, with a different Python version, you can:
 
-```sh
-docker build --build arg PYTHON_MAJOR_MINOR_VERSION=3.6 -t astronomer-certified:python3.6-2.0.0-buster
-```
+1. Clone the [astronomer/ap-airflow GitHub repository](https://github.com/astronomer/ap-airflow).
 
-> **Note:** While Astronomer's Docker image is compatible with both Python 3.6 and 3.8, it has been tested only with 3.7.
+2. In your command line, open a directory in the repo that corresponds to the version of Apache Airflow you'd like to run. For example, the folder for Apache Airflow 2.0.0 would be `ap-airflow/2.0.0/buster/`.
+
+3. Run `$ docker build` with `PYTHON_MAJOR_MINOR_VERSION` specified for the version of Python you'd like to support. For example, the command for building the image with Python 3.8 would look something like this:
+
+    ```sh
+    $ docker build --build arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t astronomer-certified:python3.8-2.0.0-buster
+    ```
+
+> **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify alpine3.10 instead of buster.

--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -71,7 +71,7 @@ $ docker exec -it <scheduler-container-id> pip freeze | grep pymongo
 pymongo==3.7.2
 ```
 
-> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less incompatability issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/).
+> **Note:** Astronomer Certified, Astronomer's distribution of Apache Airflow, is available both as a Debian and Alpine base. We strongly recommend using Debian, as it's much easier to install dependencies and often presents less compatibility issues than an Alpine Linux image. For details on both, refer to our [Airflow Versioning Doc](/docs/enterprise/stable/customize-airflow/manage-airflow-versions/).
 
 ## Add Other Dependencies
 
@@ -126,7 +126,7 @@ For security reasons, the `airflow_settings.yaml` file is currently _only_ for l
 
 > **Note:** If you're interested in programmatically managing Airflow Connections, Variables or Environment Variables, we'd recommend integrating a ["Secret Backend"](/docs/enterprise/stable/customize-airflow/secrets-backend) to help you do so.
 
-### Add Airfow Connections, Pools, Variables
+### Add Airflow Connections, Pools, Variables
 
 By default, the `airflow_settings.yaml` file will be structured as following:
 
@@ -175,7 +175,7 @@ RUN ls
 
 ## Docker Compose Override
 
-The Astronomer CLI is built on top of [Docker Compose](https://docs.docker.com/compose/), a tool for defining and running multi-container Docker applications. If you're interested in overriding any of our CLI's default configurations ([found here](https://github.com/astronomer/astro-cli/blob/main/airflow/include/composeyml.go)), you're free to do so by adding a `docker-compose.override.yml` file to your Astronomer project directory. Any values in this file wil override default settings run upon every `$ astro dev start`.
+The Astronomer CLI is built on top of [Docker Compose](https://docs.docker.com/compose/), a tool for defining and running multi-container Docker applications. If you're interested in overriding any of our CLI's default configurations ([found here](https://github.com/astronomer/astro-cli/blob/main/airflow/include/composeyml.go)), you're free to do so by adding a `docker-compose.override.yml` file to your Astronomer project directory. Any values in this file will override default settings run upon every `$ astro dev start`.
 
 To add another volume mount for a directory named `custom_dependencies`, for example, add the following to your `docker-compose.override.yml`:
 
@@ -246,7 +246,7 @@ Read below for guidelines.
 ### Prerequisites
 
 - The Astronomer CLI
-- An intialized Astronomer Airflow project and corresponding directory
+- An initialized Astronomer Airflow project and corresponding directory
 - An [SSH Key](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to your Private GitHub repo
 
 If you haven't initialized an Airflow Project on Astronomer (by running `$ astro dev init`), reference our [CLI Quickstart Guide](/docs/enterprise/stable/develop/cli-quickstart/).

--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -352,20 +352,22 @@ While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3
 
 To create a custom Astronomer Certified Docker image, with a different Python version, you can:
 
-1. Clone the [astronomer/ap-airflow GitHub repository](https://github.com/astronomer/ap-airflow).
-
-2. In your command line, open a directory in the repo that corresponds to the version of Apache Airflow you'd like to run. For example, the folder for Apache Airflow 2.0.0 would be `ap-airflow/2.0.0/buster/`.
-
-3. Run `$ docker build` with `PYTHON_MAJOR_MINOR_VERSION` specified for the version of Python you'd like to support. For example, the command for building the image with Python 3.8 would look something like this:
+1. Using `docker build`, rebuild an [Astronomer Certified Docker image](https://github.com/astronomer/ap-airflow#master:2.0.0/buster) and specify `PYTHON_MAJOR_MINOR_VERSION` for the version of Python you'd like to support. For example, the command for rebuilding the Astronomer Certified image for Airflow 2.0.0 with Python 3.8 would look something like this:
 
     ```sh
-    $ docker build --build arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t astronomer-certified:python3.8-2.0.0-buster
+    $ docker build --build-arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t <your-registry>/ap-airflow:python-3.8_2.0.0_custom https://github.com/astronomer/ap-airflow.git#master:2.0.0/buster
     ```
 
-4. Update the `FROM` line of your `Dockerfile` to reference the custom image. Based on the previous example, the line would read:
+2. Push the custom image to your Docker registry. Based on the example in the previous step, the command to do so would look something like this:
+
+    ```sh
+    $ docker push <your-registry>/ap-airflow:python-3.8_1.10.10_custom
+    ```
+
+3. Update the `FROM` line of your `Dockerfile` to reference the custom image. Based on the previous example, the line would read:
 
     ```
-    FROM astronomer-certified:python3.8-2.0.0-buster
+    FROM <your-registry>/ap-airflow:python-3.8_1.10.10_custom
     ```
 
 > **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify alpine3.10 instead of buster.

--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -345,3 +345,15 @@ Now, let's push your new image to Astronomer.
 - If you're pushing up to Astronomer, you're free to deploy by running `$ astro deploy` or by triggering your CI/CD pipeline
 
 For more detail on the Astronomer deployment process, refer to [Deploy to Astronomer via the CLI](/docs/enterprise/stable/deploy/deploy-cli/).
+
+## Change Python Versions
+
+By default, Astronomer's Docker image has been tested and built only with Python 3.7. However, can also use Python version to 3.6 or 3.8 by specifying the `PYTHON_MAJOR_MINOR_VERSION` variable when building a custom version of the image.
+
+For example, running the following command would build your image with Python 3.6:
+
+```sh
+docker build --build arg PYTHON_MAJOR_MINOR_VERSION=3.6 -t astronomer-certified:python3.6-2.0.0-buster
+```
+
+> **Note:** While Astronomer's Docker image is compatible with both Python 3.6 and 3.8, it has been tested only with 3.7.

--- a/enterprise/next/02_develop/02_customize-image.md
+++ b/enterprise/next/02_develop/02_customize-image.md
@@ -348,7 +348,7 @@ For more detail on the Astronomer deployment process, refer to [Deploy to Astron
 
 ## Change Python Versions
 
-While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3.7, and 3.8, AC Docker images have been tested and built only for Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you need to create a custom version of the image and specify `PYTHON_MAJOR_MINOR_VERSION`. To do so:
+While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3.7, and 3.8, AC Docker images have been tested and built only for Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you need to create a custom version of the image, specify the `PYTHON_MAJOR_MINOR_VERSION` build argument, and push the custom image to an existing Docker registry. To do so:
 
 To create a custom Astronomer Certified Docker image, with a different Python version, you can:
 

--- a/enterprise/next/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/next/09_resources/03_version-compatibility-reference.md
@@ -14,8 +14,8 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 | Astronomer Platform  | Kubernetes       | Helm | Terraform   | Postgres | Astronomer Certified                             | Python        | Astronomer CLI |
 |----------------------|------------------|------|-------------|----------|--------------------------------------------------|---------------|----------------|
-| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5| 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7 | 0.16           |
-| v0.23                | 1.16, 1.17, 1.18 | 3    | 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7 | 0.23           |
+| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5| 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 | 0.16           |
+| v0.23                | 1.16, 1.17, 1.18 | 3    | 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 | 0.23           |
 
 > **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12, and Astronomer v0.16.15+ is required to run Astronomer Certified 1.10.14. For instructions on how to upgrade to an Astronomer v0.16 patch version, read [Upgrade to a Patch Version of Astronomer](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer-patch).
 
@@ -23,14 +23,16 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 | Astronomer Certified | Postgres | MySQL     | Python        | System Distribution             | Airflow Helm Chart |
 | -------------------- | -------- | --------- | ------------- | ------------------------------- | ------------------ |
-| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7 | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7 | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7 | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7 | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7 | Debian 10 (Buster)              | Any                |
-| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7 | Debian 10 (Buster)              | 0.18.6             |
+| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8| Alpine 3.10, Debian 10 (Buster) | Any                |
+| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                |
+| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                |
+| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                |
+| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6             |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/next/customize-airflow/manage-airflow-versions/).
+
+> **Note:** While Astronomer Certified is compatible with Python 3.6, 3.7, and 3.8, the Docker image is built and tested only with Python 3.7. To use a different version of Python, you need to specify that version when building a custom image. For more information, read [Change Python Versions](/docs/enterprise/next/customize-image#change-python-versions).
 
 > **Note:** MySQL 5.7 is compatible with Airflow and Astronomer Certified 2.0 but it does NOT support the ability to run more than 1 Scheduler and is not recommended. If you'd like to leverage Airflow's new Highly-Available Scheduler, make sure you're running MySQL 8.0+.
 

--- a/enterprise/next/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/next/09_resources/03_version-compatibility-reference.md
@@ -32,7 +32,7 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/next/customize-airflow/manage-airflow-versions/).
 
-> **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](/docs/enterprise/next/customize-image#change-python-versions).
+> **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](/docs/enterprise/stable/customize-image#change-python-versions).
 
 > **Note:** MySQL 5.7 is compatible with Airflow and Astronomer Certified 2.0 but it does NOT support the ability to run more than 1 Scheduler and is not recommended. If you'd like to leverage Airflow's new Highly-Available Scheduler, make sure you're running MySQL 8.0+.
 

--- a/enterprise/next/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/next/09_resources/03_version-compatibility-reference.md
@@ -32,7 +32,7 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/next/customize-airflow/manage-airflow-versions/).
 
-> **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](/docs/enterprise/stable/customize-image#change-python-versions).
+> **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](/docs/enterprise/stable/customize-image#build-with-a-different-python-version).
 
 > **Note:** MySQL 5.7 is compatible with Airflow and Astronomer Certified 2.0 but it does NOT support the ability to run more than 1 Scheduler and is not recommended. If you'd like to leverage Airflow's new Highly-Available Scheduler, make sure you're running MySQL 8.0+.
 

--- a/enterprise/next/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/next/09_resources/03_version-compatibility-reference.md
@@ -32,7 +32,7 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/next/customize-airflow/manage-airflow-versions/).
 
-> **Note:** While Astronomer Certified is compatible with Python 3.6, 3.7, and 3.8, the Docker image is built and tested only with Python 3.7. To use a different version of Python, you need to specify that version when building a custom image. For more information, read [Change Python Versions](/docs/enterprise/next/customize-image#change-python-versions).
+> **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](/docs/enterprise/next/customize-image#change-python-versions).
 
 > **Note:** MySQL 5.7 is compatible with Airflow and Astronomer Certified 2.0 but it does NOT support the ability to run more than 1 Scheduler and is not recommended. If you'd like to leverage Airflow's new Highly-Available Scheduler, make sure you're running MySQL 8.0+.
 

--- a/enterprise/next/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/next/09_resources/03_version-compatibility-reference.md
@@ -14,8 +14,8 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 | Astronomer Platform  | Kubernetes       | Helm | Terraform   | Postgres | Astronomer Certified                             | Python        | Astronomer CLI |
 |----------------------|------------------|------|-------------|----------|--------------------------------------------------|---------------|----------------|
-| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5| 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7, 3.8 | 0.16           |
-| v0.23                | 1.16, 1.17, 1.18 | 3    | 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7, 3.8 | 0.23           |
+| v0.16                | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5| 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14        | 3.6, 3.7 | 0.16           |
+| v0.23                | 1.16, 1.17, 1.18 | 3    | 0.13.5      | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 2.0.0 | 3.6, 3.7 | 0.23           |
 
 > **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12, and Astronomer v0.16.15+ is required to run Astronomer Certified 1.10.14. For instructions on how to upgrade to an Astronomer v0.16 patch version, read [Upgrade to a Patch Version of Astronomer](https://www.astronomer.io/docs/enterprise/v0.16/manage-astronomer/upgrade-astronomer-patch).
 
@@ -23,12 +23,12 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 | Astronomer Certified | Postgres | MySQL     | Python        | System Distribution             | Airflow Helm Chart |
 | -------------------- | -------- | --------- | ------------- | ------------------------------- | ------------------ |
-| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                |
-| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6             |
+| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7 | Alpine 3.10, Debian 10 (Buster) | Any                |
+| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7 | Alpine 3.10, Debian 10 (Buster) | Any                |
+| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7 | Alpine 3.10, Debian 10 (Buster) | Any                |
+| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7 | Alpine 3.10, Debian 10 (Buster) | Any                |
+| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7 | Debian 10 (Buster)              | Any                |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7 | Debian 10 (Buster)              | 0.18.6             |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/next/customize-airflow/manage-airflow-versions/).
 

--- a/enterprise/v0.15/02_develop/02_customize-image.md
+++ b/enterprise/v0.15/02_develop/02_customize-image.md
@@ -348,3 +348,33 @@ Now, let's push your new image to Astronomer.
 - If you're pushing up to Astronomer, you're free to deploy by running `$ astro deploy` or by triggering your CI/CD pipeline
 
 For more detail on the Astronomer deployment process, refer to our [Code Deployment doc](/docs/enterprise/v0.15/deploy/deploy-code/).
+
+## Build with a Different Python Version
+
+While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3.7, and 3.8, AC Docker images have been tested and built only for Python 3.7.
+
+To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you need to create a custom version of the image, specify the `PYTHON_MAJOR_MINOR_VERSION` build argument, and push the custom image to an existing Docker registry. To do so:
+
+1. Using `docker build`, build a custom [Astronomer Certified Docker image](https://github.com/astronomer/ap-airflow) and specify `PYTHON_MAJOR_MINOR_VERSION` for the version of Python you'd like to support. For example, the command for building a custom Astronomer Certified image for Airflow 1.10.10 with Python 3.8 would look something like this:
+
+    ```sh
+    $ docker build --build-arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t <your-registry>/ap-airflow:<image-tag> https://github.com/astronomer/ap-airflow.git#master:1.10.10/buster
+    ```
+
+    We recommend using an image tag that indicates the image is using a different Python version, such as `1.10.10-buster-python3.8`.
+
+    > **Note:** To use a different version of Airflow, update the URL to point towards the desired Airflow version. For instance, if you're running Airflow 1.10.14, the GitHub URL here would be: `https://github.com/astronomer/ap-airflow.git#master:1.10.14/buster`
+
+2. Push the custom image to your Docker registry. Based on the example in the previous step, the command to do so would look something like this:
+
+    ```sh
+    $ docker push <your-registry>/ap-airflow:<image-tag>
+    ```
+
+3. Update the `FROM` line of your `Dockerfile` to reference the custom image. Based on the previous example, the line would read:
+
+    ```
+    FROM <your-registry>/ap-airflow:<image-tag>
+    ```
+
+> **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify `alpine3.10` instead of `buster` in the GitHub URL.

--- a/enterprise/v0.16/02_develop/02_customize-image.md
+++ b/enterprise/v0.16/02_develop/02_customize-image.md
@@ -348,3 +348,33 @@ Now, let's push your new image to Astronomer.
 - If you're pushing up to Astronomer, you're free to deploy by running `$ astro deploy` or by triggering your CI/CD pipeline
 
 For more detail on the Astronomer deployment process, refer to our [Code Deployment doc](/docs/enterprise/v0.16/deploy/deploy-code/).
+
+## Build with a Different Python Version
+
+While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3.7, and 3.8, AC Docker images have been tested and built only for Python 3.7.
+
+To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you need to create a custom version of the image, specify the `PYTHON_MAJOR_MINOR_VERSION` build argument, and push the custom image to an existing Docker registry. To do so:
+
+1. Using `docker build`, build a custom [Astronomer Certified Docker image](https://github.com/astronomer/ap-airflow) and specify `PYTHON_MAJOR_MINOR_VERSION` for the version of Python you'd like to support. For example, the command for building a custom Astronomer Certified image for Airflow 1.10.10 with Python 3.8 would look something like this:
+
+    ```sh
+    $ docker build --build-arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t <your-registry>/ap-airflow:<image-tag> https://github.com/astronomer/ap-airflow.git#master:1.10.10/buster
+    ```
+
+    We recommend using an image tag that indicates the image is using a different Python version, such as `1.10.10-buster-python3.8`.
+
+    > **Note:** To use a different version of Airflow, update the URL to point towards the desired Airflow version. For instance, if you're running Airflow 1.10.14, the GitHub URL here would be: `https://github.com/astronomer/ap-airflow.git#master:1.10.14/buster`
+
+2. Push the custom image to your Docker registry. Based on the example in the previous step, the command to do so would look something like this:
+
+    ```sh
+    $ docker push <your-registry>/ap-airflow:<image-tag>
+    ```
+
+3. Update the `FROM` line of your `Dockerfile` to reference the custom image. Based on the previous example, the line would read:
+
+    ```
+    FROM <your-registry>/ap-airflow:<image-tag>
+    ```
+
+> **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify `alpine3.10` instead of `buster` in the GitHub URL.

--- a/enterprise/v0.16/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/v0.16/09_resources/03_version-compatibility-reference.md
@@ -32,7 +32,7 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/).
 
-> **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](/docs/enterprise/v0.16/customize-image#change-python-versions).
+> **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](/docs/enterprise/v0.16/customize-image#build-with-a-different-python-version).
 
 > **Note:** MySQL 5.7 is compatible with Airflow and Astronomer Certified 2.0 but it does NOT support the ability to run more than 1 Scheduler and is not recommended. If you'd like to leverage Airflow's new Highly-Available Scheduler, make sure you're running MySQL 8.0+.
 

--- a/enterprise/v0.16/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/v0.16/09_resources/03_version-compatibility-reference.md
@@ -32,6 +32,8 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/v0.16/customize-airflow/manage-airflow-versions/).
 
+> **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](/docs/enterprise/v0.16/customize-image#change-python-versions).
+
 > **Note:** MySQL 5.7 is compatible with Airflow and Astronomer Certified 2.0 but it does NOT support the ability to run more than 1 Scheduler and is not recommended. If you'd like to leverage Airflow's new Highly-Available Scheduler, make sure you're running MySQL 8.0+.
 
 ## Additional Resources

--- a/enterprise/v0.23/02_develop/02_customize-image.md
+++ b/enterprise/v0.23/02_develop/02_customize-image.md
@@ -344,3 +344,33 @@ Now, let's push your new image to Astronomer.
 - If you're pushing up to Astronomer, you're free to deploy by running `$ astro deploy` or by triggering your CI/CD pipeline
 
 For more detail on the Astronomer deployment process, refer to [Deploy to Astronomer via the CLI](/docs/enterprise/v0.23/deploy/deploy-cli/).
+
+## Build with a Different Python Version
+
+While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3.7, and 3.8, AC Docker images have been tested and built only for Python 3.7.
+
+To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you need to create a custom version of the image, specify the `PYTHON_MAJOR_MINOR_VERSION` build argument, and push the custom image to an existing Docker registry. To do so:
+
+1. Using `docker build`, build a custom [Astronomer Certified Docker image](https://github.com/astronomer/ap-airflow) and specify `PYTHON_MAJOR_MINOR_VERSION` for the version of Python you'd like to support. For example, the command for building a custom Astronomer Certified image for Airflow 2.0.0 with Python 3.8 would look something like this:
+
+    ```sh
+    $ docker build --build-arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t <your-registry>/ap-airflow:<image-tag> https://github.com/astronomer/ap-airflow.git#master:2.0.0/buster
+    ```
+
+    We recommend using an image tag that indicates the image is using a different Python version, such as `2.0.0-buster-python3.8`.
+
+    > **Note:** To use a different version of Airflow, update the URL to point towards the desired Airflow version. For instance, if you're running Airflow 1.10.14, the GitHub URL here would be: `https://github.com/astronomer/ap-airflow.git#master:1.10.14/buster`
+
+2. Push the custom image to your Docker registry. Based on the example in the previous step, the command to do so would look something like this:
+
+    ```sh
+    $ docker push <your-registry>/ap-airflow:<image-tag>
+    ```
+
+3. Update the `FROM` line of your `Dockerfile` to reference the custom image. Based on the previous example, the line would read:
+
+    ```
+    FROM <your-registry>/ap-airflow:<image-tag>
+    ```
+
+> **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify `alpine3.10` instead of `buster` in the GitHub URL.

--- a/enterprise/v0.23/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/v0.23/09_resources/03_version-compatibility-reference.md
@@ -32,6 +32,8 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/v0.23/customize-airflow/manage-airflow-versions/).
 
+> **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](/docs/enterprise/v0.23/customize-image#change-python-versions).
+
 > **Note:** MySQL 5.7 is compatible with Airflow and Astronomer Certified 2.0 but it does NOT support the ability to run more than 1 Scheduler and is not recommended. If you'd like to leverage Airflow's new Highly-Available Scheduler, make sure you're running MySQL 8.0+.
 
 ## Additional Resources

--- a/enterprise/v0.23/09_resources/03_version-compatibility-reference.md
+++ b/enterprise/v0.23/09_resources/03_version-compatibility-reference.md
@@ -32,7 +32,7 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/v0.23/customize-airflow/manage-airflow-versions/).
 
-> **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](/docs/enterprise/v0.23/customize-image#change-python-versions).
+> **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](/docs/enterprise/v0.23/customize-image#build-with-a-different-python-version).
 
 > **Note:** MySQL 5.7 is compatible with Airflow and Astronomer Certified 2.0 but it does NOT support the ability to run more than 1 Scheduler and is not recommended. If you'd like to leverage Airflow's new Highly-Available Scheduler, make sure you're running MySQL 8.0+.
 


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/271.

Per a Slack discussion last week with @krisdock , it sounds like we don't properly support Python 3.8 yet for AC images (and Enterprise by extension, I assume?)

Because of that, I've removed Python 3.8 from our version compatibility chart. If this looks good, I'll add it to other docsets as well. 

