### PR TITLE
Add Celery and Redis to AC Version Compatibility Matrix

### DIFF
--- a/enterprise/v0.23/09_resources/04_version-compatibility-reference.md
+++ b/enterprise/v0.23/09_resources/04_version-compatibility-reference.md
@@ -22,18 +22,18 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Certified
 
-| Astronomer Certified | Postgres | MySQL     | Python        | System Distribution             | Airflow Helm Chart     |
-| -------------------- | -------- | --------- | ------------- | ------------------------------- | ---------------------- |
-| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    |
-| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    |
-| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    |
-| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    |
-| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    |
-| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    |
-| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 |
-| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 |
+| Astronomer Certified | Postgres | MySQL     | Python        | System Distribution             | Airflow Helm Chart     | Redis   | Celery |
+| -------------------- | -------- | --------- | ------------- | ------------------------------- | ---------------------- | --------|--------|
+| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1   | 4.4.7  |
+| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1   | 4.4.7  |
+| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1   | 4.4.7  |
+| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1   | 4.4.7  |
+| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 6.2.1   | 4.4.7  |
+| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 6.2.1   | 4.4.7  |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1   | 4.4.7  |
+| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1   | 4.4.7  |
 
-For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/v0.23/customize-airflow/manage-airflow-versions/).
+For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our [Upgrade Apache Airflow](https://www.astronomer.io/docs/enterprise/v0.23/customize-airflow/manage-airflow-versions/).
 
 > **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](https://www.astronomer.io/docs/enterprise/v0.23/develop/customize-image#build-with-a-different-python-version).
 

--- a/enterprise/v0.23/09_resources/04_version-compatibility-reference.md
+++ b/enterprise/v0.23/09_resources/04_version-compatibility-reference.md
@@ -33,7 +33,7 @@ It's worth noting that while the tables below reference the minimum compatible v
 | 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1   | 4.4.7  |
 | 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1   | 4.4.7  |
 
-For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our [Upgrade Apache Airflow](https://www.astronomer.io/docs/enterprise/v0.23/customize-airflow/manage-airflow-versions/).
+For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to [Upgrade Apache Airflow](https://www.astronomer.io/docs/enterprise/v0.23/customize-airflow/manage-airflow-versions/).
 
 > **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](https://www.astronomer.io/docs/enterprise/v0.23/develop/customize-image#build-with-a-different-python-version).
 

--- a/enterprise/v0.25/09_resources/04_version-compatibility-reference.md
+++ b/enterprise/v0.25/09_resources/04_version-compatibility-reference.md
@@ -21,18 +21,18 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Certified
 
-| Astronomer Certified | Postgres | MySQL     | Python        | System Distribution             | Airflow Helm Chart     |
-| -------------------- | -------- | --------- | ------------- | ------------------------------- | ---------------------- |
-| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    |
-| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    |
-| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    |
-| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    |
-| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    |
-| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    |
-| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 |
-| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 |
+| Astronomer Certified | Postgres | MySQL     | Python        | System Distribution             | Airflow Helm Chart     | Redis  | Celery |
+| -------------------- | -------- | --------- | ------------- | ------------------------------- | ---------------------- | -------|--------|
+| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 3.2    | 4.3    |
+| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 3.2    | 4.3    |
+| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 3.2    | 4.3    |
+| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 3.2    | 4.3    |
+| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 3.2    | 4.3    |
+| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 3.2    | 4.3    |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 3.2    | 4.4.2  |
+| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 3.2    | 4.4.2  |
 
-For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to our ["Manage Airflow Versions" doc](https://www.astronomer.io/docs/enterprise/v0.25/customize-airflow/manage-airflow-versions/).
+For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to [Upgrade Apache Airflow](https://www.astronomer.io/docs/enterprise/v0.25/customize-airflow/manage-airflow-versions/).
 
 > **Note:** While the Astronomer Certified Python Wheel supports Python versions 3.6, 3.7, and 3.8, Astronomer Certified Docker images have been tested and built only with Python 3.7. To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you can create a custom image with a different Python version specified. For more information, read [Change Python Versions](/docs/enterprise/v0.25/customize-image#build-with-a-different-python-version).
 

--- a/enterprise/v0.25/09_resources/04_version-compatibility-reference.md
+++ b/enterprise/v0.25/09_resources/04_version-compatibility-reference.md
@@ -21,16 +21,16 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Certified
 
-| Astronomer Certified | Postgres | MySQL     | Python        | System Distribution             | Airflow Helm Chart     | Redis  | Celery |
-| -------------------- | -------- | --------- | ------------- | ------------------------------- | ---------------------- | -------|--------|
-| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 3.2    | 4.3    |
-| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 3.2    | 4.3    |
-| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 3.2    | 4.3    |
-| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 3.2    | 4.3    |
-| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 3.2    | 4.3    |
-| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 3.2    | 4.3    |
-| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 3.2    | 4.4.2  |
-| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 3.2    | 4.4.2  |
+| Astronomer Certified | Postgres | MySQL     | Python        | System Distribution             | Airflow Helm Chart     | Redis          | Celery |
+| -------------------- | -------- | --------- | ------------- | ------------------------------- | ---------------------- | ---------------|--------|
+| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1 (Server) | 4.4.7  |
+| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1 (Server) | 4.4.7  |
+| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1 (Server) | 4.4.7  |
+| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1 (Server) | 4.4.7  |
+| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 6.2.1 (Server) | 4.4.7  |
+| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 6.2.1 (Server) | 4.4.7  |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1 (Server) | 4.4.7  |
+| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1 (Server) | 4.4.7  |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to [Upgrade Apache Airflow](https://www.astronomer.io/docs/enterprise/v0.25/customize-airflow/manage-airflow-versions/).
 

--- a/enterprise/v0.25/09_resources/04_version-compatibility-reference.md
+++ b/enterprise/v0.25/09_resources/04_version-compatibility-reference.md
@@ -12,25 +12,25 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Enterprise
 
-| Astronomer Platform | Kubernetes       | Helm | Terraform    | Postgres | Astronomer Certified                                      | Python        | Astronomer CLI |
-| ------------------- | ---------------- | ---- | ------------ | -------- | --------------------------------------------------------- | ------------- | -------------- |
-| v0.16               | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5 | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14                 | 3.6, 3.7, 3.8 | 0.16           |
+| Astronomer Platform | Kubernetes       | Helm | Terraform    | Postgres | Astronomer Certified                                      | Python               | Astronomer CLI |
+| ------------------- | ---------------- | ---- | ------------ | -------- | --------------------------------------------------------- | -------------------- | ---------------|
+| v0.16               | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5 | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14                 | 3.6, 3.7, 3.8        | 0.16           |
 | v0.23               | 1.16, 1.17, 1.18 | 3    | 0.13.5       | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 1.10.15, 2.0.0, 2.0.2 | 3.6, 3.7, 3.8 | 0.23           |
 
 > **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12, and Astronomer v0.16.15+ is required to run Astronomer Certified 1.10.14. For instructions on how to upgrade to an Astronomer v0.16 patch version, read [Upgrade to a Patch Version of Astronomer](https://www.astronomer.io/docs/enterprise/v0.25/manage-astronomer/upgrade-astronomer-patch). As of Astronomer v0.23, the platform is compatible with all versions of Astronomer Certified.
 
 ## Astronomer Certified
 
-| Astronomer Certified | Postgres | MySQL     | Python        | System Distribution             | Airflow Helm Chart     | Redis          | Celery |
-| -------------------- | -------- | --------- | ------------- | ------------------------------- | ---------------------- | ---------------|--------|
-| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1 (Server) | 4.4.7  |
-| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1 (Server) | 4.4.7  |
-| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1 (Server) | 4.4.7  |
-| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1 (Server) | 4.4.7  |
-| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 6.2.1 (Server) | 4.4.7  |
-| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 6.2.1 (Server) | 4.4.7  |
-| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1 (Server) | 4.4.7  |
-| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1 (Server) | 4.4.7  |
+| Astronomer Certified | Postgres | MySQL     | Python        | System Distribution             | Airflow Helm Chart     | Redis   | Celery |
+| -------------------- | -------- | --------- | ------------- | ------------------------------- | ---------------------- | --------|--------|
+| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1   | 4.4.7  |
+| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1   | 4.4.7  |
+| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1   | 4.4.7  |
+| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Alpine 3.10, Debian 10 (Buster) | Any                    | 6.2.1   | 4.4.7  |
+| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 6.2.1   | 4.4.7  |
+| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 6.2.1   | 4.4.7  |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1   | 4.4.7  |
+| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1   | 4.4.7  |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to [Upgrade Apache Airflow](https://www.astronomer.io/docs/enterprise/v0.25/customize-airflow/manage-airflow-versions/).
 


### PR DESCRIPTION
Our Astronomer Certified customers often request a more detailed version compatibility doc that specifies both Celery and Redis as Airflow components for folks who leverage the Celery Executor.

Creating a PR here that adds versions of Redis and Celery we support with all versions of AC. For context:

- Both the Celery and Redis providers are installed in our [AC Dockerfile under ARG SUBMODULES](https://github.com/astronomer/ap-airflow/blob/master/2.0.2/buster/Dockerfile#L112)
- To narrow in on the versions of each, I looked at Airflow's `setup.py` file here (filtered per version): https://github.com/apache/airflow/blob/2.0.2/setup.py

cc: @kaxil @ernest-kr Any chance either or both of you two could check me on versions here? Much appreesh 😊 