### PR TITLE
Added information about deleting Deployments

### DIFF
--- a/cloud/stable/03_deploy/02_configure-deployment.md
+++ b/cloud/stable/03_deploy/02_configure-deployment.md
@@ -132,3 +132,9 @@ These can include setting Airflow Parallelism, an SMTP service for Alerts, or a 
 Environment Variables can be set for your Airflow Deployment either in the **Variables** tab of the Astronomer UI or in your `Dockerfile`. If you're developing locally, they can also be added to a local `.env` file. For more information on configuring Environment Variables, read [Environment Variables on Astronomer](/docs/cloud/stable/deploy/environment-variables/).
 
 > **Note**: Environment Variables are distinct from [Airflow Variables](https://airflow.apache.org/docs/apache-airflow/stable/howto/variable.html?highlight=variables) and [XComs](https://airflow.apache.org/docs/apache-airflow/stable/concepts.html?highlight=xcom#concepts-xcom), which you can configure directly via the Airflow UI and are used for inter-task communication.
+
+## Delete a Deployment
+
+You can delete an Airflow Deployment using the **Delete Deployment** button at the bottom of your Deployment's **Settings** tab.
+
+When you delete a Deployment, your Airflow Webserver, Scheduler, metadata database, and deploy history will be deleted, and you will lose any configurations set in the Airflow UI.

--- a/cloud/stable/03_deploy/02_configure-deployment.md
+++ b/cloud/stable/03_deploy/02_configure-deployment.md
@@ -22,16 +22,16 @@ To create an Airflow Deployment, you'll need:
 To create an Airflow Deployment on Astronomer:
 
 1. Log in to [Astronomer Cloud](https://app.gcp0001.us-east4.astronomer.io/), open your Workspace, and click **New Deployment**.
-
 2. Use the **New Deployment** menu to configure the following:
 
-  * **Name**
-  * **Description** (Optional)
-  * **Airflow Version**: We recommend using the latest version.
-  * **Executor**: We recommend starting with Local.
+  - **Name**
+  - **Description** (Optional)
+  - **Airflow Version**: We recommend using the latest version.
+  - **Executor**: We recommend starting with Local.
 
 3. Click **Create Deployment** and give the Deployment a few moments to spin up. Within a few seconds, you'll have access to the **Settings** page of your new Deployment:
-![New Deployment Celery Dashboard](https://assets2.astronomer.io/main/docs/deploying-code/v0.23-new_deployment-dashboard.png)
+
+    ![New Deployment Celery Dashboard](https://assets2.astronomer.io/main/docs/deploying-code/v0.23-new_deployment-dashboard.png)
 
 This tab is the best place to modify resources for your Deployment. Specifically, you can:
 

--- a/enterprise/v0.23/04_deploy/02_configure-deployment.md
+++ b/enterprise/v0.23/04_deploy/02_configure-deployment.md
@@ -137,4 +137,4 @@ You can delete an Airflow Deployment using the **Delete Deployment** button at t
 
 When you delete a Deployment, your Airflow Webserver, Scheduler, metadata database, and deploy history will be deleted, and you will lose any configurations set in the Airflow UI.
 
-> Note: If you give a Deployment a custom release name and delete the Deployment, that custom release name cannot normally be reused with any future Deployments. If you need to reuse a custom release name after deleting its respective Deployment, reach out to Astronomer support.
+> Note: If you give a Deployment a custom release name and delete the Deployment, that custom release name cannot normally be reused with any future Deployments. If you need to reuse a custom release name after deleting its respective Deployment, reach out to [Astronomer support](https://www.astronomer.io/docs/enterprise/v0.23/resources/support).

--- a/enterprise/v0.23/04_deploy/02_configure-deployment.md
+++ b/enterprise/v0.23/04_deploy/02_configure-deployment.md
@@ -130,3 +130,11 @@ These can include setting Airflow Parallelism, an SMTP service for Alerts, or a 
 Environment Variables can be set for your Airflow Deployment either in the **Variables** tab of the Astronomer UI or in your `Dockerfile`. If you're developing locally, they can also be added to a local `.env` file. For more information on configuring Environment Variables, read [Environment Variables on Astronomer](/docs/enterprise/v0.23/deploy/environment-variables/).
 
 > **Note**: Environment Variables are distinct from [Airflow Variables](https://airflow.apache.org/docs/apache-airflow/stable/howto/variable.html?highlight=variables) and [XComs](https://airflow.apache.org/docs/apache-airflow/stable/concepts.html?highlight=xcom#concepts-xcom), which you can configure directly via the Airflow UI and are used for inter-task communication.
+
+## Delete a Deployment
+
+You can delete an Airflow Deployment using the **Delete Deployment** button at the bottom of the Deployment's **Settings** tab.
+
+When you delete a Deployment, your Airflow Webserver, Scheduler, metadata database, and deploy history will be deleted, and you will lose any configurations set in the Airflow UI.
+
+> Note: If you give a Deployment a custom release name and delete the Deployment, that custom release name cannot normally be reused with any future Deployments. If you need to reuse a custom release name after deleting its respective Deployment, reach out to Astronomer support.

--- a/enterprise/v0.23/04_deploy/02_configure-deployment.md
+++ b/enterprise/v0.23/04_deploy/02_configure-deployment.md
@@ -22,7 +22,6 @@ To create an Airflow Deployment, you'll need:
 To create an Airflow Deployment on Astronomer:
 
 1. Log in to your Astronomer platform at `app.BASEDOMAIN`, open your Workspace, and click **New Deployment**.
-
 2. Use the **New Deployment** menu to configure the following:
 
   * **Name**
@@ -134,7 +133,9 @@ Environment Variables can be set for your Airflow Deployment either in the **Var
 
 ## Customize Release Names
 
-To specify custom release names for Deployments, you first need to enable the feature on your Astronomer platform. To do so, set the following value in your `config.yaml` file:
+An Airflow Deployment's release name on Astronomer is a unique, immutable identifier for that Deployment that corresponds to its Kubernetes namespace and that renders in Grafana, Kibana, and other platform-level monitoring tools. By default, release names are randomly generated in the following format: `noun-noun-<4-digit-number>`. For example: `elementary-zenith-7243`.
+
+To customize the release name for a Deployment as you're creating it, you first need to enable the feature on your Astronomer platform. To do so, set the following value in your `config.yaml` file:
 
 ```yaml
 astronomer:
@@ -160,4 +161,4 @@ In your Astronomer database, the corresponding `Deployment` record will be given
 
 > Note: If you give a Deployment a custom release name, that custom release name cannot be reused to create another Airflow Deployment, including one in another Workspace.
 >
-> To reuse a custom release name that was previously given to a Deployment that has since been deleted via the Astronomer UI or CLI, you need to permanently delete its entry in both your Astronomer database and the Deployment's metadata database. For guidance, reach out to [Astronomer support](https://www.astronomer.io/docs/enterprise/v0.23/resources/support).
+> To reuse a custom release name that was previously given to a Deployment that has since been deleted via the Astronomer UI or CLI, you need to permanently delete both the Deployment's metadata database and the Deployment's entry in your Astronomer database. For guidance, reach out to [Astronomer support](https://www.astronomer.io/docs/enterprise/v0.23/resources/support).

--- a/enterprise/v0.23/04_deploy/02_configure-deployment.md
+++ b/enterprise/v0.23/04_deploy/02_configure-deployment.md
@@ -31,7 +31,8 @@ To create an Airflow Deployment on Astronomer:
   * **Executor**: We recommend starting with Local.
 
 3. Click **Create Deployment** and give the Deployment a few moments to spin up. Within a few seconds, you'll have access to the **Settings** page of your new Deployment:
-![New Deployment Celery Dashboard](https://assets2.astronomer.io/main/docs/deploying-code/v0.23-new_deployment-dashboard.png)
+
+   ![New Deployment Celery Dashboard](https://assets2.astronomer.io/main/docs/deploying-code/v0.23-new_deployment-dashboard.png)
 
 This tab is the best place to modify resources for your Deployment. Specifically, you can:
 
@@ -131,10 +132,32 @@ Environment Variables can be set for your Airflow Deployment either in the **Var
 
 > **Note**: Environment Variables are distinct from [Airflow Variables](https://airflow.apache.org/docs/apache-airflow/stable/howto/variable.html?highlight=variables) and [XComs](https://airflow.apache.org/docs/apache-airflow/stable/concepts.html?highlight=xcom#concepts-xcom), which you can configure directly via the Airflow UI and are used for inter-task communication.
 
+## Customize Release Names
+
+To specify custom release names for Deployments, you first need to explicitly enable the feature on your Astronomer platform. To do so, ensure that the following value is set in your `config.yaml` file:
+
+```yaml
+astronomer:
+  houston:
+    config:
+      deployments:
+        manualReleaseNames: true # Allows you to set your release names
+```
+
+Then, push the updated `config.yaml` file to your installation as described in [Apply a Config Change](https://www.astronomer.io/docs/enterprise/v0.23/manage-astronomer/apply-platform-config).
+
+After applying this change, the  **Release Name** field in the Astronomer UI becomes configurable:
+
+![Custom Release Name Field](https://assets2.astronomer.io/main/docs/astronomer-ui/custom-release-name.png)
+
 ## Delete a Deployment
 
 You can delete an Airflow Deployment using the **Delete Deployment** button at the bottom of the Deployment's **Settings** tab.
 
 When you delete a Deployment, your Airflow Webserver, Scheduler, metadata database, and deploy history will be deleted, and you will lose any configurations set in the Airflow UI.
 
-> Note: If you give a Deployment a custom release name and delete the Deployment, that custom release name cannot normally be reused with any future Deployments. If you need to reuse a custom release name after deleting its respective Deployment, reach out to [Astronomer support](https://www.astronomer.io/docs/enterprise/v0.23/resources/support).
+In your Astronomer database, the corresponding `Deployment` record will be given a `deletedAt` value and continue to persist until permanently deleted.
+
+> Note: If you give a Deployment a custom release name, that custom release name cannot be reused to create another Airflow Deployment, including one in another Workspace.
+>
+> To reuse a custom release name that was previously given to a Deployment that has since been deleted via the Astronomer UI or CLI, you need to permanently delete its entry in both your Astronomer database and the Deployment's metadata database. For guidance, reach out to [Astronomer support](https://www.astronomer.io/docs/enterprise/v0.23/resources/support).

--- a/enterprise/v0.23/04_deploy/02_configure-deployment.md
+++ b/enterprise/v0.23/04_deploy/02_configure-deployment.md
@@ -134,7 +134,7 @@ Environment Variables can be set for your Airflow Deployment either in the **Var
 
 ## Customize Release Names
 
-To specify custom release names for Deployments, you first need to explicitly enable the feature on your Astronomer platform. To do so, ensure that the following value is set in your `config.yaml` file:
+To specify custom release names for Deployments, you first need to enable the feature on your Astronomer platform. To do so, set the following value in your `config.yaml` file:
 
 ```yaml
 astronomer:
@@ -146,7 +146,7 @@ astronomer:
 
 Then, push the updated `config.yaml` file to your installation as described in [Apply a Config Change](https://www.astronomer.io/docs/enterprise/v0.23/manage-astronomer/apply-platform-config).
 
-After applying this change, the  **Release Name** field in the Astronomer UI becomes configurable:
+After applying this change, the **Release Name** field in the Astronomer UI becomes configurable:
 
 ![Custom Release Name Field](https://assets2.astronomer.io/main/docs/astronomer-ui/custom-release-name.png)
 


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/327.

We talk a lot about creating Deployments in docs, but never about deleting them. This simple PR adds information around deleting Deployments. I also added some Enterprise-specific information about deleting Deployments with custom release names, as we get a lot of questions about this and should have at least some cursory information about it in our docs.