### PR TITLE
Astronomer Runtime documentation improvements

### DIFF
--- a/cloud/configure-deployment.md
+++ b/cloud/configure-deployment.md
@@ -22,6 +22,7 @@ To create an Airflow Deployment on Astronomer Cloud:
 1. Log in to the [Astronomer UI](https://cloud.astronomer.io) and go to the **Deployments** tab on the left navigation bar.
 2. On the top right-hand side of the Deployments page, click **New Deployment**.
 3. Set the following:
+
     - **Name**
     - **Description**
     - **Astronomer Runtime**: By default, the latest version of Astronomer Runtime is selected
@@ -34,6 +35,12 @@ To create an Airflow Deployment on Astronomer Cloud:
     All Deployments show an initial health status of `UNHEALTHY` after their creation. This indicates that the Deployment's Webserver and Scheduler are still spinning up in your cloud. Wait a few minutes for this status to become `HEALTHY` before proceeding to the next step.
 
 4. To access the Airflow UI, select **Open Airflow** on the top right.
+
+### Available Runtime Versions
+
+Only the latest patch version of a given major/minor Runtime version will be available for selection when configuring a Deployment. If a Runtime version has reached the end of its maintenance window, it will no longer be available for new Deployments.
+
+Once you select and save a Deployment's Runtime version, you can change that version only by upgrading via your Dockerfile. For more information on upgrading Runtime, read [Upgrade Runtime](upgrade-runtime.md)
 
 ## Configure Resource Settings
 

--- a/cloud/runtime-overview.md
+++ b/cloud/runtime-overview.md
@@ -1,0 +1,87 @@
+---
+sidebar_label: "Overview"
+title: "Astronomer Runtime Overview"
+id: runtime-overview
+description: Learn about the various components that make up Astronomer Runtime.
+---
+
+## Overview
+
+The Astronomer Runtime Docker image for Apache Airflow extends the community-developed Airflow image in a way that makes running Airflow more secure, reliable, and extensible. It is the base image for all Airflow Deployments on Astronomer Cloud.
+
+This guide provides reference information for the building blocks of Astronomer Runtime, as well as information on its release and distribution.
+
+## Distribution
+
+Astronomer Runtime is distributed as a Debian-based Docker image. This image includes:
+
+- A robust testing suite that covers performance benchmarking and end-to-end functionality and upgrade testing for Runtime environments.
+- A built-in directory of example DAGs that demonstrate Airflow's most powerful features.
+- A collection of Airflow functions, such as deferrable operators and custom timetables, that are exclusive to Astronomer customers.
+
+The Dockerfiles for all supported Astronomer Runtime images can be found in [Astronomer's quay.io repository](quay.io/astronomer/astro-runtime).
+
+## Provider Packages
+
+Astronomer Runtime includes provider packages that are utilized in some background processes, as well as packages which are commonly used by the Airflow community:
+
+- [amazon](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/index.html)
+- [celery](https://airflow.apache.org/docs/apache-airflow-providers-celery/stable/index.html)
+- [cncf.kubernetes](https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/index.html)
+- [postgres](https://airflow.apache.org/docs/apache-airflow-providers-postgres/stable/index.html)
+- [redis](https://airflow.apache.org/docs/apache-airflow-providers-redis/stable/index.html)
+
+## System Dependencies
+
+Astronomer Runtime includes a number of OS-level dependencies for running basic system processes:
+
+- [apt-utils](https://packages.debian.org/bullseye/apt-utils)
+- [gosu](https://packages.debian.org/bullseye/gosu)
+- [curl](https://packages.debian.org/bullseye/curl)
+- [libffi-dev](https://packages.debian.org/bullseye/libffi-dev)
+- [libpq5](https://packages.debian.org/bullseye/libpq5)
+- [libssl1.1](https://packages.debian.org/bullseye/libssl1.1)
+- [locales](https://packages.debian.org/bullseye/locales)
+- [netcat](https://packages.debian.org/bullseye/netcat)
+- [sudo](https://packages.debian.org/bullseye/sudo)
+- [tini](https://packages.debian.org/bullseye/tini)
+- [postgresql-client](https://packages.debian.org/bullseye/postgresql-client)
+
+## Commercial Airflow Support
+
+Astronomer Runtime includes a number of Airflow functions available exclusively to Astronomer customers. This topic includes a list of all additional Airflow functions available in Runtime.
+
+### Deferrable Operators
+
+Astronomer maintains a number of deferrable operators available exclusively through Runtime. For a full list of these operators and guidance on how to use them, read [Astronomer's Deferrable Operators](deferrable-operators.md#astronomers-deferrable-operators).
+
+### Custom Timetables
+
+Astronomer maintains a `TradingHoursTimetable` available out of the box in Runtime. You can use this timetable to run a DAG based on whether or not a particular global market is open for trade.
+
+### Monitoring DAG
+
+Astronomer Runtime includes a monitoring DAG that is pre-installed in the Docker image and enabled for all customers. In addition to existing Deployment health and metrics functionality, this DAG allows the Astronomer team to better monitor the health of your Data Plane by enabling real-time visibility into whether your Workers are healthy and tasks are running.
+
+The `astronomer_monitoring_dag` runs a simple bash task every 5 minutes to ensure that your Airflow Scheduler and Workers are functioning as expected. If the task fails twice in a row or is not scheduled within a 10-minute interval, Astronomer support receives an alert and will work with you to troubleshoot.
+
+## Extras
+
+Astronomer Runtime includes a few packages that don't have a corresponding provider. These packages are used for basic system functions or optional Airflow functionality. The following list contains all extra packages built into Astronomer Runtime by default:
+
+- `password`: Adds support for user password hashing
+- `statsd`: Adds support for sending metrics to StatsD
+- `virtualenv`: Adds support for running Python tasks in local virtual environments
+
+## Version Compatibility Reference
+
+Astronomer Runtime is compatible with specific versions for key system components. Additionally, Astronomer Runtime versions follow a lifecycle as described in the [Runtime Versioning and Lifecycle Policy](runtime-version-lifecycle-policy.md).
+
+The following table lists all version compatibility requirements and key lifecycle dates for each major version of Astronomer Runtime:
+
+| Runtime Version                                          | Release Date    | Python | System Distribution  | End of Maintenance Date |
+| -------------------------------------------------------- | --------------- | ------ | -------------------- | ----------------------- |
+| [3.0.x](runtime-release-notes.md#astronomer-runtime-300) | August 12, 2021 | 3.8    | Debian 11 (Bullseye) | February 2022           |
+| [4.0.x](runtime-release-notes.md#astronomer-runtime-400) | Oct 12, 2021    | 3.9    | Debian 11 (Bullseye) | April 2022              |
+
+If you have any questions or concerns, reach out to [Astronomer Support](https://support.astronomer.io).

--- a/cloud/runtime-overview.md
+++ b/cloud/runtime-overview.md
@@ -31,6 +31,8 @@ Astronomer Runtime includes provider packages that are utilized in some backgrou
 - [postgres](https://airflow.apache.org/docs/apache-airflow-providers-postgres/stable/index.html)
 - [redis](https://airflow.apache.org/docs/apache-airflow-providers-redis/stable/index.html)
 
+Runtime uses the same version constraints for these packages as the open source Apache Airflow image.
+
 ## System Dependencies
 
 Astronomer Runtime includes a number of OS-level dependencies for running basic system processes:

--- a/cloud/runtime-overview.md
+++ b/cloud/runtime-overview.md
@@ -7,7 +7,7 @@ description: Learn about the various components that make up Astronomer Runtime.
 
 ## Overview
 
-The Astronomer Runtime Docker image for Apache Airflow extends the community-developed Airflow image in a way that makes running Airflow more secure, reliable, and extensible. It is the base image for all Airflow Deployments on Astronomer Cloud.
+Astronomer Runtime is a Docker image built and published by Astronomer that extends the Apache Airflow project to provide a differentiated data orchestration experience. It is the base image for all Airflow Deployments on Astronomer Cloud.
 
 This guide provides reference information for the building blocks of Astronomer Runtime, as well as information on its release and distribution.
 

--- a/cloud/runtime-overview.md
+++ b/cloud/runtime-overview.md
@@ -55,9 +55,9 @@ Astronomer Runtime includes a number of Airflow functions available exclusively 
 
 Astronomer maintains a number of deferrable operators available exclusively through Runtime. For a full list of these operators and guidance on how to use them, read [Astronomer's Deferrable Operators](deferrable-operators.md#astronomers-deferrable-operators).
 
-### Custom Timetables
+### Timetables
 
-Astronomer maintains a `TradingHoursTimetable` available out of the box in Runtime. You can use this timetable to run a DAG based on whether or not a particular global market is open for trade.
+Astronomer maintains a custom [timetable](https://airflow.apache.org/docs/apache-airflow/stable/howto/timetable.html) called `TradingHoursTimetable` available out of the box in Runtime. You can use this timetable to run a DAG based on whether or not a particular global market is open for trade. More custom timetables will be made available in future releases of Runtime.
 
 ### Monitoring DAG
 
@@ -75,7 +75,7 @@ Astronomer Runtime includes a few packages that don't have a corresponding provi
 
 ## Version Compatibility Reference
 
-Astronomer Runtime is compatible with specific versions for key system components. Additionally, Astronomer Runtime versions follow a lifecycle as described in the [Runtime Versioning and Lifecycle Policy](runtime-version-lifecycle-policy.md).
+Astronomer Runtime is compatible with specific versions of key system components. Additionally, each version of Astronomer Runtime has a lifecycle as described in [Runtime Versioning and Lifecycle Policy](runtime-version-lifecycle-policy.md).
 
 The following table lists all version compatibility requirements and key lifecycle dates for each major version of Astronomer Runtime:
 

--- a/cloud/runtime-version-lifecycle-policy.md
+++ b/cloud/runtime-version-lifecycle-policy.md
@@ -100,13 +100,6 @@ To ensure reliability, service will not be interrupted for Deployments running a
 
 Maintenance is discontinued the last day of the month for a given version. For example, if the maintenance window for a version of Astronomer Runtime is January - June of a given year, that version will be maintained by Astronomer until the last day of June.
 
-## Astronomer Runtime Lifecycle Schedule
+All patch versions within the same minor series share the same maintenance end of maintenance date. For example, the maintenance duration for the Astronomer Runtime `4.0.x` series started on October 12, 2021 and ends in April 2022. The maintenance window for Astronomer Runtime `4.0.8`, which was released on December 21, 2021, also ends in April 2022.
 
-The following table contains the exact lifecycle for each published version of Astronomer Runtime. These timelines are based on the LTS and Stable release channel maintenance policies.
-
-| Runtime Version                                          | Release Date    |     End of Maintenance Date |
-| -------------------------------------------------------- | --------------- ------------------ | ----------------------- |
-| [3.0.x](runtime-release-notes.md#astronomer-runtime-300) | August 12, 2021 |  February 2022      |
-| [4.0.x](runtime-release-notes.md#astronomer-runtime-400) | Oct 12, 2021    |  April 2022         |
-
-If you have any questions or concerns, reach out to [Astronomer Support](https://support.astronomer.io).
+For a table of currently supported Runtime versions and their maintenance durations, see [Version Compatibility Reference](runtime-overview.md#version-compatibility-reference).

--- a/sidebarsCloud.js
+++ b/sidebarsCloud.js
@@ -60,6 +60,7 @@ module.exports = {
       type: 'category',
       label: 'Astronomer Runtime',
       items: [
+        'runtime-overview',
         'upgrade-runtime',
         'runtime-version-lifecycle-policy',
       ],


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/312
Resolves https://github.com/astronomer/docs/issues/73

Creating a new "Runtime Overview" doc that should include all high level reference information that anyone should need for understanding Runtime. I also moved some existing content around and clarified Runtime availability in our Deployment documentation.

Much of the content is based on our existing [Certified architecture doc](https://docs.astronomer.io/enterprise/image-architecture), but there is also some new content under "Commercial Airflow Support"