### PR TITLE
Fixed Deployment Viewer permission information

### DIFF
--- a/cloud/stable/05_manage-astronomer/01_workspace-permissions.md
+++ b/cloud/stable/05_manage-astronomer/01_workspace-permissions.md
@@ -20,7 +20,7 @@ The guidelines below will cover:
 
 Workspace and Deployment _Admins_ can invite and otherwise manage users both via the Astronomer UI and CLI. All users who have access to a Workspace must be assigned 1 of 3 Workspace roles, though deployment-level roles are not required.
 
-Read below for guidelines. 
+Read below for guidelines.
 
 ### Invite to Workspace
 
@@ -216,7 +216,7 @@ Below a Workspace _Admin_, an _Editor_:
 
 #### Workpace Viewer
 
-A Workspace _Viewer_ is limited to read-only mode. _Viewers_: 
+A Workspace _Viewer_ is limited to read-only mode. _Viewers_:
 
 - Can list users in a Workspace
 - Can view all Airflow Deployments in the Workspace
@@ -267,7 +267,6 @@ Deployment _Viewers_ are limited to read-only mode. They:
 - Can view the **Metrics** and **Logs** tab of the Astro UI
 - Can access the Airflow UI
 - Cannot deploy to, modify, or delete anything within an Airflow Deployment
-- Cannot view Airflow task logs
 
 Viewers _cannot_ push code to an Airflow Deployment or create Service Accounts to do so. Attempts to view logs, trigger DAGs, etc. will result in a `403` and an `Access is Denied` message.
 

--- a/cloud/stable/05_manage-astronomer/01_workspace-permissions.md
+++ b/cloud/stable/05_manage-astronomer/01_workspace-permissions.md
@@ -261,12 +261,12 @@ Behind _Admins_, a Deployment _Editor_:
 
 #### Deployment Viewer
 
-Deployment _Viewers_ are limited to read-only mode. They can:
+Deployment _Viewers_ are limited to read-only mode. They can only:
 
 - View Deployment users
 - View the **Metrics** and **Logs** tab of the Astro UI
 - View information about DAGs and tasks in the Airflow UI
 
-Deployment Viewers _cannot_ deploy to, modify, or delete anything within an Airflow Deployment. Additionally, they cannot create or use Service Accounts to do so. Attempts to modify a Deployment in any way will result in a `403` and an `Access is Denied` message.
+Deployment Viewers cannot deploy to, modify, or delete anything within an Airflow Deployment. Additionally, they cannot create or use Service Accounts to do so. Attempts to modify a Deployment in any way will result in a `403` and an `Access is Denied` message.
 
 ![Access Denied](https://assets2.astronomer.io/main/docs/astronomer-ui/access_denied.png)

--- a/cloud/stable/05_manage-astronomer/01_workspace-permissions.md
+++ b/cloud/stable/05_manage-astronomer/01_workspace-permissions.md
@@ -261,13 +261,12 @@ Behind _Admins_, a Deployment _Editor_:
 
 #### Deployment Viewer
 
-Deployment _Viewers_ are limited to read-only mode. They:
+Deployment _Viewers_ are limited to read-only mode. They can:
 
-- Can view Deployment users
-- Can view the **Metrics** and **Logs** tab of the Astro UI
-- Can access the Airflow UI
-- Cannot deploy to, modify, or delete anything within an Airflow Deployment
+- View Deployment users
+- View the **Metrics** and **Logs** tab of the Astro UI
+- View information about DAGs and tasks in the Airflow UI
 
-Viewers _cannot_ push code to an Airflow Deployment or create Service Accounts to do so. Attempts to view logs, trigger DAGs, etc. will result in a `403` and an `Access is Denied` message.
+Deployment Viewers _cannot_ deploy to, modify, or delete anything within an Airflow Deployment. Additionally, they cannot create or use Service Accounts to do so. Attempts to modify a Deployment in any way will result in a `403` and an `Access is Denied` message.
 
 ![Access Denied](https://assets2.astronomer.io/main/docs/astronomer-ui/access_denied.png)

--- a/enterprise/v0.23/06_manage-astronomer/03_workspace-permissions.md
+++ b/enterprise/v0.23/06_manage-astronomer/03_workspace-permissions.md
@@ -265,7 +265,6 @@ Deployment _Viewers_ are limited to read-only mode. They:
 - Can view the **Metrics** and **Logs** tab of the Astro UI
 - Can access the Airflow UI
 - Cannot deploy to, modify, or delete anything within an Airflow Deployment
-- Cannot view Airflow task logs
 
 Viewers _cannot_ push code to an Airflow Deployment or create Service Accounts to do so. Attempts to view logs, trigger DAGs, etc. will result in a `403` and an `Access is Denied` message.
 

--- a/enterprise/v0.23/06_manage-astronomer/03_workspace-permissions.md
+++ b/enterprise/v0.23/06_manage-astronomer/03_workspace-permissions.md
@@ -269,7 +269,6 @@ Deployment Viewers _cannot_ deploy to, modify, or delete anything within an Airf
 
 ![Access Denied](https://assets2.astronomer.io/main/docs/astronomer-ui/access_denied.png)
 
-
 ## What's Next
 
 As an Astronomer Enterprise user, you're free to customize all user permissions at the platform-level. For more information, read:

--- a/enterprise/v0.23/06_manage-astronomer/03_workspace-permissions.md
+++ b/enterprise/v0.23/06_manage-astronomer/03_workspace-permissions.md
@@ -259,13 +259,13 @@ Behind _Admins_, a Deployment _Editor_:
 
 #### Deployment Viewer
 
-Deployment _Viewers_ are limited to read-only mode. They can:
+Deployment _Viewers_ are limited to read-only mode. They can only:
 
 - View Deployment users
 - View the **Metrics** and **Logs** tab of the Astro UI
 - View information about DAGs and tasks in the Airflow UI
 
-Deployment Viewers _cannot_ deploy to, modify, or delete anything within an Airflow Deployment. Additionally, they cannot create or use Service Accounts to do so. Attempts to modify a Deployment in any way will result in a `403` and an `Access is Denied` message.
+Deployment Viewers cannot deploy to, modify, or delete anything within an Airflow Deployment. Additionally, they cannot create or use Service Accounts to do so. Attempts to modify a Deployment in any way will result in a `403` and an `Access is Denied` message.
 
 ![Access Denied](https://assets2.astronomer.io/main/docs/astronomer-ui/access_denied.png)
 

--- a/enterprise/v0.23/06_manage-astronomer/03_workspace-permissions.md
+++ b/enterprise/v0.23/06_manage-astronomer/03_workspace-permissions.md
@@ -259,16 +259,16 @@ Behind _Admins_, a Deployment _Editor_:
 
 #### Deployment Viewer
 
-Deployment _Viewers_ are limited to read-only mode. They:
+Deployment _Viewers_ are limited to read-only mode. They can:
 
-- Can view Deployment users
-- Can view the **Metrics** and **Logs** tab of the Astro UI
-- Can access the Airflow UI
-- Cannot deploy to, modify, or delete anything within an Airflow Deployment
+- View Deployment users
+- View the **Metrics** and **Logs** tab of the Astro UI
+- View information about DAGs and tasks in the Airflow UI
 
-Viewers _cannot_ push code to an Airflow Deployment or create Service Accounts to do so. Attempts to view logs, trigger DAGs, etc. will result in a `403` and an `Access is Denied` message.
+Deployment Viewers _cannot_ deploy to, modify, or delete anything within an Airflow Deployment. Additionally, they cannot create or use Service Accounts to do so. Attempts to modify a Deployment in any way will result in a `403` and an `Access is Denied` message.
 
 ![Access Denied](https://assets2.astronomer.io/main/docs/astronomer-ui/access_denied.png)
+
 
 ## What's Next
 

--- a/enterprise/v0.25/06_manage-astronomer/03_workspace-permissions.md
+++ b/enterprise/v0.25/06_manage-astronomer/03_workspace-permissions.md
@@ -259,14 +259,13 @@ Behind _Admins_, a Deployment _Editor_:
 
 #### Deployment Viewer
 
-Deployment _Viewers_ are limited to read-only mode. They:
+Deployment _Viewers_ are limited to read-only mode. They can:
 
-- Can view Deployment users
-- Can view the **Metrics** and **Logs** tab of the Astro UI
-- Can access the Airflow UI
-- Cannot deploy to, modify, or delete anything within an Airflow Deployment
+- View Deployment users
+- View the **Metrics** and **Logs** tab of the Astro UI
+- View information about DAGs and tasks in the Airflow UI
 
-Viewers _cannot_ push code to an Airflow Deployment or create Service Accounts to do so. Attempts to view logs, trigger DAGs, etc. will result in a `403` and an `Access is Denied` message.
+Deployment Viewers _cannot_ deploy to, modify, or delete anything within an Airflow Deployment. Additionally, they cannot create or use Service Accounts to do so. Attempts to modify a Deployment in any way will result in a `403` and an `Access is Denied` message.
 
 ![Access Denied](https://assets2.astronomer.io/main/docs/astronomer-ui/access_denied.png)
 

--- a/enterprise/v0.25/06_manage-astronomer/03_workspace-permissions.md
+++ b/enterprise/v0.25/06_manage-astronomer/03_workspace-permissions.md
@@ -265,7 +265,6 @@ Deployment _Viewers_ are limited to read-only mode. They:
 - Can view the **Metrics** and **Logs** tab of the Astro UI
 - Can access the Airflow UI
 - Cannot deploy to, modify, or delete anything within an Airflow Deployment
-- Cannot view Airflow task logs
 
 Viewers _cannot_ push code to an Airflow Deployment or create Service Accounts to do so. Attempts to view logs, trigger DAGs, etc. will result in a `403` and an `Access is Denied` message.
 

--- a/enterprise/v0.25/06_manage-astronomer/03_workspace-permissions.md
+++ b/enterprise/v0.25/06_manage-astronomer/03_workspace-permissions.md
@@ -259,13 +259,13 @@ Behind _Admins_, a Deployment _Editor_:
 
 #### Deployment Viewer
 
-Deployment _Viewers_ are limited to read-only mode. They can:
+Deployment _Viewers_ are limited to read-only mode. They can only:
 
 - View Deployment users
 - View the **Metrics** and **Logs** tab of the Astro UI
 - View information about DAGs and tasks in the Airflow UI
 
-Deployment Viewers _cannot_ deploy to, modify, or delete anything within an Airflow Deployment. Additionally, they cannot create or use Service Accounts to do so. Attempts to modify a Deployment in any way will result in a `403` and an `Access is Denied` message.
+Deployment Viewers cannot deploy to, modify, or delete anything within an Airflow Deployment. Additionally, they cannot create or use Service Accounts to do so. Attempts to modify a Deployment in any way will result in a `403` and an `Access is Denied` message.
 
 ![Access Denied](https://assets2.astronomer.io/main/docs/astronomer-ui/access_denied.png)
 


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/351

At some point in v0.23, we wrote that Deployment Viewers cannot view Airflow task logs, which are available in the Airflow UI. I tried to be more clear about what was / wasn't possible for this type of user. By saying "They can only", I avoid having to list out the many things that Deployment Viewers *can't* do.

It seems like we might have mistook task log access for Kibana logging metrics, but I don't think it's even necessary to mention that lack of permission here. 