### PR TITLE
Update WSL2 and Powershell install instructions

### DIFF
--- a/enterprise/cli-install-windows-10.md
+++ b/enterprise/cli-install-windows-10.md
@@ -9,7 +9,7 @@ Welcome to Astronomer!
 
 If you're a Windows User looking to install and use the Astronomer CLI, you have 2 options:
 
-1. Install the Unix-based CLI a Windows Subsystem for Linux (WSL)
+1. Install the Unix-based CLI on Windows Subsystem for Linux (WSL)
 2. Install the Windows-based CLI
 
 > **Note:** Either option will require Windows 10 or greater.
@@ -18,60 +18,28 @@ If you're a Windows User looking to install and use the Astronomer CLI, you have
 
 This guide will walk you through the setup and configuration process for using the Astronomer CLI in the Windows Subsystem for Linux (WSL) on Windows 10. Before you start, make sure:
  - You're running the bash terminal
- - You have the [the WSL enabled](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
- - You're on Windows 10
+ - You have [WSL enabled](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
+ - You're running Windows 10 version 2004 and higher (Build 19041 and higher) or Windows 11.
 
 **Note:** We use Ubuntu as our Linux flavor of choice, but this guide should work for other distributions as well.
 
-Much of the setup process is borrowed from a guide written by Nick Janetakis. Find the full guide here: [Setting Up Docker for Windows and WSL to Work Flawlessly](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
+Find the full WSL installation guide here: [Install WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
 
 ### Step 1. Install Docker CE for Windows
 
 Follow the [Docker for Windows Install Guide](https://docs.docker.com/docker-for-windows/install/).
 
-### Step 2. Expose the Docker Daemon
-
-In your docker settings, under general, enable the `Expose daemon on tcp://localhost:2375 without TLS` setting.
-
-This will allow the docker daemon running on windows to act as a remote docker service for our WSL instance.
-
-### Step 3. Install Docker for Linux in WSL
-
-In your WSL terminal, follow the Docker CE for Ubuntu install guide here: [Install Docker CE for Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
-
-Docker will not run in the WSL instance, however this will give us access to the docker CLI through our Linux environment.
-
-### Step 4. Connect your WSL instance to Docker on Windows
-
-Now, you need to point our docker host route to the remote docker daemon running in Windows. To do this we need to add an export path to our `~/.bashrc` file.
-
-Run: `echo "export DOCKER_HOST=tcp://0.0.0.0:2375" >> ~/.bashrc && source ~/.bashrc` to add a new line to your bashrc file pointing the docker host to your exposed  daemon and re-source your bashrc file.
-
-### Step 5. Custom Mount Points
-
-To ensure docker can properly mount volumes, we need to create custom mount paths that work in the WSL instance.
-
-This process differs depending on the version of Windows 10 you're running. In our case, we're running build 1709.
-
-First, create a new mount point directory:
-
-`sudo mkdir /c`
-
-Then bind this mount point:
-
-`sudo  mount --bind /mnt/c /c`
-
-You're all set! You can now run `docker run hello-world` through your WSL instance to ensure everything works as expected. Keep in mind that you will need to bind your mount point each time you start up a new WSL instance.
+Open a new WSL session, using the distro shell or Windows Terminal. You can now run `docker run hello-world` through your WSL instance to ensure everything works as expected.
 
 **Last thing**: Whenever you run Docker-compose up, you'll want to make sure you navigate to the `/c/Users/name/dev/myapplication` first, otherwise your volume won't work. In other words, never access `/mnt/c` directly.
 
-### Step 6. Final Install
+### Step 2. CLI Install
 
 Once you've completed the steps above, head over to our [CLI Quickstart Guide](cli-quickstart.md) to finish the installation and start deployment DAGs.
 
-## Astronomer CLI on Windows 10
+## Astronomer CLI on Windows 10 (PowerShell)
 
-If for any reason you can't install WSL, you can install a Windows adapted version of the Astronomer CLI directly by following the instructions below.
+You can install a Windows adapted version of the Astronomer CLI directly by following the instructions below.
 
 ### Step 1. Pre-Flight Checklist
 
@@ -80,9 +48,9 @@ Make sure you have the following installed:
 - Windows 10
 - [Docker](https://docs.docker.com/docker-for-windows/install/)
 
-### Step 2. Enable Hyper-V
+### Step 2. Enable Hyper-V or WSL-2 Based Docker Engine (legacy)
 
-Make sure you enabled Hyper-V, which is required to run Docker and Linux Containers.
+Make sure that the WSL 2 based engine is enabled in Docker Settings (preferred). If this is not possible, enable Hyper-V (legacy). This is required to run Docker and Linux Containers.
 
 If you have any issues with Docker, check out [Docker's Troubleshooting Guide for Windows](https://docs.docker.com/docker-for-windows/troubleshoot/).
 
@@ -103,7 +71,7 @@ After following step 3, you should see a zip file on your machine that contains 
 
 Grab that `astro.exe` file and move it to a location that won't be deleted.
 
-### Step 5. Extract the contents
+### Step 5. Add Executable to Path
 Add the location of `astro.exe` in your %PATH%. If you don't know how to do this, check out [this helpful guide](https://helpdeskgeek.com/windows-10/add-windows-path-environment-variable/).
 
 ### Step 6. Final Command


### PR DESCRIPTION
While testing `astrocloud` on Windows, I noticed that the CLI instructions are outdated. 

Now that Docker Desktop uses WSL2 as the Docker Engine instead of Hyper-V, if someone were to follow the instructions as it was, they would have receive a received an error referencing the Docker Daemon not being on. We no longer need to install a docker engine version in WSL2, or expose the 2375 port. With updated docker, the CLI can be installed in both WSL2 or PowerShell and used easily. 

I purposely did not add the PowerShell instructions at this time, and left the download from github option as I wasn't sure if we published a windows version of the CLI for Enterprise in the same way we do for Cloud. 