### PR TITLE
Extend 0.25 through December 2022

### DIFF
--- a/enterprise/release-lifecycle-policy.md
+++ b/enterprise/release-lifecycle-policy.md
@@ -85,6 +85,8 @@ The following table contains the exact lifecycle for each published version of A
 | ------------------ | ---------------- | ----------------------- |
 | 0.16 (LTS)         | June 29, 2020    | June 2021               |
 | 0.23 (LTS)         | January 20, 2021 | January 2022            |
-| 0.25 (LTS)         | May 11, 2021     | May 2022                |
+| 0.25 (LTS)         | May 11, 2021     | December 2022           |
 | 0.26               | Nov 23, 2021     | May 2022                |
 | 0.27               | Dec 21, 2021     | June 2022               |
+
+Given the wide usage of Enterprise 0.25, Astronomer has extended the maintenance period for this version through December 2022.


### PR DESCRIPTION
After reviewing with Vishwas, we want to extend maintenance of 0.25 through December of this year to ease the burden on customers.