### PR TITLE
Add "version" tags to relevant places in Enterprise docs

### DIFF
--- a/enterprise/apply-platform-config.md
+++ b/enterprise/apply-platform-config.md
@@ -30,6 +30,8 @@ This file was created when you installed Astronomer using one of the following g
 
 ## Step 2: Update Key-Value Pairs
 
+<!--- Version-specific -->
+
 To update any of your existing settings, modify them directly in your `config.yaml` file. To update a setting you haven't already specified, copy the corresponding key-value pair from the [default configuration file](https://github.com/astronomer/docs/blob/main/enterprise_configs/0.27/default.yaml) into your `config.yaml` file and modify the value from there.
 
 When you have finished updating the key-value pairs, ensure that they have the same relative order and indentation as they do in the default configuration file. If they don't, your changes might not be properly applied.

--- a/enterprise/install-aws-standard.md
+++ b/enterprise/install-aws-standard.md
@@ -292,6 +292,8 @@ These are the minimum values you need to configure for installing Astronomer. Fo
 
 ## Step 9: Install Astronomer
 
+<!--- Version-specific -->
+
 Now that you have an EKS cluster set up and your `config.yaml` file defined, you're ready to deploy all components of our platform.
 
 First, run:

--- a/enterprise/install-azure-standard.md
+++ b/enterprise/install-azure-standard.md
@@ -346,6 +346,8 @@ These are the minimum values you need to configure for installing Astronomer. Fo
 
 ## Step 9: Install Astronomer
 
+<!--- Version-specific -->
+
 Now that you have an AKS cluster set up and your `config.yaml` defined, you're ready to deploy all components of our platform.
 
 First, run:

--- a/enterprise/install-gcp-standard.md
+++ b/enterprise/install-gcp-standard.md
@@ -342,6 +342,8 @@ These are the minimum values you need to configure for installing Astronomer. Fo
 
 ## Step 9: Install Astronomer
 
+<!--- Version-specific -->
+
 Now that you have a GCP cluster set up and your `config.yaml` defined, you're ready to deploy all components of our platform.
 
 First, run:

--- a/enterprise/manage-platform-users.md
+++ b/enterprise/manage-platform-users.md
@@ -84,6 +84,8 @@ To customize permissions, follow the steps below.
 
 ### Identify a Permission Change
 
+<!--- Version-specific -->
+
 First, take a look at our default roles and permissions in the [default Houston API configuration](https://github.com/astronomer/docs/tree/main/enterprise_configs/0.27/default.yaml) and identify two things:
 
 1. What role do you want to configure? (e.g. `DEPLOYMENT_EDITOR`)
@@ -155,6 +157,8 @@ On Astronomer, System Admins specifically can:
 By default, the first user to log into an Astronomer Enterprise installation is granted the System Admin permission set.
 
 ### System Editor, Viewer
+
+<!--- Version-specific -->
 
 In addition to the commonly used System Admin role, the Astronomer platform also supports both a System Editor and System Viewer permission set.
 

--- a/enterprise/release-lifecycle-policy.md
+++ b/enterprise/release-lifecycle-policy.md
@@ -77,6 +77,8 @@ In rare instances, the Astronomer team may make an exception and backport a bug 
 
 ## Enterprise Lifecycle Schedule
 
+<!--- Version-specific -->
+
 The following table contains the exact lifecycle for each published version of Astronomer Enterprise. These timelines are based on the LTS and stable release channel maintenance policies.
 
 | Enterprise Version | Release Date     | Release Channel | Maintenance Period | End of Maintenance Date |
@@ -86,4 +88,3 @@ The following table contains the exact lifecycle for each published version of A
 | 0.25               | May 11, 2021     | LTS             | 12 months          | May 2022                |
 | 0.26               | Nov 23, 2021     | Stable          | 6 months           | May 2022                |
 | 0.27               | Dec 21, 2021     | Stable          | 6 months           | June 2022               |
-

--- a/enterprise/release-notes.md
+++ b/enterprise/release-notes.md
@@ -7,6 +7,8 @@ description: Astronomer Enterprise release notes.
 
 ## Overview
 
+<!--- Version-specific -->
+
 This document includes all release notes for Astronomer Enterprise v0.27.
 
 Astronomer v0.27 is the latest Stable version of Astronomer Enterprise, while v0.25 remains the latest long-term support (LTS) version. To upgrade to Astronomer v0.27 from v0.26, read [Upgrade to a Stable Version](upgrade-astronomer-stable.md). For more information about Enterprise release channels, read [Release and Lifecycle Policies](release-lifecycle-policy.md).

--- a/enterprise/version-compatibility-reference.md
+++ b/enterprise/version-compatibility-reference.md
@@ -13,6 +13,8 @@ It's worth noting that while the tables below reference the minimum compatible v
 
 ## Astronomer Enterprise
 
+<!--- Version-specific -->
+
 | Astronomer Platform | Kubernetes                   | Helm | Terraform    | Postgres | Python                                    | Astronomer CLI |
 | ------------------- | ---------------------------- | ---- | ------------ | -------- | ----------------------------------------- | -------------- |
 | v0.16               | 1.16, 1.17, 1.18             | 3    | 0.12, 0.13.5 | 9.6+     | 3.6, 3.7, 3.8                             | 0.16.x         |

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,5 +1,4 @@
 export const siteVariables = {
   cliVersion: '1.0.4',
   runtimeVersion: '4.0.8',
-  enterpriseLatest: '0.27',
 };

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,4 +1,5 @@
 export const siteVariables = {
   cliVersion: '1.0.4',
-  runtimeVersion: '4.0.8'
+  runtimeVersion: '4.0.8',
+  enterpriseLatest: '0.27',
 };


### PR DESCRIPTION
Resolves https://app.zenhub.com/workspaces/documentation-5fcfce583ed44e0011db3db5/issues/astronomer/docs/248

After attempting a number of solutions for Markdown-level environment variables as described [here](https://github.com/facebook/docusaurus/issues/395), I think the best strategy for maintaining release numbers is to add an invisible HTML tag in places where we need to update version numbers for new releases. A writer can search for this tag and update any instance of the Enterprise version within the tagged Markdown topic. 

Automated env vars would be as much if not more maintenance, given that we'd have to cut new environment variables with each release in order to maintain versioning across multiple docsets. This strategy works better in Cloud, where there will only ever be one docset version at a time. 