### PR TITLE
Document 0.26 change to service account pods

### DIFF
--- a/enterprise/access-airflow-database.md
+++ b/enterprise/access-airflow-database.md
@@ -277,7 +277,7 @@ geocentric-instrument-2346-pgbouncer-stats                        Opaque        
 geocentric-instrument-2346-redis-password                         Opaque                                1      93d
 geocentric-instrument-2346-registry                               kubernetes.io/dockerconfigjson        1      93d
 geocentric-instrument-2346-scheduler-serviceaccount-token-w29bn   kubernetes.io/service-account-token   3      93d
-geocentric-instrument-2346-worker-serviceaccount-token-gqr4w      kubernetes.io/service-account-token   3      93d
+geocentric-instrument-2346-airflow-worker-token-gqr4w      kubernetes.io/service-account-token   3      93d
 ```
 
 The secret we're looking for lives in that "airflow-metadata" pod (for Airflow's Metadata database).

--- a/enterprise/integrate-iam.md
+++ b/enterprise/integrate-iam.md
@@ -322,7 +322,7 @@ astronomer:
     ```bash
       kubectl run -it \
       --image google/cloud-sdk:slim \
-      --serviceaccount <worker-serviceaccount> \
+      --serviceaccount <airflow-worker> \
       --namespace <your-airflow-namespace> \
       workload-identity-test
     ```

--- a/enterprise/kubepodoperator.md
+++ b/enterprise/kubepodoperator.md
@@ -82,7 +82,7 @@ In terms of resource allocation, we recommend starting with **10AU** in `Extra C
 ```
 ERROR - Exception when attempting to create Namespace Pod.
 Reason: Forbidden
-"Failure","message":"pods is forbidden: User \"system:serviceaccount:astronomer-cloud-solar-orbit-4143:solar-orbit-4143-worker-serviceaccount\" cannot create pods in the namespace \"datarouter\"","reason":"Forbidden","details":{"kind":"pods"},"code":403}
+"Failure","message":"pods is forbidden: User \"system:serviceaccount:astronomer-cloud-solar-orbit-4143:solar-orbit-4143-airflow-worker\" cannot create pods in the namespace \"datarouter\"","reason":"Forbidden","details":{"kind":"pods"},"code":403}
 ```
 
 On Astronomer Enterprise, the largest node a single pod can occupy is dependent on the size of your underlying node pool.

--- a/enterprise_versioned_docs/version-0.26/access-airflow-database.md
+++ b/enterprise_versioned_docs/version-0.26/access-airflow-database.md
@@ -279,7 +279,7 @@ geocentric-instrument-2346-pgbouncer-stats                        Opaque        
 geocentric-instrument-2346-redis-password                         Opaque                                1      93d
 geocentric-instrument-2346-registry                               kubernetes.io/dockerconfigjson        1      93d
 geocentric-instrument-2346-scheduler-serviceaccount-token-w29bn   kubernetes.io/service-account-token   3      93d
-geocentric-instrument-2346-worker-serviceaccount-token-gqr4w      kubernetes.io/service-account-token   3      93d
+geocentric-instrument-2346-airflow-worker-token-gqr4w             kubernetes.io/service-account-token   3      93d
 ```
 
 The secret we're looking for lives in that "airflow-metadata" pod (for Airflow's Metadata database).

--- a/enterprise_versioned_docs/version-0.26/integrate-iam.md
+++ b/enterprise_versioned_docs/version-0.26/integrate-iam.md
@@ -322,7 +322,7 @@ astronomer:
     ```bash
       kubectl run -it \
       --image google/cloud-sdk:slim \
-      --serviceaccount <worker-serviceaccount> \
+      --serviceaccount <airflow-worker> \
       --namespace <your-airflow-namespace> \
       workload-identity-test
     ```

--- a/enterprise_versioned_docs/version-0.26/kubepodoperator.md
+++ b/enterprise_versioned_docs/version-0.26/kubepodoperator.md
@@ -82,7 +82,7 @@ In terms of resource allocation, we recommend starting with **10AU** in `Extra C
 ```
 ERROR - Exception when attempting to create Namespace Pod.
 Reason: Forbidden
-"Failure","message":"pods is forbidden: User \"system:serviceaccount:astronomer-cloud-solar-orbit-4143:solar-orbit-4143-worker-serviceaccount\" cannot create pods in the namespace \"datarouter\"","reason":"Forbidden","details":{"kind":"pods"},"code":403}
+"Failure","message":"pods is forbidden: User \"system:serviceaccount:astronomer-cloud-solar-orbit-4143:solar-orbit-4143-airflow-worker" cannot create pods in the namespace \"datarouter\"","reason":"Forbidden","details":{"kind":"pods"},"code":403}
 ```
 
 On Astronomer Enterprise, the largest node a single pod can occupy is dependent on the size of your underlying node pool.

--- a/enterprise_versioned_docs/version-0.26/release-notes.md
+++ b/enterprise_versioned_docs/version-0.26/release-notes.md
@@ -45,6 +45,7 @@ The flag prints out different levels of logs depending on the value that you pas
 - In the `astronomer.houston.config` section of your `config.yaml` file, you can now configure a list of `allowedSystemLevelDomains []`. If you configure this list, only users with emails from domains specified in the list (for example, `<company>.com`) can be granted System Admin privileges.
 - Greatly improved load times for the **System Admin** page in the UI.
 - You can now specify a node port for 3rd party ingress controllers with a service type of `nodePort`.
+- The naming format of service account pods has been changed from `<release-name>-dags-prod-worker-serviceaccount` to `release_name-dags-prod-airflow-worker`.
 
 ### Bug Fixes
 


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/275

@rbankston I found a few places where the names might have to change around our docs but I'm not sure. Can you let me know if these are correct? Also not sure whether to include the `prod` in your example, since I'm having trouble finding examples in our docs where `prod` is there as standard. 