### PR TITLE
Updated astro config set command and related doc link

### DIFF
--- a/cloud/stable/06_resources/03_cli-reference.md
+++ b/cloud/stable/06_resources/03_cli-reference.md
@@ -164,11 +164,11 @@ Use `astro completion <subcommand>` to generate autocompletion scripts, which ca
 
 ## astro config
 
-Modifies certain platform-level settings on Astronomer Enterprise without you needing to manually adjust them in your `config.yaml` file.
+Modifies certain platform-level settings on Astronomer without needing to manually adjust them in your `config.yaml` file.
 
 ### Usage
 
-Run `astro config get` to list values for all settings in your `config.yaml` file. To update or override a value, run `astro config set <setting-name>:<value>`
+Run `astro config get <setting-name>` to list the value for a particular setting in your `config.yaml` file. To update or override a value, run `astro config set <setting-name> <value>`
 
 The settings that you can update via the command line are:
 
@@ -199,7 +199,7 @@ The settings that you can update via the command line are:
 
 ### Related documentation
 
-- [Apply a Platform Configuration Change on Astronomer](https://www.astronomer.io/docs/cloud/stable/manage-astronomer/apply-platform-config)
+- [Apply a Platform Configuration Change on Astronomer](https://www.astronomer.io/docs/enterprise/stable/manage-astronomer/apply-platform-config)
 
 ## astro deploy
 

--- a/cloud/stable/06_resources/03_cli-reference.md
+++ b/cloud/stable/06_resources/03_cli-reference.md
@@ -164,11 +164,11 @@ Use `astro completion <subcommand>` to generate autocompletion scripts, which ca
 
 ## astro config
 
-Modifies certain platform-level settings on Astronomer without needing to manually adjust them in your `config.yaml` file.
+Modifies certain platform-level settings on Astronomer Enterprise without needing to manually adjust them in your `config.yaml` file.
 
 ### Usage
 
-Run `astro config get <setting-name>` to list the value for a particular setting in your `config.yaml` file. To update or override a value, run `astro config set <setting-name> <value>`
+Run `astro config get <setting-name>` to list the value for a particular setting in your `config.yaml` file. To update or override a value, run `astro config set <setting-name> <value>`.
 
 The settings that you can update via the command line are:
 

--- a/enterprise/v0.15/09_resources/03_cli-reference.md
+++ b/enterprise/v0.15/09_resources/03_cli-reference.md
@@ -165,11 +165,11 @@ Use `astro completion <subcommand>` to generate autocompletion scripts, which ca
 
 ## astro config
 
-Modifies certain platform-level settings on Astronomer Enterprise without you needing to manually adjust them in your `config.yaml` file.
+Modifies certain platform-level settings on Astronomer Enterprise without needing to manually adjust them in your `config.yaml` file.
 
 ### Usage
 
-Run `astro config get` to list values for all settings in your `config.yaml` file. To update or override a value, run `astro config set <setting-name>:<value>`
+Run `astro config get <setting-name>` to list the value for a particular setting in your `config.yaml` file. To update or override a value, run `astro config set <setting-name> <value>`.
 
 The settings that you can update via the command line are:
 

--- a/enterprise/v0.16/09_resources/03_cli-reference.md
+++ b/enterprise/v0.16/09_resources/03_cli-reference.md
@@ -164,11 +164,11 @@ Use `astro completion <subcommand>` to generate autocompletion scripts, which ca
 
 ## astro config
 
-Modifies certain platform-level settings on Astronomer Enterprise without you needing to manually adjust them in your `config.yaml` file.
+Modifies certain platform-level settings on Astronomer Enterprise without needing to manually adjust them in your `config.yaml` file.
 
 ### Usage
 
-Run `astro config get` to list values for all settings in your `config.yaml` file. To update or override a value, run `astro config set <setting-name>:<value>`
+Run `astro config get <setting-name>` to list the value for a particular setting in your `config.yaml` file. To update or override a value, run `astro config set <setting-name> <value>`.
 
 The settings that you can update via the command line are:
 

--- a/enterprise/v0.23/09_resources/03_cli-reference.md
+++ b/enterprise/v0.23/09_resources/03_cli-reference.md
@@ -165,11 +165,11 @@ Use `astro completion <subcommand>` to generate autocompletion scripts, which ca
 
 ## astro config
 
-Modifies certain platform-level settings on Astronomer Enterprise without you needing to manually adjust them in your `config.yaml` file.
+Modifies certain platform-level settings on Astronomer Enterprise without needing to manually adjust them in your `config.yaml` file.
 
 ### Usage
 
-Run `astro config get` to list values for all settings in your `config.yaml` file. To update or override a value, run `astro config set <setting-name>:<value>`
+Run `astro config get <setting-name>` to list the value for a particular setting in your `config.yaml` file. To update or override a value, run `astro config set <setting-name> <value>`.
 
 The settings that you can update via the command line are:
 

--- a/enterprise/v0.25/09_resources/03_cli-reference.md
+++ b/enterprise/v0.25/09_resources/03_cli-reference.md
@@ -165,11 +165,11 @@ Use `astro completion <subcommand>` to generate autocompletion scripts, which ca
 
 ## astro config
 
-Modifies certain platform-level settings on Astronomer Enterprise without you needing to manually adjust them in your `config.yaml` file.
+Modifies certain platform-level settings on Astronomer Enterprise without needing to manually adjust them in your `config.yaml` file.
 
 ### Usage
 
-Run `astro config get` to list values for all settings in your `config.yaml` file. To update or override a value, run `astro config set <setting-name>:<value>`
+Run `astro config get <setting-name>` to list the value for a particular setting in your `config.yaml` file. To update or override a value, run `astro config set <setting-name> <value>`.
 
 The settings that you can update via the command line are:
 


### PR DESCRIPTION
Minor changes to the `astro config` section of the CLI Reference Guide:
- Current documentation of the `astro config set` command is `astro config set <setting-name>:<value>`, however, the working command does not require a colon between the key and value
- Updated `astro config get` verbiage
- Updated the "Related documentation" link; throwing a 404 error when attempting to navigate via the existing link