### PR TITLE
Update metrics doc

### DIFF
--- a/cloud/deployment-metrics.md
+++ b/cloud/deployment-metrics.md
@@ -47,7 +47,7 @@ The following sections describe each of the 4 available charts.
 
 ### DAG Runs
 
-The **DAG Runs** Deployment metric records successful and failed DAG runs over hour-long intervals. A [DAG run](https://airflow.apache.org/docs/apache-airflow/stable/dag-run.html) is defined as an instantiation of a DAG at a specific point in time.
+The **DAG Runs** metric records successful and failed DAG runs over hour-long intervals. A [DAG run](https://airflow.apache.org/docs/apache-airflow/stable/dag-run.html) is defined as an instantiation of a DAG at a specific point in time.
 
 You can hover over each bar to see the corresponding hour interval displayed in both UTC and your local timezone. Below that, you can see the number of successful DAG runs and the number of failed DAG runs. If a bar is partially or fully red, it means that one or more DAG runs failed within that hour interval.
 

--- a/cloud/deployment-metrics.md
+++ b/cloud/deployment-metrics.md
@@ -7,22 +7,23 @@ description: Monitor Deployment performance, health, and total task volume in th
 
 ## Overview
 
-The Astronomer UI contains a suite of metrics that show real-time data related to the performance and health of your Deployments. Viewing metrics is a useful first step for troubleshooting or rethinking the code you run on your Deployments. This document explains each available metric and where to find them.
+The Astronomer UI exposes a suite of observability metrics that show real-time data related to the performance and health of your Deployments. These metrics are a useful reference as you troubleshoot issues and can inform how you allocate resources. They can also help you estimate the cost of your Deployments. This document explains each available metric and where to find them.
 
 ## Deployment Health
 
-The Deployment health status is a metric that appears on the top of your Deployment's information page. Your Deployment's health is based on whether its Airflow components are running as expected.
+Deployment health appears as a real-time status at the top of your Deployment's information page. Deployment health is meant to show whether or not the most important components within your Deployment are running as expected.
 
 ![Deployment Health status](/img/docs/deployment-health.png)
 
 Deployment health can have one of two statuses:
 
-- **Healthy**: The Deployment's webserver and scheduler are running as expected.
-- **Unhealthy**: This status can mean one of two things:
+- **Healthy** (Green): The Airflow Webserver and Scheduler are both healthy and running as expected.
+- **Unhealthy** (Red): This status can mean one of two things:
 
-    - The Deployment's webserver and/or scheduler are restarting or having issues that require further investigation.
-    - Your Deployment was recently created, and its webserver and scheduler are still spinning up in your cluster.
+    - Your Deployment was recently created and the Airflow Webserver and Scheduler are still spinning up.
+    - Your Deployment's Webserver and/or Scheduler are restarting or otherwise not in a healthy, running state.
 
+If your Deployment is unhealthy, we recommend checking the status of your tasks and waiting for a few minutes. If your Deployment is unhealthy for more than 5 minutes, we recommend [reviewing Scheduler logs](scheduler-logs.md) in the Astronomer UI or reaching out to [Astronomer Support](https://support.astronomer.io).
 ## Deployment Performance
 
 Each Deployment includes four high-level performance charts which you can view from both the **Deployments** menu and individual Deployment pages. They include:

--- a/cloud/deployment-metrics.md
+++ b/cloud/deployment-metrics.md
@@ -7,7 +7,25 @@ description: Monitor Deployment performance, health, and total task volume in th
 
 ## Overview
 
-The Astronomer Cloud UI shows 4 high-level charts for each Deployment in your Workspace over the last 24 hours. These charts can be viewed from both the **Deployments** menu and individual Deployment pages. They include:
+The Astronomer UI contains a suite of metrics that show real-time data related to the performance and health of your Deployments. Viewing metrics is a useful first step for troubleshooting or rethinking the code you run on your Deployments. This document explains each available metric and where to find them.
+
+## Deployment Health
+
+The **Deployment Health** status is a metric that appears on the top of your Deployment's information page. Your Deployment's health is based on whether its Airflow components are running as expected.
+
+![Deployment Health status](/img/docs/deployment-health.png)
+
+**Deployment Health** can have one of two values:
+
+- **Healthy**: The Deployment's webserver and scheduler are running as expected.
+- **Unhealthy**: This status can mean one of two things:
+
+    - The Deployment's webserver and/or scheduler are restarting or having issues that require further investigation.
+    - Your Deployment was recently created, and its webserver and scheduler are still spinning up in your cluster.
+
+## Deployment Performance
+
+Each Deployment includes four high-level performance charts which you can view from both the **Deployments** menu and individual Deployment pages. They include:
 
 - DAG Runs
 - Task Instances
@@ -18,21 +36,17 @@ The Astronomer Cloud UI shows 4 high-level charts for each Deployment in your Wo
   <img src="/img/docs/deployment-metrics.png" alt="Metrics dashboard in the Cloud UI" />
 </div>
 
-The data in these 4 graphs is recorded hourly and is displayed in both UTC and your local browser timezone. Each bar across all graphs covers a complete hour while the entire time window for a single graph is 24 hours. For example, a single bar might represent `16:00` to `17:00` while the entire time window of the graph might represent `Nov 1 16:00` to `Nov 2 16:00`.
+The data in these four charts is recorded hourly and is displayed in both UTC and your local browser timezone. Each bar across all graphs covers a complete hour while the entire time window for a single graph is 24 hours. For example, a single bar might represent `16:00` to `17:00` while the entire time window of the graph might represent `Nov 1 16:00` to `Nov 2 16:00`.
 
-The data for the most recent hour will be for the hour to date. For example, if you are looking at this page at 16:30, then the bar for the `16:00-17:00` hour interval would show data for `16:00-16:30`.
+The data for the most recent hour is for the hour to date. For example, if you are looking at this page at 16:30, then the bar for the `16:00-17:00` hour interval would show data for `16:00-16:30`.
 
 These charts serve as high-level reports that are intended to be viewed at a glance. For example, you might notice failed task instances in the Astronomer Cloud UI and then open the Airflow UI to troubleshoot.
 
-The following sections describe each of the 4 available charts from left to right.
-
-## Deployment Performance
-
-The **DAG** and **Tasks** charts in the Astronomer UI give you visibility into the performance of your Deployment as measured by successes and failures of both DAG runs and task instances.
+The following sections describe each of the 4 available charts.
 
 ### DAG Runs
 
-The first Deployment metric records successful and failed DAG runs over hour-long intervals. A [DAG run](https://airflow.apache.org/docs/apache-airflow/stable/dag-run.html) is defined as an instantiation of a DAG at a specific point in time.
+The **DAG Runs** Deployment metric records successful and failed DAG runs over hour-long intervals. A [DAG run](https://airflow.apache.org/docs/apache-airflow/stable/dag-run.html) is defined as an instantiation of a DAG at a specific point in time.
 
 You can hover over each bar to see the corresponding hour interval displayed in both UTC and your local timezone. Below that, you can see the number of successful DAG runs and the number of failed DAG runs. If a bar is partially or fully red, it means that one or more DAG runs failed within that hour interval.
 
@@ -52,7 +66,7 @@ You can hover over each bar to see the corresponding hour interval displayed in 
 
 The bolded value above the graph denotes the total number of tasks that have run in the last 24 hours.
 
-## Resource Usage
+### Resource Usage
 
 The **Worker CPU** and **Worker Memory** charts in the Astronomer UI provide visibility into the resources being consumed by the Workers in your Deployment as measured by CPU and memory consumption.
 
@@ -62,7 +76,7 @@ The number of Celery workers per Deployment autoscales based on a combination of
 
 :::
 
-### Worker CPU
+#### Worker CPU
 
 **Worker CPU** records the peak CPU usage by worker nodes over hour-long intervals.
 
@@ -70,7 +84,7 @@ Each bar in the graph shows how much CPU was being used by a single worker at th
 
 The bolded value above the graph shows maximum CPU usage by a single worker at any point in time over the last 24 hours. This can help you answer, "Did any of my workers approach 100% usage of total available CPU in the past 24 hours?"
 
-### Worker Memory
+#### Worker Memory
 
 **Worker Memory** records the peak memory usage by worker nodes over hour-long intervals.
 

--- a/cloud/deployment-metrics.md
+++ b/cloud/deployment-metrics.md
@@ -11,11 +11,11 @@ The Astronomer UI contains a suite of metrics that show real-time data related t
 
 ## Deployment Health
 
-The **Deployment Health** status is a metric that appears on the top of your Deployment's information page. Your Deployment's health is based on whether its Airflow components are running as expected.
+The Deployment health status is a metric that appears on the top of your Deployment's information page. Your Deployment's health is based on whether its Airflow components are running as expected.
 
 ![Deployment Health status](/img/docs/deployment-health.png)
 
-**Deployment Health** can have one of two values:
+Deployment health can have one of two statuses:
 
 - **Healthy**: The Deployment's webserver and scheduler are running as expected.
 - **Unhealthy**: This status can mean one of two things:


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/234
Resolves https://github.com/astronomer/docs/issues/220

This PR updates the Metrics docs on two fronts:
- Add information about Deployment health as a metric
- Reorganize intro/ headers so that chart metrics are just one part of the metric suite. We were describing them in the overview as the only metrics even though we also document Usage on the same page. 