### PR TITLE
Created a guide for deploying DAGs on Airflow using Astronomer Core

### DIFF
--- a/ac/next/04_deploy-dags.md
+++ b/ac/next/04_deploy-dags.md
@@ -88,20 +88,20 @@ Then, for every time that you update a DAG:
 1. Build the Docker image using the following command:
 
     ```sh
-    docker build -t path/to/file/docker-airflow:<your-image-tag>
+    docker build -t /path/to/file/docker-airflow:<your-image-tag>
     ```
 
 2. Push the Dockerfile to your registry with the following command:
 
     ```sh
-    docker push path/to/file/docker-airflow:<your-image-tag>
+    docker push /path/to/file/docker-airflow:<your-image-tag>
     ```
 
 3. Upgrade your Helm release using the following command:
 
     ```sh
     helm upgrade <your-release-name> . \
-    --set images.airflow.repository=path/to/file/docker-airflow \
+    --set images.airflow.repository=/path/to/file/docker-airflow \
     --set images.airflow.tag=<your-image-tag>
     ```
 

--- a/ac/next/04_deploy-dags.md
+++ b/ac/next/04_deploy-dags.md
@@ -6,7 +6,7 @@ description: "Use automation tools to continuously deploy DAGs at production sca
 
 ## Overview
 
-When running Airflow at production scale, every machine running Airflow needs a copy of your DAG files. In addition, these DAG files all need to appear in the same folder. This guide will cover two popular methods for deploying DAGs across your machines:
+When running Airflow at production scale, every machine running Airflow needs a copy of your DAG files. In addition, these DAG files all need to appear in the same directory. This guide will cover two popular methods for deploying DAGs across your machines:
 
 - Using a cron job to regularly pull DAGs into your local directories from a central Git repository.
 - Adding DAGs directly to a Docker image and rebuilding the image whenever DAGs are updated. Note that this method works only for users running Airflow on Kubernetes.

--- a/ac/next/04_deploy-dags.md
+++ b/ac/next/04_deploy-dags.md
@@ -1,13 +1,13 @@
 ---
-title: "Deploy DAGs in a Production Environment"
+title: "Deploy DAGs to Airflow"
 navTitle: "Deploy DAGs"
-description: "Use open source automation tools to ensure that DAGs are accurately updated across all of your machines. ."
+description: "Use automation tools to continuously deploy DAGs at production scale."
 ---
 
-Every machine running Airflow needs a copy of your DAG files, and these DAG files all need to appear in the same DAG folder. While there are many ways to make this happen, this guide will cover two of the most popular and recommended methods for deploying DAGs across your machines:
+When running Airflow at production scale, every machine running Airflow needs a copy of your DAG files. In addition, these DAG files all need to appear in the same folder. This guide will cover two popular methods for deploying DAGs across your machines:
 
-- Use a cron job to regularly pull DAGs into your local directories from a central Git repository.
-- Add DAGs directly to the AC Docker image and rebuild the image whenever DAGs are updated. Note that this method works only for users running Airflow on Kubernetes.
+- Using a cron job to regularly pull DAGs into your local directories from a central Git repository.
+- Adding DAGs directly to a Docker image and rebuilding the image whenever DAGs are updated. Note that this method works only for users running Airflow on Kubernetes.
 
 
 ## Automate DAG Deployment with a Cron Job

--- a/ac/next/04_deploy-dags.md
+++ b/ac/next/04_deploy-dags.md
@@ -4,6 +4,8 @@ navTitle: "Deploy DAGs"
 description: "Use automation tools to continuously deploy DAGs at production scale."
 ---
 
+## Overview
+
 When running Airflow at production scale, every machine running Airflow needs a copy of your DAG files. In addition, these DAG files all need to appear in the same folder. This guide will cover two popular methods for deploying DAGs across your machines:
 
 - Using a cron job to regularly pull DAGs into your local directories from a central Git repository.
@@ -41,7 +43,7 @@ If you run Airflow in Docker, you can deploy DAGs via the [Astronomer Core Helm 
 1. Create a Helm repository using the following command:
 
     ```sh
-    $ helm repo add astronomer https://helm.astronomer.io
+    helm repo add astronomer https://helm.astronomer.io
     ```
 
 2. Install the Helm chart using the following command:

--- a/ac/next/04_deploy-dags.md
+++ b/ac/next/04_deploy-dags.md
@@ -17,8 +17,7 @@ If you installed Airflow on a VM, you can use a cron job and an open source file
 
 - Installed Airflow via the Astronomer Core Python wheel according to [Install Apache Airflow on a Virtual Machine].
 - Host your DAGs in a Git repository.
-- Have a system user named `airflow`.
-- Have [incron](https://github.com/sschober/kqwait) installed on all machines running Airflow.
+- Have [incron](https://github.com/ar-/incron) installed on all machines running Airflow.
 - Are using a Debian-based OS.
 
 For each of your machines running Airflow:

--- a/ac/next/04_deploy-dags.md
+++ b/ac/next/04_deploy-dags.md
@@ -11,7 +11,6 @@ Whether you're running Airflow on virtual machines or in Docker, every node in y
 - Using a cron job to regularly pull DAGs into your local directories from a central Git repository.
 - Adding DAGs directly to a Docker image and rebuilding the image whenever DAGs are updated. To implement this method, Kubernetes is required.
 
-
 ## Deploy DAGs to Multiple Machines via Cron Job
 
 If you installed Airflow on a virtual machine, you can use a simple cron job, as well as open source file detection tools like `incron`, to pull new DAGs onto your Airflow machines on a regular basis and restart Airflow when necessary. This setup assumes that you:

--- a/ac/next/04_deploy-dags.md
+++ b/ac/next/04_deploy-dags.md
@@ -1,0 +1,89 @@
+---
+title: "Deploy DAGs in a Production Environment"
+navTitle: "Deploy DAGs"
+description: "Use open source automation tools to ensure that DAGs are accurately updated across all of your machines. ."
+---
+
+Every machine running Airflow needs a copy of your DAG files, and these DAG files all need to appear in the same DAG folder. While there are many ways to make this happen, this guide will cover two of the most popular and recommended methods for deploying DAGs across your machines:
+
+- Use a cron job to regularly pull DAGs into your local directories from a central Git repository.
+- Add DAGs directly to the AC Docker image and rebuild the image whenever DAGs are updated. Note that this method works only for users running Airflow on Kubernetes.
+
+
+## Automate DAG Deployment with a Cron Job
+
+We recommend using an automation tool to continuously pull new or updated DAGs to your Airflow machines. If you host your DAGs in a Git repository, you can use a cron job to pull new DAGs onto your machines on a regular basis. For each of your machines running Airflow:
+
+1. Open your DAGs directory and ensure that the folder is empty. If you followed the Installing at Production Scale guide, this folder would be `/usr/local/airflow`.
+
+2. Clone your DAG repository into the folder using `$ git clone`.
+
+3. As your `airflow` system user, run `crontab -e`.
+
+4. Create a cron job that continuously pulls from the DAG repository. For example, if you want to pull to the `/usr/local/airflow` folder every 3 minutes, your cron job would look something like this:
+
+    ```
+    * */3 * * * cd /usr/local/airflow && git pull
+    ```
+
+Once you have this simple cron job in place, you can modify it to run on a per-merge basis using automation tools such as [Ansible](https://docs.ansible.com/ansible/latest/user_guide/index.html).
+
+## Deploy DAGs on Kubernetes via Helm Chart
+
+If you run Airflow in Docker, you can deploy DAGs via the [Astronomer Core Helm chart](https://github.com/astronomer/airflow-chart). This is also known as "baking in" DAGs because you're adding DAGs to the image itself.  To use this method, you'll need:
+
+- A Dockerfile that pulls Astronomer Core's [Docker image](https://hub.docker.com/r/astronomerinc/ap-airflow).
+- A Kubernetes deployment.
+- The kubectl command line tool.
+- Helm.
+- A Docker registry.
+
+1. Create a Helm repository using the following command:
+
+    ```sh
+    $ helm repo add astronomer https://helm.astronomer.io
+    ```
+
+2. Install the Helm chart using the following command:
+
+    ```sh
+    $ helm install --name <your-release-name>
+    ```
+
+    To find your release name for Airflow, you can run:
+
+    ```sh
+    kubectl get ns
+    ```
+
+3. Edit your Dockerfile with the following minimum lines:
+
+    ```
+    FROM quay.io/astronomer/ap-airflow:latest-onbuild
+
+    COPY <your-dag-directory> ~astro/airflow-venv
+    ```
+
+4. Build the Docker image using the following command:
+
+    ```sh
+    docker build -t <filepath>/ap-airflow:<your-image-tag>
+    ```
+
+5. Push the Dockerfile to your registry with the following command:
+
+    ```sh
+    docker push <filepath>/ap-airflow:<your-image-tag>
+    ```
+
+6. Upgrade your image using the following Helm command:
+
+    ```sh
+    helm upgrade <your-release-name> . \
+    --set images.airflow.repository=<filepath>/ap-airflow \
+    --set images.airflow.tag=<your-image-tag>
+    ```
+
+With this method, you no longer need to store your DAG folder on each individual machine running Airflow. While baking DAGs into an image is a great way to keep all of the code for your project running in one place, it can be labor-intensive to rebuild your image each time you update a DAG.
+
+As a next step, we recommend hosting your DAG folder in a Git repository and implementing a CI/CD tool to automatically rebuild your image whenever code is pushed or merged to the repository.  

--- a/ac/next/04_deploy-dags.md
+++ b/ac/next/04_deploy-dags.md
@@ -50,6 +50,7 @@ If you run Airflow in Docker, you can deploy DAGs via the [Astronomer Core Helm 
 - A Dockerfile that pulls Astronomer Core's [Docker image](https://hub.docker.com/r/astronomerinc/ap-airflow)
 - A Kubernetes Cluster
 - The [Kubernetes CLI (kubectl)](https://kubernetes.io/docs/tasks/tools/)
+- The Astronomer CLI
 - Helm
 - A Docker registry
 
@@ -101,6 +102,8 @@ If you run Airflow in Docker, you can deploy DAGs via the [Astronomer Core Helm 
     --set images.airflow.repository=etc/ap-airflow \
     --set images.airflow.tag=<your-image-tag>
     ```
+
+7. `cd` to your Airflow project folder and run `astro dev stop && astro dev start` to restart your Airflow services.
 
 With this method, you no longer need to store your DAG folder on each individual machine running Airflow. While baking DAGs into an image is a great way to keep all of the code for your project running in one place, it can be labor-intensive to rebuild your image each time you update a DAG.
 

--- a/ac/next/04_deploy-dags.md
+++ b/ac/next/04_deploy-dags.md
@@ -15,7 +15,7 @@ Whether you're running Apache Airflow on a virtual machine (VM) and/or within a 
 
 If you installed Airflow on a VM, you can use a cron job and an open source file detection tool like `incron` to regularly deploy new DAGs to your Airflow instance. This setup assumes that you:
 
-- Installed Airflow via the Astronomer Core Python wheel according to [Install Apache Airflow on a Virtual Machine].
+- Manage your Airflow services using Systemd as described in [Install Apache Airflow on a Virtual Machine].
 - Host your DAGs in a Git repository.
 - Have [incron](https://github.com/ar-/incron) installed on all machines running Airflow.
 - Are using a Debian-based OS.

--- a/ac/next/04_deploy-dags.md
+++ b/ac/next/04_deploy-dags.md
@@ -1,12 +1,12 @@
 ---
 title: "Deploy DAGs to Airflow"
 navTitle: "Deploy DAGs"
-description: "Use automation tools to continuously deploy DAGs at production scale."
+description: "Use automation tools to continuously deploy DAGs on both virtual machines and Docker."
 ---
 
 ## Overview
 
-When deploying Airflow at production scale, anything running Airflow, such as a virtual machine or a Docker image, needs a copy of your DAG files. In addition, these DAG files all need to appear in the same directory. This guide will cover two popular methods for deploying DAGs across your machines:
+Whether you're running Airflow on virtual machines or in Docker, every node in your Airflow cluster needs a copy of your DAG files. In addition, these DAG files all need to appear in the same directory. This guide will cover two popular methods for deploying DAGs across your machines:
 
 - Using a cron job to regularly pull DAGs into your local directories from a central Git repository.
 - Adding DAGs directly to a Docker image and rebuilding the image whenever DAGs are updated. To implement this method, Kubernetes is required.
@@ -14,7 +14,7 @@ When deploying Airflow at production scale, anything running Airflow, such as a 
 
 ## Deploy DAGs to Multiple Machines via Cron Job
 
-If you host your DAGs in a Git repository, you can use a simple cron job, as well as open source file detection tools like `incron` to pull new DAGs onto your Airflow machines on a regular basis and restart Airflow when necessary. This setup assumes that you:
+If you installed Airflow on a virtual machine, you can use a simple cron job, as well as open source file detection tools like `incron`, to pull new DAGs onto your Airflow machines on a regular basis and restart Airflow when necessary. This setup assumes that you:
 
 - Installed Airflow via Python wheel according to [Installing at Production Scale].
 - Host your DAGs in a Git repository.

--- a/ac/next/04_deploy-dags.md
+++ b/ac/next/04_deploy-dags.md
@@ -15,7 +15,7 @@ Whether you're running Apache Airflow on a virtual machine (VM) and/or within a 
 
 If you installed Airflow on a VM, you can use a cron job and an open source file detection tool like `incron` to regularly deploy new DAGs to your Airflow instance. This setup assumes that you:
 
-- Manage your Airflow services using Systemd as described in [Install Apache Airflow on a Virtual Machine].
+- Manage your Airflow services using [systemd](https://systemd.io/) as described in [Install Apache Airflow on a Virtual Machine].
 - Host your DAGs in a Git repository.
 - Have [incron](https://github.com/ar-/incron) installed on all machines running Airflow.
 - Are using a Debian-based OS.

--- a/ac/next/04_deploy-dags.md
+++ b/ac/next/04_deploy-dags.md
@@ -6,39 +6,52 @@ description: "Use automation tools to continuously deploy DAGs at production sca
 
 ## Overview
 
-When running Airflow at production scale, every machine running Airflow needs a copy of your DAG files. In addition, these DAG files all need to appear in the same directory. This guide will cover two popular methods for deploying DAGs across your machines:
+When deploying Airflow at production scale, anything running Airflow, such as a virtual machine or a Docker image, needs a copy of your DAG files. In addition, these DAG files all need to appear in the same directory. This guide will cover two popular methods for deploying DAGs across your machines:
 
 - Using a cron job to regularly pull DAGs into your local directories from a central Git repository.
-- Adding DAGs directly to a Docker image and rebuilding the image whenever DAGs are updated. Note that this method works only for users running Airflow on Kubernetes.
+- Adding DAGs directly to a Docker image and rebuilding the image whenever DAGs are updated. To implement this method, Kubernetes is required.
 
 
-## Automate DAG Deployment with a Cron Job
+## Deploy DAGs to Multiple Machines via Cron Job
 
-We recommend using an automation tool to continuously pull new or updated DAGs to your Airflow machines. If you host your DAGs in a Git repository, you can use a cron job to pull new DAGs onto your machines on a regular basis. For each of your machines running Airflow:
+If you host your DAGs in a Git repository, you can use a simple cron job, as well as open source file detection tools like `incron` to pull new DAGs onto your Airflow machines on a regular basis and restart Airflow when necessary. This setup assumes that you:
+
+- Installed Airflow via Python wheel according to [Installing at Production Scale].
+- Host your DAGs in a Git repository.
+- Have a system user named `airflow`.
+- Have [incron](https://github.com/sschober/kqwait) installed on all machines running Airflow.
+- Are using a Debian-like OS.
+
+For each of your machines running Airflow:
 
 1. Open your DAGs directory and ensure that the folder is empty. If you followed the Installing at Production Scale guide, this folder would be `/usr/local/airflow`.
 
-2. Clone your DAG repository into the folder using `$ git clone`.
+2. Clone the Git repository holding your DAGs into the folder using `$ git clone`.
 
-3. As your `airflow` system user, run `crontab -e`.
+3. As your `airflow` system user, run `crontab -e` to create a new cron job. You can specify an editor using the `EDITOR` environment variable (e.g. `env EDITOR=atom crontab -e`).
 
 4. Create a cron job that continuously pulls from the DAG repository. For example, if you want to pull to the `/usr/local/airflow` folder every 3 minutes, your cron job would look something like this:
 
     ```
     * */3 * * * cd /usr/local/airflow && git pull
+    /usr/local/airflow IN_MODIFY systemctl restart airflow
     ```
 
-Once you have this simple cron job in place, you can modify it to run on a per-merge basis using automation tools such as [Ansible](https://docs.ansible.com/ansible/latest/user_guide/index.html).
+    This cron job first pulls from a Git repository, then checks to see if any files in the repository have been modified since the last pull. If a file was modified, the cron job restarts Airflow so that the updated DAGs are successfully deployed.
+
+5. Run `systemctl start incron.service` to begin monitoring the DAG directory for changes.
+
+Once you have this simple cron job saved, you can scale it and use tools such as [Ansible](https://docs.ansible.com/ansible/latest/user_guide/index.html) to integrate into a larger CI/CD workflow. If you are running MacOS, you can complete a similar setup using [kqwait](https://github.com/sschober/kqwait).
 
 ## Deploy DAGs on Kubernetes via Helm Chart
 
 If you run Airflow in Docker, you can deploy DAGs via the [Astronomer Core Helm chart](https://github.com/astronomer/airflow-chart). This is also known as "baking in" DAGs because you're adding DAGs to the image itself.  To use this method, you'll need:
 
-- A Dockerfile that pulls Astronomer Core's [Docker image](https://hub.docker.com/r/astronomerinc/ap-airflow).
-- A Kubernetes deployment.
-- The kubectl command line tool.
-- Helm.
-- A Docker registry.
+- A Dockerfile that pulls Astronomer Core's [Docker image](https://hub.docker.com/r/astronomerinc/ap-airflow)
+- A Kubernetes Cluster
+- The [Kubernetes CLI (kubectl)](https://kubernetes.io/docs/tasks/tools/)
+- Helm
+- A Docker registry
 
 1. Create a Helm repository using the following command:
 
@@ -61,6 +74,7 @@ If you run Airflow in Docker, you can deploy DAGs via the [Astronomer Core Helm 
 3. Edit your Dockerfile with the following minimum lines:
 
     ```
+    # Use a different tag to run a different version of Airflow
     FROM quay.io/astronomer/ap-airflow:latest-onbuild
 
     COPY <your-dag-directory> ~astro/airflow-venv
@@ -72,17 +86,19 @@ If you run Airflow in Docker, you can deploy DAGs via the [Astronomer Core Helm 
     docker build -t <filepath>/ap-airflow:<your-image-tag>
     ```
 
+    As a best practice, the image tag you specify here should indicate which version of Airflow you're using.
+
 5. Push the Dockerfile to your registry with the following command:
 
     ```sh
-    docker push <filepath>/ap-airflow:<your-image-tag>
+    docker push etc/ap-airflow:<your-image-tag>
     ```
 
 6. Upgrade your image using the following Helm command:
 
     ```sh
     helm upgrade <your-release-name> . \
-    --set images.airflow.repository=<filepath>/ap-airflow \
+    --set images.airflow.repository=etc/ap-airflow \
     --set images.airflow.tag=<your-image-tag>
     ```
 

--- a/ac/next/04_deploy-dags.md
+++ b/ac/next/04_deploy-dags.md
@@ -26,7 +26,7 @@ For each of your machines running Airflow:
 
 1. Open your DAGs directory and ensure that the folder is empty. If you followed the Installing at Production Scale guide, this folder would be `/usr/local/airflow`.
 
-2. Clone the Git repository holding your DAGs into the folder using `$ git clone`.
+2. Clone the Git repository holding your DAGs into the folder using `git clone`.
 
 3. As your `airflow` system user, run `crontab -e` to create a new cron job. You can specify an editor using the `EDITOR` environment variable (e.g. `env EDITOR=atom crontab -e`).
 
@@ -63,7 +63,7 @@ If you run Airflow in Docker, you can deploy DAGs via the [Astronomer Core Helm 
 2. Install the Helm chart using the following command:
 
     ```sh
-    $ helm install --name <your-release-name>
+    helm install --name <your-release-name>
     ```
 
     To find your release name for Airflow, you can run:


### PR DESCRIPTION
This guide is one of the key components of our "Getting started" series for Astronomer Core. Essentially, we want to provide some basic guidelines for deploying DAGs at production scale. 

I wanted to give a sense of how to do this without being overly prescriptive. To do that, I gave instructions for the essential actions you need to complete, but leave it up to the reader to implement any automation tools they might want to use going forward. 