### PR TITLE
Created a reference guide for AC's image architecture

### DIFF
--- a/ac/next/image.md
+++ b/ac/next/image.md
@@ -6,25 +6,37 @@ description: "A reference guide of every minimum package and process required to
 
 ## Overview
 
+The Astronomer Core image for Apache Airflow extends the community-developed Airflow image in a way that makes running Airfow more secure, reliable, and extensible.
+
+Every part of the Astronomer Core image is available as [source code](https://github.com/astronomer/docker-airflow). This guide gives more in-depth explanations for some of the key components of the AC image.
 
 ## Environment Variables
 
+When an Airflow service is started, it checks a file for runtime environment variables. If you installed [Astronomer Core via Python wheel], this file is called `astronomer-core`.
+
+If you installed [Astronomer Core on Docker], Docker first checks your Dockerfile for environment variables, then any variables defined in a `docker run` command.
+
+The following environment variables
 
 | Variable | Description | Default Value |
 |----------|-------------|---------------|
 | AIRFLOW__CORE__EXECUTOR| The method used for executing airflow tasks| CeleryExecutor |
-| AIRFLOW__CORE__SQL_ALCHEMY_CONN| The connection ID for your database | None |
-| AIRFLOW__CELERY__RESULT_BACKEND|||
-| AIRFLOW__CELERY__BROKER_URL|||
-| AIRFLOW__CORE__FERNET_KEY|||
-| AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION|||
+| AIRFLOW__CORE__SQL_ALCHEMY_CONN| The connection ID for your metadata db | sqlite:///{AIRFLOW_HOME}/airflow.db |
+| AIRFLOW__CELERY__RESULT_BACKEND| The Celery result backend | db+postgresql://postgres:airflow@postgres/airflow|
+| AIRFLOW__CELERY__BROKER_URL| The URL for the DB message broker | redis://redis:6379/0|
+| AIRFLOW__CORE__FERNET_KEY| The secret key for saving connection passwords in the metadata DB | {FERNET_KEY} |
+| AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION| Determines whether DAGs are paused by default at creation | True |
 | AIRFLOW__CORE__LOAD_EXAMPLES| Determines whether example DAGs are loaded when staring Airflow | True |
-| AIRFLOW_HOME | Filepath for your Airflow project directory | None |
-| AIRFLOW__WEBSERVER__BASE_URL | The URL used to access the Airflow UI | None |
+| AIRFLOW_HOME | Filepath for your Airflow project directory | ~/airflow |
+| AIRFLOW__WEBSERVER__BASE_URL | The URL used to access the Airflow UI | http://localhost:8080 |
 
 
 ## Package Dependencies
 
-By default,
+The AC image comes packaged with dependencies that are utilized in some background processes, as well as provided for use by the community.
 
 "async,azure,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,google,grpc,hashicorp,http,ldap,google,microsoft.azure,mysql,password,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv"
+
+## Astronomer FAB Security Manager
+
+One significant difference between AC's Airflow image

--- a/ac/next/image.md
+++ b/ac/next/image.md
@@ -1,0 +1,33 @@
+---
+title: "Astronomer Core Image Architecture"
+navTitle: "Image Architecture"
+description: "A reference guide of every minimum package and process required to run Astronomer Core."
+---
+
+## Overview
+
+
+## Environment Variables
+
+### Environment
+
+| Variable | Description | Default Value |
+|----------|-------------|---------------|
+| AIRFLOW__CORE__EXECUTOR|||
+| AIRFLOW__CORE__SQL_ALCHEMY_CONN|||
+| AIRFLOW__CELERY__RESULT_BACKEND|||
+| AIRFLOW__CELERY__BROKER_URL|||
+| AIRFLOW__CORE__FERNET_KEY|||
+| AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION|||
+| AIRFLOW__CORE__LOAD_EXAMPLES|||
+| AIRFLOW__WEBSERVER__BASE_URL |||
+| AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD|||
+
+### Services
+
+
+## Dependencies
+
+By default,
+
+"async,azure,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,google,grpc,hashicorp,http,ldap,google,microsoft.azure,mysql,password,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv"

--- a/ac/next/image.md
+++ b/ac/next/image.md
@@ -6,37 +6,80 @@ description: "A reference guide of every minimum package and process required to
 
 ## Overview
 
-The Astronomer Core image for Apache Airflow extends the community-developed Airflow image in a way that makes running Airfow more secure, reliable, and extensible.
+The Astronomer Core image for Apache Airflow extends the community-developed Airflow image in a way that makes running Airflow more secure, reliable, and extensible.
 
 Every part of the Astronomer Core image is available as [source code](https://github.com/astronomer/docker-airflow). This guide gives more in-depth explanations for some of the key components of the AC image.
 
+## Versioning
+
+For each release of Apache Airflow, Astronomer releases a corresponding version of Astronomer Core. If you install via Python wheel, the release name is defined in the following syntax:
+
+```
+astronomer-core[dependencies]==2.0.1.*
+```
+
+In this example, the `*` will pull the latest Astronomer Core patch release of Airflow 2.0.1. This version might include additional bug and security fixes not present in the corresponding open source version.
+
+Astronomer Core's Docker image is defined in the following syntax:
+
+```
+quay.io/astronomer/docker-airflow:2.0.1-1-buster-onbuild
+```
+
+Astronomer maintains two Docker images for each version: one with an `onbuild` tag, and one without. If you plan on building additional dependencies and customizations into the image, we recommend pulling from the version without the `onbuild` tag.
+
 ## Environment Variables
 
-When an Airflow service is started, it checks a file for runtime environment variables. If you installed [Astronomer Core via Python wheel], this file is called `astronomer-core`.
+When an Airflow service is started, it checks a file for runtime environment variables.
 
-If you installed [Astronomer Core on Docker], Docker first checks your Dockerfile for environment variables, then any variables defined in a `docker run` command.
+If you installed [Astronomer Core via Python wheel], this file is called `astronomer-core`. If you installed [Astronomer Core on Docker], Docker first checks your Dockerfile for environment variables. Environment variables in these files can be overwritten with a runtime command, such as `docker run`.
 
-The following environment variables
+Astronomer Core supports the same environment variables as Apache Airflow. For a list of all configurable environment variables, read the [Apache Airflow documentation](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html).
 
-| Variable | Description | Default Value |
-|----------|-------------|---------------|
-| AIRFLOW__CORE__EXECUTOR| The method used for executing airflow tasks| CeleryExecutor |
-| AIRFLOW__CORE__SQL_ALCHEMY_CONN| The connection ID for your metadata db | sqlite:///{AIRFLOW_HOME}/airflow.db |
-| AIRFLOW__CELERY__RESULT_BACKEND| The Celery result backend | db+postgresql://postgres:airflow@postgres/airflow|
-| AIRFLOW__CELERY__BROKER_URL| The URL for the DB message broker | redis://redis:6379/0|
-| AIRFLOW__CORE__FERNET_KEY| The secret key for saving connection passwords in the metadata DB | {FERNET_KEY} |
-| AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION| Determines whether DAGs are paused by default at creation | True |
-| AIRFLOW__CORE__LOAD_EXAMPLES| Determines whether example DAGs are loaded when staring Airflow | True |
-| AIRFLOW_HOME | Filepath for your Airflow project directory | ~/airflow |
-| AIRFLOW__WEBSERVER__BASE_URL | The URL used to access the Airflow UI | http://localhost:8080 |
+The following table lists the essential environment variables used when running Airflow via Astronomer Core. These environment variables should always be reviewed or overridden when completing a new installation:
 
+| Variable                                   | Description                                                        | Default Value                                     |
+| ------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------- |
+| AIRFLOW__CELERY__RESULT_BACKEND            | The Celery result backend (Celery Executor only).                  | db+postgresql://postgres:airflow@postgres/airflow |
+| AIRFLOW__CELERY__BROKER_URL                | The URL for the DB message broker (Celery Executor only).          | redis://redis:6379/0                              |
+| AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION | Determines whether DAGs are paused by default at creation.         | True                                              |
+| AIRFLOW__CORE__EXECUTOR                    | The method used for executing airflow tasks.                       | CeleryExecutor                                    |
+| AIRFLOW__CORE__FERNET_KEY                  | The secret key for saving connection passwords in the metadata DB. | {FERNET_KEY}                                      |
+| AIRFLOW__CORE__LOAD_EXAMPLES               | Determines whether example DAGs are loaded when starting Airflow.   | True                                              |
+| AIRFLOW__CORE__SQL_ALCHEMY_CONN            | The connection ID for your metadata db.                            | sqlite:///{AIRFLOW_HOME}/airflow.db               |
+| AIRFLOW_HOME                               | Filepath for your Airflow project directory.                       | ~/airflow                                         |
+| AIRFLOW__WEBSERVER__BASE_URL               | The URL used to access the Airflow UI.                             | http://localhost:8080                             |
 
 ## Package Dependencies
 
-The AC image comes packaged with dependencies that are utilized in some background processes, as well as provided for use by the community.
+By default, the Astronomer Core image includes provider packages that are utilized in some background processes, as well as packages which are commonly used by the community. The following list contains links to the Apache Airflow documentation for each default of Astronomer Core's default provider packages:
 
-"async,azure,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,google,grpc,hashicorp,http,ldap,google,microsoft.azure,mysql,password,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv"
+- [azure](https://airflow.apache.org/docs/apache-airflow-providers-microsoft-azure/stable/index.html)
+- [amazon](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/index.html)
+- [celery](https://airflow.apache.org/docs/apache-airflow-providers-celery/stable/index.html)
+- [cncf.kubernetes](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/index.html)
+- [docker](https://airflow.apache.org/docs/apache-airflow-providers-docker/stable/index.html)
+- [elasticsearch](https://airflow.apache.org/docs/apache-airflow-providers-elasticsearch/stable/index.html)
+- [ftp](https://airflow.apache.org/docs/apache-airflow-providers-ftp/stable/index.html)
+- [google](https://airflow.apache.org/docs/apache-airflow-providers-google/stable/index.html)
+- [grpc](https://airflow.apache.org/docs/apache-airflow-providers-grpc/stable/index.html)
+- [hashicorp](https://airflow.apache.org/docs/apache-airflow-providers-hashicorp/stable/index.html)
+- [http](https://airflow.apache.org/docs/apache-airflow-providers-http/stable/index.html)
+- [mysql](https://airflow.apache.org/docs/apache-airflow-providers-microsoft-mssql/stable/index.html)
+- [postgres](https://airflow.apache.org/docs/apache-airflow-providers-postgres/stable/index.html)
+- [redis](https://airflow.apache.org/docs/apache-airflow-providers-redis/stable/index.html)
+- [sendgrid](https://airflow.apache.org/docs/apache-airflow-providers-sendgrid/stable/index.html)
+- [sftp](https://airflow.apache.org/docs/apache-airflow-providers-sftp/stable/index.html)
+- [slack](https://airflow.apache.org/docs/apache-airflow-providers-slack/stable/index.html)
+- [ssh](https://airflow.apache.org/docs/apache-airflow-providers-ssh/stable/index.html)
 
-## Astronomer FAB Security Manager
+## Extras
 
-One significant difference between AC's Airflow image
+Astronomer Core includes a few packages that do not have a corresponding provider. These packages are used for basic system functions or optional Airflow functionality. The following list contains all extra packages built into Astronomer Core by default:
+
+- async: Provides asynchronous workers for Gunicorn
+- dask: Adds support for the [Dask Executor](https://airflow.apache.org/docs/apache-airflow/stable/executor/dask.html)
+- ldap: Adds support for LDAP authentication
+- password: Adds support for user password hashing
+- statsd: Adds support for sending metrics to StatsD
+- virtualenv: Adds support for running Python tasks in local virtual environments

--- a/ac/next/image.md
+++ b/ac/next/image.md
@@ -1,7 +1,7 @@
 ---
 title: "Astronomer Core Image Architecture"
-navTitle: "Image Architecture"
-description: "A reference guide of every minimum package and process required to run Astronomer Core."
+navTitle: "Image Reference"
+description: "A reference guide for the key components used to build Astronomer Core."
 ---
 
 ## Overview

--- a/ac/next/image.md
+++ b/ac/next/image.md
@@ -9,24 +9,21 @@ description: "A reference guide of every minimum package and process required to
 
 ## Environment Variables
 
-### Environment
 
 | Variable | Description | Default Value |
 |----------|-------------|---------------|
-| AIRFLOW__CORE__EXECUTOR|||
-| AIRFLOW__CORE__SQL_ALCHEMY_CONN|||
+| AIRFLOW__CORE__EXECUTOR| The method used for executing airflow tasks| CeleryExecutor |
+| AIRFLOW__CORE__SQL_ALCHEMY_CONN| The connection ID for your database | None |
 | AIRFLOW__CELERY__RESULT_BACKEND|||
 | AIRFLOW__CELERY__BROKER_URL|||
 | AIRFLOW__CORE__FERNET_KEY|||
 | AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION|||
-| AIRFLOW__CORE__LOAD_EXAMPLES|||
-| AIRFLOW__WEBSERVER__BASE_URL |||
-| AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD|||
-
-### Services
+| AIRFLOW__CORE__LOAD_EXAMPLES| Determines whether example DAGs are loaded when staring Airflow | True |
+| AIRFLOW_HOME | Filepath for your Airflow project directory | None |
+| AIRFLOW__WEBSERVER__BASE_URL | The URL used to access the Airflow UI | None |
 
 
-## Dependencies
+## Package Dependencies
 
 By default,
 


### PR DESCRIPTION
This is a starting draft for what is essentially an editorialized version of the Astronomer Core source code. The info here should provide additional context for various components of the software. When we don't have the exact info someone might be looking for, there should always be a link to the most relevant source code/ documentation. 

Most "controversial" call here was to not document the Astronomer FAB security manager. Based on this [Slack thread](https://astronomerteam.slack.com/archives/CGQSYG25V/p1613011191412100), it looks like the security manager isn't actually used in the open source image. It has to be configured, and that info is probably better suited in another document. 

Looking at other image docs online, there's some additional directions we can take with this. Following [Prisma's example](https://v1.prisma.io/docs/1.34/prisma-server/deployment-environments/docker-rty1/), do we want to provide some basic Docker commands for folks to see what's going on in their image? Or is that out of the scope of this document? What else might people be interested in learning about here? Let me know. 

