### PR TITLE
fix example and instruction for setting variables in .env file

### DIFF
--- a/cloud/stable/03_deploy/05_environment-variables.md
+++ b/cloud/stable/03_deploy/05_environment-variables.md
@@ -44,10 +44,10 @@ To add Environment Variables locally,
 2. Add your Environment Variables of choice to that `.env` file
 3. Rebuild your image to apply those changes by running `$ astro dev start --env .env`
 
-In your `.env` file, insert the value and key beginning with `ENV`, ensuring all-caps for all characters. For example:
+In your `.env` file, insert the value and key, ensuring all-caps for all characters. For example:
 
 ```
-ENV AIRFLOW__CORE__DAG_CONCURRENCY=5
+AIRFLOW__CORE__DAG_CONCURRENCY=5
 ```
 
 > **Note:** If your Environment Variables contain secrets you don't want to expose in plain-text, you may want to add your `.env` file to `.gitignore` if and when you deploy these changes to your version control tool.

--- a/enterprise/v0.13/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.13/04_deploy/05_environment-variables.md
@@ -44,10 +44,10 @@ To add Environment Variables locally,
 2. Add your Environment Variables of choice to that `.env` file
 3. Rebuild your image to apply those changes by running `$ astro dev start --env .env`
 
-In your `.env` file, insert the value and key beginning with `ENV`, ensuring all-caps for all characters. For example:
+In your `.env` file, insert the value and key, ensuring all-caps for all characters. For example:
 
 ```
-ENV AIRFLOW__CORE__DAG_CONCURRENCY=5
+AIRFLOW__CORE__DAG_CONCURRENCY=5
 ```
 
 > **Note:** If your Environment Variables contain secrets you don't want to expose in plain-text, you may want to add your `.env` file to `.gitignore` if and when you deploy these changes to your version control tool.

--- a/enterprise/v0.15/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.15/04_deploy/05_environment-variables.md
@@ -44,10 +44,10 @@ To add Environment Variables locally,
 2. Add your Environment Variables of choice to that `.env` file
 3. Rebuild your image to apply those changes by running `$ astro dev start --env .env`
 
-In your `.env` file, insert the value and key beginning with `ENV`, ensuring all-caps for all characters. For example:
+In your `.env` file, insert the value, ensuring all-caps for all characters. For example:
 
 ```
-ENV AIRFLOW__CORE__DAG_CONCURRENCY=5
+AIRFLOW__CORE__DAG_CONCURRENCY=5
 ```
 
 > **Note:** If your Environment Variables contain secrets you don't want to expose in plain-text, you may want to add your `.env` file to `.gitignore` if and when you deploy these changes to your version control tool.

--- a/enterprise/v0.16/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.16/04_deploy/05_environment-variables.md
@@ -44,10 +44,10 @@ To add Environment Variables locally,
 2. Add your Environment Variables of choice to that `.env` file
 3. Rebuild your image to apply those changes by running `$ astro dev start --env .env`
 
-In your `.env` file, insert the value and key beginning with `ENV`, ensuring all-caps for all characters. For example:
+In your `.env` file, insert the value and key, ensuring all-caps for all characters. For example:
 
 ```
-ENV AIRFLOW__CORE__DAG_CONCURRENCY=5
+AIRFLOW__CORE__DAG_CONCURRENCY=5
 ```
 
 > **Note:** If your Environment Variables contain secrets you don't want to expose in plain-text, you may want to add your `.env` file to `.gitignore` if and when you deploy these changes to your version control tool.

--- a/enterprise/v0.23/04_deploy/05_environment-variables.md
+++ b/enterprise/v0.23/04_deploy/05_environment-variables.md
@@ -44,10 +44,10 @@ To add Environment Variables locally,
 2. Add your Environment Variables of choice to that `.env` file
 3. Rebuild your image to apply those changes by running `$ astro dev start --env .env`
 
-In your `.env` file, insert the value and key beginning with `ENV`, ensuring all-caps for all characters. For example:
+In your `.env` file, insert the value and key, ensuring all-caps for all characters. For example:
 
 ```
-ENV AIRFLOW__CORE__DAG_CONCURRENCY=5
+AIRFLOW__CORE__DAG_CONCURRENCY=5
 ```
 
 > **Note:** If your Environment Variables contain secrets you don't want to expose in plain-text, you may want to add your `.env` file to `.gitignore` if and when you deploy these changes to your version control tool.

--- a/enterprise/v0.25/04_deploy/06_environment-variables.md
+++ b/enterprise/v0.25/04_deploy/06_environment-variables.md
@@ -44,10 +44,10 @@ To add Environment Variables locally,
 2. Add your Environment Variables of choice to that `.env` file
 3. Rebuild your image to apply those changes by running `$ astro dev start --env .env`
 
-In your `.env` file, insert the value and key beginning with `ENV`, ensuring all-caps for all characters. For example:
+In your `.env` file, insert the value and key, ensuring all-caps for all characters. For example:
 
 ```
-ENV AIRFLOW__CORE__DAG_CONCURRENCY=5
+AIRFLOW__CORE__DAG_CONCURRENCY=5
 ```
 
 > **Note:** If your Environment Variables contain secrets you don't want to expose in plain-text, you may want to add your `.env` file to `.gitignore` if and when you deploy these changes to your version control tool.


### PR DESCRIPTION
When adding environment variables into a .env file, the syntax is `KEY=VAR`. We accidentally said to use `ENV KEY=VAR`, which is the syntax for adding environment variables to a Dockerfile. 

When users follow the instructions as is, environment variables silently aren't loaded, which leaves a very confused customer :) We should consider adding a check to make sure that environment variables are properly formatted and that the key is uppercase in the future. 