### PR TITLE
Replace curly quotes in code blocks with straight quotes

### DIFF
--- a/cloud/stable/04_customize-airflow/07_airflow_api.md
+++ b/cloud/stable/04_customize-airflow/07_airflow_api.md
@@ -82,9 +82,9 @@ The command for your request should look like this:
 ```
 curl -v -X POST
 https://<AIRFLOW-DOMAIN>/airflow/api/experimental/dags/<DAG-ID>/dag_runs
--H 'Authorization: <API-Key> ’
--H ‘Cache-Control: no-cache’
--H ‘content-type: application/json’ -d ‘{}’
+-H 'Authorization: <API-Key> '
+-H 'Cache-Control: no-cache'
+-H 'content-type: application/json' -d '{}'
 ```
 
 To run this, replace the following placeholder values:
@@ -93,7 +93,7 @@ To run this, replace the following placeholder values:
 - `<DAG-ID>`: Name of your DAG (_case-sensitive_)
 - `<API-Key>`: API Key from your Service Account
 
-This will trigger a DAG run for your desired DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the “Play” button in the main "DAGs" view of the Airflow UI.
+This will trigger a DAG run for your desired DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the "Play" button in the main "DAGs" view of the Airflow UI.
 
 > **Note:** Your request will have the same permissions as the role of the Service Account you created on Astronomer.
 
@@ -104,7 +104,7 @@ If you'd like to choose a specific `execution_date` (i.e. start timestamp) to tr
 The string needs to be in the following format (in UTC):
 
 ```
-“YYYY-MM-DDTHH:MM:SS”
+"YYYY-MM-DDTHH:MM:SS"
 ```
 
 Where, `YYYY`: Year, `MM`: Month, `DD`: Day, `HH`: Hour, `MM`: Minute, `SS`: Second.
@@ -112,7 +112,7 @@ Where, `YYYY`: Year, `MM`: Month, `DD`: Day, `HH`: Hour, `MM`: Minute, `SS`: Sec
 For example:
 
 ```
-“2019-11-16T11:34:00”
+"2019-11-16T11:34:00"
 ```
 
 Here, your request becomes:
@@ -120,9 +120,9 @@ Here, your request becomes:
 ```
 curl -v -X POST
 https://<AIRFLOW_DOMAIN>/api/experimental/dags/customer_health_score/dag_runs
--H ‘Authorization: <API-Key>’
--H ‘Cache-Control: no-cache’
--H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-11-16T11:34:00”}’
+-H 'Authorization: <API-Key>'
+-H 'Cache-Control: no-cache'
+-H 'content-type: application/json' -d '{"execution_date":"2019-11-16T11:34:00"}'
 ```
 
 ### Get all Pools

--- a/enterprise/v0.16/05_customize-airflow/07_airflow-api.md
+++ b/enterprise/v0.16/05_customize-airflow/07_airflow-api.md
@@ -90,9 +90,9 @@ This command would look like this:
 ```
 curl -v -X POST
 https://AIRFLOW_DOMAIN/airflow/api/experimental/dags/<DAG_ID>/dag_runs
--H 'Authorization: <API_Key> ’
--H ‘Cache-Control: no-cache’
--H ‘content-type: application/json’ -d ‘{}’
+-H 'Authorization: <API_Key> '
+-H 'Cache-Control: no-cache'
+-H 'content-type: application/json' -d '{}'
 ```
 
 To run this, replace:
@@ -101,7 +101,7 @@ To run this, replace:
 - **DAG_ID**: Name of your DAG (_case-sensitive_)
 - **API_Key**: API Key from your Service Account
 
-This will successfully kick off a DAG run for your DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the “Play” button in the main "DAGs" view of the Airflow UI (Webserver).
+This will successfully kick off a DAG run for your DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the "Play" button in the main "DAGs" view of the Airflow UI (Webserver).
 
 > **Note:** Your request will have the same permissions as the role of the Service Account you created on Astronomer.
 
@@ -112,13 +112,13 @@ If you'd like to choose a specific `execution_date` (i.e. start timestamp) to ki
 The string needs to be in the following format (in UTC):
 
 ```
-“YYYY-mm-DDTHH:MM:SS”
+"YYYY-mm-DDTHH:MM:SS"
 ```
 
 For example:
 
 ```
-“2016-11-16T11:34:15”
+"2016-11-16T11:34:15"
 ```
 
 Here, your request becomes:
@@ -126,9 +126,9 @@ Here, your request becomes:
 ```
 curl -v -X POST
 https://AIRFLOW_DOMAIN/api/experimental/dags/customer_health_score/dag_runs
--H ‘Authorization: XXXX’
--H ‘Cache-Control: no-cache’
--H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-03-05T08:30:00”}’
+-H 'Authorization: XXXX'
+-H 'Cache-Control: no-cache'
+-H 'content-type: application/json' -d '{"execution_date":"2019-03-05T08:30:00"}'
 ```
 
 ### Get all Pools

--- a/enterprise/v0.23/05_customize-airflow/08_airflow-api.md
+++ b/enterprise/v0.23/05_customize-airflow/08_airflow-api.md
@@ -81,9 +81,9 @@ The command for your request should look like this:
 ```
 curl -v -X POST
 https://<AIRFLOW-DOMAIN>/airflow/api/experimental/dags/<DAG-ID>/dag_runs
--H 'Authorization: <API-Key> ’
--H ‘Cache-Control: no-cache’
--H ‘content-type: application/json’ -d ‘{}’
+-H 'Authorization: <API-Key> '
+-H 'Cache-Control: no-cache'
+-H 'content-type: application/json' -d '{}'
 ```
 
 To run this, replace the following placeholder values:
@@ -92,7 +92,7 @@ To run this, replace the following placeholder values:
 - `<DAG-ID>`: Name of your DAG (_case-sensitive_)
 - `<API-Key>`: API Key from your Service Account
 
-This will trigger a DAG run for your desired DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the “Play” button in the main "DAGs" view of the Airflow UI.
+This will trigger a DAG run for your desired DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the "Play" button in the main "DAGs" view of the Airflow UI.
 
 > **Note:** Your request will have the same permissions as the role of the Service Account you created on Astronomer.
 
@@ -103,7 +103,7 @@ If you'd like to choose a specific `execution_date` (i.e. start timestamp) to tr
 The string needs to be in the following format (in UTC):
 
 ```
-“YYYY-MM-DDTHH:MM:SS”
+"YYYY-MM-DDTHH:MM:SS"
 ```
 
 Where, `YYYY`: Year, `MM`: Month, `DD`: Day, `HH`: Hour, `MM`: Minute, `SS`: Second.
@@ -111,7 +111,7 @@ Where, `YYYY`: Year, `MM`: Month, `DD`: Day, `HH`: Hour, `MM`: Minute, `SS`: Sec
 For example:
 
 ```
-“2019-11-16T11:34:00”
+"2019-11-16T11:34:00"
 ```
 
 Here, your request becomes:
@@ -119,9 +119,9 @@ Here, your request becomes:
 ```
 curl -v -X POST
 https://<AIRFLOW_DOMAIN>/api/experimental/dags/customer_health_score/dag_runs
--H ‘Authorization: <API-Key>’
--H ‘Cache-Control: no-cache’
--H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-11-16T11:34:00”}’
+-H 'Authorization: <API-Key>'
+-H 'Cache-Control: no-cache'
+-H 'content-type: application/json' -d '{"execution_date":"2019-11-16T11:34:00"}'
 ```
 
 ### Get all Pools

--- a/enterprise/v0.25/05_customize-airflow/08_airflow-api.md
+++ b/enterprise/v0.25/05_customize-airflow/08_airflow-api.md
@@ -81,9 +81,9 @@ The command for your request should look like this:
 ```
 curl -v -X POST
 https://<AIRFLOW-DOMAIN>/airflow/api/experimental/dags/<DAG-ID>/dag_runs
--H 'Authorization: <API-Key> ’
--H ‘Cache-Control: no-cache’
--H ‘content-type: application/json’ -d ‘{}’
+-H 'Authorization: <API-Key> '
+-H 'Cache-Control: no-cache'
+-H 'content-type: application/json' -d '{}'
 ```
 
 To run this, replace the following placeholder values:
@@ -92,7 +92,7 @@ To run this, replace the following placeholder values:
 - `<DAG-ID>`: Name of your DAG (_case-sensitive_)
 - `<API-Key>`: API Key from your Service Account
 
-This will trigger a DAG run for your desired DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the “Play” button in the main "DAGs" view of the Airflow UI.
+This will trigger a DAG run for your desired DAG with an `execution_date` value of `NOW()`, which is equivalent to clicking the "Play" button in the main "DAGs" view of the Airflow UI.
 
 > **Note:** Your request will have the same permissions as the role of the Service Account you created on Astronomer.
 
@@ -103,7 +103,7 @@ If you'd like to choose a specific `execution_date` (i.e. start timestamp) to tr
 The string needs to be in the following format (in UTC):
 
 ```
-“YYYY-MM-DDTHH:MM:SS”
+"YYYY-MM-DDTHH:MM:SS"
 ```
 
 Where, `YYYY`: Year, `MM`: Month, `DD`: Day, `HH`: Hour, `MM`: Minute, `SS`: Second.
@@ -111,7 +111,7 @@ Where, `YYYY`: Year, `MM`: Month, `DD`: Day, `HH`: Hour, `MM`: Minute, `SS`: Sec
 For example:
 
 ```
-“2019-11-16T11:34:00”
+"2019-11-16T11:34:00"
 ```
 
 Here, your request becomes:
@@ -119,9 +119,9 @@ Here, your request becomes:
 ```
 curl -v -X POST
 https://<AIRFLOW_DOMAIN>/api/experimental/dags/customer_health_score/dag_runs
--H ‘Authorization: <API-Key>’
--H ‘Cache-Control: no-cache’
--H ‘content-type: application/json’ -d ‘{“execution_date”:“2019-11-16T11:34:00”}’
+-H 'Authorization: <API-Key>'
+-H 'Cache-Control: no-cache'
+-H 'content-type: application/json' -d '{"execution_date":"2019-11-16T11:34:00"}'
 ```
 
 ### Get all Pools


### PR DESCRIPTION
Curly quotes cause syntax error. Replace with straight quotes