### PR TITLE
Add section on Astronomer Registry to Docs

### DIFF
--- a/cloud/develop-project.md
+++ b/cloud/develop-project.md
@@ -93,13 +93,13 @@ To rebuild your project after making a change to any of these files, you must [r
 
 ## Explore Airflow Providers and Modules
 
-As you customize your Astronomer Project and expand your use case for Airflow, we recommend exploring the [Astronomer Registry](https://registry.astronomer.io/), a central library of Airflow modules, providers and DAGs that become the building blocks for your DAGs.
+As you customize your Astronomer Project and expand your use case for Airflow, we recommend exploring the [Astronomer Registry](https://registry.astronomer.io/), a library of Airflow modules, providers, and DAGs that serve as the building blocks for data pipelines.
 
 The Astronomer Registry includes:
 
-- Example DAGs for many data sources and destinations. For instance, an example DAG that [showcases a data quality use case with Snowflake and Great Expectations](https://registry.astronomer.io/dags/simple-great-expectations-snowflake-el).
+- Example DAGs for many data sources and destinations. For example, you can build out a data quality use case with Snowflake and Great Expectations based on the [Great Expectations Snowflake Example DAG](https://registry.astronomer.io/dags/simple-great-expectations-snowflake-el).
 - Documentation for Airflow providers, such as [Databricks](https://registry.astronomer.io/providers/databricks), [Snowflake](https://registry.astronomer.io/providers/snowflake), and [Postgres](https://registry.astronomer.io/providers/postgres). This documentation is comprehensive and based on Airflow source code.
-- Documentation for Airflow modules, such as the [PythonOperator](https://registry.astronomer.io/providers/apache-airflow/modules/pythonoperator), [BashOperator](https://registry.astronomer.io/providers/apache-airflow/modules/bashoperator), or [S3ToRedshiftOperator](https://registry.astronomer.io/providers/amazon/modules/s3toredshiftoperator). These modules include guidance on how to set Airflow Connections and parameters for them.
+- Documentation for Airflow modules, such as the [PythonOperator](https://registry.astronomer.io/providers/apache-airflow/modules/pythonoperator), [BashOperator](https://registry.astronomer.io/providers/apache-airflow/modules/bashoperator), and [S3ToRedshiftOperator](https://registry.astronomer.io/providers/amazon/modules/s3toredshiftoperator). These modules include guidance on how to set Airflow connections and their parameters. 
 
 As you browse the Astronomer Registry, follow this document for instructions on how to install providers as Python packages and make other changes to your Astronomer Project.
 

--- a/cloud/develop-project.md
+++ b/cloud/develop-project.md
@@ -91,6 +91,18 @@ All changes made to the following files require rebuilding your image:
 
 To rebuild your project after making a change to any of these files, you must [restart your local environment](develop-project.md#restart-your-local-environment).
 
+## Explore Airflow Providers and Modules
+
+As you customize your Astronomer Project and expand your use case for Airflow, we recommend exploring the [Astronomer Registry](https://registry.astronomer.io/), a central library of Airflow modules, providers and DAGs that become the building blocks for your DAGs.
+
+The Astronomer Registry includes:
+
+- Example DAGs for many data sources and destinations. For instance, an example DAG that [showcases a data quality use case with Snowflake and Great Expectations](https://registry.astronomer.io/dags/simple-great-expectations-snowflake-el).
+- Documentation for Airflow providers, such as [Databricks](https://registry.astronomer.io/providers/databricks), [Snowflake](https://registry.astronomer.io/providers/snowflake), and [Postgres](https://registry.astronomer.io/providers/postgres). This documentation is comprehensive and based on Airflow source code.
+- Documentation for Airflow modules, such as the [PythonOperator](https://registry.astronomer.io/providers/apache-airflow/modules/pythonoperator), [BashOperator](https://registry.astronomer.io/providers/apache-airflow/modules/bashoperator), or [S3ToRedshiftOperator](https://registry.astronomer.io/providers/amazon/modules/s3toredshiftoperator). These modules include guidance on how to set Airflow Connections and parameters for them.
+
+As you browse the Astronomer Registry, follow this document for instructions on how to install providers as Python packages and make other changes to your Astronomer Project.
+
 ## Add Python and OS-level Packages
 
 To build Python and OS-level packages into your Astronomer project, add them to your `requirements.txt` and `packages.txt` files. Add Python packages to your `requirements.txt` and OS-level packages to your `packages.txt` file.


### PR DESCRIPTION
To address #192, opening up this PR to add a new section in our [Develop your Project doc](https://docs.astronomer.io/cloud/develop-project) called `Browse Airflow Providers and Modules` that:

- Briefly describes and links out to Astronomer Registry
- Has 3 bullet points with main 3 things you can reference the Registry for
- Brief line at the end connecting the registry to the rest of this doc

@jwitz @virajmparekh Do you two want to take a look at this and LMK what you think? TBH I think in the future this can go into some sort of "Write a DAG" tutorial, but I felt like this was the best place for it for now. Acknowledging that it's the least "specific" or "action oriented" section in this doc