### PR TITLE
Clarified namespace creation command

### DIFF
--- a/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
@@ -112,15 +112,13 @@ Helm is a package manager for Kubernetes. It allows you to easily deploy complex
 
 ### Create a Kubernetes Namespace
 
-<<<<<<< HEAD
-Create a [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) called `astronomer` to host the core Astronomer platform. Once Astronomer is running, it generates a separate, isolated namespace for each Airflow Deployment that you create.
-=======
-Create a [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) to host the core Astronomer platform. Once the Astronomer platform is running, it generates separate, isolated namespaces for each Airflow Deployment that you create.
->>>>>>> fa5e9a56844fae847e45e292f1fff7918267d416
+Create a [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) called `astronomer` to host the core Astronomer platform: 
 
 ```sh
 kubectl create namespace astronomer
 ```
+
+Once Astronomer is running, it generates a separate, isolated namespace for each Airflow Deployment that you create.
 
 ## Step 4: Configure TLS
 

--- a/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
@@ -112,7 +112,7 @@ Helm is a package manager for Kubernetes. It allows you to easily deploy complex
 
 ### Create a Kubernetes Namespace
 
-Create a namespace to host the core Astronomer Platform. If you are running through a standard installation, each Airflow deployment you provision will be created in a separate namespace that our platform will provision for you, this initial namespace will just contain the core Astronomer platform.
+Create a [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) called `astronomer` to host the core Astronomer platform. Once Astronomer is running, it generates a separate, isolated namespace for each Airflow Deployment that you create.
 
 ```sh
 kubectl create namespace astronomer

--- a/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
@@ -115,9 +115,7 @@ Helm is a package manager for Kubernetes. It allows you to easily deploy complex
 Create a namespace to host the core Astronomer Platform. If you are running through a standard installation, each Airflow deployment you provision will be created in a separate namespace that our platform will provision for you, this initial namespace will just contain the core Astronomer platform.
 
 ```sh
-kubectl create secret generic astronomer-bootstrap \
---from-literal connection="postgres://USERNAME:$PASSWORD@host:5432" \
---namespace astronomer
+kubectl create namespace astronomer
 ```
 
 ## Step 4: Configure TLS

--- a/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/next/03_install/02_gcp/01_install-gcp-standard.md
@@ -114,8 +114,10 @@ Helm is a package manager for Kubernetes. It allows you to easily deploy complex
 
 Create a namespace to host the core Astronomer Platform. If you are running through a standard installation, each Airflow deployment you provision will be created in a separate namespace that our platform will provision for you, this initial namespace will just contain the core Astronomer platform.
 
-```
-$ kubectl create namespace <my-namespace>
+```sh
+kubectl create secret generic astronomer-bootstrap \
+--from-literal connection="postgres://USERNAME:$PASSWORD@host:5432" \
+--namespace astronomer
 ```
 
 ## Step 4: Configure TLS

--- a/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
@@ -100,11 +100,13 @@ Helm is a package manager for Kubernetes. It allows you to easily deploy complex
 
 ### Create a Kubernetes Namespace
 
-Create a [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) called `astronomer` to host the core Astronomer platform. Once Astronomer is running, it generates a separate, isolated namespace for each Airflow Deployment that you create.
+Create a [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) called `astronomer` to host the core Astronomer platform:
 
+```sh
+kubectl create namespace astronomer
 ```
-$ kubectl create namespace <my-namespace>
-```
+
+Once Astronomer is running, it generates a separate, isolated namespace for each Airflow Deployment that you create.
 
 ## Step 4: Configure TLS
 

--- a/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
+++ b/enterprise/v0.23/03_install/02_gcp/01_install-gcp-standard.md
@@ -100,7 +100,7 @@ Helm is a package manager for Kubernetes. It allows you to easily deploy complex
 
 ### Create a Kubernetes Namespace
 
-Create a namespace to host the core Astronomer Platform. If you are running through a standard installation, each Airflow deployment you provision will be created in a separate namespace that our platform will provision for you, this initial namespace will just contain the core Astronomer platform.
+Create a [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) called `astronomer` to host the core Astronomer platform. Once Astronomer is running, it generates a separate, isolated namespace for each Airflow Deployment that you create.
 
 ```
 $ kubectl create namespace <my-namespace>


### PR DESCRIPTION
Closes https://github.com/astronomer/docs/issues/293

Not sure when this got changed, but I think we can start establishing a writing best practice of suggesting specific names for components of the Astronomer system. It's easier to follow and create consistent instructions throughout our docs when things have specific names, especially when there's little reason for an organization to name these components anything other than what we suggest. 

In docs where the namespace is already assumed to be created, this could be a little more ambiguous, but for installation guides I agree that we should be consistent with naming to make an install as easy and clear as possible. 

If this looks good, I'll push it to the `v0.23` version of this doc as well. 