### PR TITLE
Fixed Alertmanager configuration examples

### DIFF
--- a/enterprise/v0.16/07_monitor/03_platform-alerts.md
+++ b/enterprise/v0.16/07_monitor/03_platform-alerts.md
@@ -32,7 +32,7 @@ Then visit `localhost:9090` or `localhost:9093` on your computer.
 
 Alertmanager is the Astronomer platform component that manages alerts, including silencing, inhibiting, aggregating and sending out notifications via methods such as email, on-call notification systems, and chat platforms.
 
-You can [configure Alertmanager](https://prometheus.io/docs/alerting/configuration/) to send alerts to email, HipChat, PagerDuty, Pushover, Slack, OpsGenie, and more by editing the [Alertmanager ConfigMap](https://github.com/astronomer/astronomer/blob/master/charts/alertmanager/templates/alertmanager-configmap.yaml). 
+You can [configure Alertmanager](https://prometheus.io/docs/alerting/configuration/) to send alerts to email, HipChat, PagerDuty, Pushover, Slack, OpsGenie, and more by editing the [Alertmanager ConfigMap](https://github.com/astronomer/astronomer/blob/master/charts/alertmanager/templates/alertmanager-configmap.yaml).
 
 You can also configure Alertmanager's `route` block by editing the [Alertmanager ConfigMap](https://github.com/astronomer/astronomer/blob/master/charts/alertmanager/templates/alertmanager-configmap.yaml). The `route` block defines values such as `repeat_interval` (the interval at which alert notifications are sent). You can find more information on the `route` block [here](https://prometheus.io/docs/alerting/configuration/#route)
 
@@ -100,17 +100,20 @@ Admins can subscribe to these configured alerts by editing the [Alertmanager Con
 
 Example:
 
-```
+```yaml
 alertmanager:
   receivers:
+    # Configs for platform alerts
     platform:
-      slack_configs:
-      - api_url: https://hooks.slack.com/services/T02J89GPR/BDBSG6L1W/4Vm7zo542XYgvv3
-        channel: '#astronomer_platform_alerts'
-        text: |-
-          {{ range .Alerts }}{{ .Annotations.description }}
-          {{ end }}
-        title: '{{ .CommonAnnotations.summary }}'
+
+    platformCritical:
+        slack_configs:
+        - api_url: https://hooks.slack.com/services/T02J89GPR/BDBSG6L1W/4Vm7zo542XYgvv3
+          channel: '#astronomer_platform_alerts'
+          text: |-
+            {{ range .Alerts }}{{ .Annotations.description }}
+            {{ end }}
+          title: '{{ .CommonAnnotations.summary }}'
 ```
 
 You can read more about configuration options [here](https://prometheus.io/docs/alerting/configuration/).

--- a/enterprise/v0.23/07_monitor/03_platform-alerts.md
+++ b/enterprise/v0.23/07_monitor/03_platform-alerts.md
@@ -48,10 +48,9 @@ For example, adding the following receiver to `receivers.platformCritical` would
 alertmanager:
   receivers:
     # Configs for platform alerts
-    platform: {}
+    platform:
 
-    platformCritical: {
-      - name: platform-critical-receiver
+    platformCritical:
         slack_configs:
         - api_url: https://hooks.slack.com/services/T02J89GPR/BDBSG6L1W/4Vm7zo542XYgvv3
           channel: '#astronomer_platform_alerts'
@@ -59,7 +58,6 @@ alertmanager:
             {{ range .Alerts }}{{ .Annotations.description }}
             {{ end }}
           title: '{{ .CommonAnnotations.summary }}'
-    }
 ```
 
 By default, the Alertmanager Helm Chart includes alert objects for platform, critical platform, and Deployment alerts. To configure a receiver for a non-default alert type, such as Deployment alerts with high severity, add that receiver to the `customRoutes` list with the appropriate `match_re` and receiver configuration values. For example:

--- a/enterprise/v0.25/07_monitor/03_platform-alerts.md
+++ b/enterprise/v0.25/07_monitor/03_platform-alerts.md
@@ -48,10 +48,9 @@ For example, adding the following receiver to `receivers.platformCritical` would
 alertmanager:
   receivers:
     # Configs for platform alerts
-    platform: {}
+    platform:
 
-    platformCritical: {
-      - name: platform-critical-receiver
+    platformCritical:
         slack_configs:
         - api_url: https://hooks.slack.com/services/T02J89GPR/BDBSG6L1W/4Vm7zo542XYgvv3
           channel: '#astronomer_platform_alerts'
@@ -59,7 +58,6 @@ alertmanager:
             {{ range .Alerts }}{{ .Annotations.description }}
             {{ end }}
           title: '{{ .CommonAnnotations.summary }}'
-    }
 ```
 
 By default, the Alertmanager Helm Chart includes alert objects for platform, critical platform, and Deployment alerts. To configure a receiver for a non-default alert type, such as Deployment alerts with high severity, add that receiver to the `customRoutes` list with the appropriate `match_re` and receiver configuration values. For example:


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/387

Simple copy-paste job of Ralph's suggestion in the original issue. I like the idea of having "Certified" builds of some of these features that rival the functionality we have in Cloud, but between the Cloud beta heating up and the potential of the new docs site, I don't think now is a great time for me to work on this. These docs might need to look very different in a few months, and we can reapproach that idea then. 

