### PR TITLE
Added new Helm configuration to install guides

### DIFF
--- a/enterprise/next/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/next/03_install/01_aws/01_install-aws-standard.md
@@ -144,7 +144,7 @@ If you received a certificate from a private CA, follow the steps below instead:
     $ kubectl create secret generic private-root-ca --from-file=cert.pem=./<your-certificate-filepath>
     ```
 
-    > **Note:** The root certificate which you specify here should be the certificate of the authority that signed the Astronomer certificate, rather than the Astronomer certificate itself. This is the same certificate you need to install with all clients to get them to trust your services. 
+    > **Note:** The root certificate which you specify here should be the certificate of the authority that signed the Astronomer certificate, rather than the Astronomer certificate itself. This is the same certificate you need to install with all clients to get them to trust your services.
 
     > **Note:** The name of the secret file must be `cert.pem` for your certificate to be trusted properly.
 
@@ -218,10 +218,12 @@ global:
 ### Nginx configuration
 #################################
 nginx:
-  # IP address the nginx ingress should bind to
+  # String IP address the nginx ingress should bind to
   loadBalancerIP: ~
   #  Set to 'true' when deploying to a private EKS cluster
   privateLoadBalancer: false
+  # Dict of arbitrary annotations to add to the nginx ingress. For full configuration options, see https://docs.nginx.com/nginx-ingress-controller/configuration/ingress-resources/advanced-configuration-with-annotations/
+  ingressAnnotations: {}
 
 #################################
 ### SMTP configuration

--- a/enterprise/next/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/next/03_install/01_aws/01_install-aws-standard.md
@@ -223,7 +223,7 @@ nginx:
   #  Set to 'true' when deploying to a private EKS cluster
   privateLoadBalancer: false
   # Dict of arbitrary annotations to add to the nginx ingress. For full configuration options, see https://docs.nginx.com/nginx-ingress-controller/configuration/ingress-resources/advanced-configuration-with-annotations/
-  ingressAnnotations: {}
+  ingressAnnotations: {service.beta.kubernetes.io/aws-load-balancer-type: nlb}
 
 #################################
 ### SMTP configuration

--- a/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
@@ -197,7 +197,7 @@ If you received a certificate from a private CA, follow the steps below instead:
     $ kubectl create secret generic private-root-ca --from-file=cert.pem=./<your-certificate-filepath>
     ```
 
-    > **Note:** The root certificate which you specify here should be the certificate of the authority that signed the Astronomer certificate, rather than the Astronomer certificate itself. This is the same certificate you need to install with all clients to get them to trust your services. 
+    > **Note:** The root certificate which you specify here should be the certificate of the authority that signed the Astronomer certificate, rather than the Astronomer certificate itself. This is the same certificate you need to install with all clients to get them to trust your services.
 
     > **Note:** The name of the secret file must be `cert.pem` for your certificate to be trusted properly.
 
@@ -271,6 +271,8 @@ global:
 nginx:
   # IP address the nginx ingress should bind to
   loadBalancerIP: ~
+  # Dict of arbitrary annotations to add to the nginx ingress. For full configuration options, see https://docs.nginx.com/nginx-ingress-controller/configuration/ingress-resources/advanced-configuration-with-annotations/
+  ingressAnnotations: {}
 
 #################################
 ### SMTP configuration

--- a/enterprise/next/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/next/03_install/03_azure/01_install-azure-standard.md
@@ -257,6 +257,8 @@ postgresql:
 nginx:
   # IP address the nginx ingress should bind to
   loadBalancerIP: ~
+  # Dict of arbitrary annotations to add to the nginx ingress. For full configuration options, see https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/
+  ingressAnnotations: {}
 
 #################################
 ### SMTP configuration

--- a/enterprise/v0.23/03_install/01_aws/01_install-aws-standard.md
+++ b/enterprise/v0.23/03_install/01_aws/01_install-aws-standard.md
@@ -222,6 +222,8 @@ nginx:
   loadBalancerIP: ~
   #  Set to 'true' when deploying to a private EKS cluster
   privateLoadBalancer: false
+  # Dict of arbitrary annotations to add to the nginx ingress. For full configuration options, see https://docs.nginx.com/nginx-ingress-controller/configuration/ingress-resources/advanced-configuration-with-annotations/
+  ingressAnnotations: {service.beta.kubernetes.io/aws-load-balancer-type: nlb}
 
 #################################
 ### SMTP configuration

--- a/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
@@ -260,6 +260,8 @@ global:
 nginx:
   # IP address the nginx ingress should bind to
   loadBalancerIP: ~
+  # Dict of arbitrary annotations to add to the nginx ingress. For full configuration options, see https://docs.nginx.com/nginx-ingress-controller/configuration/ingress-resources/advanced-configuration-with-annotations/
+  ingressAnnotations: {}
 
 #################################
 ### SMTP configuration

--- a/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
+++ b/enterprise/v0.23/03_install/03_azure/01_install-azure-standard.md
@@ -256,6 +256,8 @@ postgresql:
 nginx:
   # IP address the nginx ingress should bind to
   loadBalancerIP: ~
+  # Dict of arbitrary annotations to add to the nginx ingress. For full configuration options, see https://docs.nginx.com/nginx-ingress-controller/configuration/ingress-resources/advanced-configuration-with-annotations/
+  ingressAnnotations: {}
 
 #################################
 ### SMTP configuration


### PR DESCRIPTION
Closes https://github.com/astronomer/docs/issues/292#issuecomment-804077298

For 0.23.12, we need to describe how to configure various ingress annotations, as some of these are likely to be configured at installation. I have yet to add the example configuration for `service.beta.kubernetes.io/aws-load-balancer-type` as suggested by @rbankston because I still need clarity on these questions from the GH issue:

> @rbankston Is the example value you included something we expect all AWS customers to want by default? In the future we should have a full chart config guide, but I don't want to provide opinionated setup in a general installation guide.

>If this is something we want everyone to configure, is there an equivalent, generally-used value we can configure for GCP and AKS? If it's not something for everyone, I will probably just link out to this doc in the inline comments and let users figure out what they need.