### PR TITLE
Update gtag trackingID

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,7 +14,7 @@ module.exports = {
   themeConfig: {
     image: 'img/meta.png',
     gtag: {
-          trackingID: 'UA-141789564-1',
+          trackingID: 'G-W97HK48NPT',
           anonymizeIP: true,
         },
     algolia: {


### PR DESCRIPTION
PR updates trackingID to point to [our new GA4 property](https://analytics.google.com/analytics/web/?authuser=0#/p297190505/reports/reportinghub) for docs.astro.