### PR TITLE
Update Enterprise Upgrade/Version Docs

### DIFF
--- a/cloud/airflow-api.md
+++ b/cloud/airflow-api.md
@@ -25,11 +25,11 @@ All Airflow API calls require the following two values:
 - An access token
 - A Deployment URL
 
-To retrieve an access token, [create a Deployment API key](api-keys#create-an-api-key) on Astronomer and follow the instructions in [Request Access Token](api-keys#request-access-token). Note that you need to refresh that token every time you make a request to the Airflow API. To avoid manually doing so, we strongly recommend adding a step that fetches a new access token to any CI/CD pipeline that calls the Airflow API. That way, your access token is automatically refreshed every time your CI/CD pipeline needs it. For examples of this implementation, see [CI/CD Templates](ci-cd.md#cicd-templates).
+To retrieve an access token, [create a Deployment API key](api-keys.md#create-an-api-key) on Astronomer and follow the instructions in [Request Access Token](api-keys.md#request-access-token). Note that you need to refresh that token every time you make a request to the Airflow API. To avoid manually doing so, we strongly recommend adding a step that fetches a new access token to any CI/CD pipeline that calls the Airflow API. That way, your access token is automatically refreshed every time your CI/CD pipeline needs it. For examples of this implementation, see [CI/CD Templates](ci-cd.md#cicd-templates).
 
 :::info
 
-If you need to call the Airflow API only once, you can retrieve a temporary access token (24 hours) at `https://cloud.astronomer.io/token`. If you retrieve a token here, you can skip the instructions in [Request Access Token](api-keys#request-access-token).
+If you need to call the Airflow API only once, you can retrieve a temporary access token (24 hours) at `https://cloud.astronomer.io/token`. If you retrieve a token here, you can skip the instructions in [Request Access Token](api-keys.md#request-access-token).
 
 :::
 

--- a/enterprise/release-lifecycle-policy.md
+++ b/enterprise/release-lifecycle-policy.md
@@ -85,3 +85,5 @@ The following table contains the exact lifecycle for each published version of A
 | 0.23               | January 20, 2021 | LTS             | 12 months          | January 2022            |
 | 0.25               | May 11, 2021     | LTS             | 12 months          | May 2022                |
 | 0.26               | Nov 23, 2021     | Stable          | 6 months           | May 2022                |
+| 0.27               | Dec 21, 2021     | Stable          | 6 months           | June 2022               |
+

--- a/enterprise/upgrade-astronomer-stable.md
+++ b/enterprise/upgrade-astronomer-stable.md
@@ -1,25 +1,31 @@
 ---
 title: 'Upgrade to a Stable or Patch Version of Astronomer Enterprise'
-sidebar_label: 'Upgrade to a Stable or Patch Version'
+sidebar_label: 'Upgrade Astronomer'
 id: upgrade-astronomer-stable
-description: Update your Astronomer Enterprise Platform to a new stable or patch version.
+description: Upgrade to a new stable or patch version of Astronomer Enterprise.
 ---
 
 ## Overview
 
-Stable releases of Astronomer Enterprise are available to Enterprise customers on a monthly basis as part of the release model described in [Release and Lifecycle Policy](release-lifecycle-policy.md). Patch release of Astronomer Enterprise follow up on stable releases with additional bug and security fixes.
+For Astronomer Enterprise customers, new product features are regularly made available in stable and long-term support (LTS) releases as described in [Release and Lifecycle Policy](release-lifecycle-policy.md). Patch versions of Astronomer Enterprise with additional bug and security fixes are also released on a regular basis.
 
-Stable and patch releases require a simple upgrade process. Follow this guide to upgrade to any stable or patch version before the next available LTS release. For information on all stable and patch releases, refer to [Enterprise Release Notes](release-notes.md).
+All stable and patch releases of Astronomer Enterprise require a simple upgrade process. When an [LTS version](release-lifecycle-policy.md#release-channels) is released, additional upgrade guidance specific to that version will be made available.
+
+Follow this guide to upgrade to any stable or patch version of Astronomer Enterprise. For information on new features and changes, refer to [Enterprise Release Notes](release-notes.md).
 
 A few notes before you get started:
-- The patch upgrade process will not affect running Airflow tasks as long as `upgradeDeployments.enabled=false` is set in the script below.
-- Patch and stable version updates will not cause any downtime to Astronomer services (Astronomer UI, Houston API, Astronomer CLI).
+- The upgrade process will not affect running Airflow tasks as long as `upgradeDeployments.enabled=false` is set in the script below.
+- Patch and stable version updates will not cause any downtime to Astronomer services, including the Astronomer UI, the Astronomer CLI, and the Houston API.
 
-> **Note:** Astronomer v0.16.5 and beyond includes an improved upgrade process that allows Airflow Deployments to remain unaffected through a platform upgrade that includes changes to the [Astronomer Airflow Chart](https://github.com/astronomer/airflow-chart).
->
-> Now, Airflow Chart changes only take effect when another restart event is triggered by a user (e.g. a code push, Environment Variable change, resource or executor adjustment, etc).
+:::info
 
-## Step 1: Ensure You Have a Copy of Your Astronomer config.yaml File
+Astronomer v0.16.5 and beyond includes an improved upgrade process that allows Airflow Deployments to remain unaffected through a platform upgrade that includes changes to the [Astronomer Airflow Chart](https://github.com/astronomer/airflow-chart).
+
+Now, Airflow Chart changes only take effect when another restart event is triggered by a user. This includes a code push, a change to Environment Variables, or an adjustment to Deployment resources.
+
+:::
+
+## Step 1: Ensure You Have a Copy of Your Astronomer `config.yaml` File
 
 First, ensure you have a copy of the `config.yaml` file of your platform namespace.
 
@@ -39,15 +45,9 @@ To verify the version of Astronomer you're currently operating with, run:
 helm list --all-namespaces | grep astronomer
 ```
 
-## Step 3: Run Astronomer's Patch Upgrade Script
+## Step 3: Run Astronomer's Upgrade Script
 
-Now, review and run the script below to upgrade to the patch version of your choice.
-
-Make sure to substitute the following 3 variables with your own values:
-
-- `RELEASE_NAME`
-- `NAMESPACE`
-- `ASTRO_VERSION`
+Now, review and run the script below to upgrade to the version of your choice.
 
 ```sh
 #!/bin/bash
@@ -55,7 +55,7 @@ set -xe
 
 RELEASE_NAME=<astronomer-platform-release-name>
 NAMESPACE=<astronomer-platform-namespace>
-ASTRO_VERSION=0.27.<astronomer-patch-version>
+ASTRO_VERSION=<astronomer-version>
 
 helm3 repo add astronomer https://helm.astronomer.io
 helm3 repo update
@@ -63,17 +63,26 @@ helm3 repo update
 # upgradeDeployments false ensures that Airflow charts are not upgraded when this script is ran
 # If you deployed a config change that is intended to reconfigure something inside Airflow,
 # then you may set this value to "true" instead. When it is "true", then each Airflow chart will
-# restart.
-# To ensure that your Deployments update to the latest Airflow chart version (1.0.7),
-# set upgradeDeployments.enabled=true.
+# restart. Note that some stable version upgrades require setting this value to true regardless of your own configuration.
 helm3 upgrade --namespace $NAMESPACE \
             -f ./config.yaml \
             --reset-values \
             --version $ASTRO_VERSION \
             --set astronomer.houston.upgradeDeployments.enabled=false \
-            --set astronomer.houston.upgradeDeployments.enabled=true \
             $RELEASE_NAME \
             astronomer/astronomer
 ```
 
-> **Note:** If you do not specify a patch version above, the script will automatically pull the latest Astronomer Enterprise patch available in the [Astronomer Helm Chart](https://github.com/astronomer/astronomer/releases). If you set `ASTRO_VERSION=0.27` and `--version 0.27`, for example, Astronomer v0.27.9 will be installed if it is the latest v0.27 patch available.
+Make sure to substitute the following 3 variables with your own values:
+
+- `RELEASE_NAME`
+- `NAMESPACE`
+- `ASTRO_VERSION`
+
+To upgrade to Astronomer Enterprise v0.27.0, for example, set `ASTRO_VERSION=0.27.0`.
+
+:::tip
+
+If you do not specify a patch version above, the script will automatically pull the latest Astronomer Enterprise patch available in the [Astronomer Helm Chart](https://github.com/astronomer/astronomer/releases). If you set `ASTRO_VERSION=0.26` for example, Astronomer v0.26.5 will be installed if it is the latest v0.26 patch available.
+
+:::

--- a/enterprise/upgrade-astronomer-stable.md
+++ b/enterprise/upgrade-astronomer-stable.md
@@ -75,9 +75,9 @@ helm3 upgrade --namespace $NAMESPACE \
 
 Make sure to substitute the following 3 variables with your own values:
 
-- `RELEASE_NAME`
-- `NAMESPACE`
-- `ASTRO_VERSION`
+- `<astronomer-platform-release-name>`
+- `<astronomer-platform-namespace>`
+- `<astronomer-patch-version>`
 
 To upgrade to Astronomer Enterprise v0.27.0, for example, set `ASTRO_VERSION=0.27.0`.
 

--- a/enterprise/version-compatibility-reference.md
+++ b/enterprise/version-compatibility-reference.md
@@ -23,7 +23,7 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 > **Note:** On Astronomer v0.23+, new versions of Apache Airflow on Astronomer Certified are automatically made available in the Astronomer UI and CLI within 24 hours of their publication. For more information, refer to [Available Astronomer Certified Versions](manage-airflow-versions.md#available-astronomer-certified-versions).
 
-> **Note:** Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private CAs starting with Kubernetes 1.19. If you use a private CA, contact [Astronomer support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on AKS.
+> **Note:** Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private CAs starting with Kubernetes 1.19. If you use a private CA, contact [Astronomer Support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on AKS.
 
 > **Note:** While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow Triggerer is available only in Astronomer v0.26+. To use [Deferrable Operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), which require the Airflow Triggerer, you must upgrade.
 
@@ -44,9 +44,9 @@ It's worth noting that while the tables below reference the minimum compatible v
 | 2.1.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9            | Debian 10 (Buster)              | 0.18.6+            |
 | 2.1.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9            | Debian 10 (Buster)              | 0.18.6+            |
 | 2.2.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9            | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9(_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9(_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9(_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
+| 2.2.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
+| 2.2.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
+| 2.2.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to [Upgrade Apache Airflow](manage-airflow-versions.md).
 

--- a/enterprise_versioned_docs/version-0.23/release-lifecycle-policy.md
+++ b/enterprise_versioned_docs/version-0.23/release-lifecycle-policy.md
@@ -1,0 +1,88 @@
+---
+title: Astronomer Release and Lifecycle Policy
+sidebar_label: Release and Lifecycle Policy
+id: release-lifecycle-policy
+description: Astronomer's release and lifecycle policy for Astronomer Enterprise.
+---
+
+## Overview
+
+Astronomer supports a variety of policies that drives the naming, release cadence, and maintenance commitments associated with all published software.
+
+This document offers guidelines on the version lifecycle of Astronomer Enterprise. It includes a description of:
+
+- How Astronomer is versioned.
+- Which versions of Astronomer Enterprise are currently available.
+- Release channels and the maintenance schedule for all versions.
+
+For information on the latest Astronomer Enterprise releases, see [release notes](release-notes.md). For the release and maintenance policy for Astronomer Certified, see the Certified [Versioning and Maintenance Policy](ac-support-policy.md).
+
+For information on compatibility between all versioned software, see [Enterprise Version Compatibility Reference](release-lifecycle-policy.md).
+
+## Release Channels
+
+To meet the unique needs of different operating environments, we offer all Astronomer customers two release channels:
+
+- **Stable:** Includes the latest Astronomer and Airflow features
+- **Long-term Support (LTS):** Includes long-term testing, stability, and maintenance for a core set of features
+
+For customers looking to access Astronomer's newest features on an incremental basis, we recommend following the stable release channel and upgrading to new versions as soon as they are made generally available. Stable releases are issued roughly once per month for Astronomer Enterprise and the Astronomer CLI.
+
+For customers looking for less frequent upgrades and functional changes, we recommend following the LTS release channel. Release channels are not binding, so you are free to upgrade to any available version of Astronomer Enterprise at any time.
+
+> **Note:** Release channels apply to Astronomer Enterprise and Astronomer Certified versions. We do not currently support a long-term release channel for the Astronomer CLI.
+
+## Astronomer Enterprise Versioning
+
+Astronomer follows [Semantic Versioning](https://semver.org/) for all published software. This means that we use Major, Minor, and Patch releases across our product in the format of `major.minor.patch`.
+
+- **Major** versions are released for significant feature additions, including backward-incompatible changes to an API or DAG specification.
+- **Minor** versions are released for functional changes, including backward-compatible changes to an API or DAG specification.
+- **Patch** versions are released for bug and security fixes that resolve incorrect behavior.
+
+It is considered safe to upgrade to minor and patch versions within a major version. Upgrade guidance for major and LTS versions is provided with each release.
+
+## Version Maintenance Policy
+
+The maintenance period for an Astronomer Enterprise version depends on its release channel:
+
+| Release Channel | Frequency of Releases | Maintenance Duration |
+| --------------- | --------------------- | -------------------- |
+| Stable          | Monthly               | 6 Months             |
+| LTS             | Yearly                | 12 Months            |
+
+For each `major.minor` pair, only the latest patch is supported at any given time.
+
+For example, if Astronomer Enterprise v0.26 were a stable version first released in October 2021:
+
+- Support for Astronomer Enterprise v0.26 would end 6 months later in April 2022.
+- If a patch version for v0.26 came out in December 2021 (e.g. `v0.26.4`), it would not affect the maintenance duration. Maintenance for v0.26 would still end in April 2022.
+- If a major bug was identified in v0.26, a fix would be backported by the Astronomer team and released as a patch to v0.26 as long as it remained the latest stable release.
+- If Astronomer Enterprise v0.27 came out as a new stable release, bug fixes would no longer be backported to Astronomer v0.26 and customers would be encouraged to upgrade.
+- If a major security issue was identified in v0.26, a fix would be backported and released as a patch at any time during its 6 month maintenance period. Even if v0.27 is the latest stable version of Astronomer Enterprise, a security fix would still be backported to v0.26.
+
+If you contact [Astronomer Support](https://support.astronomer.io) about an issue you are experiencing while running an unmaintained version, our team will invite you to upgrade as an initial mitigation step.
+
+### End of Maintenance Date
+
+Maintenance is discontinued the last day of the month for a given version. For example, if a version of Astronomer Enterprise were supported between January - June of a given year, that version would be maintained by Astronomer until the last day of June.
+
+## Backport Policy for Bug and Security Fixes
+
+If a major stability bug is identified by our team, a fix will be backported to all LTS versions and only the latest stable version. For users on a stable version that is not latest, our team will recommend that you upgrade. Major issues in this category may result in significant delays in task scheduling as well as potential data loss.
+
+If a major security issue is identified, a fix will be backported and made available as a new patch version for _all_ supported stable and LTS releases. Major issues in this category are classified by a combination of impact and exploitability.
+
+In rare instances, the Astronomer team may make an exception and backport a bug or security fix to a release that is beyond the commitment stated above. To submit a request for consideration, please reach out to your customer success manager.
+
+## Enterprise Lifecycle Schedule
+
+The following table contains the exact lifecycle for each published version of Astronomer Enterprise. These timelines are based on the LTS and stable release channel maintenance policies.
+
+| Enterprise Version | Release Date     | Release Channel | Maintenance Period | End of Maintenance Date |
+| ------------------ | ---------------- | --------------- | ------------------ | ----------------------- |
+| 0.16               | June 29, 2020    | LTS             | 12 months          | June 2021               |
+| 0.23               | January 20, 2021 | LTS             | 12 months          | January 2022            |
+| 0.25               | May 11, 2021     | LTS             | 12 months          | May 2022                |
+| 0.26               | Nov 23, 2021     | Stable          | 6 months           | May 2022                |
+| 0.27               | Dec 21, 2021     | Stable          | 6 months           | June 2022               |

--- a/enterprise_versioned_docs/version-0.25/release-lifecycle-policy.md
+++ b/enterprise_versioned_docs/version-0.25/release-lifecycle-policy.md
@@ -1,0 +1,88 @@
+---
+title: Astronomer Release and Lifecycle Policy
+sidebar_label: Release and Lifecycle Policy
+id: release-lifecycle-policy
+description: Astronomer's release and lifecycle policy for Astronomer Enterprise.
+---
+
+## Overview
+
+Astronomer supports a variety of policies that drives the naming, release cadence, and maintenance commitments associated with all published software.
+
+This document offers guidelines on the version lifecycle of Astronomer Enterprise. It includes a description of:
+
+- How Astronomer is versioned.
+- Which versions of Astronomer Enterprise are currently available.
+- Release channels and the maintenance schedule for all versions.
+
+For information on the latest Astronomer Enterprise releases, see [release notes](release-notes.md). For the release and maintenance policy for Astronomer Certified, see the Certified [Versioning and Maintenance Policy](ac-support-policy.md).
+
+For information on compatibility between all versioned software, see [Enterprise Version Compatibility Reference](release-lifecycle-policy.md).
+
+## Release Channels
+
+To meet the unique needs of different operating environments, we offer all Astronomer customers two release channels:
+
+- **Stable:** Includes the latest Astronomer and Airflow features
+- **Long-term Support (LTS):** Includes long-term testing, stability, and maintenance for a core set of features
+
+For customers looking to access Astronomer's newest features on an incremental basis, we recommend following the stable release channel and upgrading to new versions as soon as they are made generally available. Stable releases are issued roughly once per month for Astronomer Enterprise and the Astronomer CLI.
+
+For customers looking for less frequent upgrades and functional changes, we recommend following the LTS release channel. Release channels are not binding, so you are free to upgrade to any available version of Astronomer Enterprise at any time.
+
+> **Note:** Release channels apply to Astronomer Enterprise and Astronomer Certified versions. We do not currently support a long-term release channel for the Astronomer CLI.
+
+## Astronomer Enterprise Versioning
+
+Astronomer follows [Semantic Versioning](https://semver.org/) for all published software. This means that we use Major, Minor, and Patch releases across our product in the format of `major.minor.patch`.
+
+- **Major** versions are released for significant feature additions, including backward-incompatible changes to an API or DAG specification.
+- **Minor** versions are released for functional changes, including backward-compatible changes to an API or DAG specification.
+- **Patch** versions are released for bug and security fixes that resolve incorrect behavior.
+
+It is considered safe to upgrade to minor and patch versions within a major version. Upgrade guidance for major and LTS versions is provided with each release.
+
+## Version Maintenance Policy
+
+The maintenance period for an Astronomer Enterprise version depends on its release channel:
+
+| Release Channel | Frequency of Releases | Maintenance Duration |
+| --------------- | --------------------- | -------------------- |
+| Stable          | Monthly               | 6 Months             |
+| LTS             | Yearly                | 12 Months            |
+
+For each `major.minor` pair, only the latest patch is supported at any given time.
+
+For example, if Astronomer Enterprise v0.26 were a stable version first released in October 2021:
+
+- Support for Astronomer Enterprise v0.26 would end 6 months later in April 2022.
+- If a patch version for v0.26 came out in December 2021 (e.g. `v0.26.4`), it would not affect the maintenance duration. Maintenance for v0.26 would still end in April 2022.
+- If a major bug was identified in v0.26, a fix would be backported by the Astronomer team and released as a patch to v0.26 as long as it remained the latest stable release.
+- If Astronomer Enterprise v0.27 came out as a new stable release, bug fixes would no longer be backported to Astronomer v0.26 and customers would be encouraged to upgrade.
+- If a major security issue was identified in v0.26, a fix would be backported and released as a patch at any time during its 6 month maintenance period. Even if v0.27 is the latest stable version of Astronomer Enterprise, a security fix would still be backported to v0.26.
+
+If you contact [Astronomer Support](https://support.astronomer.io) about an issue you are experiencing while running an unmaintained version, our team will invite you to upgrade as an initial mitigation step.
+
+### End of Maintenance Date
+
+Maintenance is discontinued the last day of the month for a given version. For example, if a version of Astronomer Enterprise were supported between January - June of a given year, that version would be maintained by Astronomer until the last day of June.
+
+## Backport Policy for Bug and Security Fixes
+
+If a major stability bug is identified by our team, a fix will be backported to all LTS versions and only the latest stable version. For users on a stable version that is not latest, our team will recommend that you upgrade. Major issues in this category may result in significant delays in task scheduling as well as potential data loss.
+
+If a major security issue is identified, a fix will be backported and made available as a new patch version for _all_ supported stable and LTS releases. Major issues in this category are classified by a combination of impact and exploitability.
+
+In rare instances, the Astronomer team may make an exception and backport a bug or security fix to a release that is beyond the commitment stated above. To submit a request for consideration, please reach out to your customer success manager.
+
+## Enterprise Lifecycle Schedule
+
+The following table contains the exact lifecycle for each published version of Astronomer Enterprise. These timelines are based on the LTS and stable release channel maintenance policies.
+
+| Enterprise Version | Release Date     | Release Channel | Maintenance Period | End of Maintenance Date |
+| ------------------ | ---------------- | --------------- | ------------------ | ----------------------- |
+| 0.16               | June 29, 2020    | LTS             | 12 months          | June 2021               |
+| 0.23               | January 20, 2021 | LTS             | 12 months          | January 2022            |
+| 0.25               | May 11, 2021     | LTS             | 12 months          | May 2022                |
+| 0.26               | Nov 23, 2021     | Stable          | 6 months           | May 2022                |
+| 0.27               | Dec 21, 2021     | Stable          | 6 months           | June 2022               |

--- a/enterprise_versioned_docs/version-0.26/release-lifecycle-policy.md
+++ b/enterprise_versioned_docs/version-0.26/release-lifecycle-policy.md
@@ -85,5 +85,6 @@ The following table contains the exact lifecycle for each published version of A
 | 0.23               | January 20, 2021 | LTS             | 12 months          | January 2022            |
 | 0.25               | May 11, 2021     | LTS             | 12 months          | May 2022                |
 | 0.26               | Nov 23, 2021     | Stable          | 6 months           | May 2022                |
+| 0.27               | Dec 21, 2021     | Stable          | 6 months           | June 2022               |
 
 > **Note:** This maintenance policy is in effect as of October 2021. To ease the impact of this updated policy, Astronomer will provide extended maintenance, backporting major security fixes for these versions. For questions or concerns, reach out to us.

--- a/enterprise_versioned_docs/version-0.26/upgrade-astronomer-stable.md
+++ b/enterprise_versioned_docs/version-0.26/upgrade-astronomer-stable.md
@@ -1,25 +1,31 @@
 ---
 title: 'Upgrade to a Stable or Patch Version of Astronomer Enterprise'
-sidebar_label: 'Upgrade to a Stable or Patch Version'
+sidebar_label: 'Upgrade Astronomer'
 id: upgrade-astronomer-stable
 description: Update your Astronomer Enterprise Platform to a new stable or patch version.
 ---
 
 ## Overview
 
-Stable releases of Astronomer Enterprise are available to Enterprise customers on a monthly basis as part of the release model described in [Release and Lifecycle Policy](release-lifecycle-policy.md). Patch release of Astronomer Enterprise follow up on stable releases with additional bug and security fixes.
+For Astronomer Enterprise customers, new product features are regularly made available in stable and long-term support (LTS) releases as described in [Release and Lifecycle Policy](release-lifecycle-policy.md). Patch versions of Astronomer Enterprise with additional bug and security fixes are also released on a regular basis.
 
-Stable and patch releases require a simple upgrade process. Follow this guide to upgrade to any stable or patch version before the next available LTS release. For information on all stable and patch releases, refer to [Enterprise Release Notes](release-notes.md).
+All stable and patch releases of Astronomer Enterprise require a simple upgrade process. When an [LTS version](release-lifecycle-policy.md#release-channels) is released, additional upgrade guidance specific to that version will be made available.
+
+Follow this guide to upgrade to any stable or patch version of Astronomer Enterprise. For information on new features and changes, refer to [Enterprise Release Notes](release-notes.md).
 
 A few notes before you get started:
 - The patch upgrade process will not affect running Airflow tasks as long as `upgradeDeployments.enabled=false` is set in the script below.
-- Patch and stable version updates will not cause any downtime to Astronomer services (Astronomer UI, Houston API, Astronomer CLI).
+- Patch and stable version updates will not cause any downtime to Astronomer services, including the Astronomer UI, the Astronomer CLI, and the Houston API.
 
-> **Note:** Astronomer v0.16.5 and beyond includes an improved upgrade process that allows Airflow Deployments to remain unaffected through a platform upgrade that includes changes to the [Astronomer Airflow Chart](https://github.com/astronomer/airflow-chart).
->
-> Now, Airflow Chart changes only take effect when another restart event is triggered by a user (e.g. a code push, Environment Variable change, resource or executor adjustment, etc).
+:::info
 
-## Step 1: Ensure You Have a Copy of Your Astronomer config.yaml File
+Astronomer v0.16.5 and beyond includes an improved upgrade process that allows Airflow Deployments to remain unaffected through a platform upgrade that includes changes to the [Astronomer Airflow Chart](https://github.com/astronomer/airflow-chart).
+
+Now, Airflow Chart changes only take effect when another restart event is triggered by a user (e.g. a code push, Environment Variable change, resource or executor adjustment, etc).
+
+:::
+
+## Step 1: Ensure You Have a Copy of Your Astronomer `config.yaml` File
 
 First, ensure you have a copy of the `config.yaml` file of your platform namespace.
 
@@ -39,15 +45,9 @@ To verify the version of Astronomer you're currently operating with, run:
 helm list --all-namespaces | grep astronomer
 ```
 
-## Step 3: Run Astronomer's Patch Upgrade Script
+## Step 3: Run Astronomer's Upgrade Script
 
-Now, review and run the script below to upgrade to the patch version of your choice.
-
-Make sure to substitute the following 3 variables with your own values:
-
-- `RELEASE_NAME`
-- `NAMESPACE`
-- `ASTRO_VERSION`
+Now, review and run the script below to upgrade to the version of your choice.
 
 ```sh
 #!/bin/bash
@@ -55,7 +55,7 @@ set -xe
 
 RELEASE_NAME=<astronomer-platform-release-name>
 NAMESPACE=<astronomer-platform-namespace>
-ASTRO_VERSION=0.25.<astronomer-patch-version>
+ASTRO_VERSION=<astronomer-version>
 
 helm3 repo add astronomer https://helm.astronomer.io
 helm3 repo update
@@ -73,4 +73,16 @@ helm3 upgrade --namespace $NAMESPACE \
             astronomer/astronomer
 ```
 
-> **Note:** If you do not specify a patch version above, the script will automatically pull the latest Astronomer Enterprise patch available in the [Astronomer Helm Chart](https://github.com/astronomer/astronomer/releases). If you set `ASTRO_VERSION=0.25` and `--version 0.25`, for example, Astronomer v0.25.9 will be installed if it is the latest v0.25 patch available.
+Make sure to substitute the following 3 variables with your own values:
+
+- `RELEASE_NAME`
+- `NAMESPACE`
+- `ASTRO_VERSION`
+
+To upgrade to Astronomer Enterprise v0.26.5, for example, set `ASTRO_VERSION=0.26.5`.
+
+:::tip
+
+If you do not specify a patch version above, the script will automatically pull the latest Astronomer Enterprise patch available in the [Astronomer Helm Chart](https://github.com/astronomer/astronomer/releases). If you set `ASTRO_VERSION=0.26`, for example, Astronomer v0.26.5 will be installed if it is the latest v0.26 patch available.
+
+:::

--- a/enterprise_versioned_docs/version-0.26/upgrade-astronomer-stable.md
+++ b/enterprise_versioned_docs/version-0.26/upgrade-astronomer-stable.md
@@ -2,7 +2,7 @@
 title: 'Upgrade to a Stable or Patch Version of Astronomer Enterprise'
 sidebar_label: 'Upgrade Astronomer'
 id: upgrade-astronomer-stable
-description: Update your Astronomer Enterprise Platform to a new stable or patch version.
+description: Upgrade to a new stable or patch version of Astronomer Enterprise.
 ---
 
 ## Overview

--- a/enterprise_versioned_docs/version-0.26/upgrade-astronomer-stable.md
+++ b/enterprise_versioned_docs/version-0.26/upgrade-astronomer-stable.md
@@ -75,9 +75,9 @@ helm3 upgrade --namespace $NAMESPACE \
 
 Make sure to substitute the following 3 variables with your own values:
 
-- `RELEASE_NAME`
-- `NAMESPACE`
-- `ASTRO_VERSION`
+- `<astronomer-platform-release-name>`
+- `<astronomer-platform-namespace>`
+- `<astronomer-patch-version>`
 
 To upgrade to Astronomer Enterprise v0.26.5, for example, set `ASTRO_VERSION=0.26.5`.
 


### PR DESCRIPTION
Hey @jwitz - was looking at our "Upgrade Astronomer" doc and decided to make a few changes. Included in this PR is:

- Renaming the sidebar version of this doc to just "Upgrade Astronomer"
- Fixed a reference to 0.25 in the 0.26 version of this doc to address #254
- Tweaked language in the `Overview` to make the purpose of this doc (and the difference with LTS upgrades) more clear
- Added 0.27 to "Release and Lifecycle Policy" - it was missing

@vishwas-astro Could you take a look at this too and confirm we're not missing anything? This PR assumes that no "additional" upgrade guidance is required for 0.26 or 0.27, and that neither are LTS releases