### PR TITLE
Correct Build Image

### DIFF
--- a/cloud/stable/03_deploy/06_ci-cd.md
+++ b/cloud/stable/03_deploy/06_ci-cd.md
@@ -163,7 +163,7 @@ At its core, your CI/CD pipeline will first authenticate to Astronomer Cloud's p
 ```yaml
 pipeline:
   build:
-    image: quay.io/astronomer/ap-airflow:1.10.12-buster
+    image: quay.io/astronomer/ap-build:latest
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -173,7 +173,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: quay.io/astronomer/ap-airflow:1.10.12-buster
+    image: quay.io/astronomer/ap-build:latest
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -224,7 +224,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  quay.io/astronomer/ap-airflow:1.10.12-buster
+      - image:  quay.io/astronomer/ap-build:latest
     steps:
       - checkout
       - setup_remote_docker:
@@ -281,7 +281,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: quay.io/astronomer/ap-airflow:1.10.12-buster
+image: quay.io/astronomer/ap-build:latest
 
 pipelines:
   branches:

--- a/enterprise/next/04_deploy/06_ci-cd.md
+++ b/enterprise/next/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: quay.io/astronomer/ap-airflow:1.10.12-buster
+    image: quay.io/astronomer/ap-build:latest
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: quay.io/astronomer/ap-airflow:1.10.12-buster
+    image: quay.io/astronomer/ap-build:latest
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  quay.io/astronomer/ap-airflow:1.10.12-buster
+      - image:  quay.io/astronomer/ap-build:latest
     steps:
       - checkout
       - setup_remote_docker:
@@ -280,7 +280,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: quay.io/astronomer/ap-airflow:1.10.12-buster
+image: quay.io/astronomer/ap-build:latest
 
 pipelines:
   branches:

--- a/enterprise/v0.23/04_deploy/06_ci-cd.md
+++ b/enterprise/v0.23/04_deploy/06_ci-cd.md
@@ -162,7 +162,7 @@ At its core, your CI/CD pipeline will be authenticating to the private registry 
 ```yaml
 pipeline:
   build:
-    image: quay.io/astronomer/ap-airflow:1.10.12-buster
+    image: quay.io/astronomer/ap-build:latest
     commands:
       - docker build -t registry.gcp0001.us-east4.astronomer.io/infrared-photon-7780/airflow:ci-${DRONE_BUILD_NUMBER} .
     volumes:
@@ -172,7 +172,7 @@ pipeline:
       branch: [ master, release-* ]
 
   push:
-    image: quay.io/astronomer/ap-airflow:1.10.12-buster
+    image: quay.io/astronomer/ap-build:latest
     commands:
       - echo $${SERVICE_ACCOUNT_KEY}
       - docker login registry.gcp0001.us-east4.astronomer.io -u _ -p $${SERVICE_ACCOUNT_KEY}
@@ -223,7 +223,7 @@ jobs:
             pycodestyle .
   deploy:
     docker:
-      - image:  quay.io/astronomer/ap-airflow:1.10.12-buster
+      - image:  quay.io/astronomer/ap-build:latest
     steps:
       - checkout
       - setup_remote_docker:
@@ -280,7 +280,7 @@ pipeline {
 If you are using [Bitbucket](https://bitbucket.org/), this script should work (courtesy of our friends at [Das42](https://www.das42.com/))
 
 ```yaml
-image: quay.io/astronomer/ap-airflow:1.10.12-buster
+image: quay.io/astronomer/ap-build:latest
 
 pipelines:
   branches:


### PR DESCRIPTION
A user has pointed out that our build images referenced as ap-airflow is incorrect and should be ap-build. Without Docker installed in ap-airflow, it will not successfully build.