### PR TITLE
Adjust table styles for small tables

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -259,6 +259,7 @@ html[data-theme="dark"] .DocSearch {
 /* Table Styling */
 table {
   border: solid 1px var(--ifm-table-border-color);
+  max-width: fit-content;
 }
 
 table tr th:first-child,


### PR DESCRIPTION
Adds `max-width: fit-content;` to table styles to account for smaller tables. 
![Screen Shot 2021-12-22 at 10 16 14 AM](https://user-images.githubusercontent.com/15950548/147114406-423ac355-06e9-459c-850e-327f71997c59.png)

