### PR TITLE
Remove reference to Worker Termination Grace Period

### DIFF
--- a/cloud/configure-deployment.md
+++ b/cloud/configure-deployment.md
@@ -52,12 +52,6 @@ All Celery Workers assume the same resources. If you set Worker Resources to 10 
 
 The ability to set minimum and/or maximum number of Workers is coming soon.
 
-### Worker Grace Period
-
-Celery Workers are forced to restart upon every change to Environment Variables and every code deploy to your Deployment. This is to make sure that Workers are executing with the most up-to-date code. To minimize disruption to task execution, however, Astronomer supports the ability to set a **Worker Grace Period**.
-
-If a deploy is triggered while a Celery Worker is executing a task and Worker Grace Period is set, the Worker will continue to process that task up to a certain number of minutes before restarting itself. By default, the grace period is 10 minutes.
-
 ### Scheduler
 
 The [Airflow Scheduler](https://airflow.apache.org/docs/apache-airflow/stable/concepts/scheduler.html) is responsible for monitoring task execution and triggering downstream tasks once dependencies have been met. By adjusting the **Scheduler Count** slider in the Astronomer UI, you can configure up to 4 Schedulers, each of which will be provisioned with the AU specified in **Scheduler Resources**.

--- a/cloud/deploy-code.md
+++ b/cloud/deploy-code.md
@@ -71,7 +71,7 @@ If a task does not complete within 24 hours, its Worker will be terminated. Airf
 
 :::tip
 
-If you want to force long-running tasks to terminate prior to 24 hours, you must specify an [`execution_timeout`](https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html#timeouts) of less than 24 hours in your DAG's task definition.
+If you want to force long-running tasks to terminate prior to 24 hours, you must specify an [`execution_timeout`](https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html#timeouts) in your DAG's task definition.
 
 :::
 

--- a/cloud/deploy-code.md
+++ b/cloud/deploy-code.md
@@ -64,10 +64,11 @@ When you deploy code to Astronomer Cloud, your Astronomer project is built into 
 
 If you deploy code to a Deployment that is already running a previous version of your code, then the following happens:
 
-1. Tasks that are `running` will continue to execute on existing Celery Workers and will not be interrupted, unless the task does not complete within 24 hours of the code deploy.
+1. Tasks that are `running` will continue to execute on existing Celery Workers and will not be interrupted unless the task does not complete within 24 hours of your deploy.
 2. One or more autoscaling Workers will spin up to immediately start executing new tasks based on your latest code. These Celery Workers do not wait for your previous Workers to terminate.
+3. Kubernetes pods for all other Airflow components, including the Scheduler and Webserver, are restarted.
 
-If a task does not complete within 24 hours, its Worker will be terminated. Airflow will mark the task as a [zombie]((https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html#zombie-undead-tasks)) and it will retry according to the task's retry policy. This is to ensure that Astronomer can reliably upgrade and maintain Astronomer as a service. 
+When you push code to Astronomer, Kubernetes sends a SIGTERM signal to all containers running on your Deployment. While this triggers most containers to restart immediately, Astronomer sets a grace period of 24 hours for Celery Workers to ease the impact on your tasks. If a task does not complete within 24 hours, its Worker will be terminated. Airflow will mark the task as a [zombie]((https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html#zombie-undead-tasks)) and it will retry according to the task's retry policy. This is to ensure that Astronomer can reliably upgrade and maintain Astronomer as a service. 
 
 :::tip
 

--- a/cloud/deploy-code.md
+++ b/cloud/deploy-code.md
@@ -70,9 +70,9 @@ If you are deploying code to a Deployment that is already running code from a pr
 
 :::info
 
-By default, the maximum amount of time that a task can run on a worker is 24 hours. After 24 hours, the worker running your task is automatically terminated to ensure that Astronomer can consistently upgrade and maintain your Airflow infrastructure. A worker running for longer than 24 hours will terminate regardless of its task status or any related code deploys.
+By default, the maximum amount of time that a worker can run a task is 24 hours. After 24 hours, the worker running your task is automatically terminated to ensure that Astronomer can consistently upgrade and maintain your Airflow infrastructure. A worker running for longer than 24 hours will terminate regardless of its task status or any related code deploys.
 
-If you want to run a task for longer than 24 hours, you must specify a [`execution_timeout`](https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html#timeouts) of more than 24 hours in the code for your task.
+If you want to run a task for longer than 24 hours, you must specify an [`execution_timeout`](https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html#timeouts) of more than 24 hours in the code for your task.
 
 :::
 

--- a/cloud/deploy-code.md
+++ b/cloud/deploy-code.md
@@ -58,21 +58,20 @@ Once you log in, you should see the DAGs you just deployed.
 
 ## What Happens During a Code Deploy
 
-When you deploy code to Astronomer Cloud, your Astronomer project is built into a Docker image. This includes system-level dependencies, Python-level dependencies, DAGs, and your `Dockerfile`. It does not include any of the metadata associated with your local Airflow environment, including task history and Airflow Connections or Variables that were set locally. This Docker image is then pushed to all containers running the Apache Airflow application on Astronomer Cloud, including the Airflow Scheduler, Webserver, and Celery Workers.
+When you deploy code to Astronomer Cloud, your Astronomer project is built into a Docker image. This includes system-level dependencies, Python-level dependencies, DAGs, and your `Dockerfile`. It does not include any of the metadata associated with your local Airflow environment, including task history and Airflow Connections or Variables that were set locally. This Docker image is then pushed to all containers running the Apache Airflow application on Astronomer Cloud. With the exception of the Airflow Webserver and some Celery Workers, Kubernetes gracefully terminates all containers during this process. This forces them to restart and begin running your latest code.
 
 ![Deploy Code](/img/docs/deploy-architecture.png)
 
-If you deploy code to a Deployment that is already running a previous version of your code, then the following happens:
+If you deploy code to a Deployment that is running a previous version of your code, then the following happens:
 
-1. Tasks that are `running` will continue to execute on existing Celery Workers and will not be interrupted unless the task does not complete within 24 hours of your deploy.
+1. Tasks that are `running` will continue to execute on existing Celery Workers and will not be interrupted unless the task does not complete within 24 hours of the code deploy.
 2. One or more autoscaling Workers will spin up to immediately start executing new tasks based on your latest code. These Celery Workers do not wait for your previous Workers to terminate.
-3. Kubernetes pods for all other Airflow components, including the Scheduler and Webserver, are restarted.
 
-When you push code to Astronomer, Kubernetes sends a SIGTERM signal to all containers running on your Deployment. While this triggers most containers to restart immediately, Astronomer sets a grace period of 24 hours for Celery Workers to ease the impact on your tasks. If a task does not complete within 24 hours, its Worker will be terminated. Airflow will mark the task as a [zombie]((https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html#zombie-undead-tasks)) and it will retry according to the task's retry policy. This is to ensure that Astronomer can reliably upgrade and maintain Astronomer as a service. 
+Astronomer sets a grace period of 24 hours for all Celery Workers to allow running tasks to continue executing. This grace period is not configurable. If a task does not complete within 24 hours, its Worker will be terminated. Airflow will mark the task as a [zombie](https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html#zombie-undead-tasks) and it will retry according to the task's retry policy. This is to ensure that our team can reliably upgrade and maintain Astronomer as a service.
 
 :::tip
 
-If you want to force long-running tasks to terminate prior to 24 hours, you must specify an [`execution_timeout`](https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html#timeouts) in your DAG's task definition.
+If you want to force long-running tasks to terminate sooner than 24 hours, specify an [`execution_timeout`](https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html#timeouts) in your DAG's task definition.
 
 :::
 
@@ -80,7 +79,7 @@ If you want to force long-running tasks to terminate prior to 24 hours, you must
 
 Now that you're familiar with deploying DAGs to Astronomer Cloud, consider reading:
 
-- [Develop Project](develop-project.md)
+- [Develop your Project](develop-project.md)
 - [Set Environment Variables](environment-variables.md)
 
 For up-to-date information about product limitations, read [Known Limitations](known-limitations.md).

--- a/cloud/deploy-code.md
+++ b/cloud/deploy-code.md
@@ -62,7 +62,7 @@ Once you log in, you should see the DAGs you just deployed.
 
 When you deploy code to Astronomer Cloud, your entire Astronomer project is built into a Docker image. This includes system-level dependencies, Python-level dependencies, DAGs, and your `Dockerfile`. It does not include any of the metadata associated with your local Airflow environment, including task history and Airflow Connections or Variables that were set locally. This Docker image is then pushed to all containers running the Apache Airflow application on Astronomer Cloud, including Celery Workers.
 
-If you are deploying code to a Deployment that is already running code from a previous version of your project, the following happens:
+If you deploy code to a Deployment that is already running code from a previous version of your project, then the following happens:
 
 1. Existing workers running your old project continue executing their current tasks.
 2. New workers automatically spin up using KEDA to execute code from your new project.

--- a/cloud/deploy-code.md
+++ b/cloud/deploy-code.md
@@ -76,7 +76,6 @@ If you want to run a task for longer than 24 hours, you must specify an [`execut
 
 :::
 
-
 ## Next Steps
 
 Now that you're familiar with deploying DAGs to Astronomer Cloud, consider reading:

--- a/cloud/deploy-code.md
+++ b/cloud/deploy-code.md
@@ -60,7 +60,7 @@ Once you log in, you should see the DAGs you just deployed.
 
 ## What Happens During a Code Deploy
 
-When you deploy code to Astronomer Cloud, your entire Astronomer project is built into a Docker image and pushed to Astronomer. This includes system-level dependencies, Python-level dependencies, DAGs, and your `Dockerfile`. It does not include any of the metadata associated with your local Airflow environment, including task history and Airflow Connections or Variables that were set locally. This Docker image is then pushed to all containers running the Apache Airflow application on Astronomer Cloud, including Celery Workers.
+When you deploy code to Astronomer Cloud, your entire Astronomer project is built into a Docker image. This includes system-level dependencies, Python-level dependencies, DAGs, and your `Dockerfile`. It does not include any of the metadata associated with your local Airflow environment, including task history and Airflow Connections or Variables that were set locally. This Docker image is then pushed to all containers running the Apache Airflow application on Astronomer Cloud, including Celery Workers.
 
 If you are deploying code to a Deployment that is already running code from a previous version of your project, the following happens:
 

--- a/cloud/deploy-code.md
+++ b/cloud/deploy-code.md
@@ -67,7 +67,7 @@ If you deploy code to a Deployment that is already running a previous version of
 1. Tasks that are `running` will continue to execute on existing Celery Workers and will not be interrupted, unless the task does not complete within 24 hours of the code deploy.
 2. One or more autoscaling Workers will spin up to immediately start executing new tasks based on your latest code. These Celery Workers do not wait for your previous Workers to terminate.
 
-If a task does not complete within 24 hours, its Worker will be terminated. Airflow will mark it as a [zombie]((https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html#zombie-undead-tasks)) and it will retry according to the task's retry policy. This is to ensure that Astronomer can reliably upgrade and maintain Astronomer as a service. 
+If a task does not complete within 24 hours, its Worker will be terminated. Airflow will mark the task as a [zombie]((https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html#zombie-undead-tasks)) and it will retry according to the task's retry policy. This is to ensure that Astronomer can reliably upgrade and maintain Astronomer as a service. 
 
 :::tip
 

--- a/cloud/known-limitations.md
+++ b/cloud/known-limitations.md
@@ -20,7 +20,6 @@ If you have questions or thoughts about any item below, don't hesitate to reach 
 - During the install process, your team will be added to 1 Astronomer Workspace that supports multiple users and Deployments. To create additional Workspaces in your Organization, assistance from our team is required.
 - If you're running Astronomer Runtime `2.1.1`, `3.0.0`, or `3.0.1`, the Astronomer Runtime field in the Astronomer UI shows `Unknown`. Once you upgrade to Runtime 3.0.2+, your Deployment's version of Runtime is correctly listed.
 - We do not currently support PgBouncer, but the RDS instance provisioned in your Cluster will support around 1000 connections to your database, enough to support 10-12 Deployments.
-- Tasks longer than the worker termination grace period may become zombies.
 - If a user changes Workspace roles on Astronomer, it can take a maximum of 10 minutes for corresponding Airflow permission changes to take effect.
 - The usage of [Deployment API Keys](api-keys.md) in [CI/CD processes](ci-cd.md) currently requires fetching a short-lived authentication token and making requests directly to our Docker registry and the Astronomer API. Native support for Deployment API Keys in the Astronomer CLI is coming soon.
 - The Astronomer CLI is generally limited to `astro dev` commands, in addition to `astro deploy` and `astro auth`. Full functionality is coming soon.

--- a/cloud/release-notes.md
+++ b/cloud/release-notes.md
@@ -31,7 +31,7 @@ The **Scheduler Logs** tab in the Astronomer UI has been updated to make logs ea
 ### Additional Improvements
 
 - Removed _Kubernetes Version_ column from the **Clusters** table. This value was previously inaccurate and is not needed. The Kubernetes version of any particular Astronomer Cluster is set and modified exclusively by Astronomer as part of our managed service.
-- Removed the **Worker Termination Grace Period** Deployment setting to better manage and upgrade customer infrastructure. For most tasks, this results in no change in behavior because old worker pods can continue to execute tasks while new workers spin up to execute any newly deployed code. By default, a worker can run a task for a maximum 24 hours before it is automatically terminated. Thus, the only tasks affected by this change are any tasks you run that might run for longer than 24 hours.
+- Removed the **Worker Termination Grace Period** setting so that Astronomer can more consistently upgrade and maintain your Airflow infrastructure. For most tasks, this results in no change in behavior because old worker pods can continue to execute tasks while new workers spin up to execute any newly deployed code. By default, a worker can run a task for a maximum 24 hours before it's automatically terminated. Thus, the only tasks affected by this change are those that might run for longer than 24 hours. For more information about worker termination, read [What Happens During a Code Deploy](deploy-code.md#what-happens-during-a-code-deploy).
 
 ## December 16, 2021
 

--- a/cloud/release-notes.md
+++ b/cloud/release-notes.md
@@ -28,10 +28,20 @@ The **Scheduler Logs** tab in the Astronomer UI has been updated to make logs ea
 
 ![Logs page in the UI](/img/release-notes/log-improvements.png)
 
+### Removal of Worker Termination Grace Period
+
+The **Worker Termination Grace Period** setting is no longer available in the Astronomer UI or API. Previously, users could set this to anywhere between 1 minute and 24 hours per Deployment. This was to prevent running tasks from being interrupted by a code push. Today, however, existing Celery Workers don't have to terminate in order for new Workers to spin up and start executing tasks. Instead, existing Workers will continue to execute running tasks while a new set of Workers gets spun up concurrently to start executing most recent code.
+
+To simplify Deployment configuration and reflect current functionality:
+
+- The Worker Termination Grace Period was removed from the Astronomer UI
+- This value was permanently set to 24 hours for all Deployments on Astronomer Cloud
+
+This does not change or affect execution behavior for new or existing Deployments. For more information, read [What Happens During a Code Deploy](deploy-code.md#what-happens-during-a-code-deploy).
+
 ### Additional Improvements
 
 - Removed _Kubernetes Version_ column from the **Clusters** table. This value was previously inaccurate and is not needed. The Kubernetes version of any particular Astronomer Cluster is set and modified exclusively by Astronomer as part of our managed service.
-- Removed the **Worker Termination Grace Period** setting so that Astronomer can more consistently upgrade and maintain your Airflow infrastructure. For most tasks, this results in no change in behavior because old worker pods can continue to execute tasks while new workers spin up to execute any newly deployed code. By default, a worker can run a task for a maximum 24 hours before it's automatically terminated. Thus, the only tasks affected by this change are those that might run for longer than 24 hours. For more information about worker termination, read [What Happens During a Code Deploy](deploy-code.md#what-happens-during-a-code-deploy).
 
 ## December 16, 2021
 

--- a/cloud/release-notes.md
+++ b/cloud/release-notes.md
@@ -31,6 +31,7 @@ The **Scheduler Logs** tab in the Astronomer UI has been updated to make logs ea
 ### Additional Improvements
 
 - Removed _Kubernetes Version_ column from the **Clusters** table. This value was previously inaccurate and is not needed. The Kubernetes version of any particular Astronomer Cluster is set and modified exclusively by Astronomer as part of our managed service.
+- Removed the **Worker Termination Grace Period** Deployment setting to better manage and upgrade customer infrastructure. For most tasks, this results in no change in behavior because old worker pods can continue to execute tasks while new workers spin up to execute any newly deployed code. By default, a worker can run a task for a maximum 24 hours before it is automatically terminated. Thus, the only tasks affected by this change are any tasks you run that might run for longer than 24 hours.
 
 ## December 16, 2021
 


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/270

Added a new section on "What happens During a Code Deploy Code" that can become the hub for more information related to what happens on the Data Plane side when a user deploys code. Could use review on the note related to `execution_timout`, as well as the release note explaining why we made this change. 