### PR TITLE
Add AC 2.1 to Supported AC versions + "Upgrade Airflow" Docs

### DIFF
--- a/cloud/stable/04_customize-airflow/02_manage-airflow-versions.md
+++ b/cloud/stable/04_customize-airflow/02_manage-airflow-versions.md
@@ -24,6 +24,7 @@ Read below for details.
 
 Astronomer Certified offers support for the following versions of Apache Airflow:
 
+- [Airflow 2.1.0](https://airflow.apache.org/docs/apache-airflow/2.1.0/changelog.html)
 - [Airflow 2.0.2](https://airflow.apache.org/docs/apache-airflow/2.0.2/changelog.html)
 - [Airflow 2.0.0](https://airflow.apache.org/blog/airflow-two-point-oh-is-here/)
 - [Airflow 1.10.15](https://airflow.apache.org/docs/apache-airflow/1.10.15/changelog.html)
@@ -135,6 +136,7 @@ For our platform's full collection of Docker Images, reference [Astronomer on Qu
 | [1.10.15](https://github.com/astronomer/ap-airflow/blob/master/1.10.15/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.15-buster-onbuild | N/A                                                           |
 | [2.0.0](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild   | N/A                                                           |
 | [2.0.2](https://github.com/astronomer/ap-airflow/blob/master/2.0.2/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.2-buster-onbuild   | N/A                                                           |
+| [2.1.0](https://github.com/astronomer/ap-airflow/blob/master/2.1.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.1.0-buster-onbuild   | N/A                                                           |
 
 > **Note:** We recently migrated from [Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow) to [Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags) as our Docker Registry due to a [recent change](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/) in DockerHub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer/ap-airflow` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer (e.g. `toomanyrequests: You have reached your pull rate limit`).
 

--- a/enterprise/v0.23/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.23/05_customize-airflow/01_manage-airflow-versions.md
@@ -24,6 +24,7 @@ Read below for details.
 
 Astronomer Certified offers support for the following versions of Apache Airflow:
 
+- [Airflow 2.1.0](https://airflow.apache.org/docs/apache-airflow/2.1.0/changelog.html)
 - [Airflow 2.0.2](https://github.com/apache/airflow/releases/tag/2.0.2)
 - [Airflow 2.0.0](https://airflow.apache.org/blog/airflow-two-point-oh-is-here/)
 - [Airflow 1.10.15](https://airflow.apache.org/docs/apache-airflow/1.10.15/changelog.html)
@@ -145,6 +146,7 @@ For our platform's full collection of Docker Images, reference [Astronomer on Qu
 | [1.10.15](https://github.com/astronomer/ap-airflow/blob/master/1.10.15/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.15-buster-onbuild | N/A                                                           |
 | [2.0.0](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild   | N/A                                                           |
 | [2.0.2](https://github.com/astronomer/ap-airflow/blob/master/2.0.2/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.2-buster-onbuild   | N/A                                                           |
+| [2.1.0](https://github.com/astronomer/ap-airflow/blob/master/2.1.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.1.0-buster-onbuild   | N/A                                                           |
 
 > **Note:** We recently migrated from [DockerHub](https://hub.docker.com/r/astronomerinc/ap-airflow) to [Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags) as our Docker Registry due to a [recent change](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/) in DockerHub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer/ap-airflow` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer (e.g. `toomanyrequests: You have reached your pull rate limit`).
 

--- a/enterprise/v0.23/09_resources/04_version-compatibility-reference.md
+++ b/enterprise/v0.23/09_resources/04_version-compatibility-reference.md
@@ -12,13 +12,13 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Enterprise
 
-| Astronomer Platform | Kubernetes       | Helm | Terraform    | Postgres | Astronomer Certified                                             | Python        | Astronomer CLI |
-| ------------------- | ---------------- | ---- | ------------ | -------- | ---------------------------------------------------------------- | --------------| -------------- |
-| v0.16               | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5 | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14                        | 3.6, 3.7, 3.8 | 0.16           |
-| v0.23               | 1.16, 1.17, 1.18 | 3    | 0.13.5       | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 1.10.15, 2.0.0, 2.0.2 | 3.6, 3.7, 3.8 | 0.23           |
-| v0.25               | 1.16, 1.17, 1.18 | 3    | 0.13.5       | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 1.10.15, 2.0.0, 2.0.2 | 3.6, 3.7, 3.8 | 0.25           |
+| Astronomer Platform | Kubernetes       | Helm | Terraform    | Postgres | Astronomer Certified                                                    | Python        | Astronomer CLI |
+| ------------------- | ---------------- | ---- | ------------ | -------- | ----------------------------------------------------------------------- | --------------| -------------- |
+| v0.16               | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5 | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14                               | 3.6, 3.7, 3.8 | 0.16           |
+| v0.23               | 1.16, 1.17, 1.18 | 3    | 0.13.5       | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 1.10.15, 2.0.0, 2.0.2, 2.1.0 | 3.6, 3.7, 3.8 | 0.23           |
+| v0.25               | 1.16, 1.17, 1.18 | 3    | 0.13.5       | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 1.10.15, 2.0.0, 2.0.2, 2.1.0 | 3.6, 3.7, 3.8 | 0.25           |
 
-> **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12, and Astronomer v0.16.15+ is required to run Astronomer Certified 1.10.14. For instructions on how to upgrade to an Astronomer v0.16 patch version, read [Upgrade to a Patch Version of Astronomer](https://www.astronomer.io/docs/enterprise/v0.23/manage-astronomer/upgrade-astronomer-patch). As of Astronomer v0.23, the platform is compatible with all versions of Astronomer Certified.
+> **Note:** Astronomer v0.16.9+ is required to run Astronomer Certified 1.10.12 and Astronomer v0.16.15+ is required to run Astronomer Certified 1.10.14. For instructions on how to upgrade to an Astronomer v0.16 patch version, read [Upgrade to a Patch Version of Astronomer](https://www.astronomer.io/docs/enterprise/v0.23/manage-astronomer/upgrade-astronomer-patch). As of Astronomer v0.23, the platform is compatible with all versions of Astronomer Certified.
 
 ## Astronomer Certified
 
@@ -32,6 +32,7 @@ It's worth noting that while the tables below reference the minimum compatible v
 | 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 6.2.1   | 4.4.7  |
 | 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1   | 4.4.7  |
 | 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1   | 4.4.7  |
+| 2.1.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1   | 4.4.7  |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to [Upgrade Apache Airflow](https://www.astronomer.io/docs/enterprise/v0.23/customize-airflow/manage-airflow-versions/).
 

--- a/enterprise/v0.25/05_customize-airflow/01_manage-airflow-versions.md
+++ b/enterprise/v0.25/05_customize-airflow/01_manage-airflow-versions.md
@@ -24,6 +24,7 @@ Read below for details.
 
 Astronomer Certified offers support for the following versions of Apache Airflow:
 
+- [Airflow 2.1.0](https://airflow.apache.org/docs/apache-airflow/2.1.0/changelog.html)
 - [Airflow 2.0.2](https://github.com/apache/airflow/releases/tag/2.0.2)
 - [Airflow 2.0.0](https://airflow.apache.org/blog/airflow-two-point-oh-is-here/)
 - [Airflow 1.10.15](https://airflow.apache.org/docs/apache-airflow/1.10.15/changelog.html)
@@ -145,6 +146,7 @@ For our platform's full collection of Docker Images, reference [Astronomer on Qu
 | [1.10.15](https://github.com/astronomer/ap-airflow/blob/master/1.10.15/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.15-buster-onbuild | N/A                                                           |
 | [2.0.0](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild   | N/A                                                           |
 | [2.0.2](https://github.com/astronomer/ap-airflow/blob/master/2.0.2/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.2-buster-onbuild   | N/A                                                           |
+| [2.1.0](https://github.com/astronomer/ap-airflow/blob/master/2.1.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.1.0-buster-onbuild   | N/A                                                           |
 
 > **Note:** We recently migrated from [DockerHub](https://hub.docker.com/r/astronomerinc/ap-airflow) to [Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags) as our Docker Registry due to a [recent change](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/) in DockerHub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer/ap-airflow` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer (e.g. `toomanyrequests: You have reached your pull rate limit`).
 

--- a/enterprise/v0.25/09_resources/04_version-compatibility-reference.md
+++ b/enterprise/v0.25/09_resources/04_version-compatibility-reference.md
@@ -12,11 +12,11 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Enterprise
 
-| Astronomer Platform | Kubernetes       | Helm | Terraform    | Postgres | Astronomer Certified                                             | Python        | Astronomer CLI |
-| ------------------- | ---------------- | ---- | ------------ | -------- | ---------------------------------------------------------------- | --------------| -------------- |
-| v0.16               | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5 | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14                        | 3.6, 3.7, 3.8 | 0.16           |
-| v0.23               | 1.16, 1.17, 1.18 | 3    | 0.13.5       | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 1.10.15, 2.0.0, 2.0.2 | 3.6, 3.7, 3.8 | 0.23           |
-| v0.25               | 1.16, 1.17, 1.18 | 3    | 0.13.5       | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 1.10.15, 2.0.0, 2.0.2 | 3.6, 3.7, 3.8 | 0.25           |
+| Astronomer Platform | Kubernetes       | Helm | Terraform    | Postgres | Astronomer Certified                                                    | Python        | Astronomer CLI |
+| ------------------- | ---------------- | ---- | ------------ | -------- | ----------------------------------------------------------------------- | --------------| -------------- |
+| v0.16               | 1.16, 1.17, 1.18 | 3    | 0.12, 0.13.5 | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14                               | 3.6, 3.7, 3.8 | 0.16           |
+| v0.23               | 1.16, 1.17, 1.18 | 3    | 0.13.5       | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 1.10.15, 2.0.0, 2.0.2, 2.1.0 | 3.6, 3.7, 3.8 | 0.23           |
+| v0.25               | 1.16, 1.17, 1.18 | 3    | 0.13.5       | 9.6+     | 1.10.5, 1.10.7, 1.10.10, 1.10.12, 1.10.14, 1.10.15, 2.0.0, 2.0.2, 2.1.0 | 3.6, 3.7, 3.8 | 0.25           |
 
 > **Note:** On Astronomer v0.23+, new versions of Apache Airflow on Astronomer Certified are automatically made available in the Astronomer UI and CLI within 24 hours of their publication. For more information, refer to [Available Astronomer Certified Versions](https://www.astronomer.io/docs/enterprise/v0.25/customize-airflow/manage-airflow-versions#available-astronomer-certified-versions).
 
@@ -32,6 +32,7 @@ It's worth noting that while the tables below reference the minimum compatible v
 | 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | Any                    | 6.2.1   | 4.4.7  |
 | 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1   | 4.4.7  |
 | 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1   | 4.4.7  |
+| 2.1.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8 | Debian 10 (Buster)              | 0.18.6, 0.18.7, 0.19.0 | 6.2.1   | 4.4.7  |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to [Upgrade Apache Airflow](https://www.astronomer.io/docs/enterprise/v0.25/customize-airflow/manage-airflow-versions/).
 


### PR DESCRIPTION
Quick PR that adds AC 2.1 to our docs. AC 2.1 was released on Friday, May 21 and is available on both Cloud + Platform v0.23 + v0.25 today. This PR adds 2.1 to:

- Enterprise Version Compatibility Doc (v0.23 + v0.25)
- "Upgrade Apache Airflow" for both Cloud + Enterprise docs (v0.23 + v0.25)

@jwitz Can you give dis a quick look?