### PR TITLE
Install AC with Docker Compose

### DIFF
--- a/ac/next/install-docker.md
+++ b/ac/next/install-docker.md
@@ -88,11 +88,11 @@ To install and run the Astronomer Core distribution of Apache Airflow:
     You should see a container for each Airflow service specified in your `docker-compose` file:
 
     ```
-    CONTAINER ID   IMAGE                             COMMAND                  CREATED          STATUS          PORTS                                        NAMES
-45dfd2f532fe   astronomer-core_569586/airflow:latest   "tini -- /entrypoint…"   13 seconds ago   Up 11 seconds   5555/tcp, 8793/tcp, 0.0.0.0:8080->8080/tcp   airflow2569586_webserver_1
-4fd455a109f8   astronomer-core_569586/airflow:latest   "tini -- /entrypoint…"   14 seconds ago   Up 12 seconds   5555/tcp, 8080/tcp, 8793/tcp                 airflow2569586_scheduler_1
-df802bb4c2ed   postgres:12.2                     "docker-entrypoint.s…"   3 weeks ago      Up 13 seconds   0.0.0.0:5432->5432/tcp                       airflow2569586_postgres_1
-user@LocalMachine astronomer-core %
+    CONTAINER ID   IMAGE                                   COMMAND                  CREATED          STATUS          PORTS                                        NAMES
+    45dfd2f532fe   astronomer-core_569586/airflow:latest   "tini -- /entrypoint…"   13 seconds ago   Up 11 seconds   5555/tcp, 8793/tcp, 0.0.0.0:8080->8080/tcp   airflow2569586_webserver_1
+    4fd455a109f8   astronomer-core_569586/airflow:latest   "tini -- /entrypoint…"   14 seconds ago   Up 12 seconds   5555/tcp, 8080/tcp, 8793/tcp                 airflow2569586_scheduler_1
+    df802bb4c2ed   postgres:12.2                           "docker-entrypoint.s…"   3 weeks ago      Up 13 seconds   0.0.0.0:5432->5432/tcp                       airflow2569586_postgres_1
+    user@LocalMachine astronomer-core %
     ```
 
 ## Next Steps

--- a/ac/next/install-docker.md
+++ b/ac/next/install-docker.md
@@ -8,7 +8,7 @@ description: "A complete setup for getting Airflow running on Docker using Astro
 
 Running Airflow in Docker containers is a simple and effective way to manage and scale your project. The core Airflow components — the Webserver, Scheduler, and Workers — are each run in separate containers, meaning you can easily scale resource usage based on the computing requirements of your project.
 
-This guide contains all of the necessary setup to get Airflow running on Docker. This includes creating a local project directory, pulling an Astronomer Core image and `docker-compose` file, and spinning up your environment.
+This guide contains all of the necessary setup to get Airflow running on Docker. You'll create a local project directory, pull an Astronomer Core image and `docker-compose` file, and spin up your environment.
 
 ## Prerequisites
 
@@ -21,13 +21,17 @@ To install Apache Airflow on Docker, you need:
 
 To install and run the Astronomer Core distribution of Apache Airflow:
 
-1. Create new project directory for your Airflow project and `cd` into it.
+1. Create new project directory for your Airflow project and `cd` into it:
 
-        mkdir astronomer-core && cd astronomer-core
+    ```sh
+    mkdir astronomer-core && cd astronomer-core
+    ```
 
 2. Run the following command to initialize some of the key files you'll need to run Astronomer Core:
 
-        touch .env packages.txt requirements.txt Dockerfile
+    ```sh
+    touch .env packages.txt requirements.txt Dockerfile
+    ```
 
 3. Add the the following to the `Dockerfile` to grab the latest Astronomer Core image on build:
 
@@ -48,13 +52,13 @@ To install and run the Astronomer Core distribution of Apache Airflow:
     | Postgres/ Celery Executor |`curl -lfO https://raw.githubusercontent.com/astronomer/docker-airflow/main/docker-compose-postgres-celery.yaml`|
     | Postgres/ Celery Executor |`curl -LfO https://raw.githubusercontent.com/astronomer/docker-airflow/main/docker-compose-postgres-local.yaml` |
 
-    Your `docker-compose` file contains all of the connections and commands needed to start Airflow for the first time. Additionally, the `x-airflow-env` object is where you configure Airflow's environment variables. If you want to change a default configuration, such your Webserver port or your Airflow home directory, you need to first update this file and restart your Airflow environment.
+    Your `docker-compose` file contains all of the connections and commands needed to start Airflow for the first time. Additionally, the `x-airflow-env` object is where you configure Airflow's environment variables. If you want to change a default configuration, such as your Webserver port or your Airflow home directory, you need to first update this file and restart your Airflow environment.
 
-5. Run `docker-compose up` to spin up the local Airflow Scheduler, Webserver, and Postgres containers, as well as create some key objects in for running Airflow. The default user it creates will have `admin/admin` as a username and password.
+5. Run `docker-compose up` to spin up the local Airflow Scheduler, Webserver, and Metadata DB containers, as well as create some key objects for running Airflow. The default user created will have `admin/admin` as a username and password.
 
     By default, this command will run Airflow on your machine based on your `docker-compose` file. Containers for your Airflow Metadata Database, Airflow Webserver and Airflow Scheduler are spun up programmatically.
 
-6. To confirm the installation was successful, open `localhost:8080` in a web browser. You should be able to see the Airflow UI and successfully log in:
+6. To confirm the installation was successful, open `localhost:8080` in a web browser and log in as your default `admin`. If your setup was successful, you should see the Airflow home:
 
     ![Airflow home page](https://assets2.astronomer.io/main/docs/airflow-ui/ac-install.png)
 
@@ -64,7 +68,7 @@ To install and run the Astronomer Core distribution of Apache Airflow:
     docker ps
     ```
 
-    You should see a container for each Airflow service specified in your `docker-compose` file:
+    If your installation was successful, you should see a container for each Airflow service specified in your `docker-compose` file:
 
     ```
     CONTAINER ID   IMAGE                             COMMAND                  CREATED          STATUS          PORTS                                        NAMES
@@ -77,6 +81,7 @@ user@LocalMachine astronomer-core %
 ## Next Steps
 
 This guide provided the minimum setup necessary to get Airflow running on Docker at scale. From here, you'll want to complete the following additional setup to make the most of Airflow:
+
 - Automate DAG deployment across your installation
 - Upgrade to a new version of Apache Airflow
 - Integrate an authentication system

--- a/ac/next/install-docker.md
+++ b/ac/next/install-docker.md
@@ -4,16 +4,19 @@ To install and run the Astronomer Certified distribution, ensure that Docker is 
 
         mkdir astronomer-certified && cd astronomer-certified
 
-2. Run the following command to initialize all of the necessary files you'll need to run the Airflow image locally:
+2. Run the following command to initialize all of the necessary files you'll need to run the AC image:
 
         touch .env packages.txt requirements.txt docker-compose.yml Dockerfile
 
 3. Add the the following to the `Dockerfile` to grab the latest Astronomer Certified image on build:
 
-        # For a Debian-based image
-        FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild
+    ```
+    # For a Debian-based image
+    FROM quay.io/astronomer/docker-airflow:latest
+    ```
 
-    Note that you can select which version you'd like to use via the tag appended to the image.
+    To pull from a specific version, replace `latest` in the image tag with your desired version. For a list of all image tags, refer to the [quay.io repository](https://quay.io/repository/astronomer/ap-airflow?tab=tags).  
+
 
 4. Add the following to the `docker-compose.yml` file:
 

--- a/ac/next/install-docker.md
+++ b/ac/next/install-docker.md
@@ -32,7 +32,7 @@ To install and run the Astronomer Core distribution of Apache Airflow:
 2. Run the following command to initialize some of the key files you'll need to run Astronomer Core:
 
     ```sh
-    touch .env packages.txt requirements.txt Dockerfile
+    touch .env packages.txt requirements.txt Dockerfile dags
     ```
 
     Docker references these files whenever your image is built:
@@ -41,6 +41,7 @@ To install and run the Astronomer Core distribution of Apache Airflow:
     - `packages.txt` stores Python-level dependencies.
     - `requirements.txt` stores OS-level dependencies.
     - `Dockerfile` pulls the Astronomer Core image from a Docker Registry.
+    - `dags` stores your Airflow DAGs.
 
 
 3. Add the following to your `Dockerfile` to pull the latest Astronomer Core Docker image:
@@ -61,7 +62,16 @@ To install and run the Astronomer Core distribution of Apache Airflow:
     | Postgres/ Local Executor |`curl -lfO https://raw.githubusercontent.com/astronomer/docker-airflow/main/docker-compose-postgres-celery.yaml`|
     | Postgres/ Celery Executor |`curl -LfO https://raw.githubusercontent.com/astronomer/docker-airflow/main/docker-compose-postgres-local.yaml` |
 
-    This `docker-compose.yaml` file defines the services needed to start Airflow based on the Executor and database you selected. If you want to change a default configuration, such as your Webserver port or Airflow home directory, make sure to first update this file and restart your Airflow environment. To configure Airflow [environment variables](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html), for example, add them to the `x-airflow-env` object.
+    This `docker-compose.yaml` file defines the a few things beyond the Executor and database you selected:
+
+    - Airflow environment variables required for starting the environment
+    - A default Admin Airflow user
+    - Containers for the Airflow Scheduler, Webserver, and Metadata DB services
+    - Containers for Celery workers, Redis, and Flower (Celery Executor only)
+    - Airflow commands, such as `airflow upgrade db`, which run every time you restart your environment
+    - Volumes for Airflow DAGs and logs
+
+    If you want to change a default configuration, such as your Webserver port or Airflow home directory, make sure to first update this file and restart your Airflow environment. Similarly, to configure Airflow [environment variables](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html), add the variables to your `.env` file and restart your Airflow environment.
 
 5. Run `docker-compose up` to create isolated Docker containers for the Airflow Scheduler, Webserver, and Metadata DB. If you're running the Celery Executor, this command creates one container for each Celery worker.
 

--- a/ac/next/install-docker.md
+++ b/ac/next/install-docker.md
@@ -1,6 +1,6 @@
 ---
-title: "Run Apache Airflow with Docker Compose"
-navtitle: "Run Airflow with Docker Compose"
+title: "Install Apache Airflow with Docker Compose"
+navtitle: "Install Airflow with Docker Compose"
 description: "A complete setup for creating a multi-container Apache Airflow application with Docker Compose and Astronomer Core."
 ---
 

--- a/ac/next/install-docker.md
+++ b/ac/next/install-docker.md
@@ -6,9 +6,9 @@ description: "A complete setup for getting Airflow running on Docker using Astro
 
 ## Overview
 
-Running Airflow in Docker containers is a simple and effective way to manage and scale your project. The core Airflow components — the Webserver, Scheduler, and Workers — are each run in separate containers, meaning you can easily scale resource usage based on the computing requirements of your project.
+Running Apache Airflow in Docker containers is a simple and effective way to manage and grow your project. The core Airflow components — the Webserver, Scheduler, Metadata database, and Celery Workers — are each run in separate containers, which means that you can easily scale resource usage based on the computing requirements of your project. Additionally, you can manage all Airflow Docker containers with a single YAML configuration file, thanks to [Docker Compose](https://docs.docker.com/compose/).
 
-This guide contains all of the necessary setup to get Airflow running on Docker. You'll create a local project directory, pull an Astronomer Core image and `docker-compose` file, and spin up your environment.
+This guide explains how to run Airflow on Docker with an Astronomer Core Docker image. You'll create a local project directory, pull an Astronomer Core image, set up Docker Compose, and spin up your environment.
 
 ## Prerequisites
 
@@ -17,11 +17,13 @@ To install Apache Airflow on Docker, you need:
 - [curl](https://curl.se/download.html)
 - [Docker](https://docs.docker.com/get-docker/)
 
+> **Note:** Docker Compose is pre-installed on Docker for Mac and Windows, but not for Linux. If you're running on Linux, make sure to [install Docker Compose](https://docs.docker.com/compose/install/) separately.
+
 ## Installation
 
 To install and run the Astronomer Core distribution of Apache Airflow:
 
-1. Create new project directory for your Airflow project and `cd` into it:
+1. Create new directory for your Airflow project and `cd` into it:
 
     ```sh
     mkdir astronomer-core && cd astronomer-core
@@ -33,36 +35,41 @@ To install and run the Astronomer Core distribution of Apache Airflow:
     touch .env packages.txt requirements.txt Dockerfile
     ```
 
-3. Add the the following to the `Dockerfile` to grab the latest Astronomer Core image on build:
+    Docker references these files whenever your image is built:
+
+    - `.env` stores Airflow environment variables.
+    - `packages.txt` stores Python-level dependencies.
+    - `requirements.txt` stores OS-level dependencies.
+    - `Dockerfile` pulls the Astronomer Core image from a Docker Registry.
+
+
+3. Add the following to your `Dockerfile` to pull the latest Astronomer Core Docker image:
 
     ```
     # For a Debian-based image
-    FROM quay.io/astronomer/docker-airflow:latest
+    FROM quay.io/astronomer/docker-airflow:latest-onbuild
     ```
 
-    To pull from a specific version, replace `latest` in the image tag with the tag for your desired version. For a list of all image tags, refer to the [quay.io repository](https://quay.io/repository/astronomer/ap-airflow?tab=tags).  
+    When you spin up your Airflow environment, this file pulls the corresponding Astronomer Core `on-build` image ([source code](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/buster/Dockerfile)). To specify a particular version of Apache Airflow and Astronomer Core, replace `latest` with the tag for your desired version. For a list of all image tags available, refer to [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
 
-
-4. In your project folder, run one of the following commands to download a default `docker-compose` file based on the database and Airflow Executor you want to use:
+4. In your project folder, run one of the following commands to download a default `docker-compose.yaml` file based on the database and Airflow Executor you want to use:
 
     | Configuration | Command |
     |---------------|---------|
     | MySQL/ Celery Executor |`curl -LfO https://raw.githubusercontent.com/astronomer/docker-airflow/main/docker-compose-mysql-celery.yaml`|
     | MySQL/ Local Executor |`curl -LfO https://raw.githubusercontent.com/astronomer/docker-airflow/main/docker-compose-mysql-local.yaml`|
-    | Postgres/ Celery Executor |`curl -lfO https://raw.githubusercontent.com/astronomer/docker-airflow/main/docker-compose-postgres-celery.yaml`|
+    | Postgres/ Local Executor |`curl -lfO https://raw.githubusercontent.com/astronomer/docker-airflow/main/docker-compose-postgres-celery.yaml`|
     | Postgres/ Celery Executor |`curl -LfO https://raw.githubusercontent.com/astronomer/docker-airflow/main/docker-compose-postgres-local.yaml` |
 
-    Your `docker-compose` file contains all of the connections and commands needed to start Airflow for the first time. Additionally, the `x-airflow-env` object is where you configure Airflow's environment variables. If you want to change a default configuration, such as your Webserver port or your Airflow home directory, you need to first update this file and restart your Airflow environment.
+    This `docker-compose.yaml` file defines the services needed to start Airflow based on the Executor and database you selected. If you want to change a default configuration, such as your Webserver port or Airflow home directory, make sure to first update this file and restart your Airflow environment. To configure Airflow [environment variables](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html), for example, add them to the `x-airflow-env` object.
 
-5. Run `docker-compose up` to spin up the local Airflow Scheduler, Webserver, and Metadata DB containers, as well as create some key objects for running Airflow. The default user created will have `admin/admin` as a username and password.
+5. Run `docker-compose up` to create isolated Docker containers for the Airflow Scheduler, Webserver, and Metadata DB. If you're running the Celery Executor, this command creates one container for each Celery worker.
 
-    By default, this command will run Airflow on your machine based on your `docker-compose` file. Containers for your Airflow Metadata Database, Airflow Webserver and Airflow Scheduler are spun up programmatically.
-
-6. To confirm the installation was successful, open `localhost:8080` in a web browser and log in as your default `admin`. If your setup was successful, you should see the Airflow home:
+6. To confirm that the installation was successful, open `localhost:8080` in a web browser. When prompted to log in, enter `admin` for both the username and password. If your setup was successful, you should see the Airflow home:
 
     ![Airflow home page](https://assets2.astronomer.io/main/docs/airflow-ui/ac-install.png)
 
-    You can also confirm that all Airflow components are running with the following Docker CLI command:
+    To confirm that all Airflow components are running successfully, you can also run the following command:
 
     ```sh
     docker ps
@@ -80,7 +87,7 @@ user@LocalMachine astronomer-core %
 
 ## Next Steps
 
-This guide provided the minimum setup necessary to get Airflow running on Docker at scale. From here, you'll want to complete the following additional setup to make the most of Airflow:
+This guide provided the minimum setup necessary to get Airflow running on Docker. From here, you'll want to complete the following additional setup to make the most of Airflow:
 
 - Automate DAG deployment across your installation
 - Upgrade to a new version of Apache Airflow

--- a/ac/next/install-docker.md
+++ b/ac/next/install-docker.md
@@ -1,0 +1,83 @@
+To install and run the Astronomer Certified distribution, ensure that Docker is running on your machine and follow the steps below:
+
+1. Create new project directory for your Airflow project and `cd` into it.
+
+        mkdir astronomer-certified && cd astronomer-certified
+
+2. Run the following command to initialize all of the necessary files you'll need to run the Airflow image locally:
+
+        touch .env packages.txt requirements.txt docker-compose.yml Dockerfile
+
+3. Add the the following to the `Dockerfile` to grab the latest Astronomer Certified image on build:
+
+        # For a Debian-based image
+        FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild
+
+    Note that you can select which version you'd like to use via the tag appended to the image.
+
+4. Add the following to the `docker-compose.yml` file:
+
+    ```yaml
+    version: "3"
+     volumes:
+       postgres_data:
+         driver: local
+       airflow_logs:
+         driver: local
+     services:
+       postgres:
+         container_name: postgres
+         image: postgres:10.1-alpine
+         restart: unless-stopped
+         volumes:
+           - postgres_data:/var/lib/postgresql/data
+       scheduler:
+         container_name: scheduler
+         image: "local-airflow-dev"
+         build: .
+         command: >
+           bash -c "airflow upgradedb && airflow scheduler"
+         restart: unless-stopped
+         depends_on:
+           - postgres
+         environment:
+           AIRFLOW__CORE__EXECUTOR: LocalExecutor
+           AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql://postgres:@postgres:5432
+           AIRFLOW__CORE__LOAD_EXAMPLES: "False"
+           # Do not reuse this key in production or anywhere outside your local laptop!
+           AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
+         volumes:
+           - ./dags:/usr/local/airflow/dags:ro
+           - ./plugins:/usr/local/airflow/plugins
+           - ./include:/usr/local/airflow/include
+           - airflow_logs:/usr/local/airflow/logs
+         env_file: .env
+       webserver:
+         container_name: webserver
+
+         image: "local-airflow-dev"
+         command: >
+           bash -c "airflow create_user -r Admin -u admin -e admin@example.com -f admin -l user -p admin && airflow webserver"
+         restart: unless-stopped
+         depends_on:
+           - scheduler
+           - postgres
+         environment:
+           AIRFLOW__CORE__EXECUTOR: LocalExecutor
+           AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql://postgres:@postgres:5432
+           AIRFLOW__CORE__LOAD_EXAMPLES: "False"
+           AIRFLOW__CORE__FERNET_KEY: "d6Vefz3G9U_ynXB3cr7y_Ak35tAHkEGAVxuz_B-jzWw="
+           AIRFLOW__WEBSERVER__RBAC: "True"
+         ports:
+           - 8080:8080
+         volumes:
+           - ./dags:/usr/local/airflow/dags:ro
+           - ./plugins:/usr/local/airflow/plugins
+           - ./include:/usr/local/airflow/include
+           - airflow_logs:/usr/local/airflow/logs
+         env_file: .env
+    ```
+
+5. Run `docker-compose up` to spin up the local Airflow Scheduler, Webserver, and Postgres containers. The default user that gets created for Airflow will have `admin/admin` as a username and password.
+
+By default, the above will run Airflow on your machine using the Local Executor.  Containers for your Airflow Metadata Database, Airflow Webserver and Airflow Scheduler are spun up programmatically (this is the equivalent of running the `airflow initdb`, `airflow webserver` and `airflow scheduler` commands detailed in the next section).

--- a/ac/next/install-docker.md
+++ b/ac/next/install-docker.md
@@ -40,7 +40,7 @@ To install and run the Astronomer Core distribution of Apache Airflow:
     FROM quay.io/astronomer/docker-airflow:latest
     ```
 
-    To pull from a specific version, replace `latest` in the image tag with your desired version. For a list of all image tags, refer to the [quay.io repository](https://quay.io/repository/astronomer/ap-airflow?tab=tags).  
+    To pull from a specific version, replace `latest` in the image tag with the tag for your desired version. For a list of all image tags, refer to the [quay.io repository](https://quay.io/repository/astronomer/ap-airflow?tab=tags).  
 
 
 4. In your project folder, run one of the following commands to download a default `docker-compose` file based on the database and Airflow Executor you want to use:

--- a/ac/next/install-docker.md
+++ b/ac/next/install-docker.md
@@ -1,12 +1,12 @@
 ---
-title: "Install Apache Airflow on Docker"
-navtitle: "Install on Docker"
-description: "A complete setup for getting Airflow running on Docker using Astronomer Core."
+title: "Run Apache Airflow with Docker Compose"
+navtitle: "Run Airflow with Docker Compose"
+description: "A complete setup for creating a multi-container Apache Airflow application with Docker Compose and Astronomer Core."
 ---
 
 ## Overview
 
-Running Apache Airflow in Docker containers is a simple and effective way to manage and grow your project. The core Airflow components — the Webserver, Scheduler, Metadata database, and Celery Workers — are each run in separate containers, which means that you can easily scale resource usage based on the computing requirements of your project. Additionally, you can manage all Airflow Docker containers with a single YAML configuration file, thanks to [Docker Compose](https://docs.docker.com/compose/).
+Running Apache Airflow in a containerized environment is a simple and effective way to manage and grow your project. The core Airflow components — the Webserver, Scheduler, Metadata database, and Celery Workers — are each run in separate containers, which means that you can easily scale resource usage based on the computing requirements of your project. With [Docker Compose](https://docs.docker.com/compose/), you can manage all Airflow Docker containers with a single YAML configuration file.
 
 This guide explains how to run Airflow on Docker with an Astronomer Core Docker image. You'll create a local project directory, pull an Astronomer Core image, set up Docker Compose, and spin up your environment.
 
@@ -35,12 +35,12 @@ To install and run the Astronomer Core distribution of Apache Airflow:
     touch .env packages.txt requirements.txt Dockerfile dags
     ```
 
-    Docker references these files whenever your image is built:
+    Docker containerizes these files whenever your image is built:
 
     - `.env` stores Airflow environment variables.
     - `packages.txt` stores Python-level dependencies.
     - `requirements.txt` stores OS-level dependencies.
-    - `Dockerfile` pulls the Astronomer Core image from a Docker Registry.
+    - `Dockerfile` pulls an Astronomer Core image from Astronomer's Docker registry. It can also include runtime commands and logic.
     - `dags` stores your Airflow DAGs.
 
 
@@ -51,7 +51,7 @@ To install and run the Astronomer Core distribution of Apache Airflow:
     FROM quay.io/astronomer/docker-airflow:latest-onbuild
     ```
 
-    When you spin up your Airflow environment, this file pulls the corresponding Astronomer Core `on-build` image ([source code](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/buster/Dockerfile)). To specify a particular version of Apache Airflow and Astronomer Core, replace `latest` with the tag for your desired version. For a list of all image tags available, refer to [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
+    When you create the Docker containers to run Airflow, this file pulls the latest Astronomer Core `onbuild` image ([source code](https://github.com/astronomer/ap-airflow/)) and creates a Docker image based on the logic within it. To specify a particular version of Apache Airflow and Astronomer Core, replace `latest` with the tag for your desired version. For a list of all image tags available, refer to [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
 
 4. In your project folder, run one of the following commands to download a default `docker-compose.yaml` file based on the database and Airflow Executor you want to use:
 
@@ -62,20 +62,20 @@ To install and run the Astronomer Core distribution of Apache Airflow:
     | Postgres/ Local Executor |`curl -lfO https://raw.githubusercontent.com/astronomer/docker-airflow/main/docker-compose-postgres-celery.yaml`|
     | Postgres/ Celery Executor |`curl -LfO https://raw.githubusercontent.com/astronomer/docker-airflow/main/docker-compose-postgres-local.yaml` |
 
-    This `docker-compose.yaml` file defines the a few things beyond the Executor and database you selected:
+    In addition to the Executor and database you selected, this `docker-compose.yaml` file defines:
 
-    - Airflow environment variables required for starting the environment
-    - A default Admin Airflow user
+    - System-level environment variables required to start the environment
+    - A default `Admin` Airflow user
     - Containers for the Airflow Scheduler, Webserver, and Metadata DB services
     - Containers for Celery workers, Redis, and Flower (Celery Executor only)
-    - Airflow commands, such as `airflow upgrade db`, which run every time you restart your environment
+    - Airflow commands required to start your environment (for example, `airflow upgrade db`)
     - Volumes for Airflow DAGs and logs
 
-    If you want to change a default configuration, such as your Webserver port or Airflow home directory, make sure to first update this file and restart your Airflow environment. Similarly, to configure Airflow [environment variables](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html), add the variables to your `.env` file and restart your Airflow environment.
+    If you want to change a default configuration, such as your Webserver port or Airflow home directory, make sure to first update this file and restart your Airflow environment. To configure Airflow [environment variables](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html), add the variables to your `.env` file and restart your Airflow environment.
 
 5. Run `docker-compose up` to create isolated Docker containers for the Airflow Scheduler, Webserver, and Metadata DB. If you're running the Celery Executor, this command creates one container for each Celery worker.
 
-6. To confirm that the installation was successful, open `localhost:8080` in a web browser. When prompted to log in, enter `admin` for both the username and password. If your setup was successful, you should see the Airflow home:
+6. To confirm that the installation was successful, open `localhost:8080` in a web browser to access the Airflow UI. When prompted to log in, enter `admin` for both the username and password. If your setup was successful, you should see the Airflow home:
 
     ![Airflow home page](https://assets2.astronomer.io/main/docs/airflow-ui/ac-install.png)
 
@@ -85,7 +85,7 @@ To install and run the Astronomer Core distribution of Apache Airflow:
     docker ps
     ```
 
-    If your installation was successful, you should see a container for each Airflow service specified in your `docker-compose` file:
+    You should see a container for each Airflow service specified in your `docker-compose` file:
 
     ```
     CONTAINER ID   IMAGE                             COMMAND                  CREATED          STATUS          PORTS                                        NAMES


### PR DESCRIPTION
Closes https://github.com/astronomer/issues/issues/2766

This PR completes our V1 AC Install docset (coupled with https://github.com/astronomer/docs/pull/280). 

As with the previous doc, the goal here is less to get users familiar with AC and Airflow and more to provide a straightforward set of steps that can get a minimal Airflow environment running and ready to scale. Introductions to AC and Airflow will be handled in subsequent PRs. 