### PR TITLE
Remove extended support

### DIFF
--- a/enterprise/release-lifecycle-policy.md
+++ b/enterprise/release-lifecycle-policy.md
@@ -85,5 +85,3 @@ The following table contains the exact lifecycle for each published version of A
 | 0.23               | January 20, 2021 | LTS             | 12 months          | January 2022            |
 | 0.25               | May 11, 2021     | LTS             | 12 months          | May 2022                |
 | 0.26               | Nov 23, 2021     | Stable          | 6 months           | May 2022                |
-
-> **Note:** This maintenance policy is in effect as of October 2021. To ease the impact of this updated policy, Astronomer will provide extended maintenance, backporting major security fixes for these versions. For questions or concerns, reach out to us.

--- a/enterprise_versioned_docs/version-0.16/release-lifecycle-policy.md
+++ b/enterprise_versioned_docs/version-0.16/release-lifecycle-policy.md
@@ -85,5 +85,3 @@ The following table contains the exact lifecycle for each published version of A
 | 0.23               | January 20, 2021 | LTS             | 12 months          | January 2022            |
 | 0.25               | May 11, 2021     | LTS             | 12 months          | May 2022                |
 | 0.26               | Nov 23, 2021     | Stable          | 6 months           | May 2022                |
-
-> **Note:** This maintenance policy is in effect as of October 2021. To ease the impact of this updated policy, Astronomer will provide extended maintenance, backporting major security fixes for these versions. For questions or concerns, reach out to us.


### PR DESCRIPTION
On Enterprise, we are not extending support dates beyond policy in the interim, so the note is confusing. I didn't see the same doc in 0.23 or 0.25.