### PR TITLE
Reference files migration

### DIFF
--- a/enterprise/manage-platform-users.md
+++ b/enterprise/manage-platform-users.md
@@ -78,18 +78,18 @@ Permissions are defined on Astronomer as `scope.entity.action`, where:
 - `entity`: The object or role being operated on
 - `action`: The verb describing the operation being performed on the `entity`
 
-For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view our [default Houston API configuration](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L200). Each permission is applied to the role under which it is listed.
+For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view our [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.27/default.yaml). Each permission is applied to the role under which it is listed.
 
-> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles ([source code here](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L266)).
+> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles.
 
 To customize permissions, follow the steps below.
 
 ### Identify a Permission Change
 
-First, take a look at our default roles and permissions linked above and identify two things:
+First, take a look at our default roles and permissions in the [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.27/default.yaml) and identify two things:
 
-1. What role do you want to configure? (e.g. [`DEPLOYMENT_EDITOR`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L356))
-2. What permission(s) would you like to add to or remove from that role? (e.g. [`deployment.images.push`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L362))
+1. What role do you want to configure? (e.g. `DEPLOYMENT_EDITOR`)
+2. What permission(s) would you like to add to or remove from that role? (e.g. `deployment.images.push`)
 
 For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKSPACE_EDITOR`) from deploying code to all Airflow Deployments within a Workspace and instead limit that action to users assigned the `DEPLOYMENT_ADMIN` role.
 
@@ -97,11 +97,11 @@ For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKS
 
 Unless otherwise configured, a user who creates a Workspace on Astronomer is automatically granted the `WORKSPACE_ADMIN` role and is thus able to create an unlimited number of Airflow Deployments within that Workspace. For teams looking to more strictly control resources, our platform supports limiting the Workspace creation function via a `USER` role.
 
-Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L377).
+Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this role includes the `system.workspace.create` permission.
 
 If you're an administrator on Astronomer who wants to limit Workspace Creation, you can:
 
-- Remove the `system.workspace.create` permission from the `USER` role [here](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L382)
+- Remove the `system.workspace.create` permission from the `USER` role
 - Attach it to a separate role of your choice
 
 If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
@@ -162,7 +162,7 @@ In addition to the commonly used System Admin role, the Astronomer platform also
 
 No user is assigned the System Editor or Viewer Roles by default, but they can be added by System Admins via our API. Once assigned, System Viewers, for example, can access both Grafana and Kibana but don't have permission to delete a Workspace they're not a part of.
 
-All three permission sets are entirely customizable on Astronomer Enterprise. For a full breakdown of the default configurations attached to the System Admin, Editor and Viewer Roles, refer to our [Houston API source code](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L220).
+All three permission sets are entirely customizable on Astronomer Enterprise. For a full breakdown of the default configurations attached to the System Admin, Editor and Viewer Roles, refer to our [Houston API source code](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.27/default.yaml).
 
 For guidelines on assigning users any System Level role, read below.
 
@@ -174,7 +174,7 @@ Keep in mind that:
 - Only existing System Admins can grant the SysAdmin role to another user
 - The user must have a verified email address and already exist in the system
 
-> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L246) or [`SYSTEM_EDITOR`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L259)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/enterprise/houston-api).
+> **Note:** If you'd like to assign a user a different System-Level Role (either `SYSTEM_VIEWER` or `SYSTEM_EDITOR`), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/enterprise/houston-api).
 
 #### Verify SysAdmin Access
 

--- a/enterprise_configs/0.16/default.yaml
+++ b/enterprise_configs/0.16/default.yaml
@@ -1,0 +1,562 @@
+# This file contains non-secret configurations.
+
+# API webserver configuration.
+webserver:
+  port: 8871
+  endpoint: "/v1"
+  subscriptions: "/ws"
+
+# CORS Access
+cors:
+  allowedOrigins: []
+
+# Prisma configuration.
+prisma:
+  endpoint: "http://localhost:4466/houston"
+  secret: ~
+  debug: false
+
+# Logging configuration.
+logging:
+  level: "debug"
+
+# Database connection.
+# This is mostly for knexfile now.
+# Also defined for Prisma service separately.
+database:
+  # Knex migrations
+  migrations:
+    # Table to store migrations
+    tableName: migrations
+    # Schema for migrations.
+    # prisma deploy fails if this table exists in the same schema
+    # as prisma tables.
+    schemaName: public
+    # Disable wrapping migrations with transaction
+    # Currently disabling to allow better cooperation with prisma.
+    disableTransactions: true
+
+  # Knex connection
+  connection:
+    user: postgres
+    password: postgres
+    host: localhost
+    port: 5432
+    database: postgres
+
+# Commander configuration.
+commander:
+  enabled: false
+  host: localhost
+  port: 50051
+
+# Docker Registry configuration.
+registry:
+  host: localhost
+  port: 5000
+  authHeader: ~
+
+# Email configuration.
+email:
+  # Enable sending emails.
+  enabled: false
+
+  # Open HTML emails in browser when sent.
+  preview: false
+
+  # The "from" address to use.
+  reply: "noreply@astronomer.io"
+
+  # The SMTP server URL.
+  smtpUrl: ~
+
+# Stripe configuration.
+stripe:
+  enabled: false
+  secretKey: ~
+
+# Analytics configuration
+analytics:
+  writeKey: ~
+
+# Set the length of a Cloud Trial
+trial:
+  # Cloud trial length in days
+  length: 14
+
+# UI configuration.
+ui:
+  subdomain: app
+  port: 5000
+
+# Elasticsearch configuration for Houston to pull logs.
+# This is passed striaght to the es client.
+elasticsearch:
+  # Enable or disable querying for logs in ES. This supersedes mock configuration below.
+  enabled: false
+
+  # Client configuration, passed directly to es-client constructor.
+  client:
+    host: ~
+    log: error
+
+  # If in NODE_ENV is development and this is enabled, generate sample log records.
+  mockInDevelopment: true
+
+  # Interval that data is grabbed and sent
+  pollInterval: 1000
+
+# Prometheus Metrics configuration
+prometheus:
+  # Sample data - false for no querying prometheus, true for querying prometheus.
+  enabled: false
+  host: localhost
+  port: 9090
+  pollInterval: 30000
+  statusPollInterval: 60000
+
+# Charts live here.
+# This is where the airflow chart is installed from.
+repository: "https://helm.astronomer.io/"
+
+# Helm configuration.
+# These values are set at runtime and used for airflow deployments.
+helm:
+  baseDomain: ~
+  registryAuthSecret: ~
+  releaseName: ~
+  releaseNamespace: ~
+  releaseVersion: ~
+  singleNamespace: false
+
+# Auth configuration.
+auth:
+  # Local database (user/pass) configuration.
+  local:
+    enabled: true
+
+  openidConnect:
+    # Clock skew for slightly out-of-sync clocks
+    clockTolerance: 0
+    # Auth0 integration configuration.
+    auth0:
+      # This "enabled" flag is currently a little misleading.
+      # The enabled flag refers only to showing the native
+      # Auth0 button in the UI. The rest of the settings here
+      # could potentially be used as to auth with Google/Github/etc
+      # if those integrations are enabled, but do not have connection
+      # information.
+      enabled: false
+      clientId: ~
+      discoveryUrl: https://astronomerio.auth0.com
+      authUrlParams:
+        audience: "astronomer-ee"
+
+    # Google oauth configuration.
+    google:
+      displayName: Google
+      enabled: false
+      # If blank we will go via Auth0
+      clientId: ~
+      discoveryUrl: https://accounts.google.com
+
+    okta:
+      enabled: false
+      clientId: ~
+      discoveryUrl: ~
+
+    microsoft:
+      displayName: "Azure AD"
+      enabled: false
+      claimsMapping:
+        email: preferred_username
+      clientId: ~
+      discoveryUrl: ~
+
+    adfs:
+      displayName: "ADFS"
+      enabled: false
+      # Disable userInfo request for providers such as ADFS
+      fetchUserInfo: false
+      claimsMapping:
+        email: upn
+        name: upn
+      clientId: ~
+      discoveryUrl: ~
+
+  # Github via auth0
+  github:
+    enabled: false
+
+# Houston JWT configuration.
+jwt:
+  # Development only: Passphrase to sign JWTs used to authenticate our GraphQL
+  # API.
+  #passphrase: ~
+
+  # JWT / Cookie duration in milliseconds.
+  authDuration: 86400000
+
+  # Path to folder containing tls.crt and tls.key, used for signing JWT tokens
+  # to authenticate against the Docker registry and Airflow FAB UI
+  certPath: ~
+
+  # Docker registry configuration.
+  registry:
+    certPath: ~
+    issuer: ~
+    service: ~
+    # A list of "base" images in the repository that every user will be able to
+    # pull/remount to share base layers. Pushable by SYSTEM_ADMIN and
+    # SYSTEM_EDITOR
+    baseImages:
+      - base-images/airflow
+
+# Service Account configuration.
+serviceAccounts:
+  # When a new service account is created, return the full apiKey for
+  # this many minutes. After this amount of time, return a partially obfuscated version.
+  showFor: 10
+
+  # Display this many characters of the real apiKey after showFor has been exceeded.
+  showFirstChars: 6
+
+# Allow public signups.
+publicSignups: false
+
+# URL to send users to for signup when publicSignups is disabled
+externalSignupUrl: ~
+
+# Require email confirmation.
+emailConfirmation: true
+
+# Subdomain under base domain.
+subdomain: houston
+
+# Format: ${SCOPE}.${RESOURCE}.${VERB}
+roles:
+  # To explicitly remove a permission defined in this base config set it to false in your local config
+  # roles:
+  #   SYSTEM_VIEWER:
+  #     permissions:
+  #       system.monitoring.get: false
+
+  #
+  # System Roles
+  #
+  SYSTEM_VIEWER:
+    name: System Viewer
+    permissions: &PERMS__SYSTEM_VIEWER
+      ? system.airflow.get
+      ? system.deployments.get
+      ? system.invites.get
+      ? system.invite.get
+      ? system.monitoring.get
+      ? system.serviceAccounts.get
+      ? system.updates.get
+      ? system.users.get
+      ? system.workspace.get
+
+  SYSTEM_EDITOR:
+    name: System Editor
+    permissions: &PERMS__SYSTEM_EDITOR
+      <<: *PERMS__SYSTEM_VIEWER
+      ? system.iam.update
+      ? system.serviceAccounts.update
+      ? system.airflow.user
+      ? system.registryBaseImages.push
+
+  SYSTEM_ADMIN:
+    name: System Admin
+    permissions:
+      <<: *PERMS__SYSTEM_EDITOR
+      ? system.deployments.update
+      ? system.deployments.delete
+      ? system.deployments.logs
+      ? system.deployments.metrics
+      ? system.serviceAccounts.create
+      ? system.serviceAccounts.update
+      ? system.serviceAccounts.delete
+      ? system.user.invite
+      ? system.user.delete
+      ? system.user.verifyEmail
+      ? system.workspace.addCustomerId
+      ? system.workspace.delete
+      ? system.workspace.suspend
+      ? system.workspace.extendTrial
+      ? system.airflow.admin
+
+  #
+  # Workspace Roles
+  #
+  WORKSPACE_VIEWER:
+    name: Workspace Viewer
+    permissions: &PERMS__WORKSPACE_VIEWER
+      ? workspace.config.get
+      ? workspace.deployments.get
+      ? workspace.invites.get
+      ? workspace.serviceAccounts.get
+      ? workspace.users.get
+
+  WORKSPACE_EDITOR:
+    name: Workspace Editor
+    permissions: &PERMS__WORKSPACE_EDITOR
+      <<: *PERMS__WORKSPACE_VIEWER
+      ? workspace.config.update
+      ? workspace.deployments.create
+      ? workspace.serviceAccounts.create
+      ? workspace.serviceAccounts.update
+      ? workspace.serviceAccounts.delete
+
+  WORKSPACE_ADMIN:
+    name: Workspace Admin
+    permissions:
+      <<: *PERMS__WORKSPACE_EDITOR
+      ? workspace.billing.update
+      ? workspace.config.delete
+      ? workspace.iam.update
+
+  #
+  # Deployment Roles
+  #
+  DEPLOYMENT_VIEWER:
+    name: Deployment Viewer
+    permissions: &PERMS__DEPLOYMENT_VIEWER
+      ? deployment.airflow.get
+      ? deployment.config.get
+      ? deployment.logs.get
+      ? deployment.images.pull
+      ? deployment.metrics.get
+      ? deployment.serviceAccounts.get
+
+  DEPLOYMENT_EDITOR:
+    name: Deployment Editor
+    permissions: &PERMS__DEPLOYMENT_EDITOR
+      <<: *PERMS__DEPLOYMENT_VIEWER
+      ? deployment.airflow.user
+      ? deployment.config.update
+      ? deployment.images.push
+      ? deployment.images.pull
+      ? deployment.serviceAccounts.create
+      ? deployment.serviceAccounts.update
+      ? deployment.serviceAccounts.delete
+
+  DEPLOYMENT_ADMIN:
+    name: Deployment Admin
+    permissions:
+      <<: *PERMS__DEPLOYMENT_EDITOR
+      ? deployment.airflow.admin
+      ? deployment.config.delete
+
+  #
+  # User Role (Everyone)
+  #
+  USER:
+    name: User
+    permissions:
+      ? system.workspace.create
+
+#
+# Airflow Deployment Configurations
+#
+deployments:
+  subdomain: 'deployments'
+  # Airflow chart settings
+  # Static helm configurations for this chart are found below.
+  chart:
+    # This version number controls the default Airflow chart version that will be installed
+    # when creating a new deployment in the system. This is also used to ensure all
+    # child airflow deployments are kept up to date and on the latest version.
+    version: 0.0.0
+
+  # Airflow image settings
+  # This is a list of supported airflow versions and corresponding docker tag
+  images:
+    - version: 0.0.0
+      channel: stable
+      tag: 0.0.0-alpine3.10-onbuild
+    # - version: 1.10.5
+    #   channel: stable
+    #   tag: 1.10.5-alpine3.10-onbuild
+    # - version: 1.10.6
+    #   channel: edge
+    #   tag: 1.10.6-alpine3.10-onbuild
+
+  # Labels specifed here are applied to Airflow deployment namespaces.
+  namespaceLabels: {}
+
+  # Enable manual namespace labels
+  manualReleaseNames: false
+
+  # Log out final helm values whenever they are generated, before deployment.
+  logHelmValues: false
+
+  # CLI image tag prefix
+  # This is the prefix to use for houston-generated tags.
+  tagPrefix: deploy
+
+  # This is the database connection that we use to connect
+  # and create other databases/schemas/users for each
+  # individual airflow deployment.
+  database:
+    # If disabled, skip db creation.
+    enabled: true
+
+    # Keep the airflow databases around after a
+    # deployment is deleted.
+    retainOnDelete: false
+
+    # If true, leave GRANTs in place for root user.
+    # This lets users log in with the root creds and query
+    # deployment databases.
+    allowRootAccess: false
+
+    # Connection details for root user.
+    # This can also be overridden with a connection string.
+    connection:
+      user: postgres
+      password: postgres
+      host: localhost
+      port: 5432
+      database: postgres
+
+  # Elasticsearch configuration for deployments.
+  # Airflow clients access Elasticsearch differently.
+  # Houston has full acces, while the deployments connect
+  # via NGINX for auth.
+  elasticsearch:
+    enabled: false
+    connection:
+      host: localhost
+      port: 9200
+
+  # An astro unit defines the smallest billable unit
+  # in the system. Default values are based on
+  # the GCP n1-standard-1. CPU should always be expressed
+  # in millicpu and memory should be expressed in Mibibytes.
+  astroUnit:
+    cpu: 100
+    memory: 384
+    pods: 1
+    airflowConns: 5
+    actualConns: 0.5
+    price: 0
+
+  # This defines how much extra capacity, in astro units,
+  # that a user can expand a deployment to. This is currently
+  # represented as a slider in the UI.
+  maxExtraAu: 400
+
+  # This defines the maximum size a pod can be in astro units.
+  maxPodAu: 35
+
+  # This defines any extra resources to account for any sidecars that
+  # are appied to every deployment component. Ex: istio.
+  sidecars:
+    cpu: 0
+    memory: 0
+
+  # This defines all possible components for an airflow
+  # deployment and the default AU to use for the kubernetes
+  # resource requests, as well as its limits.
+  components:
+    - name: scheduler
+      au:
+        default: 5
+        limit: 30
+        request: ~
+    - name: webserver
+      au:
+        default: 5
+        limit: 30
+        request: ~
+    - name: statsd
+      au:
+        default: 2
+        limit: 30
+        request: ~
+    - name: pgbouncer
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: flower
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: redis
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: workers
+      au:
+        default: 10
+        limit: 30
+        request: ~
+      extra:
+        - name: terminationGracePeriodSeconds
+          default: 600
+          limit: 36000
+        - name: replicas
+          default: 1
+          limit: 10
+
+  # This defines which executors should be supported, as well
+  # as the components required to run a particular
+  # executor configuration.
+  executors:
+    - name: LocalExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+      defaultExtraAu: 0
+    - name: CeleryExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+        - workers
+        - flower
+        - redis
+      defaultExtraAu: 0
+    - name: KubernetesExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+      defaultExtraAu: 10
+
+  # These are static configs that get merged directly into the values
+  # passed to helm for each deployment.
+  helm:
+    # If enabled, deploy ServiceAccounts / Roles / RoleBindings
+    # for components that require kubernetes apiserver access.
+    rbacEnabled: true
+    ingress:
+      # Attach an airflow deployment to the system level ingress controller.
+      enabled: true
+    networkPolicies:
+      # Enabled network polices to restrict the way pods can communicate.
+      enabled: true
+    pgbouncer:
+      # Adds a pgbouncer service between the airflow pods (scheduler / webserver/ workers),
+      # and the backend database.
+      enabled: true
+    # Allow scheduler/workers to launch pods by default. This is required for
+    # the KubernetesPodOperator and KubernetesExecutor. This is what signals to apply the
+    # required RoleBindings.
+    allowPodLaunching: true
+
+  # Annotation name to map the `cloud-role` from creating a deployment to on the Deployment Service account.
+  # AWS - eks.amazonaws.com/role-arn
+  # GCP - iam.gke.io/gcp-service-account
+  serviceAccountAnnotationKey: ~

--- a/enterprise_configs/0.16/default.yaml
+++ b/enterprise_configs/0.16/default.yaml
@@ -1,4 +1,4 @@
-# This is a configuration reference file that contains source code from Astronomer's private Houston API repository.
+# This is a reference configuration file that contains source code from Astronomer's private Houston API repository.
 # It is maintained by Astronomer's documentation team and should be used as a reference to help you configure
 # the `astronomer.houston.config` section of your `config.yaml` file on Astronomer Enterprise.
 

--- a/enterprise_configs/0.16/default.yaml
+++ b/enterprise_configs/0.16/default.yaml
@@ -1,4 +1,6 @@
-# This file contains non-secret configurations.
+# This is a configuration reference file that contains source code from Astronomer's private Houston API repository.
+# It is maintained by Astronomer's documentation team and should be used as a reference to help you configure
+# the `astronomer.houston.config` section of your `config.yaml` file on Astronomer Enterprise.
 
 # API webserver configuration.
 webserver:

--- a/enterprise_configs/0.23/default.yaml
+++ b/enterprise_configs/0.23/default.yaml
@@ -1,4 +1,4 @@
-# This is a configuration reference file that contains source code from Astronomer's private Houston API repository.
+# This is a reference configuration file that contains source code from Astronomer's private Houston API repository.
 # It is maintained by Astronomer's documentation team and should be used as a reference to help you configure
 # the `astronomer.houston.config` section of your `config.yaml` file on Astronomer Enterprise.
 

--- a/enterprise_configs/0.23/default.yaml
+++ b/enterprise_configs/0.23/default.yaml
@@ -1,4 +1,6 @@
-# This file contains non-secret configurations.
+# This is a configuration reference file that contains source code from Astronomer's private Houston API repository.
+# It is maintained by Astronomer's documentation team and should be used as a reference to help you configure
+# the `astronomer.houston.config` section of your `config.yaml` file on Astronomer Enterprise.
 
 # API webserver configuration.
 webserver:

--- a/enterprise_configs/0.23/default.yaml
+++ b/enterprise_configs/0.23/default.yaml
@@ -1,0 +1,608 @@
+# This file contains non-secret configurations.
+
+# API webserver configuration.
+webserver:
+  port: 8871
+  endpoint: "/v1"
+  subscriptions: "/ws"
+
+# CORS Access
+cors:
+  allowedOrigins: []
+
+# Prisma configuration.
+prisma:
+  endpoint: "http://localhost:4466/houston"
+  secret: ~
+  debug: false
+
+# NATS configuration.
+nats:
+  servers: ["nats://localhost:4222"]
+  clusterID: houston
+  ackTimeout: 120000
+  ackWait: 120000
+  connectTimeout: 3000
+  maxPubAcksInflight: 16384
+  maxReconnectAttempts: 200
+  stanMaxPingOut: 20
+  stanPingInterval: 5000
+  reconnect: true
+  reconnectTimeWait: 5000
+  reconnectJitter: 150
+  reconnectJitterTLS: 1000
+  waitOnFirstConnect: true
+
+# Logging configuration.
+logging:
+  level: "debug"
+
+# Database connection.
+# This is mostly for knexfile now.
+# Also defined for Prisma service separately.
+database:
+  schema: houston$default
+  # this is for enabling ssl connection for database
+  ssl: false
+  # Knex migrations
+  migrations:
+    # Table to store migrations
+    tableName: migrations
+    # Schema for migrations.
+    # prisma deploy fails if this table exists in the same schema
+    # as prisma tables.
+    schemaName: public
+    # Disable wrapping migrations with transaction
+    # Currently disabling to allow better cooperation with prisma.
+    disableTransactions: true
+
+  # Knex connection
+  connection:
+    user: postgres
+    password: postgres
+    host: localhost
+    port: 5432
+    database: postgres
+
+# Commander configuration.
+commander:
+  enabled: false
+  host: localhost
+  port: 50051
+
+# Docker Registry configuration.
+registry:
+  host: localhost
+  port: 5000
+  authHeader: ~
+
+# Email configuration.
+email:
+  # Enable sending emails.
+  enabled: false
+
+  # Open HTML emails in browser when sent.
+  preview: false
+
+  # The "from" address to use.
+  reply: "noreply@astronomer.io"
+
+  # The SMTP server URL.
+  smtpUrl: ~
+
+# Stripe configuration.
+stripe:
+  enabled: false
+  secretKey: ~
+
+# Analytics configuration
+analytics:
+  writeKey: ~
+
+# Apollo schema reporting configuration
+apollo:
+  key: ~
+  graphVariant: ~
+
+# Set the length of a Cloud Trial
+trial:
+  # Cloud trial length in days
+  length: 14
+
+# UI configuration.
+ui:
+  subdomain: app
+  port: 5000
+
+# Elasticsearch configuration for Houston to pull logs.
+# This is passed striaght to the es client.
+elasticsearch:
+  # Enable or disable querying for logs in ES. This supersedes mock configuration below.
+  enabled: false
+
+  # Client configuration, passed directly to es-client constructor.
+  client:
+    host: ~
+    log: error
+
+  # If in NODE_ENV is development and this is enabled, generate sample log records.
+  mockInDevelopment: true
+
+  # Interval that data is grabbed and sent
+  pollInterval: 1000
+
+# Prometheus Metrics configuration
+prometheus:
+  # Sample data - false for no querying prometheus, true for querying prometheus.
+  enabled: false
+  host: localhost
+  port: 9090
+  pollInterval: 30000
+  statusPollInterval: 60000
+
+# Charts live here.
+# This is where the airflow chart is installed from.
+repository: "https://helm.astronomer.io/"
+
+# Helm configuration.
+# These values are set at runtime and used for airflow deployments.
+helm:
+  baseDomain: ~
+  registryAuthSecret: ~
+  releaseName: ~
+  releaseNamespace: ~
+  releaseVersion: ~
+  singleNamespace: false
+
+# Auth configuration.
+auth:
+  # Local database (user/pass) configuration.
+  local:
+    enabled: true
+
+  openidConnect:
+    # Clock skew for slightly out-of-sync clocks
+    clockTolerance: 0
+    # Auth0 integration configuration.
+    auth0:
+      # This "enabled" flag is currently a little misleading.
+      # The enabled flag refers only to showing the native
+      # Auth0 button in the UI. The rest of the settings here
+      # could potentially be used as to auth with Google/Github/etc
+      # if those integrations are enabled, but do not have connection
+      # information.
+      enabled: false
+      clientId: ~
+      discoveryUrl: https://astronomerio.auth0.com
+      authUrlParams:
+        audience: "astronomer-ee"
+
+    # Google oauth configuration.
+    google:
+      displayName: Google
+      enabled: false
+      # If blank we will go via Auth0
+      clientId: ~
+      discoveryUrl: https://accounts.google.com
+
+    okta:
+      enabled: false
+      clientId: ~
+      discoveryUrl: ~
+
+    microsoft:
+      displayName: "Azure AD"
+      enabled: false
+      claimsMapping:
+        email: preferred_username
+      clientId: ~
+      discoveryUrl: ~
+
+    adfs:
+      displayName: "ADFS"
+      enabled: false
+      # Disable userInfo request for providers such as ADFS
+      fetchUserInfo: false
+      claimsMapping:
+        email: upn
+        name: upn
+      clientId: ~
+      discoveryUrl: ~
+
+  # Github via auth0
+  github:
+    enabled: false
+
+# Houston JWT configuration.
+jwt:
+  # Development only: Passphrase to sign JWTs used to authenticate our GraphQL
+  # API.
+  #passphrase: ~
+
+  # JWT / Cookie duration in milliseconds.
+  authDuration: 86400000
+
+  # Path to folder containing tls.crt and tls.key, used for signing JWT tokens
+  # to authenticate against the Docker registry and Airflow FAB UI
+  certPath: ~
+
+  # Docker registry configuration.
+  registry:
+    certPath: ~
+    issuer: ~
+    service: ~
+    # A list of "base" images in the repository that every user will be able to
+    # pull/remount to share base layers. Pushable by SYSTEM_ADMIN and
+    # SYSTEM_EDITOR
+    baseImages:
+      - base-images/airflow
+
+# Service Account configuration.
+serviceAccounts:
+  # When a new service account is created, return the full apiKey for
+  # this many minutes. After this amount of time, return a partially obfuscated version.
+  showFor: 10
+
+  # Display this many characters of the real apiKey after showFor has been exceeded.
+  showFirstChars: 6
+
+# Allow public signups.
+publicSignups: false
+
+# URL to send users to for signup when publicSignups is disabled
+externalSignupUrl: ~
+
+# Require email confirmation.
+emailConfirmation: true
+
+# Subdomain under base domain.
+subdomain: houston
+
+# Format: ${SCOPE}.${RESOURCE}.${VERB}
+roles:
+  # To explicitly remove a permission defined in this base config set it to false in your local config
+  # roles:
+  #   SYSTEM_VIEWER:
+  #     permissions:
+  #       system.monitoring.get: false
+
+  #
+  # System Roles
+  #
+  SYSTEM_VIEWER:
+    name: System Viewer
+    permissions: &PERMS__SYSTEM_VIEWER
+      ? system.airflow.get
+      ? system.deployment.variables.get
+      ? system.deployments.get
+      ? system.invites.get
+      ? system.invite.get
+      ? system.monitoring.get
+      ? system.serviceAccounts.get
+      ? system.updates.get
+      ? system.users.get
+      ? system.workspace.get
+
+  SYSTEM_EDITOR:
+    name: System Editor
+    permissions: &PERMS__SYSTEM_EDITOR
+      <<: *PERMS__SYSTEM_VIEWER
+      ? system.deployment.variables.update
+      ? system.iam.update
+      ? system.serviceAccounts.update
+      ? system.airflow.user
+      ? system.registryBaseImages.push
+
+  SYSTEM_ADMIN:
+    name: System Admin
+    permissions:
+      <<: *PERMS__SYSTEM_EDITOR
+      ? system.deployments.update
+      ? system.deployments.delete
+      ? system.deployments.logs
+      ? system.deployments.metrics
+      ? system.serviceAccounts.create
+      ? system.serviceAccounts.update
+      ? system.serviceAccounts.delete
+      ? system.user.invite
+      ? system.user.delete
+      ? system.user.verifyEmail
+      ? system.workspace.addCustomerId
+      ? system.workspace.delete
+      ? system.workspace.suspend
+      ? system.workspace.extendTrial
+      ? system.airflow.admin
+
+  #
+  # Workspace Roles
+  #
+  WORKSPACE_VIEWER:
+    name: Workspace Viewer
+    permissions: &PERMS__WORKSPACE_VIEWER
+      ? workspace.config.get
+      ? workspace.deployments.get
+      ? workspace.invites.get
+      ? workspace.serviceAccounts.get
+      ? workspace.users.get
+
+  WORKSPACE_EDITOR:
+    name: Workspace Editor
+    permissions: &PERMS__WORKSPACE_EDITOR
+      <<: *PERMS__WORKSPACE_VIEWER
+      ? workspace.config.update
+      ? workspace.deployments.create
+      ? workspace.serviceAccounts.create
+      ? workspace.serviceAccounts.update
+      ? workspace.serviceAccounts.delete
+
+  WORKSPACE_ADMIN:
+    name: Workspace Admin
+    permissions:
+      <<: *PERMS__WORKSPACE_EDITOR
+      ? workspace.billing.update
+      ? workspace.config.delete
+      ? workspace.iam.update
+
+  #
+  # Deployment Roles
+  #
+  DEPLOYMENT_VIEWER:
+    name: Deployment Viewer
+    permissions: &PERMS__DEPLOYMENT_VIEWER
+      ? deployment.airflow.get
+      ? deployment.config.get
+      ? deployment.logs.get
+      ? deployment.images.pull
+      ? deployment.metrics.get
+      ? deployment.serviceAccounts.get
+      ? deployment.variables.get
+
+  DEPLOYMENT_EDITOR:
+    name: Deployment Editor
+    permissions: &PERMS__DEPLOYMENT_EDITOR
+      <<: *PERMS__DEPLOYMENT_VIEWER
+      ? deployment.airflow.user
+      ? deployment.config.update
+      ? deployment.images.push
+      ? deployment.images.pull
+      ? deployment.serviceAccounts.create
+      ? deployment.serviceAccounts.update
+      ? deployment.serviceAccounts.delete
+      ? deployment.variables.update
+
+  DEPLOYMENT_ADMIN:
+    name: Deployment Admin
+    permissions:
+      <<: *PERMS__DEPLOYMENT_EDITOR
+      ? deployment.airflow.admin
+      ? deployment.config.delete
+      ? deployment.userRoles.update
+
+  #
+  # User Role (Everyone)
+  #
+  USER:
+    name: User
+    permissions:
+      ? system.workspace.create
+
+#
+# Airflow Deployment Configurations
+#
+deployments:
+  subdomain: 'deployments'
+  # Airflow chart settings
+  # Static helm configurations for this chart are found below.
+  chart:
+    # This version number controls the default Airflow chart version that will be installed
+    # when creating a new deployment in the system. This is also used to ensure all
+    # child airflow deployments are kept up to date and on the latest version.
+    version: 0.0.0
+
+  # releaseVerification determines what docker images are allowed to be installed
+  # STABLE = only official Astronomer Core releases that mirror Airflow releaseVersion
+  # EDGE   = also allow Astronomer Core Edge (astronomer/core:edge) to be used
+  # DEV    = also allow hand-built dev images to be used
+  releaseVerification: STABLE
+
+  airflowReleasesFile: 'airflow_releases.json'
+  # Labels specifed here are applied to Airflow deployment namespaces.
+  namespaceLabels: {}
+
+  # Enable manual namespace labels
+  manualReleaseNames: false
+
+  # Log out final helm values whenever they are generated, before deployment.
+  logHelmValues: false
+
+  # CLI image tag prefix
+  # This is the prefix to use for houston-generated tags.
+  tagPrefix: deploy
+
+  # This is the database connection that we use to connect
+  # and create other databases/schemas/users for each
+  # individual airflow deployment.
+  database:
+    # If disabled, skip db creation.
+    enabled: true
+
+    # Keep the airflow databases around after a
+    # deployment is deleted.
+    retainOnDelete: false
+
+    # If true, leave GRANTs in place for root user.
+    # This lets users log in with the root creds and query
+    # deployment databases.
+    allowRootAccess: false
+
+    # Connection details for root user.
+    # This can also be overridden with a connection string.
+    connection:
+      user: postgres
+      password: postgres
+      host: localhost
+      port: 5432
+      database: postgres
+
+  # Elasticsearch configuration for deployments.
+  # Airflow clients access Elasticsearch differently.
+  # Houston has full acces, while the deployments connect
+  # via NGINX for auth.
+  elasticsearch:
+    enabled: false
+    connection:
+      host: localhost
+      port: 9200
+
+  # An astro unit defines the smallest billable unit
+  # in the system. Default values are based on
+  # the GCP n1-standard-1. CPU should always be expressed
+  # in millicpu and memory should be expressed in Mibibytes.
+  astroUnit:
+    cpu: 100
+    memory: 384
+    pods: 1
+    airflowConns: 5
+    actualConns: 0.5
+    price: 0
+
+  # This defines how much extra capacity, in astro units,
+  # that a user can expand a deployment to. This is currently
+  # represented as a slider in the UI.
+  maxExtraAu: 400
+
+  # This defines the maximum size a pod can be in astro units.
+  maxPodAu: 35
+
+  # This defines any extra resources to account for any sidecars that
+  # are appied to every deployment component. Ex: istio.
+  sidecars:
+    cpu: 0
+    memory: 0
+
+  # This defines all possible components for an airflow
+  # deployment and the default AU to use for the kubernetes
+  # resource requests, as well as its limits.
+  components:
+    - name: scheduler
+      au:
+        default: 5
+        limit: 30
+        request: ~
+      extra:
+        - name: replicas
+          # Change default to 2 after we drop support for Airflow 1
+          default: 1
+          minimum: 1
+          limit: 4
+          minAirflowVersion: "2.0.0"
+        - name: replicasClient
+          # TODO: @adam2k Remove replicasClient after we figure out
+          # a better means of client configuration
+          default: 2
+          minimum: 1
+          limit: 4
+          minAirflowVersion: "2.0.0"
+    - name: webserver
+      au:
+        default: 5
+        limit: 30
+        request: ~
+    - name: statsd
+      au:
+        default: 2
+        limit: 30
+        request: ~
+    - name: pgbouncer
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: flower
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: redis
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: workers
+      au:
+        default: 10
+        limit: 30
+        request: ~
+      extra:
+        - name: terminationGracePeriodSeconds
+          default: 600
+          limit: 36000
+        - name: replicas
+          default: 1
+          limit: 10
+
+  # This defines which executors should be supported, as well
+  # as the components required to run a particular
+  # executor configuration.
+  executors:
+    - name: LocalExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+      defaultExtraAu: 0
+    - name: CeleryExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+        - workers
+        - flower
+        - redis
+      defaultExtraAu: 0
+    - name: KubernetesExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+      defaultExtraAu: 10
+
+  defaultDistribution: buster
+
+  # These are static configs that get merged directly into the values
+  # passed to helm for each deployment.
+  helm:
+    # Set default for debian image, which is the now the default for new
+    # deployments. On image push, this will be read from (and validated) from
+    # the labels in the docker image.
+    uid: 50000
+    gid: 50000
+
+    # If enabled, deploy ServiceAccounts / Roles / RoleBindings
+    # for components that require kubernetes apiserver access.
+    rbacEnabled: true
+    ingress:
+      # Attach an airflow deployment to the system level ingress controller.
+      enabled: true
+    networkPolicies:
+      # Enabled network polices to restrict the way pods can communicate.
+      enabled: true
+    pgbouncer:
+      # Adds a pgbouncer service between the airflow pods (scheduler / webserver/ workers),
+      # and the backend database.
+      enabled: true
+    # Allow scheduler/workers to launch pods by default. This is required for
+    # the KubernetesPodOperator and KubernetesExecutor. This is what signals to apply the
+    # required RoleBindings.
+    allowPodLaunching: true
+
+  # Annotation name to map the `cloud-role` from creating a deployment to on the Deployment Service account.
+  # AWS - eks.amazonaws.com/role-arn
+  # GCP - iam.gke.io/gcp-service-account
+  serviceAccountAnnotationKey: ~

--- a/enterprise_configs/0.25/default.yaml
+++ b/enterprise_configs/0.25/default.yaml
@@ -1,4 +1,4 @@
-# This is a configuration reference file that contains source code from Astronomer's private Houston API repository.
+# This is a reference configuration file that contains source code from Astronomer's private Houston API repository.
 # It is maintained by Astronomer's documentation team and should be used as a reference to help you configure
 # the `astronomer.houston.config` section of your `config.yaml` file on Astronomer Enterprise.
 

--- a/enterprise_configs/0.25/default.yaml
+++ b/enterprise_configs/0.25/default.yaml
@@ -1,4 +1,6 @@
-# This file contains non-secret configurations.
+# This is a configuration reference file that contains source code from Astronomer's private Houston API repository.
+# It is maintained by Astronomer's documentation team and should be used as a reference to help you configure
+# the `astronomer.houston.config` section of your `config.yaml` file on Astronomer Enterprise.
 
 # API webserver configuration.
 webserver:

--- a/enterprise_configs/0.25/default.yaml
+++ b/enterprise_configs/0.25/default.yaml
@@ -1,0 +1,628 @@
+# This file contains non-secret configurations.
+
+# API webserver configuration.
+webserver:
+  port: 8871
+  endpoint: "/v1"
+  subscriptions: "/ws"
+
+# CORS Access
+cors:
+  allowedOrigins: []
+
+# Prisma configuration.
+prisma:
+  endpoint: "http://localhost:4466/houston"
+  secret: ~
+  debug: false
+
+# NATS configuration.
+nats:
+  servers: ["nats://localhost:4222"]
+  clusterID: houston
+  ackTimeout: 120000
+  ackWait: 120000
+  connectTimeout: 3000
+  maxPubAcksInflight: 16384
+  maxReconnectAttempts: 200
+  stanMaxPingOut: 20
+  stanPingInterval: 5000
+  reconnect: true
+  reconnectTimeWait: 5000
+  reconnectJitter: 150
+  reconnectJitterTLS: 1000
+  waitOnFirstConnect: true
+
+# Logging configuration.
+logging:
+  level: "debug"
+
+# Database connection.
+# This is mostly for knexfile now.
+# Also defined for Prisma service separately.
+database:
+  schema: houston$default
+  # this is for enabling ssl connection for database
+  ssl: false
+  # Knex migrations
+  migrations:
+    # Table to store migrations
+    tableName: migrations
+    # Schema for migrations.
+    # prisma deploy fails if this table exists in the same schema
+    # as prisma tables.
+    schemaName: public
+    # Disable wrapping migrations with transaction
+    # Currently disabling to allow better cooperation with prisma.
+    disableTransactions: true
+
+  # Knex connection
+  connection:
+    user: postgres
+    password: postgres
+    host: localhost
+    port: 5432
+    database: postgres
+
+# Commander configuration.
+commander:
+  enabled: false
+  host: localhost
+  port: 50051
+
+# Docker Registry configuration.
+registry:
+  host: localhost
+  port: 5000
+  authHeader: ~
+
+# Email configuration.
+email:
+  # Enable sending emails.
+  enabled: false
+
+  # Open HTML emails in browser when sent.
+  preview: false
+
+  # The "from" address to use.
+  reply: "noreply@astronomer.io"
+
+  # The SMTP server URL.
+  smtpUrl: ~
+
+# Stripe configuration.
+stripe:
+  enabled: false
+  secretKey: ~
+
+# Analytics configuration
+analytics:
+  writeKey: ~
+
+# Apollo schema reporting configuration
+apollo:
+  key: ~
+  graphVariant: ~
+
+# Set the length of a Cloud Trial
+trial:
+  # Cloud trial length in days
+  length: 14
+
+# UI configuration.
+ui:
+  subdomain: app
+  port: 5000
+
+# Elasticsearch configuration for Houston to pull logs.
+# This is passed striaght to the es client.
+elasticsearch:
+  # Enable or disable querying for logs in ES. This supersedes mock configuration below.
+  enabled: false
+
+  # Client configuration, passed directly to es-client constructor.
+  client:
+    host: ~
+    log: error
+
+  # If in NODE_ENV is development and this is enabled, generate sample log records.
+  mockInDevelopment: true
+
+  # Interval that data is grabbed and sent
+  pollInterval: 1000
+
+# Prometheus Metrics configuration
+prometheus:
+  # Sample data - false for no querying prometheus, true for querying prometheus.
+  enabled: false
+  host: localhost
+  port: 9090
+  pollInterval: 30000
+  statusPollInterval: 60000
+
+# Charts live here.
+# This is where the airflow chart is installed from.
+repository: "https://helm.astronomer.io/"
+
+# Helm configuration.
+# These values are set at runtime and used for airflow deployments.
+helm:
+  baseDomain: ~
+  registryAuthSecret: ~
+  releaseName: ~
+  releaseNamespace: ~
+  releaseVersion: ~
+  singleNamespace: false
+
+# Auth configuration.
+auth:
+  # Local database (user/pass) configuration.
+  local:
+    enabled: true
+
+  openidConnect:
+    # Clock skew for slightly out-of-sync clocks
+    clockTolerance: 0
+    # Auth0 integration configuration.
+    auth0:
+      # This "enabled" flag is currently a little misleading.
+      # The enabled flag refers only to showing the native
+      # Auth0 button in the UI. The rest of the settings here
+      # could potentially be used as to auth with Google/Github/etc
+      # if those integrations are enabled, but do not have connection
+      # information.
+      enabled: false
+      clientId: ~
+      discoveryUrl: https://astronomerio.auth0.com
+      authUrlParams:
+        audience: "astronomer-ee"
+
+    # Google oauth configuration.
+    google:
+      displayName: Google
+      enabled: false
+      # If blank we will go via Auth0
+      clientId: ~
+      discoveryUrl: https://accounts.google.com
+
+    okta:
+      enabled: false
+      clientId: ~
+      discoveryUrl: ~
+
+    microsoft:
+      displayName: "Azure AD"
+      enabled: false
+      claimsMapping:
+        email: preferred_username
+      clientId: ~
+      discoveryUrl: ~
+
+    adfs:
+      displayName: "ADFS"
+      enabled: false
+      # Disable userInfo request for providers such as ADFS
+      fetchUserInfo: false
+      claimsMapping:
+        email: upn
+        name: upn
+      clientId: ~
+      discoveryUrl: ~
+
+  # Github via auth0
+  github:
+    enabled: false
+
+# Houston JWT configuration.
+jwt:
+  # Development only: Passphrase to sign JWTs used to authenticate our GraphQL
+  # API.
+  #passphrase: ~
+
+  # JWT / Cookie duration in milliseconds.
+  authDuration: 86400000
+
+  # Path to folder containing tls.crt and tls.key, used for signing JWT tokens
+  # to authenticate against the Docker registry and Airflow FAB UI
+  certPath: ~
+
+  # Docker registry configuration.
+  registry:
+    certPath: ~
+    issuer: ~
+    service: ~
+    # A list of "base" images in the repository that every user will be able to
+    # pull/remount to share base layers. Pushable by SYSTEM_ADMIN and
+    # SYSTEM_EDITOR
+    baseImages:
+      - base-images/airflow
+
+# Service Account configuration.
+serviceAccounts:
+  # When a new service account is created, return the full apiKey for
+  # this many minutes. After this amount of time, return a partially obfuscated version.
+  showFor: 10
+
+  # Display this many characters of the real apiKey after showFor has been exceeded.
+  showFirstChars: 6
+
+# Allow public signups.
+publicSignups: false
+
+# URL to send users to for signup when publicSignups is disabled
+externalSignupUrl: ~
+
+# Require email confirmation.
+emailConfirmation: true
+
+# Subdomain under base domain.
+subdomain: houston
+
+# Format: ${SCOPE}.${RESOURCE}.${VERB}
+roles:
+  # To explicitly remove a permission defined in this base config set it to false in your local config
+  # roles:
+  #   SYSTEM_VIEWER:
+  #     permissions:
+  #       system.monitoring.get: false
+
+  #
+  # System Roles
+  #
+  SYSTEM_VIEWER:
+    name: System Viewer
+    permissions: &PERMS__SYSTEM_VIEWER
+      ? system.airflow.get
+      ? system.deployment.variables.get
+      ? system.deployments.get
+      ? system.invite.get
+      ? system.monitoring.get
+      ? system.serviceAccounts.get
+      ? system.updates.get
+      ? system.users.get
+      ? system.workspace.get
+
+  SYSTEM_EDITOR:
+    name: System Editor
+    permissions: &PERMS__SYSTEM_EDITOR
+      <<: *PERMS__SYSTEM_VIEWER
+      ? system.deployment.variables.update
+      ? system.iam.update
+      ? system.serviceAccounts.update
+      ? system.airflow.user
+      ? system.registryBaseImages.push
+
+  SYSTEM_ADMIN:
+    name: System Admin
+    permissions:
+      <<: *PERMS__SYSTEM_EDITOR
+      ? system.deployments.create
+      ? system.deployments.update
+      ? system.deployments.delete
+      ? system.deployments.logs
+      ? system.deployments.metrics
+      ? system.invites.get
+      ? system.serviceAccounts.create
+      ? system.serviceAccounts.update
+      ? system.serviceAccounts.delete
+      ? system.user.invite
+      ? system.user.delete
+      ? system.user.verifyEmail
+      ? system.workspace.addCustomerId
+      ? system.workspace.delete
+      ? system.workspace.suspend
+      ? system.workspace.extendTrial
+      ? system.airflow.admin
+
+  #
+  # Workspace Roles
+  #
+  WORKSPACE_VIEWER:
+    name: Workspace Viewer
+    permissions: &PERMS__WORKSPACE_VIEWER
+      ? workspace.config.get
+      ? workspace.deployments.get
+      ? workspace.serviceAccounts.get
+      ? workspace.users.get
+
+  WORKSPACE_EDITOR:
+    name: Workspace Editor
+    permissions: &PERMS__WORKSPACE_EDITOR
+      <<: *PERMS__WORKSPACE_VIEWER
+      ? workspace.config.update
+      ? workspace.deployments.create
+      ? workspace.serviceAccounts.create
+      ? workspace.serviceAccounts.update
+      ? workspace.serviceAccounts.delete
+
+  WORKSPACE_ADMIN:
+    name: Workspace Admin
+    permissions:
+      <<: *PERMS__WORKSPACE_EDITOR
+      ? workspace.billing.update
+      ? workspace.invites.get
+      ? workspace.config.delete
+      ? workspace.iam.update
+
+  #
+  # Deployment Roles
+  #
+  DEPLOYMENT_VIEWER:
+    name: Deployment Viewer
+    permissions: &PERMS__DEPLOYMENT_VIEWER
+      ? deployment.airflow.get
+      ? deployment.config.get
+      ? deployment.logs.get
+      ? deployment.images.pull
+      ? deployment.metrics.get
+      ? deployment.serviceAccounts.get
+      ? deployment.variables.get
+      ? deployment.users.get
+
+  DEPLOYMENT_EDITOR:
+    name: Deployment Editor
+    permissions: &PERMS__DEPLOYMENT_EDITOR
+      <<: *PERMS__DEPLOYMENT_VIEWER
+      ? deployment.airflow.user
+      ? deployment.config.update
+      ? deployment.images.push
+      ? deployment.images.pull
+      ? deployment.serviceAccounts.create
+      ? deployment.serviceAccounts.update
+      ? deployment.serviceAccounts.delete
+      ? deployment.variables.update
+
+  DEPLOYMENT_ADMIN:
+    name: Deployment Admin
+    permissions:
+      <<: *PERMS__DEPLOYMENT_EDITOR
+      ? deployment.airflow.admin
+      ? deployment.config.delete
+      ? deployment.userRoles.update
+
+  #
+  # User Role (Everyone)
+  #
+  USER:
+    name: User
+    permissions:
+      ? system.workspace.create
+
+#
+# Airflow Deployment Configurations
+#
+deployments:
+  subdomain: 'deployments'
+  # Airflow chart settings
+  # Static helm configurations for this chart are found below.
+  chart:
+    # This version number controls the default Airflow chart version that will be installed
+    # when creating a new deployment in the system. This is also used to ensure all
+    # child airflow deployments are kept up to date and on the latest version.
+    version: 0.0.0
+
+  # releaseVerification determines what docker images are allowed to be installed
+  # STABLE = only official Astronomer Core releases that mirror Airflow releaseVersion
+  # EDGE   = also allow Astronomer Core Edge (astronomer/core:edge) to be used
+  # DEV    = also allow hand-built dev images to be used
+  releaseVerification: STABLE
+
+  airflowReleasesFile: 'airflow_releases.json'
+  # Labels specifed here are applied to Airflow deployment namespaces.
+  namespaceLabels: {}
+
+  # configureDagDeployment
+  configureDagDeployment: false
+
+  # Enable bucket based or git sync dag deployment
+  nfsMountDagDeployment: false
+
+  # Enable manual release names
+  manualReleaseNames: false
+
+  # Enable manual namespace names:
+  # Note: for now works only with combination with preCreatedNamespaces
+  manualNamespaceNames: false
+
+  # Precreated namespaces
+  preCreatedNamespaces: []
+    # - name: test1
+    # - name: test2
+
+  # Enable Hard Delete deployments
+  hardDeleteDeployment: false
+
+  # Log out final helm values whenever they are generated, before deployment.
+  logHelmValues: false
+
+  # CLI image tag prefix
+  # This is the prefix to use for houston-generated tags.
+  tagPrefix: deploy
+
+  # This is the database connection that we use to connect
+  # and create other databases/schemas/users for each
+  # individual airflow deployment.
+  database:
+    # If disabled, skip db creation.
+    enabled: true
+
+    # Keep the airflow databases around after a
+    # deployment is deleted.
+    retainOnDelete: false
+
+    # If true, leave GRANTs in place for root user.
+    # This lets users log in with the root creds and query
+    # deployment databases.
+    allowRootAccess: false
+
+    # Connection details for root user.
+    # This can also be overridden with a connection string.
+    connection:
+      user: postgres
+      password: postgres
+      host: localhost
+      port: 5432
+      database: postgres
+
+  # Elasticsearch configuration for deployments.
+  # Airflow clients access Elasticsearch differently.
+  # Houston has full acces, while the deployments connect
+  # via NGINX for auth.
+  elasticsearch:
+    enabled: false
+    connection:
+      host: localhost
+      port: 9200
+
+  # An astro unit defines the smallest billable unit
+  # in the system. Default values are based on
+  # the GCP n1-standard-1. CPU should always be expressed
+  # in millicpu and memory should be expressed in Mibibytes.
+  astroUnit:
+    cpu: 100
+    memory: 384
+    pods: 1
+    airflowConns: 5
+    actualConns: 0.5
+    price: 0
+
+  # This defines how much extra capacity, in astro units,
+  # that a user can expand a deployment to. This is currently
+  # represented as a slider in the UI.
+  maxExtraAu: 400
+
+  # This defines the maximum size a pod can be in astro units.
+  maxPodAu: 35
+
+  # This defines any extra resources to account for any sidecars that
+  # are appied to every deployment component. Ex: istio.
+  sidecars:
+    cpu: 0
+    memory: 0
+
+  # This defines all possible components for an airflow
+  # deployment and the default AU to use for the kubernetes
+  # resource requests, as well as its limits.
+  components:
+    - name: scheduler
+      au:
+        default: 5
+        limit: 30
+        request: ~
+      extra:
+        - name: replicas
+          # Change default to 2 after we drop support for Airflow 1
+          default: 1
+          minimum: 1
+          limit: 4
+          minAirflowVersion: "2.0.0"
+        - name: replicasClient
+          # TODO: @adam2k Remove replicasClient after we figure out
+          # a better means of client configuration
+          default: 1
+          minimum: 1
+          limit: 4
+          minAirflowVersion: "2.0.0"
+    - name: webserver
+      au:
+        default: 5
+        limit: 30
+        request: ~
+    - name: statsd
+      au:
+        default: 2
+        limit: 30
+        request: ~
+    - name: pgbouncer
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: flower
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: redis
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: workers
+      au:
+        default: 10
+        limit: 30
+        request: ~
+      extra:
+        - name: terminationGracePeriodSeconds
+          default: 600
+          limit: 36000
+        - name: replicas
+          default: 1
+          limit: 10
+
+  # This defines which executors should be supported, as well
+  # as the components required to run a particular
+  # executor configuration.
+  executors:
+    - name: LocalExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+      defaultExtraAu: 0
+    - name: CeleryExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+        - workers
+        - flower
+        - redis
+      defaultExtraAu: 0
+    - name: KubernetesExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+      defaultExtraAu: 10
+
+  defaultDistribution: buster
+
+  # These are static configs that get merged directly into the values
+  # passed to helm for each deployment.
+  helm:
+    # Set default for debian image, which is the now the default for new
+    # deployments. On image push, this will be read from (and validated) from
+    # the labels in the docker image.
+    uid: 50000
+    gid: 50000
+
+    # If enabled, deploy ServiceAccounts / Roles / RoleBindings
+    # for components that require kubernetes apiserver access.
+    rbacEnabled: true
+    ingress:
+      # Attach an airflow deployment to the system level ingress controller.
+      enabled: true
+    networkPolicies:
+      # Enabled network polices to restrict the way pods can communicate.
+      enabled: true
+    pgbouncer:
+      # Adds a pgbouncer service between the airflow pods (scheduler / webserver/ workers),
+      # and the backend database.
+      enabled: true
+    # Allow scheduler/workers to launch pods by default. This is required for
+    # the KubernetesPodOperator and KubernetesExecutor. This is what signals to apply the
+    # required RoleBindings.
+    allowPodLaunching: true
+
+  # Annotation name to map the `cloud-role` from creating a deployment to on the Deployment Service account.
+  # AWS - eks.amazonaws.com/role-arn
+  # GCP - iam.gke.io/gcp-service-account
+  serviceAccountAnnotationKey: ~

--- a/enterprise_configs/0.26/default.yaml
+++ b/enterprise_configs/0.26/default.yaml
@@ -1,4 +1,4 @@
-# This is a configuration reference file that contains source code from Astronomer's private Houston API repository.
+# This is a reference configuration file that contains source code from Astronomer's private Houston API repository.
 # It is maintained by Astronomer's documentation team and should be used as a reference to help you configure
 # the `astronomer.houston.config` section of your `config.yaml` file on Astronomer Enterprise.
 

--- a/enterprise_configs/0.26/default.yaml
+++ b/enterprise_configs/0.26/default.yaml
@@ -1,4 +1,6 @@
-# This file contains non-secret configurations.
+# This is a configuration reference file that contains source code from Astronomer's private Houston API repository.
+# It is maintained by Astronomer's documentation team and should be used as a reference to help you configure
+# the `astronomer.houston.config` section of your `config.yaml` file on Astronomer Enterprise.
 
 # API webserver configuration.
 webserver:

--- a/enterprise_configs/0.26/default.yaml
+++ b/enterprise_configs/0.26/default.yaml
@@ -1,0 +1,650 @@
+# This file contains non-secret configurations.
+
+# API webserver configuration.
+webserver:
+  port: 8871
+  endpoint: "/v1"
+  subscriptions: "/ws"
+
+
+# CORS Access
+cors:
+  allowedOrigins: []
+
+# Prisma configuration.
+prisma:
+  endpoint: "http://localhost:4466/houston"
+  secret: ~
+  debug: false
+
+# NATS configuration.
+nats:
+  servers: ["nats://localhost:4222"]
+  clusterID: houston
+  ackTimeout: 120000
+  ackWait: 120000
+  connectTimeout: 3000
+  maxPubAcksInflight: 16384
+  maxReconnectAttempts: 200
+  stanMaxPingOut: 20
+  stanPingInterval: 5000
+  reconnect: true
+  reconnectTimeWait: 5000
+  reconnectJitter: 150
+  reconnectJitterTLS: 1000
+  waitOnFirstConnect: true
+
+# Logging configuration.
+logging:
+  level: "debug"
+
+# Database connection.
+# This is mostly for knexfile now.
+# Also defined for Prisma service separately.
+database:
+  schema: houston$default
+  # this is for enabling ssl connection for database
+  ssl: false
+  # Knex migrations
+  migrations:
+    # Table to store migrations
+    tableName: migrations
+    # Schema for migrations.
+    # prisma deploy fails if this table exists in the same schema
+    # as prisma tables.
+    schemaName: public
+    # Disable wrapping migrations with transaction
+    # Currently disabling to allow better cooperation with prisma.
+    disableTransactions: true
+
+  # Knex connection
+  connection:
+    user: postgres
+    password: postgres
+    host: localhost
+    port: 5432
+    database: postgres
+
+# Commander configuration.
+commander:
+  enabled: false
+  host: localhost
+  port: 50051
+
+# Docker Registry configuration.
+registry:
+  host: localhost
+  port: 5000
+  authHeader: ~
+
+# Email configuration.
+email:
+  # Enable sending emails.
+  enabled: false
+
+  # Open HTML emails in browser when sent.
+  preview: false
+
+  # The "from" address to use.
+  reply: "noreply@astronomer.io"
+
+  # The SMTP server URL.
+  smtpUrl: ~
+
+# Stripe configuration.
+stripe:
+  enabled: false
+  secretKey: ~
+
+# Analytics configuration
+analytics:
+  writeKey: ~
+
+# Apollo schema reporting configuration
+apollo:
+  key: ~
+  graphVariant: ~
+
+# Set the length of a Cloud Trial
+trial:
+  # Cloud trial length in days
+  length: 14
+
+# UI configuration.
+ui:
+  subdomain: app
+  port: 5000
+
+# Elasticsearch configuration for Houston to pull logs.
+# This is passed striaght to the es client.
+elasticsearch:
+  # Enable or disable querying for logs in ES. This supersedes mock configuration below.
+  enabled: false
+
+  # Client configuration, passed directly to es-client constructor.
+  client:
+    host: ~
+    log: error
+
+  # If in NODE_ENV is development and this is enabled, generate sample log records.
+  mockInDevelopment: true
+
+  # Interval that data is grabbed and sent
+  pollInterval: 1000
+
+# Prometheus Metrics configuration
+prometheus:
+  # Sample data - false for no querying prometheus, true for querying prometheus.
+  enabled: false
+  host: localhost
+  port: 9090
+  pollInterval: 30000
+  statusPollInterval: 60000
+
+# Charts live here.
+# This is where the airflow chart is installed from.
+repository: "https://helm.astronomer.io/"
+
+# Helm configuration.
+# These values are set at runtime and used for airflow deployments.
+helm:
+  baseDomain: ~
+  registryAuthSecret: ~
+  releaseName: ~
+  releaseNamespace: ~
+  releaseVersion: ~
+  singleNamespace: false
+
+allowedSystemLevelDomains: []
+
+# Auth configuration.
+auth:
+  # Local database (user/pass) configuration.
+  local:
+    enabled: true
+
+  openidConnect:
+    # Clock skew for slightly out-of-sync clocks
+    clockTolerance: 0
+    # Auth0 integration configuration.
+    auth0:
+      # This "enabled" flag is currently a little misleading.
+      # The enabled flag refers only to showing the native
+      # Auth0 button in the UI. The rest of the settings here
+      # could potentially be used as to auth with Google/Github/etc
+      # if those integrations are enabled, but do not have connection
+      # information.
+      enabled: false
+      clientId: ~
+      discoveryUrl: https://astronomerio.auth0.com
+      authUrlParams:
+        audience: "astronomer-ee"
+
+    # Google oauth configuration.
+    google:
+      displayName: Google
+      enabled: false
+      # If blank we will go via Auth0
+      clientId: ~
+      discoveryUrl: https://accounts.google.com
+
+    okta:
+      enabled: false
+      clientId: ~
+      discoveryUrl: ~
+
+    microsoft:
+      displayName: "Azure AD"
+      enabled: false
+      claimsMapping:
+        email: preferred_username
+      clientId: ~
+      discoveryUrl: ~
+
+    adfs:
+      displayName: "ADFS"
+      enabled: false
+      # Disable userInfo request for providers such as ADFS
+      fetchUserInfo: false
+      claimsMapping:
+        email: upn
+        name: upn
+      clientId: ~
+      discoveryUrl: ~
+
+  # Github via auth0
+  github:
+    enabled: false
+
+# Houston JWT configuration.
+jwt:
+  # Development only: Passphrase to sign JWTs used to authenticate our GraphQL
+  # API.
+  #passphrase: ~
+
+  # JWT / Cookie duration in milliseconds.
+  authDuration: 86400000
+
+  # Path to folder containing tls.crt and tls.key, used for signing JWT tokens
+  # to authenticate against the Docker registry and Airflow FAB UI
+  certPath: ~
+
+  # Docker registry configuration.
+  registry:
+    certPath: ~
+    issuer: ~
+    service: ~
+    # A list of "base" images in the repository that every user will be able to
+    # pull/remount to share base layers. Pushable by SYSTEM_ADMIN and
+    # SYSTEM_EDITOR
+    baseImages:
+      - base-images/airflow
+
+# Service Account configuration.
+serviceAccounts:
+  # When a new service account is created, return the full apiKey for
+  # this many minutes. After this amount of time, return a partially obfuscated version.
+  showFor: 10
+
+  # Display this many characters of the real apiKey after showFor has been exceeded.
+  showFirstChars: 6
+
+# Allow public signups.
+publicSignups: false
+
+# URL to send users to for signup when publicSignups is disabled
+externalSignupUrl: ~
+
+# Require email confirmation.
+emailConfirmation: true
+
+# Subdomain under base domain.
+subdomain: houston
+
+# Format: ${SCOPE}.${RESOURCE}.${VERB}
+roles:
+  # To explicitly remove a permission defined in this base config set it to false in your local config
+  # roles:
+  #   SYSTEM_VIEWER:
+  #     permissions:
+  #       system.monitoring.get: false
+
+  #
+  # System Roles
+  #
+  SYSTEM_VIEWER:
+    name: System Viewer
+    permissions: &PERMS__SYSTEM_VIEWER
+      ? system.airflow.get
+      ? system.deployment.variables.get
+      ? system.deployments.get
+      ? system.invite.get
+      ? system.monitoring.get
+      ? system.serviceAccounts.get
+      ? system.updates.get
+      ? system.users.get
+      ? system.workspace.get
+
+  SYSTEM_EDITOR:
+    name: System Editor
+    permissions: &PERMS__SYSTEM_EDITOR
+      <<: *PERMS__SYSTEM_VIEWER
+      ? system.deployment.variables.update
+      ? system.iam.update
+      ? system.serviceAccounts.update
+      ? system.airflow.user
+      ? system.registryBaseImages.push
+
+  SYSTEM_ADMIN:
+    name: System Admin
+    permissions:
+      <<: *PERMS__SYSTEM_EDITOR
+      ? system.deployments.create
+      ? system.deployments.update
+      ? system.deployments.delete
+      ? system.deployments.logs
+      ? system.deployments.metrics
+      ? system.invites.get
+      ? system.serviceAccounts.create
+      ? system.serviceAccounts.update
+      ? system.serviceAccounts.delete
+      ? system.user.invite
+      ? system.user.delete
+      ? system.user.verifyEmail
+      ? system.workspace.addCustomerId
+      ? system.workspace.delete
+      ? system.workspace.suspend
+      ? system.workspace.extendTrial
+      ? system.airflow.admin
+
+  #
+  # Workspace Roles
+  #
+  WORKSPACE_VIEWER:
+    name: Workspace Viewer
+    permissions: &PERMS__WORKSPACE_VIEWER
+      ? workspace.config.get
+      ? workspace.deployments.get
+      ? workspace.serviceAccounts.get
+      ? workspace.users.get
+
+  WORKSPACE_EDITOR:
+    name: Workspace Editor
+    permissions: &PERMS__WORKSPACE_EDITOR
+      <<: *PERMS__WORKSPACE_VIEWER
+      ? workspace.config.update
+      ? workspace.deployments.create
+      ? workspace.serviceAccounts.create
+      ? workspace.serviceAccounts.update
+      ? workspace.serviceAccounts.delete
+
+  WORKSPACE_ADMIN:
+    name: Workspace Admin
+    permissions:
+      <<: *PERMS__WORKSPACE_EDITOR
+      ? workspace.billing.update
+      ? workspace.invites.get
+      ? workspace.config.delete
+      ? workspace.iam.update
+
+  #
+  # Deployment Roles
+  #
+  DEPLOYMENT_VIEWER:
+    name: Deployment Viewer
+    permissions: &PERMS__DEPLOYMENT_VIEWER
+      ? deployment.airflow.get
+      ? deployment.config.get
+      ? deployment.logs.get
+      ? deployment.images.pull
+      ? deployment.metrics.get
+      ? deployment.serviceAccounts.get
+      ? deployment.variables.get
+      ? deployment.users.get
+
+  DEPLOYMENT_EDITOR:
+    name: Deployment Editor
+    permissions: &PERMS__DEPLOYMENT_EDITOR
+      <<: *PERMS__DEPLOYMENT_VIEWER
+      ? deployment.airflow.user
+      ? deployment.config.update
+      ? deployment.images.push
+      ? deployment.images.pull
+      ? deployment.serviceAccounts.create
+      ? deployment.serviceAccounts.update
+      ? deployment.serviceAccounts.delete
+      ? deployment.variables.update
+
+  DEPLOYMENT_ADMIN:
+    name: Deployment Admin
+    permissions:
+      <<: *PERMS__DEPLOYMENT_EDITOR
+      ? deployment.airflow.admin
+      ? deployment.config.delete
+      ? deployment.userRoles.update
+
+  #
+  # User Role (Everyone)
+  #
+  USER:
+    name: User
+    permissions:
+      ? system.workspace.create
+
+#
+# Airflow Deployment Configurations
+#
+deployments:
+  subdomain: 'deployments'
+  # Airflow chart settings
+  # Static helm configurations for this chart are found below.
+  chart:
+    # This version number controls the default Airflow chart version that will be installed
+    # when creating a new deployment in the system. This is also used to ensure all
+    # child airflow deployments are kept up to date and on the latest version.
+    version: 0.0.0
+
+  # releaseVerification determines what docker images are allowed to be installed
+  # STABLE = only official Astronomer Core releases that mirror Airflow releaseVersion
+  # EDGE   = also allow Astronomer Core Edge (astronomer/core:edge) to be used
+  # DEV    = also allow hand-built dev images to be used
+  releaseVerification: STABLE
+
+  airflowReleasesFile: 'airflow_releases.json'
+  # Labels specifed here are applied to Airflow deployment namespaces.
+  namespaceLabels: {}
+
+  # configureDagDeployment
+  configureDagDeployment: false
+
+  # Enable bucket based or git sync dag deployment
+  nfsMountDagDeployment: false
+
+  # Enable manual release names
+  manualReleaseNames: false
+
+  # Enable manual namespace names:
+  # Note: for now works only with combination with preCreatedNamespaces
+  manualNamespaceNames: false
+
+  # Precreated namespaces
+  preCreatedNamespaces: []
+    # - name: test1
+    # - name: test2
+
+  # Enable Hard Delete deployments
+  hardDeleteDeployment: false
+
+  # Enable Triggerer Airflow component
+  triggererEnabled: false
+
+  # Enable Feature Flag that improves the performance of the sys admin page at the cost of some features
+  sysAdminScalabilityImprovementsEnabled: false
+
+  # Log out final helm values whenever they are generated, before deployment.
+  logHelmValues: false
+
+  # CLI image tag prefix
+  # This is the prefix to use for houston-generated tags.
+  tagPrefix: deploy
+
+  authSideCar:
+    enabled: false
+    repository: nginxinc/nginx-unprivileged
+    tag: stable
+    pullPolicy: IfNotPresent
+    port: 8084
+  # This is the database connection that we use to connect
+  # and create other databases/schemas/users for each
+  # individual airflow deployment.
+  database:
+    # If disabled, skip db creation.
+    enabled: true
+
+    # Keep the airflow databases around after a
+    # deployment is deleted.
+    retainOnDelete: false
+
+    # If true, leave GRANTs in place for root user.
+    # This lets users log in with the root creds and query
+    # deployment databases.
+    allowRootAccess: false
+
+    # Connection details for root user.
+    # This can also be overridden with a connection string.
+    connection:
+      user: postgres
+      password: postgres
+      host: localhost
+      port: 5432
+      database: postgres
+
+  # An astro unit defines the smallest billable unit
+  # in the system. Default values are based on
+  # the GCP n1-standard-1. CPU should always be expressed
+  # in millicpu and memory should be expressed in Mibibytes.
+  astroUnit:
+    cpu: 100
+    memory: 384
+    pods: 1
+    airflowConns: 5
+    actualConns: 0.5
+    price: 0
+
+  # This defines how much extra capacity, in astro units,
+  # that a user can expand a deployment to. This is currently
+  # represented as a slider in the UI.
+  maxExtraAu: 400
+
+  # This defines the maximum size a pod can be in astro units.
+  maxPodAu: 35
+
+  # This defines any extra resources to account for any sidecars that
+  # are appied to every deployment component. Ex: istio.
+  sidecars:
+    cpu: 0
+    memory: 0
+
+  # This defines all possible components for an airflow
+  # deployment and the default AU to use for the kubernetes
+  # resource requests, as well as its limits.
+  components:
+    - name: scheduler
+      au:
+        default: 5
+        limit: 30
+        request: ~
+      extra:
+        - name: replicas
+          # Change default to 2 after we drop support for Airflow 1
+          default: 1
+          minimum: 1
+          limit: 4
+          minAirflowVersion: "2.0.0"
+    - name: webserver
+      au:
+        default: 5
+        limit: 30
+        request: ~
+    - name: statsd
+      au:
+        default: 2
+        limit: 30
+        request: ~
+    - name: pgbouncer
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: flower
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: redis
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: workers
+      au:
+        default: 10
+        limit: 30
+        request: ~
+      extra:
+        - name: terminationGracePeriodSeconds
+          default: 600
+          limit: 36000
+        - name: replicas
+          default: 1
+          limit: 10
+    - name: triggerer
+      au:
+        default: 5
+        limit: 30
+        request: ~
+      extra:
+        - name: replicas
+          default: 0
+          minimum: 0
+          limit: 2
+          minAirflowVersion: "2.2.0"
+  # This defines which executors should be supported, as well
+  # as the components required to run a particular
+  # executor configuration.
+  executors:
+    - name: LocalExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+        - triggerer
+      defaultExtraAu: 0
+    - name: CeleryExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+        - workers
+        - flower
+        - redis
+        - triggerer
+      defaultExtraAu: 0
+    - name: KubernetesExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+        - triggerer
+      defaultExtraAu: 10
+
+  defaultDistribution: buster
+
+  # These are static configs that get merged directly into the values
+  # passed to helm for each deployment.
+  helm:
+    airflow:
+      # Elasticsearch configuration for deployments.
+      # Airflow clients access Elasticsearch differently.
+      # Houston has full acces, while the deployments connect
+      # via NGINX for auth.
+      elasticsearch:
+        enabled: false
+        connection:
+          host: localhost
+          port: 9200
+      # Set default for debian image, which is the now the default for new
+      # deployments. On image push, this will be read from (and validated) from
+      # the labels in the docker image.
+      uid: 50000
+      gid: 50000
+
+      # If enabled, deploy ServiceAccounts / Roles / RoleBindings
+      # for components that require kubernetes apiserver access.
+      rbac:
+        create: true
+      networkPolicies:
+        # Enabled network polices to restrict the way pods can communicate.
+        enabled: true
+      pgbouncer:
+        # Adds a pgbouncer service between the airflow pods (scheduler / webserver/ workers),
+        # and the backend database.
+        enabled: true
+      # Allow scheduler/workers to launch pods by default. This is required for
+      # the KubernetesPodOperator and KubernetesExecutor. This is what signals to apply the
+      # required RoleBindings.
+      allowPodLaunching: true
+    ingress:
+      # Attach an airflow deployment to the system level ingress controller.
+      enabled: true
+
+  # Annotation name to map the `cloud-role` from creating a deployment to on the Deployment Service account.
+  # AWS - eks.amazonaws.com/role-arn
+  # GCP - iam.gke.io/gcp-service-account
+  serviceAccountAnnotationKey: ~

--- a/enterprise_configs/0.27/default.yaml
+++ b/enterprise_configs/0.27/default.yaml
@@ -1,4 +1,4 @@
-# This is a configuration reference file that contains source code from Astronomer's private Houston API repository.
+# This is a reference configuration file that contains source code from Astronomer's private Houston API repository.
 # It is maintained by Astronomer's documentation team and should be used as a reference to help you configure
 # the `astronomer.houston.config` section of your `config.yaml` file on Astronomer Enterprise.
 

--- a/enterprise_configs/0.27/default.yaml
+++ b/enterprise_configs/0.27/default.yaml
@@ -1,4 +1,6 @@
-# This file contains non-secret configurations.
+# This is a configuration reference file that contains source code from Astronomer's private Houston API repository.
+# It is maintained by Astronomer's documentation team and should be used as a reference to help you configure
+# the `astronomer.houston.config` section of your `config.yaml` file on Astronomer Enterprise.
 
 # API webserver configuration.
 webserver:

--- a/enterprise_configs/0.27/default.yaml
+++ b/enterprise_configs/0.27/default.yaml
@@ -1,0 +1,684 @@
+# This file contains non-secret configurations.
+
+# API webserver configuration.
+webserver:
+  port: 8871
+  endpoint: "/v1"
+  subscriptions: "/ws"
+
+
+# CORS Access
+cors:
+  allowedOrigins: []
+
+# Prisma configuration.
+prisma:
+  endpoint: "http://localhost:4466/houston"
+  secret: ~
+  debug: false
+
+# NATS configuration.
+nats:
+  servers: ["nats://localhost:4222"]
+  clusterID: houston
+  ackTimeout: 120000
+  ackWait: 120000
+  connectTimeout: 3000
+  maxPubAcksInflight: 16384
+  maxReconnectAttempts: 200
+  stanMaxPingOut: 20
+  stanPingInterval: 5000
+  reconnect: true
+  reconnectTimeWait: 5000
+  reconnectJitter: 150
+  reconnectJitterTLS: 1000
+  waitOnFirstConnect: true
+
+# Logging configuration.
+logging:
+  level: "debug"
+
+# Database connection.
+# This is mostly for knexfile now.
+# Also defined for Prisma service separately.
+database:
+  schema: houston$default
+  # this is for enabling ssl connection for database
+  ssl: false
+  # Knex migrations
+  migrations:
+    # Table to store migrations
+    tableName: migrations
+    # Schema for migrations.
+    # prisma deploy fails if this table exists in the same schema
+    # as prisma tables.
+    schemaName: public
+    # Disable wrapping migrations with transaction
+    # Currently disabling to allow better cooperation with prisma.
+    disableTransactions: true
+
+  # Knex connection
+  connection:
+    user: postgres
+    password: postgres
+    host: localhost
+    port: 5432
+    database: postgres
+
+# Commander configuration.
+commander:
+  enabled: false
+  host: localhost
+  port: 50051
+
+# Docker Registry configuration.
+registry:
+  host: localhost
+  port: 5000
+  authHeader: ~
+
+# Email configuration.
+email:
+  # Enable sending emails.
+  enabled: false
+
+  # Open HTML emails in browser when sent.
+  preview: false
+
+  # The "from" address to use.
+  reply: "noreply@astronomer.io"
+
+  # The SMTP server URL.
+  smtpUrl: ~
+
+# Stripe configuration.
+stripe:
+  enabled: false
+  secretKey: ~
+
+# Analytics configuration
+analytics:
+  writeKey: ~
+
+# Apollo schema reporting configuration
+apollo:
+  key: ~
+  graphVariant: ~
+
+# Set the length of a Cloud Trial
+trial:
+  # Cloud trial length in days
+  length: 14
+
+# UI configuration.
+ui:
+  subdomain: app
+  port: 5000
+
+# Elasticsearch configuration for Houston to pull logs.
+# This is passed striaght to the es client.
+elasticsearch:
+  # Enable or disable querying for logs in ES. This supersedes mock configuration below.
+  enabled: false
+
+  # Client configuration, passed directly to es-client constructor.
+  client:
+    host: ~
+    log: error
+
+  # If in NODE_ENV is development and this is enabled, generate sample log records.
+  mockInDevelopment: true
+
+  # Interval that data is grabbed and sent
+  pollInterval: 1000
+
+# Prometheus Metrics configuration
+prometheus:
+  # Sample data - false for no querying prometheus, true for querying prometheus.
+  enabled: false
+  host: localhost
+  port: 9090
+  pollInterval: 30000
+  statusPollInterval: 60000
+
+# Charts live here.
+# This is where the airflow chart is installed from.
+repository: "https://helm.astronomer.io/"
+
+# Helm configuration.
+# These values are set at runtime and used for airflow deployments.
+helm:
+  baseDomain: ~
+  registryAuthSecret: ~
+  releaseName: ~
+  releaseNamespace: ~
+  releaseVersion: ~
+  singleNamespace: false
+
+allowedSystemLevelDomains: []
+  # - astronomer.io
+  # - gmail.com
+
+# Auth configuration.
+auth:
+  # Local database (user/pass) configuration.
+  local:
+    enabled: true
+
+  openidConnect:
+    # flow option is needed until we EOL impicit (valid values "code" and "impicit")
+    flow: "implicit"
+    # import and reconcile groups from OpenID Connect
+    idpGroupsImportEnabled: false
+    # interval (in miuntes) when reconciler runs
+    idpGroupReconcilerInterval: 60
+    clockTolerance: 0
+    # Auth0 integration configuration.
+    auth0:
+      # This "enabled" flag is currently a little misleading.
+      # The enabled flag refers only to showing the native
+      # Auth0 button in the UI. The rest of the settings here
+      # could potentially be used as to auth with Google/Github/etc
+      # if those integrations are enabled, but do not have connection
+      # information.
+      enabled: false
+      clientId: ~
+      discoveryUrl: https://astronomerio.auth0.com
+      authUrlParams:
+        audience: "astronomer-ee"
+
+    # Google oauth configuration.
+    google:
+      displayName: Google
+      enabled: false
+      # If blank we will go via Auth0
+      clientId: ~
+      discoveryUrl: https://accounts.google.com
+
+    okta:
+      enabled: false
+      clientId: ~
+      discoveryUrl: ~
+
+    custom:
+      displayName: "Custom oAuth"
+      enabled: false
+      # If blank we will go via Auth0
+      clientId: ~
+      discoveryUrl: ~
+
+    microsoft:
+      displayName: "Azure AD"
+      enabled: false
+      claimsMapping:
+        email: preferred_username
+      clientId: ~
+      discoveryUrl: ~
+
+    adfs:
+      displayName: "ADFS"
+      enabled: false
+      # Disable userInfo request for providers such as ADFS
+      fetchUserInfo: false
+      claimsMapping:
+        email: upn
+        name: upn
+      clientId: ~
+      discoveryUrl: ~
+
+  # Github via auth0
+  github:
+    enabled: false
+
+# Houston JWT configuration.
+jwt:
+  # Development only: Passphrase to sign JWTs used to authenticate our GraphQL
+  # API.
+  #passphrase: ~
+
+  # JWT / Cookie duration in milliseconds.
+  authDuration: 86400000
+
+  # Path to folder containing tls.crt and tls.key, used for signing JWT tokens
+  # to authenticate against the Docker registry and Airflow FAB UI
+  certPath: ~
+
+  # Docker registry configuration.
+  registry:
+    certPath: ~
+    issuer: ~
+    service: ~
+    # A list of "base" images in the repository that every user will be able to
+    # pull/remount to share base layers. Pushable by SYSTEM_ADMIN and
+    # SYSTEM_EDITOR
+    baseImages:
+      - base-images/airflow
+
+# Service Account configuration.
+serviceAccounts:
+  # When a new service account is created, return the full apiKey for
+  # this many minutes. After this amount of time, return a partially obfuscated version.
+  showFor: 10
+
+  # Display this many characters of the real apiKey after showFor has been exceeded.
+  showFirstChars: 6
+
+# Allow public signups.
+publicSignups: false
+
+# URL to send users to for signup when publicSignups is disabled
+externalSignupUrl: ~
+
+# Require email confirmation.
+emailConfirmation: true
+
+# Subdomain under base domain.
+subdomain: houston
+
+# Format: ${SCOPE}.${RESOURCE}.${VERB}
+roles:
+  # To explicitly remove a permission defined in this base config set it to false in your local config
+  # roles:
+  #   SYSTEM_VIEWER:
+  #     permissions:
+  #       system.monitoring.get: false
+
+  #
+  # System Roles
+  #
+  SYSTEM_VIEWER:
+    name: System Viewer
+    permissions: &PERMS__SYSTEM_VIEWER
+      ? system.airflow.get
+      ? system.deployment.variables.get
+      ? system.deployments.get
+      ? system.invite.get
+      ? system.monitoring.get
+      ? system.serviceAccounts.get
+      ? system.updates.get
+      ? system.users.get
+      ? system.teams.get
+      ? system.workspace.get
+
+  SYSTEM_EDITOR:
+    name: System Editor
+    permissions: &PERMS__SYSTEM_EDITOR
+      <<: *PERMS__SYSTEM_VIEWER
+      ? system.deployment.variables.update
+      ? system.iam.update
+      ? system.serviceAccounts.update
+      ? system.airflow.user
+      ? system.registryBaseImages.push
+
+  SYSTEM_ADMIN:
+    name: System Admin
+    permissions:
+      <<: *PERMS__SYSTEM_EDITOR
+      ? system.deployments.create
+      ? system.deployments.update
+      ? system.deployments.delete
+      ? system.deployments.logs
+      ? system.deployments.metrics
+      ? system.invites.get
+      ? system.serviceAccounts.create
+      ? system.serviceAccounts.update
+      ? system.serviceAccounts.delete
+      ? system.user.invite
+      ? system.user.delete
+      ? system.user.verifyEmail
+      ? system.workspace.addCustomerId
+      ? system.workspace.delete
+      ? system.workspace.suspend
+      ? system.workspace.extendTrial
+      ? system.airflow.admin
+      ? system.deployments.images.push
+
+  #
+  # Workspace Roles
+  #
+  WORKSPACE_VIEWER:
+    name: Workspace Viewer
+    permissions: &PERMS__WORKSPACE_VIEWER
+      ? workspace.config.get
+      ? workspace.deployments.get
+      ? workspace.serviceAccounts.get
+      ? workspace.users.get
+      ? workspace.teams.get
+
+  WORKSPACE_EDITOR:
+    name: Workspace Editor
+    permissions: &PERMS__WORKSPACE_EDITOR
+      <<: *PERMS__WORKSPACE_VIEWER
+      ? workspace.config.update
+      ? workspace.deployments.create
+      ? workspace.serviceAccounts.create
+      ? workspace.serviceAccounts.update
+      ? workspace.serviceAccounts.delete
+
+  WORKSPACE_ADMIN:
+    name: Workspace Admin
+    permissions:
+      <<: *PERMS__WORKSPACE_EDITOR
+      ? workspace.billing.update
+      ? workspace.invites.get
+      ? workspace.config.delete
+      ? workspace.iam.update
+
+  #
+  # Deployment Roles
+  #
+  DEPLOYMENT_VIEWER:
+    name: Deployment Viewer
+    permissions: &PERMS__DEPLOYMENT_VIEWER
+      ? deployment.airflow.get
+      ? deployment.config.get
+      ? deployment.logs.get
+      ? deployment.images.pull
+      ? deployment.metrics.get
+      ? deployment.serviceAccounts.get
+      ? deployment.variables.get
+      ? deployment.users.get
+      ? deployment.teams.get
+
+  DEPLOYMENT_EDITOR:
+    name: Deployment Editor
+    permissions: &PERMS__DEPLOYMENT_EDITOR
+      <<: *PERMS__DEPLOYMENT_VIEWER
+      ? deployment.airflow.user
+      ? deployment.config.update
+      ? deployment.images.push
+      ? deployment.images.pull
+      ? deployment.serviceAccounts.create
+      ? deployment.serviceAccounts.update
+      ? deployment.serviceAccounts.delete
+      ? deployment.variables.update
+
+  DEPLOYMENT_ADMIN:
+    name: Deployment Admin
+    permissions:
+      <<: *PERMS__DEPLOYMENT_EDITOR
+      ? deployment.airflow.admin
+      ? deployment.config.delete
+      ? deployment.userRoles.update
+      ? deployment.teamRoles.update
+
+  #
+  # User Role (Everyone)
+  #
+  USER:
+    name: User
+    permissions:
+      ? system.workspace.create
+
+#
+# Airflow Deployment Configurations
+#
+deployments:
+  subdomain: 'deployments'
+  # Airflow chart settings
+  # Static helm configurations for this chart are found below.
+  chart:
+    # This version number controls the default Airflow chart version that will be installed
+    # when creating a new deployment in the system. This is also used to ensure all
+    # child airflow deployments are kept up to date and on the latest version.
+    version: 0.0.0
+
+  # releaseVerification determines what docker images are allowed to be installed
+  # STABLE = only official Astronomer Core releases that mirror Airflow releaseVersion
+  # EDGE   = also allow Astronomer Core Edge (astronomer/core:edge) to be used
+  # DEV    = also allow hand-built dev images to be used
+  releaseVerification: STABLE
+
+  airflowReleasesFile: 'airflow_releases.json'
+  # Labels specifed here are applied to Airflow deployment namespaces.
+  namespaceLabels: {}
+
+  # configureDagDeployment
+  configureDagDeployment: false
+
+  # Enable bucket based dag deployment
+  nfsMountDagDeployment: false
+
+  # Enable git sync dag deployment
+  gitSyncDagDeployment: false
+
+  # shows kibana in ui flag is set in config map in astronomer/astronomer
+  kibanaUIEnabled: true
+
+  # shows grafana in ui flag is set in config map in astronomer/astronomer
+  grafanaUIEnabled: true
+
+  # Enable manual release names
+  manualReleaseNames: false
+
+  # Enable manual namespace names:
+  # Note: for now works only with combination with preCreatedNamespaces
+  manualNamespaceNames: false
+
+  # Precreated namespaces
+  preCreatedNamespaces: []
+    # - name: test1
+    # - name: test2
+
+  # Enable Hard Delete deployments
+  hardDeleteDeployment: false
+
+  # Enable Triggerer Airflow component
+  triggererEnabled: false
+
+  # Enable Feature Flag that improves the performance of the sys admin page at the cost of some features
+  sysAdminScalabilityImprovementsEnabled: false
+
+  # Feature flag that controls whether the docker registry webhook endpoint is exposed
+  exposeDockerWebhookEndpoint: true
+  # Feature flag that controls whether the update deployment image endpoint is enabled
+  enableUpdateDeploymentImageEndpoint: false
+
+  # Log out final helm values whenever they are generated, before deployment.
+  logHelmValues: false
+
+  # CLI image tag prefix
+  # This is the prefix to use for houston-generated tags.
+  tagPrefix: deploy
+
+  authSideCar:
+    enabled: false
+    repository: nginxinc/nginx-unprivileged
+    tag: stable
+    pullPolicy: IfNotPresent
+    port: 8084
+    annotations: {}
+  # This is the database connection that we use to connect
+  # and create other databases/schemas/users for each
+  # individual airflow deployment.
+  database:
+    # If disabled, skip db creation.
+    enabled: true
+
+    # Keep the airflow databases around after a
+    # deployment is deleted.
+    retainOnDelete: false
+
+    # If true, leave GRANTs in place for root user.
+    # This lets users log in with the root creds and query
+    # deployment databases.
+    allowRootAccess: false
+
+    # Connection details for root user.
+    # This can also be overridden with a connection string.
+    connection:
+      user: postgres
+      password: postgres
+      host: localhost
+      port: 5432
+      database: postgres
+
+  # An astro unit defines the smallest billable unit
+  # in the system. Default values are based on
+  # the GCP n1-standard-1. CPU should always be expressed
+  # in millicpu and memory should be expressed in Mibibytes.
+  astroUnit:
+    cpu: 100
+    memory: 384
+    pods: 1
+    airflowConns: 5
+    actualConns: 0.5
+    price: 0
+
+  # This defines how much extra capacity, in astro units,
+  # that a user can expand a deployment to. This is currently
+  # represented as a slider in the UI.
+  maxExtraAu: 400
+
+  # This defines the maximum size a pod can be in astro units.
+  maxPodAu: 35
+
+  # This defines any extra resources to account for any sidecars that
+  # are appied to every deployment component. Ex: istio.
+  sidecars:
+    cpu: 0
+    memory: 0
+
+  # This defines all possible components for an airflow
+  # deployment and the default AU to use for the kubernetes
+  # resource requests, as well as its limits.
+  components:
+    - name: scheduler
+      au:
+        default: 5
+        limit: 30
+        request: ~
+      extra:
+        - name: replicas
+          # Change default to 2 after we drop support for Airflow 1
+          default: 1
+          minimum: 1
+          limit: 4
+          minAirflowVersion: "2.0.0"
+    - name: webserver
+      au:
+        default: 5
+        limit: 30
+        request: ~
+    - name: statsd
+      au:
+        default: 2
+        limit: 30
+        request: ~
+    - name: pgbouncer
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: flower
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: redis
+      au:
+        default: 2
+        limit: 2
+        request: ~
+    - name: workers
+      au:
+        default: 10
+        limit: 30
+        request: ~
+      extra:
+        - name: terminationGracePeriodSeconds
+          default: 600
+          limit: 36000
+        - name: replicas
+          default: 1
+          limit: 10
+    - name: triggerer
+      au:
+        default: 5
+        limit: 30
+        request: ~
+      extra:
+        - name: replicas
+          default: 0
+          minimum: 0
+          limit: 2
+          minAirflowVersion: "2.2.0"
+  # This defines which executors should be supported, as well
+  # as the components required to run a particular
+  # executor configuration.
+  executors:
+    - name: LocalExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+        - triggerer
+      defaultExtraAu: 0
+    - name: CeleryExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+        - workers
+        - flower
+        - redis
+        - triggerer
+      defaultExtraAu: 0
+    - name: KubernetesExecutor
+      enabled: true
+      components:
+        - scheduler
+        - webserver
+        - statsd
+        - pgbouncer
+        - triggerer
+      defaultExtraAu: 10
+
+  defaultDistribution: buster
+
+  # These are static configs that get merged directly into the values
+  # passed to helm for each deployment.
+  helm:
+    airflow:
+      # Elasticsearch configuration for deployments.
+      # Airflow clients access Elasticsearch differently.
+      # Houston has full acces, while the deployments connect
+      # via NGINX for auth.
+      elasticsearch:
+        enabled: false
+        connection:
+          host: localhost
+          port: 9200
+      # Set default for debian image, which is the now the default for new
+      # deployments. On image push, this will be read from (and validated) from
+      # the labels in the docker image.
+      uid: 50000
+      gid: 50000
+
+      # If enabled, deploy ServiceAccounts / Roles / RoleBindings
+      # for components that require kubernetes apiserver access.
+      rbac:
+        create: true
+      networkPolicies:
+        # Enabled network polices to restrict the way pods can communicate.
+        enabled: true
+      pgbouncer:
+        # Adds a pgbouncer service between the airflow pods (scheduler / webserver/ workers),
+        # and the backend database.
+        enabled: true
+      # Allow scheduler/workers to launch pods by default. This is required for
+      # the KubernetesPodOperator and KubernetesExecutor. This is what signals to apply the
+      # required RoleBindings.
+      allowPodLaunching: true
+    ingress:
+      # Attach an airflow deployment to the system level ingress controller.
+      enabled: true
+
+  # Annotation name to map the `cloud-role` from creating a deployment to on the Deployment Service account.
+  # AWS - eks.amazonaws.com/role-arn
+  # GCP - iam.gke.io/gcp-service-account
+  serviceAccountAnnotationKey: ~

--- a/enterprise_versioned_docs/version-0.16/manage-platform-users.md
+++ b/enterprise_versioned_docs/version-0.16/manage-platform-users.md
@@ -78,9 +78,9 @@ Permissions are defined on Astronomer as `scope.entity.action`, where:
 - `entity`: The object or role being operated on
 - `action`: The verb describing the operation being performed on the `entity`
 
-For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view our [default Houston API configuration](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L200). Each permission is applied to the role under which it is listed.
+For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view the [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.23/default.yaml). Each permission is applied to the role under which it is listed.
 
-> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles ([source code here](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L266)).
+> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles.
 
 To customize permissions, follow the steps below.
 
@@ -88,8 +88,8 @@ To customize permissions, follow the steps below.
 
 First, take a look at our default roles and permissions linked above and identify two things:
 
-1. What role do you want to configure? (e.g. [`DEPLOYMENT_EDITOR`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L356))
-2. What permission(s) would you like to add to or remove from that role? (e.g. [`deployment.images.push`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L362))
+1. What role do you want to configure? (e.g. `DEPLOYMENT_EDITOR`)
+2. What permission(s) would you like to add to or remove from that role? (e.g. `deployment.images.push`)
 
 For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKSPACE_EDITOR`) from deploying code to all Airflow Deployments within a Workspace and instead limit that action to users assigned the `DEPLOYMENT_ADMIN` role.
 
@@ -97,11 +97,11 @@ For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKS
 
 Unless otherwise configured, a user who creates a Workspace on Astronomer is automatically granted the `WORKSPACE_ADMIN` role and is thus able to create an unlimited number of Airflow Deployments within that Workspace. For teams looking to more strictly control resources, our platform supports limiting the Workspace creation function via a `USER` role.
 
-Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L377).
+Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this role includes the `system.workspace.create` permission.
 
 If you're an administrator on Astronomer who wants to limit Workspace Creation, you can:
 
-- Remove the `system.workspace.create` permission from the `USER` role [here](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L382)
+- Remove the `system.workspace.create` permission from the `USER` role
 - Attach it to a separate role of your choice
 
 If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
@@ -162,7 +162,7 @@ In addition to the commonly used System Admin role, the Astronomer platform also
 
 No user is assigned the System Editor or Viewer Roles by default, but they can be added by System Admins via our API. Once assigned, System Viewers, for example, can access both Grafana and Kibana but don't have permission to delete a Workspace they're not a part of.
 
-All three permission sets are entirely customizable on Astronomer Enterprise. For a full breakdown of the default configurations attached to the System Admin, Editor and Viewer Roles, refer to our [Houston API source code](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L220).
+All three permission sets are entirely customizable on Astronomer Enterprise. For a full breakdown of the default configurations attached to the System Admin, Editor and Viewer Roles, refer to the [Houston API source code](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.23/default.yaml).
 
 For guidelines on assigning users any System Level role, read below.
 
@@ -174,7 +174,7 @@ Keep in mind that:
 - Only existing System Admins can grant the SysAdmin role to another user
 - The user must have a verified email address and already exist in the system
 
-> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L246) or [`SYSTEM_EDITOR`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L259)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/enterprise/houston-api).
+> **Note:** If you'd like to assign a user a different System-Level Role (either `SYSTEM_VIEWER` or `SYSTEM_EDITOR`, you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/enterprise/houston-api).
 
 #### Verify SysAdmin Access
 

--- a/enterprise_versioned_docs/version-0.16/manage-platform-users.md
+++ b/enterprise_versioned_docs/version-0.16/manage-platform-users.md
@@ -78,7 +78,7 @@ Permissions are defined on Astronomer as `scope.entity.action`, where:
 - `entity`: The object or role being operated on
 - `action`: The verb describing the operation being performed on the `entity`
 
-For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view the [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.23/default.yaml). Each permission is applied to the role under which it is listed.
+For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view the [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.16/default.yaml). Each permission is applied to the role under which it is listed.
 
 > **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles.
 
@@ -86,7 +86,7 @@ To customize permissions, follow the steps below.
 
 ### Identify a Permission Change
 
-First, take a look at our default roles and permissions linked above and identify two things:
+First, take a look at the default roles and permissions in the [Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.16/default.yaml) and identify two things:
 
 1. What role do you want to configure? (e.g. `DEPLOYMENT_EDITOR`)
 2. What permission(s) would you like to add to or remove from that role? (e.g. `deployment.images.push`)
@@ -162,7 +162,7 @@ In addition to the commonly used System Admin role, the Astronomer platform also
 
 No user is assigned the System Editor or Viewer Roles by default, but they can be added by System Admins via our API. Once assigned, System Viewers, for example, can access both Grafana and Kibana but don't have permission to delete a Workspace they're not a part of.
 
-All three permission sets are entirely customizable on Astronomer Enterprise. For a full breakdown of the default configurations attached to the System Admin, Editor and Viewer Roles, refer to the [Houston API source code](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.23/default.yaml).
+All three permission sets are entirely customizable on Astronomer Enterprise. For a full breakdown of the default configurations attached to the System Admin, Editor and Viewer Roles, refer to the [Houston API source code](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.16/default.yaml).
 
 For guidelines on assigning users any System Level role, read below.
 

--- a/enterprise_versioned_docs/version-0.16/release-notes.md
+++ b/enterprise_versioned_docs/version-0.16/release-notes.md
@@ -239,7 +239,7 @@ Historically, upgrades to Astronomer (major, minor or patch) that have included 
 
 This change allows for Airflow Deployments to remain unaffected through the upgrade and for Airflow Chart changes to take effect _only_ when another restart event is triggered by a user (e.g. a code push, Environment Variable change, resource or executor adjustment, etc).
 
-More specifically, this changes the behavior of our API's `updateDeployment` mutation to perform the Airflow Helm Chart version upgrade only if/when a Houston config is updated. [Source Code here](https://github.com/astronomer/docs/blob/9cd8da9a4382bc89d7b8c07f5585ad1daa64a250/enterprise/v0.16/reference/update-deployment-index.js#L86).
+More specifically, this changes the behavior of our API's `updateDeployment` mutation to perform the Airflow Helm Chart version upgrade only if/when a Houston config is updated.
 
 #### Bug Fixes and Improvements
 

--- a/enterprise_versioned_docs/version-0.23/manage-platform-users.md
+++ b/enterprise_versioned_docs/version-0.23/manage-platform-users.md
@@ -86,7 +86,7 @@ To customize permissions, follow the steps below.
 
 ### Identify a Permission Change
 
-First, take a look at our default roles and permissions in the [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.23/default.yaml) and identify two things:
+First, take a look at the default roles and permissions in the [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.23/default.yaml) and identify two things:
 
 1. What role do you want to configure? (e.g. `DEPLOYMENT_EDITOR`)
 2. What permission(s) would you like to add to or remove from that role? (e.g. `deployment.images.push`)

--- a/enterprise_versioned_docs/version-0.23/manage-platform-users.md
+++ b/enterprise_versioned_docs/version-0.23/manage-platform-users.md
@@ -2,6 +2,7 @@
 title: 'Manage Users on Astronomer Enterprise'
 sidebar_label: 'Platform User Management'
 id: manage-platform-users
+description: Add and customize user permissions on Astronomer Enterprise.
 ---
 
 ## Overview
@@ -77,18 +78,18 @@ Permissions are defined on Astronomer as `scope.entity.action`, where:
 - `entity`: The object or role being operated on
 - `action`: The verb describing the operation being performed on the `entity`
 
-For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view our [default Houston API configuration](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L200). Each permission is applied to the role under which it is listed.
+For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view our [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.23/default.yaml). Each permission is applied to the role under which it is listed.
 
-> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles ([source code here](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L266)).
+> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles.
 
 To customize permissions, follow the steps below.
 
 ### Identify a Permission Change
 
-First, take a look at our default roles and permissions linked above and identify two things:
+First, take a look at our default roles and permissions in the [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.23/default.yaml) and identify two things:
 
-1. What role do you want to configure? (e.g. [`DEPLOYMENT_EDITOR`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L356))
-2. What permission(s) would you like to add to or remove from that role? (e.g. [`deployment.images.push`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L362))
+1. What role do you want to configure? (e.g. `DEPLOYMENT_EDITOR`)
+2. What permission(s) would you like to add to or remove from that role? (e.g. `deployment.images.push`)
 
 For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKSPACE_EDITOR`) from deploying code to all Airflow Deployments within a Workspace and instead limit that action to users assigned the `DEPLOYMENT_ADMIN` role.
 
@@ -96,11 +97,11 @@ For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKS
 
 Unless otherwise configured, a user who creates a Workspace on Astronomer is automatically granted the `WORKSPACE_ADMIN` role and is thus able to create an unlimited number of Airflow Deployments within that Workspace. For teams looking to more strictly control resources, our platform supports limiting the Workspace creation function via a `USER` role.
 
-Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L377).
+Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this role includes the `system.workspace.create` permission.
 
 If you're an administrator on Astronomer who wants to limit Workspace Creation, you can:
 
-- Remove the `system.workspace.create` permission from the `USER` role [here](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L382)
+- Remove the `system.workspace.create` permission from the `USER` role
 - Attach it to a separate role of your choice
 
 If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
@@ -161,7 +162,7 @@ In addition to the commonly used System Admin role, the Astronomer platform also
 
 No user is assigned the System Editor or Viewer Roles by default, but they can be added by System Admins via our API. Once assigned, System Viewers, for example, can access both Grafana and Kibana but don't have permission to delete a Workspace they're not a part of.
 
-All three permission sets are entirely customizable on Astronomer Enterprise. For a full breakdown of the default configurations attached to the System Admin, Editor and Viewer Roles, refer to our [Houston API source code](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L220).
+All three permission sets are entirely customizable on Astronomer Enterprise. For a full breakdown of the default configurations attached to the System Admin, Editor and Viewer Roles, refer to our [Houston API source code](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.23/default.yaml).
 
 For guidelines on assigning users any System Level role, read below.
 
@@ -173,7 +174,7 @@ Keep in mind that:
 - Only existing System Admins can grant the SysAdmin role to another user
 - The user must have a verified email address and already exist in the system
 
-> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L246) or [`SYSTEM_EDITOR`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L259)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/enterprise/houston-api).
+> **Note:** If you'd like to assign a user a different System-Level Role (either `SYSTEM_VIEWER` or `SYSTEM_EDITOR`), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/enterprise/houston-api).
 
 #### Verify SysAdmin Access
 

--- a/enterprise_versioned_docs/version-0.25/manage-platform-users.md
+++ b/enterprise_versioned_docs/version-0.25/manage-platform-users.md
@@ -2,6 +2,7 @@
 title: 'Manage Users on Astronomer Enterprise'
 sidebar_label: 'Platform User Management'
 id: manage-platform-users
+description: Add and customize user permissions on Astronomer Enterprise.
 ---
 
 ## Overview
@@ -77,18 +78,18 @@ Permissions are defined on Astronomer as `scope.entity.action`, where:
 - `entity`: The object or role being operated on
 - `action`: The verb describing the operation being performed on the `entity`
 
-For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view our [default Houston API configuration](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L200). Each permission is applied to the role under which it is listed.
+For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view our [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.25/default.yaml). Each permission is applied to the role under which it is listed.
 
-> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles ([source code here](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L266)).
+> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles.
 
 To customize permissions, follow the steps below.
 
 ### Identify a Permission Change
 
-First, take a look at our default roles and permissions linked above and identify two things:
+First, take a look at our default roles and permissions in the [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.25/default.yaml) and identify two things:
 
-1. What role do you want to configure? (e.g. [`DEPLOYMENT_EDITOR`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L356))
-2. What permission(s) would you like to add to or remove from that role? (e.g. [`deployment.images.push`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L362))
+1. What role do you want to configure? (e.g. `DEPLOYMENT_EDITOR`)
+2. What permission(s) would you like to add to or remove from that role? (e.g. `deployment.images.push`)
 
 For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKSPACE_EDITOR`) from deploying code to all Airflow Deployments within a Workspace and instead limit that action to users assigned the `DEPLOYMENT_ADMIN` role.
 
@@ -96,11 +97,11 @@ For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKS
 
 Unless otherwise configured, a user who creates a Workspace on Astronomer is automatically granted the `WORKSPACE_ADMIN` role and is thus able to create an unlimited number of Airflow Deployments within that Workspace. For teams looking to more strictly control resources, our platform supports limiting the Workspace creation function via a `USER` role.
 
-Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L377).
+Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this role includes the `system.workspace.create` permission.
 
 If you're an administrator on Astronomer who wants to limit Workspace Creation, you can:
 
-- Remove the `system.workspace.create` permission from the `USER` role [here](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L382)
+- Remove the `system.workspace.create` permission from the `USER` role
 - Attach it to a separate role of your choice
 
 If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
@@ -161,7 +162,7 @@ In addition to the commonly used System Admin role, the Astronomer platform also
 
 No user is assigned the System Editor or Viewer Roles by default, but they can be added by System Admins via our API. Once assigned, System Viewers, for example, can access both Grafana and Kibana but don't have permission to delete a Workspace they're not a part of.
 
-All three permission sets are entirely customizable on Astronomer Enterprise. For a full breakdown of the default configurations attached to the System Admin, Editor and Viewer Roles, refer to our [Houston API source code](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L220).
+All three permission sets are entirely customizable on Astronomer Enterprise. For a full breakdown of the default configurations attached to the System Admin, Editor and Viewer Roles, refer to our [Houston API source code](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.25/default.yaml).
 
 For guidelines on assigning users any System Level role, read below.
 
@@ -173,7 +174,7 @@ Keep in mind that:
 - Only existing System Admins can grant the SysAdmin role to another user
 - The user must have a verified email address and already exist in the system
 
-> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L246) or [`SYSTEM_EDITOR`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L259)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/enterprise/houston-api).
+> **Note:** If you'd like to assign a user a different System-Level Role (either `SYSTEM_VIEWER` or `SYSTEM_EDITOR`), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/enterprise/houston-api).
 
 #### Verify SysAdmin Access
 

--- a/enterprise_versioned_docs/version-0.25/manage-platform-users.md
+++ b/enterprise_versioned_docs/version-0.25/manage-platform-users.md
@@ -86,7 +86,7 @@ To customize permissions, follow the steps below.
 
 ### Identify a Permission Change
 
-First, take a look at our default roles and permissions in the [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.25/default.yaml) and identify two things:
+First, take a look at the default roles and permissions in the [Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.25/default.yaml) and identify two things:
 
 1. What role do you want to configure? (e.g. `DEPLOYMENT_EDITOR`)
 2. What permission(s) would you like to add to or remove from that role? (e.g. `deployment.images.push`)

--- a/enterprise_versioned_docs/version-0.26/manage-platform-users.md
+++ b/enterprise_versioned_docs/version-0.26/manage-platform-users.md
@@ -86,7 +86,7 @@ To customize permissions, follow the steps below.
 
 ### Identify a Permission Change
 
-First, take a look at our [default roles and permissions](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.26/default.yaml) and identify two things:
+First, take a look at the default roles and permissions in the [Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.26/default.yaml) and identify two things:
 
 1. What role do you want to configure? (e.g. `DEPLOYMENT_EDITOR`)
 2. What permission(s) would you like to add to or remove from that role? (e.g. `deployment.images.push`)

--- a/enterprise_versioned_docs/version-0.26/manage-platform-users.md
+++ b/enterprise_versioned_docs/version-0.26/manage-platform-users.md
@@ -78,18 +78,18 @@ Permissions are defined on Astronomer as `scope.entity.action`, where:
 - `entity`: The object or role being operated on
 - `action`: The verb describing the operation being performed on the `entity`
 
-For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view our [default Houston API configuration](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L200). Each permission is applied to the role under which it is listed.
+For example, the `deployment.serviceAccounts.create` permission translates to the ability for a usr to create a Deployment-level Service Account. To view all available platform permissions, view our [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.26/default.yaml). Each permission is applied to the role under which it is listed.
 
-> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles ([source code here](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L266)).
+> **Note:** Higher-level roles by default encompass permissions that are found and explicitly defined in lower-level roles, both at the Workspace and System levels. For example, a `SYSTEM_ADMIN` encompasses all permission listed under its role _as well as_ all permissions listed under the `SYSTEM_EDITOR` and `SYSTEM_VIEWER` roles ([source code here](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.26/default.yaml)).
 
 To customize permissions, follow the steps below.
 
 ### Identify a Permission Change
 
-First, take a look at our default roles and permissions linked above and identify two things:
+First, take a look at our [default roles and permissions](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.26/default.yaml) and identify two things:
 
-1. What role do you want to configure? (e.g. [`DEPLOYMENT_EDITOR`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L356))
-2. What permission(s) would you like to add to or remove from that role? (e.g. [`deployment.images.push`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L362))
+1. What role do you want to configure? (e.g. `DEPLOYMENT_EDITOR`)
+2. What permission(s) would you like to add to or remove from that role? (e.g. `deployment.images.push`)
 
 For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKSPACE_EDITOR`) from deploying code to all Airflow Deployments within a Workspace and instead limit that action to users assigned the `DEPLOYMENT_ADMIN` role.
 
@@ -97,11 +97,11 @@ For example, you might want to block a `DEPLOYMENT_EDITOR` (and therefore `WORKS
 
 Unless otherwise configured, a user who creates a Workspace on Astronomer is automatically granted the `WORKSPACE_ADMIN` role and is thus able to create an unlimited number of Airflow Deployments within that Workspace. For teams looking to more strictly control resources, our platform supports limiting the Workspace creation function via a `USER` role.
 
-Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this [role includes the `system.workspace.create` permission](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L377).
+Astronomer ships with a `USER` role that is synthetically bound to _all_ users within a single cluster. By default, this role includes the `system.workspace.create` permission.
 
 If you're an administrator on Astronomer who wants to limit Workspace Creation, you can:
 
-- Remove the `system.workspace.create` permission from the `USER` role [here](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L382)
+- Remove the `system.workspace.create` permission from the `USER` role.
 - Attach it to a separate role of your choice
 
 If you'd like to reserve the ability to create a Workspace _only_ to System Admins who otherwise manage cluster-level resources and costs, you might limit that permission to the `SYSTEM_ADMIN` role on the platform.
@@ -162,7 +162,7 @@ In addition to the commonly used System Admin role, the Astronomer platform also
 
 No user is assigned the System Editor or Viewer Roles by default, but they can be added by System Admins via our API. Once assigned, System Viewers, for example, can access both Grafana and Kibana but don't have permission to delete a Workspace they're not a part of.
 
-All three permission sets are entirely customizable on Astronomer Enterprise. For a full breakdown of the default configurations attached to the System Admin, Editor and Viewer Roles, refer to our [Houston API source code](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L220).
+All three permission sets are entirely customizable on Astronomer Enterprise. For a full breakdown of the default configurations attached to the System Admin, Editor and Viewer Roles, refer to the [Houston API default configuration file](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.26/default.yaml).
 
 For guidelines on assigning users any System Level role, read below.
 
@@ -174,7 +174,7 @@ Keep in mind that:
 - Only existing System Admins can grant the SysAdmin role to another user
 - The user must have a verified email address and already exist in the system
 
-> **Note:** If you'd like to assign a user a different System-Level Role (either [`SYSTEM_VIEWER`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L246) or [`SYSTEM_EDITOR`](https://github.com/astronomer/docs/blob/082e949a7b5ac83ed7a933fca5bcf185b351dc39/enterprise/next/reference/default.yaml#L259)), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/enterprise/houston-api).
+> **Note:** If you'd like to assign a user a different System-Level Role (either `SYSTEM_VIEWER` or `SYSTEM_EDITOR`), you'll have to do so via an API call from your platform's GraphQL playground. For guidelines, refer to our ["Houston API" doc](/enterprise/houston-api).
 
 #### Verify SysAdmin Access
 


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/255#issuecomment-1002161482

Creating a new `enterprise_configs` folder to house any sort of private configuration file that we might want to reference in documentation. The remaining files in our old [reference folder](https://github.com/astronomer/docs-archived/tree/main/enterprise/v0.26/reference) were either out of date or scarcely/ never mentioned in our docs, so I think it's fine to only import `default.yaml` for now. 

This PR also solves another problem, which is inline source code referencing. Updating these links is quite a maintenance burden, as the specific line referenced might change with each new release of the configuration chart. To make it easier to maintain these docs as accurate in the future, I removed all of these references, instead linking only to the config files in general. We still need to figure out a workflow for adding new config files, but for now that might just be yet another task for when we cut a new release. 