### PR TITLE
Remove folder parameter from link checker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,4 +46,3 @@ jobs:
           config-file: './mlc_config.json'
           check-modified-files-only: 'yes'
           base-branch: 'main'
-          folder-path: './enterprise/next/, ./cloud/stable/, ./cloud/stable/ ./enterprise/next/'


### PR DESCRIPTION
We no longer have an `enterprise/next` folder, so the link checker started failing every time it ran. I looked into this more, and given that `check-modified-files-only` is set to yes we should be able to eliminate the `folder-path` parameter entirely.

As long as it's only looking at modified files, it should be fine that the [default behavior of the action](https://github.com/gaurav-nelson/github-action-markdown-link-check#configuration) is to check all folders in the repository. This will also decrease maintenance over time, as we wont have to add new Enterprise folder versions to the GH Action. 