### PR TITLE
Embedded new YouTube video in quickstart guides

### DIFF
--- a/cloud/stable/01_get-started/01_quickstart.md
+++ b/cloud/stable/01_get-started/01_quickstart.md
@@ -285,7 +285,7 @@ For guidance on how to navigate the Airflow UI, refer to [Apache Airflow documen
 
 ## Video Tutorial
 
-Watch our video tutorial for a brief review of the workflows and concepts described in this quickstart guide:
+Watch our video tutorial for a brief review of the workflows and concepts described in this quickstart:
 
 <iframe width="560" height="315" src="https://youtu.be/OihokE8u9D0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 

--- a/cloud/stable/01_get-started/01_quickstart.md
+++ b/cloud/stable/01_get-started/01_quickstart.md
@@ -4,11 +4,13 @@ navTitle: "Quickstart"
 description: "Get started with Astronomer Cloud."
 ---
 
+## Overview
+
 Welcome to Astronomer.
 
 This guide will help you kick off your trial on Astronomer by walking you through a sample DAG deployment from start to finish.
 
-Whether you're exploring our Enterprise or Cloud offering, we've designed this to be a great way to become familiar with our platform.
+Whether you're exploring our Enterprise or Cloud offering, we've designed this quickstart to be a great way to become familiar with our platform.
 
 ## Step 1: Start Your Trial
 
@@ -280,6 +282,12 @@ Once you deploy to Astronomer, reopen the [Astronomer UI](https://app.gcp0001.us
 This links to your Deployment's Airflow UI, where you'll find your example DAG and all other DAGs in your project.
 
 For guidance on how to navigate the Airflow UI, refer to [Apache Airflow documentation](https://airflow.apache.org/docs/apache-airflow/stable/ui.html).
+
+## Video Tutorial
+
+Watch our video tutorial for a brief review of the workflows and concepts described in this quickstart guide:
+
+<iframe width="560" height="315" src="https://youtu.be/OihokE8u9D0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
 ## What's Next?
 

--- a/cloud/stable/02_develop/01_cli-quickstart.md
+++ b/cloud/stable/02_develop/01_cli-quickstart.md
@@ -265,6 +265,12 @@ For more information on Astronomer and Astronomer CLI releases, refer to:
 * [CLI Release Changelog](https://github.com/astronomer/astro-cli/releases)
 * [Astronomer Release Notes](https://www.astronomer.io/docs/cloud/stable/resources/release-notes)
 
+## Video Tutorial
+
+Watch our video tutorial for a brief review of the workflows and concepts described in this quickstart:
+
+<iframe width="560" height="315" src="https://youtu.be/OihokE8u9D0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+
 ## Next Steps
 
 After installing and trying out the Astronomer CLI, we recommend reading through the following guides:

--- a/enterprise/v0.25/01_get-started/01_quickstart.md
+++ b/enterprise/v0.25/01_get-started/01_quickstart.md
@@ -161,27 +161,33 @@ For a production environment, you'll likely need to set resources and configure 
 You can now use Astronomer to start Airflow locally and deploy code. To do so:
 
 1. Go to the Airflow project directory you created in **Step 4** and run the following command:
-   ```sh
-   $ astro dev start
-   ```
-   This command spins up 3 Docker containers on your machine, each for a different Airflow component:
 
-   - **Postgres:** [Airflow's Metadata Database](/docs/enterprise/v0.25/customize-airflow/access-airflow-database/)
-   - **Webserver:** The Airflow component responsible for rendering the Airflow UI
-   - **Scheduler:** The Airflow component responsible for monitoring and triggering tasks
-   > **Note:** If you’re running the Astronomer CLI with the [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) feature enabled in Docker, you may see an error (`buildkit not supported by daemon`). Learn more in [this forum post](https://forum.astronomer.io/t/buildkit-not-supported-by-daemon-error-command-docker-build-t-airflow-astro-bcb837-airflow-latest-failed-failed-to-execute-cmd-exit-status-1/857).
+    ```sh
+    $ astro dev start
+    ```
+
+    This command spins up 3 Docker containers on your machine, each for a different Airflow component:
+
+    - **Postgres:** [Airflow's Metadata Database](/docs/enterprise/v0.25/customize-airflow/access-airflow-database/)
+    - **Webserver:** The Airflow component responsible for rendering the Airflow UI
+    - **Scheduler:** The Airflow component responsible for monitoring and triggering tasks
+
+    > **Note:** If you’re running the Astronomer CLI with the [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) feature enabled in Docker, you may see an error (`buildkit not supported by daemon`). Learn more in [this forum post](https://forum.astronomer.io/t/buildkit-not-supported-by-daemon-error-command-docker-build-t-airflow-astro-bcb837-airflow-latest-failed-failed-to-execute-cmd-exit-status-1/857).
 
 2. Verify that all 3 Docker containers were created by running the following command:
-   ```
-   $ docker ps
-   ```
-   > **Note**: Running `$ astro dev start` will start your project with the Airflow Webserver exposed at port 8080 and Postgres exposed at port 5432. If you already have either of those ports allocated, you can either [stop existing docker containers](https://forum.astronomer.io/t/docker-error-in-cli-bind-for-0-0-0-0-5432-failed-port-is-already-allocated/151) or [change the port](https://forum.astronomer.io/t/i-already-have-the-ports-that-the-cli-is-trying-to-use-8080-5432-occupied-can-i-change-the-ports-when-starting-a-project/48).
+
+    ```
+    docker ps
+    ```
+
+    > **Note**: Running `$ astro dev start` will start your project with the Airflow Webserver exposed at port 8080 and Postgres exposed at port 5432. If you already have either of those ports allocated, you can either [stop existing docker containers](https://forum.astronomer.io/t/docker-error-in-cli-bind-for-0-0-0-0-5432-failed-port-is-already-allocated/151) or [change the port](https://forum.astronomer.io/t/i-already-have-the-ports-that-the-cli-is-trying-to-use-8080-5432-occupied-can-i-change-the-ports-when-starting-a-project/48).
 
 
 3. Deploy the `example-dag` from `hello-astro` to Airflow by running the following command:
-   ```sh
-   $ astro deploy
-   ```
+
+    ```sh
+    astro deploy
+    ```
 
 4. Confirm the deploy was successful by going to your local Airflow instance at `http://localhost:8080`.
 
@@ -196,6 +202,12 @@ The **Metrics** tab only shows metrics for a given Deployment. If you are the fi
 ![Admin](https://assets2.astronomer.io/main/docs/enterprise_quickstart/admin_panel.png)
 
 These views show logs and metrics across all Deployments running on your Astronomer platform. To learn more about using Grafana, read [Metrics in Astronomer Enterprise](https://www.astronomer.io/docs/enterprise/v0.25/monitor/grafana-metrics). To learn more about using Kibana, read [Logging in Astronomer Enterprise](/docs/enterprise/v0.25/monitor/kibana-logging/).
+
+## Video Tutorial
+
+Watch our video tutorial for a brief review of the workflows and concepts described in this quickstart:
+
+<iframe width="560" height="315" src="https://youtu.be/OihokE8u9D0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
 ## What's Next?
 

--- a/enterprise/v0.25/02_develop/01_cli-quickstart.md
+++ b/enterprise/v0.25/02_develop/01_cli-quickstart.md
@@ -261,6 +261,12 @@ For more information on Astronomer and Astronomer CLI releases, refer to:
 * [CLI Release Changelog](https://github.com/astronomer/astro-cli/releases)
 * [Astronomer Release Notes](https://www.astronomer.io/docs/enterprise/v0.25/resources/release-notes)
 
+## Video Tutorial
+
+Watch our video tutorial for a brief review of the workflows and concepts described in this quickstart:
+
+<iframe width="560" height="315" src="https://youtu.be/OihokE8u9D0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+
 ## Next Steps
 
 After installing and trying out the Astronomer CLI, we recommend reading through the following guides:


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/347

Marc's latest [YouTube video](https://youtu.be/OihokE8u9D0) covers almost identical ground to our Cloud and CLI quickstarts, so I think it makes sense to offer it as an alternative to the written steps.

Just so there's not too much information at the beginning, I embedded it after the written quickstart as an h2 header. If people are looking for a video, they'll be able to see the title in the righthand side nav.

I also added this to the Enterprise quickstarts, although there's some differences between those guides and the video. For one, the `auth login` section of the video assumes the viewer is using Cloud. Also, unlike the quickstart, we don't cover accessing metrics in the video. Still I think they share enough in common that we should still include it. WDYT?