### PR TITLE
Created a new guide for installing packages on AC

### DIFF
--- a/ac/next/install-dependencies.md
+++ b/ac/next/install-dependencies.md
@@ -6,7 +6,7 @@ description: "Learn how to install OS-level and Python-level packages on Airflow
 
 ## Overview
 
-By default, the Astronomer Core (AC) Airflow image includes several provider packages in order to better integrate between popular applications. For a full list of built in packages, read [Astronomer Core Image Architecture].
+By default, the Astronomer Core distribution of Airflow is built with a collection of pre-installed provider packages to help users integrate with popular applications. For the full list of built-in packages, read [Astronomer Core Image Architecture].
 
 If you require additional dependencies to run your DAGs, you can either install those packages onto your local machines or build them into a Docker image.
 
@@ -15,18 +15,16 @@ If you require additional dependencies to run your DAGs, you can either install 
 To build Python and OS-level packages into a machine running Airflow, run the following command:
 
 ```sh
-sudo -u astro ~astro/airflow-venv/bin/pip install --extra-index-url=https://pip.astronomer.io/simple/ 'astronomer-certified[<your-dependency>]==1.10.10.*'
+sudo -u astro ~astro/airflow-venv/bin/pip install --extra-index-url=https://pip.astronomer.io/simple/ 'astronomer-core[<your-dependency>]==<airflow-version>.*'
 ```
 
-You can also create your own Python packages and install them on your environment via Python wheel, or you can configure an environment variable to automatically add a Python package to your Airflow project folder. For more information on this setup, read the [Apache Airflow documentation on managing modules](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/modules_management.html).
+You can also create your own Python packages and install them into your Airflow environment via a Python wheel, or you can configure an environment variable to automatically add the packages to your Airflow project directory. For more information on this setup, read the [Apache Airflow documentation on managing modules](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/modules_management.html).
 
 ## Install Packages Using the Astronomer CLI
 
-If you installed AC via the [Quickstart], you can add Python-level packages to your `requirements.txt` file and OS-level packages to your `packages.txt` file.
+If you're running Astronomer Core locally via the Astronomer CLI [Quickstart], you can add Python-level packages to your `requirements.txt` file and OS-level packages to your `packages.txt` file.
 
-To add the package, simply list the package name on its own line in one of the two files.
-
-You can also pin a specific package version to use. For example, if wanted to exclusively use Pymongo 3.7.2, you'd add the following line to your `requirements.txt` file:
+To add the package, list the package name on its own line in the corresponding file. To install a particular version of any packages, pin that version to the package name in the format of `<package-name>==<package-version>`. To install Pymongo 3.7.2, for example, add the following to your `requirements.txt` file:
 
 ```
 pymongo==3.7.2
@@ -36,9 +34,24 @@ If you don't pin a package to a version, the latest version of the package that'
 
 Once you've saved those packages to the appropriate `.txt` files, rebuild your image by running `astro dev stop`, followed by `astro dev start`. This process stops your running Docker containers and restarts them with your updated image.
 
+To confirm that a package was successfully installed:
+
+1. Run `$ docker ps` and retrieve the container ID of your Scheduler container.
+2. Run the following command:
+
+    ```
+    docker exec -it <scheduler-container-id> pip freeze | grep <package-name>
+    ```
+
+    If the package was successfully installed, you should see the following output:
+
+    ```
+    <package-name>==<version>
+    ```
+
 ## Install Packages on a Custom Docker Image
 
-If you [installed AC on Docker], you can add packages directly to your image. To install OS-level packages, you can specify them using a `RUN` directive with `apt-get`. For example, the following Dockerfile will install `your-dependency` on the image:
+If you [installed AC on Docker], you can install the packages directly onto your image via your Dockerfile. To install OS-level packages, you can specify them using a `RUN` directive with `apt-get`. For example, the following Dockerfile would install `your-dependency` on the image:
 
 ```
 FROM: quay.io/astronomer/docker-airflow:latest-onbuild
@@ -57,7 +70,7 @@ FROM: quay.io/astronomer/docker-airflow:latest-onbuild
 RUN pip install --no-cache-dir --user your-dependency
 ```
 
-Once you rebuild your image with `docker-build`, the image will have access to any packages that you specified. You can confirm that a package was installed by running a `$ docker exec` command into your Scheduler. To do so:
+Once you rebuild your image with `docker-build`, the image will have access to any packages that you specified. To confirm that a package was installed:
 
 1. Run `$ docker ps` and retrieve the container ID of your Scheduler container.
 2. Run the following command:

--- a/ac/next/install-dependencies.md
+++ b/ac/next/install-dependencies.md
@@ -1,0 +1,54 @@
+---
+title: "Install Dependencies in a Production Environment"
+navTitle: "Install Dependencies"
+description: "Learn how to instal OS-Level and Python-Level packages on Airflow."
+---
+
+## Overview
+
+By default, the Astronomer Core (AC) Docker image includes several additional third party packages in order to better integrate between applications. For a full list of built in packages, read about the [Astronomer Core image architecture].
+
+If your DAGs need additional packages to run, you can add those packages either to your machine or to your Docker image.
+
+## Install Python-level and OS-level Packages on a Machine
+
+To build Python and OS-level packages into a machine running Airflow, run the following command:
+
+```sh
+sudo -u astro ~astro/airflow-venv/bin/pip install --extra-index-url=https://pip.astronomer.io/simple/ 'astronomer-certified[<your-dependency>]==1.10.10.*'
+```
+
+You can also create your own Python packages and install them on your environment using a Python wheel, or you can configure an environment variable to automatically add a Python directory to your Airflow project folder. For more information on this setup, read the [Apache Airflow documentation on managing modules](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/modules_management.html).
+
+## Install Python-level and OS-level Packages in Docker
+
+If you installed AC locally using the [Quickstart] and the Astro CLI, you can add Python packages to your `requirements.txt` file and OS-level packages to your `packages.txt` file.
+
+To add the package, simply list the package name on its own line in one of the two files.
+
+You can also pin a specific package version to use. For example, if wanted to exclusively use Pymongo 3.7.2, you'd add the following line to your `requirements.txt` file:
+
+```
+pymongo==3.7.2
+```
+
+If you don't pin a package to a version, the latest version of the package that's publicly available will be installed by default.
+
+Once you've saved those packages to the appropriate `.txt` files, rebuild your image by running `astro dev stop`, followed by `astro dev start`. This process stops your running Docker containers and restarts them with your updated image.
+
+### Confirm a Package Installation
+
+If you run Astronomer Core in Docker, you can confirm that a package was installed by running a `$ docker exec` command into your Scheduler. To do so:
+
+1. Run `$ docker ps` and retrieve the container ID of your Scheduler container.
+2. Run the following command:
+
+    ```
+    docker exec -it <scheduler-container-id> pip freeze | grep <package-name>
+    ```
+
+    If the package was successfully installed, you should see the following output:
+
+    ```
+    <package-name>==<version>
+    ```

--- a/ac/next/install-dependencies.md
+++ b/ac/next/install-dependencies.md
@@ -20,7 +20,7 @@ sudo -u astro ~astro/airflow-venv/bin/pip install --extra-index-url=https://pip.
 
 You can also create your own Python packages and install them on your environment via Python wheel, or you can configure an environment variable to automatically add a Python package to your Airflow project folder. For more information on this setup, read the [Apache Airflow documentation on managing modules](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/modules_management.html).
 
-## Install Packages using the Astronomer CLI
+## Install Packages Using the Astronomer CLI
 
 If you installed AC via the [Quickstart], you can add Python-level packages to your `requirements.txt` file and OS-level packages to your `packages.txt` file.
 
@@ -36,7 +36,7 @@ If you don't pin a package to a version, the latest version of the package that'
 
 Once you've saved those packages to the appropriate `.txt` files, rebuild your image by running `astro dev stop`, followed by `astro dev start`. This process stops your running Docker containers and restarts them with your updated image.
 
-## Install Packages in a Custom Docker Image
+## Install Packages on a Custom Docker Image
 
 If you [installed AC on Docker], you can add packages directly to your image. To install OS-level packages, you can specify them using a `RUN` directive with `apt-get`. For example, the following Dockerfile will install `your-dependency` on the image:
 

--- a/ac/next/install-dependencies.md
+++ b/ac/next/install-dependencies.md
@@ -1,7 +1,7 @@
 ---
 title: "Install Dependencies in a Production Environment"
 navTitle: "Install Dependencies"
-description: "Learn how to instal OS-Level and Python-Level packages on Airflow."
+description: "Learn how to install OS-level and Python-level packages on Airflow."
 ---
 
 ## Overview
@@ -10,7 +10,7 @@ By default, the Astronomer Core (AC) Docker image includes several additional th
 
 If your DAGs need additional packages to run, you can add those packages either to your machine or to your Docker image.
 
-## Install Python-level and OS-level Packages on a Machine
+## Install Python-Level and OS-Level Packages on a Machine
 
 To build Python and OS-level packages into a machine running Airflow, run the following command:
 
@@ -20,7 +20,7 @@ sudo -u astro ~astro/airflow-venv/bin/pip install --extra-index-url=https://pip.
 
 You can also create your own Python packages and install them on your environment using a Python wheel, or you can configure an environment variable to automatically add a Python directory to your Airflow project folder. For more information on this setup, read the [Apache Airflow documentation on managing modules](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/modules_management.html).
 
-## Install Python-level and OS-level Packages in Docker
+## Install Python-Level and OS-Level Packages in Docker
 
 If you installed AC locally using the [Quickstart] and the Astro CLI, you can add Python packages to your `requirements.txt` file and OS-level packages to your `packages.txt` file.
 

--- a/ac/next/install-dependencies.md
+++ b/ac/next/install-dependencies.md
@@ -6,11 +6,11 @@ description: "Learn how to install OS-level and Python-level packages on Airflow
 
 ## Overview
 
-By default, the Astronomer Core (AC) Docker image includes several additional third party packages in order to better integrate between applications. For a full list of built in packages, read about the [Astronomer Core image architecture].
+By default, the Astronomer Core (AC) Airflow image includes several provider packages in order to better integrate between popular applications. For a full list of built in packages, read [Astronomer Core Image Architecture].
 
-If your DAGs need additional packages to run, you can add those packages either to your machine or to your Docker image.
+If you require additional dependencies to run your DAGs, you can either install those packages onto your local machines or build them into a Docker image.
 
-## Install Python-Level and OS-Level Packages on a Machine
+## Install Packages on a Virtual Machine
 
 To build Python and OS-level packages into a machine running Airflow, run the following command:
 
@@ -18,11 +18,11 @@ To build Python and OS-level packages into a machine running Airflow, run the fo
 sudo -u astro ~astro/airflow-venv/bin/pip install --extra-index-url=https://pip.astronomer.io/simple/ 'astronomer-certified[<your-dependency>]==1.10.10.*'
 ```
 
-You can also create your own Python packages and install them on your environment using a Python wheel, or you can configure an environment variable to automatically add a Python directory to your Airflow project folder. For more information on this setup, read the [Apache Airflow documentation on managing modules](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/modules_management.html).
+You can also create your own Python packages and install them on your environment via Python wheel, or you can configure an environment variable to automatically add a Python package to your Airflow project folder. For more information on this setup, read the [Apache Airflow documentation on managing modules](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/modules_management.html).
 
-## Install Python-Level and OS-Level Packages in Docker
+## Install Packages using the Astronomer CLI
 
-If you installed AC locally using the [Quickstart] and the Astro CLI, you can add Python packages to your `requirements.txt` file and OS-level packages to your `packages.txt` file.
+If you installed AC via the [Quickstart], you can add Python-level packages to your `requirements.txt` file and OS-level packages to your `packages.txt` file.
 
 To add the package, simply list the package name on its own line in one of the two files.
 
@@ -36,9 +36,28 @@ If you don't pin a package to a version, the latest version of the package that'
 
 Once you've saved those packages to the appropriate `.txt` files, rebuild your image by running `astro dev stop`, followed by `astro dev start`. This process stops your running Docker containers and restarts them with your updated image.
 
-### Confirm a Package Installation
+## Install Packages in a Custom Docker Image
 
-If you run Astronomer Core in Docker, you can confirm that a package was installed by running a `$ docker exec` command into your Scheduler. To do so:
+If you [installed AC on Docker], you can add packages directly to your image. To install OS-level packages, you can specify them using a `RUN` directive with `apt-get`. For example, the following Dockerfile will install `your-dependency` on the image:
+
+```
+FROM: quay.io/astronomer/docker-airflow:latest-onbuild
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+         your-dependency \
+  && apt-get autoremove -yqq --purge \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+```
+
+To install a Python-level package, specify the package using a `RUN` directive with `pip install` instead. For example:
+
+```
+FROM: quay.io/astronomer/docker-airflow:latest-onbuild
+RUN pip install --no-cache-dir --user your-dependency
+```
+
+Once you rebuild your image with `docker-build`, the image will have access to any packages that you specified. You can confirm that a package was installed by running a `$ docker exec` command into your Scheduler. To do so:
 
 1. Run `$ docker ps` and retrieve the container ID of your Scheduler container.
 2. Run the following command:


### PR DESCRIPTION
As part of our V1 AC Documentation Suite, this guide provides some options for installing both OS and Python-level dependencies on Airflow. 

Some interesting things to note in the guide, and some follow-up questions:
- Instead of documenting how to build a Python wheel ourselves, I linked out to the Airflow documentation describing that process. How do you feel about that link - should we be documenting that process ourselves?
-  I struggled between using "Dependencies" and "Packages" throughout the guide. Can these processes install anything other than packages? If not, then I will probably remove the word "dependencies" from the guide. 