### PR TITLE
Update Hashicorp secrets backend setup + Enterprise secrets backend docs

### DIFF
--- a/cloud/secrets-backend.md
+++ b/cloud/secrets-backend.md
@@ -133,7 +133,7 @@ Then, add the following environment variables to your `Dockerfile`:
 ```text
 # Make sure to replace `<your-approle-id>` and `<your-approle-secret>` with your own values.
 ENV AIRFLOW__SECRETS__BACKEND="airflow.contrib.secrets.hashicorp_vault.VaultBackend"
-ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_path": "airflow/connections", "variables_path": null, "config_path": null, "url": "https://vault.vault.svc.cluster.local:8200", "auth_type": "approle", "role_id":"<your-approle-id>", "secret_id":"<your-approle-secret>"}'
+ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_path": "onnections", "variables_path": variables, "config_path": null, "url": "https://vault.vault.svc.cluster.local:8200", "auth_type": "approle", "role_id":"<your-approle-id>", "secret_id":"<your-approle-secret>"}'
 ```
 
 This tells Airflow to look for variable and connection information at the `secret/variables/*` and `secret/connections/*` paths in your Vault server. In the next step, you'll test this configuration in a local Airflow environment.

--- a/cloud/secrets-backend.md
+++ b/cloud/secrets-backend.md
@@ -58,7 +58,7 @@ This topic provides steps for how to use [Hashicorp Vault](https://www.vaultproj
 To use this feature, you need:
 
 - A [Deployment](configure-deployment.md) on Astronomer.
-- [The Astronomer CLI](install-cli.md).
+- [The Astronomer CLI](install-code.md).
 - A [Hashicorp Vault server](https://learn.hashicorp.com/tutorials/vault/getting-started-dev-server?in=vault/getting-started).
 - An [Astronomer project](create-project.md).
 - [The Vault CLI](https://www.vaultproject.io/docs/install).
@@ -199,7 +199,7 @@ Once you've confirmed that the integration with Vault works locally, you can com
   :::
 
 2. In your Astronomer project, delete the environment variables from your `Dockerfile`.
-3. [Deploy your changes](deploy-cli.md) to Astronomer Cloud.
+3. [Deploy your changes](deploy-code.md) to Astronomer Cloud.
 
 Now, any Airflow variable or connection that you write to your Vault server can be successfully accessed and pulled by any DAG in your Deployment on Astronomer Cloud.
 

--- a/cloud/secrets-backend.md
+++ b/cloud/secrets-backend.md
@@ -47,7 +47,7 @@ Setting Airflow connections via secrets requires knowledge of how to generate Ai
 
 This topic provides steps for how to use [Hashicorp Vault](https://www.vaultproject.io/) as a secrets backend for both local development and on Astronomer Cloud. To do this, you will:
 
-1. Create an AppRole which grants Astronomer minimal required permissions.
+1. Create an AppRole in Vault which grants Astronomer minimal required permissions.
 2. Write a test Airflow variable or connection as a secret to your Vault server.
 3. Configure your Astronomer project to pull the secret from Vault.
 4. Test the backend in a local environment.
@@ -69,18 +69,18 @@ If you do not already have a Vault server deployed but would like to test this f
 - Sign up for a Vault trial on [Hashicorp Cloud Platform (HCP)](https://cloud.hashicorp.com/products/vault) or
 - Deploy a local Vault server via the instructions in [our Airflow Guide](https://www.astronomer.io/guides/airflow-and-hashicorp-vault).
 
-### Step 1: Configure Vault
+### Step 1: Create a Policy and AppRole in Vault
 
-To use Vault as a secrets backend, we recommend configuring a Vault role with a policy that grants only the minimum necessary permissions for Astronomer. To do this:
+To use Vault as a secrets backend, we recommend configuring a Vault AppRole with a policy that grants only the minimum necessary permissions for Astronomer. To do this:
 
 1. [Create a Vault policy](https://www.vaultproject.io/docs/concepts/policies) with the following permissions:
 
     ```hcl
-    path "secret/variables/*" {
+    path "secret/data/variables/*" {
       capabilities = ["read", "list"]
     }
 
-    path "secret/connections/*" {
+    path "secret/data/connections/*" {
       capabilities = ["read", "list"]
     }
     ```

--- a/enterprise/secrets-backend.md
+++ b/enterprise/secrets-backend.md
@@ -47,11 +47,11 @@ Setting Airflow connections via secrets requires knowledge of how to generate Ai
 
 This topic provides steps for how to use [Hashicorp Vault](https://www.vaultproject.io/) as a secrets backend for both local development and on Astronomer Enterprise. To do this, you will:
 
-1. Create an AppRole which grants Astronomer minimal required permissions.
+1. Create an AppRole in Vault which grants Astronomer minimal required permissions.
 2. Write a test Airflow variable or connection as a secret to your Vault server.
 3. Configure your Astronomer project to pull the secret from Vault.
 4. Test the backend in a local environment.
-5. Deploy your changes to Astronomer Cloud.
+5. Deploy your changes to Astronomer Enterprise.
 
 ### Prerequisites
 
@@ -60,7 +60,7 @@ To use this feature, you need:
 - A [Deployment](configure-deployment.md) on Astronomer.
 - [The Astronomer CLI](cli-quickstart.md).
 - A [Hashicorp Vault server](https://learn.hashicorp.com/tutorials/vault/getting-started-dev-server?in=vault/getting-started).
-- An [Astronomer project](create-project.md).
+- An Astronomer project initialized via `astro dev init`.
 - [The Vault CLI](https://www.vaultproject.io/docs/install).
 - Your Vault Server's URL. If you're using a local server, this should be `http://127.0.0.1:8200/`.
 
@@ -69,18 +69,18 @@ If you do not already have a Vault server deployed but would like to test this f
 - Sign up for a Vault trial on [Hashicorp Cloud Platform (HCP)](https://cloud.hashicorp.com/products/vault) or
 - Deploy a local Vault server via the instructions in [our Airflow Guide](https://www.astronomer.io/guides/airflow-and-hashicorp-vault).
 
-### Step 1: Configure Vault
+### Step 1: Create a Policy and AppRole in Vault
 
-To use Vault as a secrets backend, we recommend configuring a Vault role with a policy that grants only the minimum necessary permissions for Astronomer. To do this:
+To use Vault as a secrets backend, we recommend configuring a Vault AppRole with a policy that grants only the minimum necessary permissions for Astronomer. To do this:
 
 1. [Create a Vault policy](https://www.vaultproject.io/docs/concepts/policies) with the following permissions:
 
     ```hcl
-    path "secret/variables/*" {
+    path "secret/data/variables/*" {
       capabilities = ["read", "list"]
     }
 
-    path "secret/connections/*" {
+    path "secret/data/connections/*" {
       capabilities = ["read", "list"]
     }
     ```
@@ -133,7 +133,7 @@ Then, add the following environment variables to your `Dockerfile`:
 ```text
 # Make sure to replace `<your-approle-id>` and `<your-approle-secret>` with your own values.
 ENV AIRFLOW__SECRETS__BACKEND="airflow.contrib.secrets.hashicorp_vault.VaultBackend"
-ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_path": "airflow/connections", "variables_path": null, "config_path": null, "url": "https://vault.vault.svc.cluster.local:8200", "auth_type": "approle", "role_id":"<your-approle-id>", "secret_id":"<your-approle-secret>"}'
+ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_path": "onnections", "variables_path": variables, "config_path": null, "url": "https://vault.vault.svc.cluster.local:8200", "auth_type": "approle", "role_id":"<your-approle-id>", "secret_id":"<your-approle-secret>"}'
 ```
 
 This tells Airflow to look for variable and connection information at the `secret/variables/*` and `secret/connections/*` paths in your Vault server. In the next step, you'll test this configuration in a local Airflow environment.
@@ -213,7 +213,7 @@ To use this feature, you need:
 
 - A [Deployment](configure-deployment.md).
 - The [Astronomer CLI](cli-quickstart.md).
-- An [Astronomer project](create-project.md).
+- An Astronomer project initialized via `astro dev init`.
 - Access to AWS SSM Parameter Store.
 - A valid AWS Access Key ID and Secret Access Key.
 
@@ -322,7 +322,7 @@ To use Google Cloud Secret Manager as your Airflow secrets backend, you need:
 
 - A [Deployment](configure-deployment.md).
 - The [Astronomer CLI](cli-quickstart.md).
-- An [Astronomer project](create-project.md).
+- An Astronomer project initialized via `astro dev init`.
 - [Cloud SDK](https://cloud.google.com/sdk/gcloud).
 - A Google Cloud environment with [Secret Manager](https://cloud.google.com/secret-manager/docs/configuring-secret-manager) configured.
 - A [service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts) with the [Secret Manager Secret Accessor](https://cloud.google.com/secret-manager/docs/access-control) role on Google Cloud.
@@ -434,7 +434,7 @@ To use Azure Key Vault as a secrets backend, you need:
 
 - A [Deployment](configure-deployment.md).
 - The [Astronomer CLI](cli-quickstart.md).
-- An [Astronomer project](create-project.md).
+- An Astronomer project initialized via `astro dev init`.
 - An existing Azure Key Vault linked to a resource group.
 - Your Key Vault URL. To find this, go to your Key Vault overview page > **Vault URI**.
 

--- a/enterprise/secrets-backend.md
+++ b/enterprise/secrets-backend.md
@@ -2,248 +2,538 @@
 title: 'Configure an External Secrets Backend on Astronomer Enterprise'
 sidebar_label: 'Configure a Secrets Backend'
 id: secrets-backend
-description: Configure a secret backend tool on Astronomer Enterprise to store Airflow Connections and Variables.
+description: Configure a secrets backend on Astronomer Enterprise to store Airflow variables and connections in a centralized place.
 ---
 
-As of [Airflow 1.10.10](https://airflow.apache.org/docs/1.10.10/howto/use-alternative-secrets-backend.html), users can manage and sync Airflow Connections and Variables from a variety of external secrets backend tools, including [Hashicorp Vault](https://www.vaultproject.io/), [AWS SSM Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html), and [GCP Secret Manager](https://cloud.google.com/secret-manager).
+## Overview
 
-This guide will walk you through how to leverage Airflow's latest feature on Astronomer with specific instructions for the following tools:
+Apache Airflow [variables](https://airflow.apache.org/docs/apache-airflow/stable/howto/variable.html) and [connections](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html#) often contain sensitive information about your external systems that should be kept [secret](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/secrets/index.html) in a secure, centralized location that complies with your organization's security requirements. While secret values of Airflow variables and connections are encrypted in the Airflow metadata database of every Deployment, Astronomer recommends integrating with a secrets backend tool.
+
+Integrating a secrets backend tool on Astronomer Enterprise allows you to:
+
+- Store Airflow variables and connections in a centralized location alongside secrets from other tools and systems used by your team, including Kubernetes secrets, SSL certificates, and more.
+- Comply with internal security postures and policies that protect your organization.
+- Recover in the case of an incident.
+- Automatically pull Airflow variables and connections that are already stored in your secrets backend when you create a new Deployment instead of having to set them manually in the Airflow UI.
+
+To meet these requirements, Astronomer Enterprise supports integration with a variety of secret backend tools. This guide provides setup steps for configuring the following tools as secrets backends on Astronomer:
 
 - Hashicorp Vault
-- AWS SSM Parameter Store
+- AWS Systems Manager Parameter Store
 - Google Cloud Secret Manager
+- Azure Key Vault
+
+All secrets backend integrations are set per Deployment on Astronomer Enterprise.
+
+:::info
+
+If you enable a secrets backend on Astronomer, you can continue to define Airflow variables and connections either [as environment variables](environment-variables.md#add-airflow-connections-and-variables-via-environment-variables) or in the Airflow UI as needed. If set via the Airflow UI, variables and connections are stored as encrypted values in Airflow's metadata database.
+
+When Airflow checks for the value of an Airflow variable or connection, it does so in the following order of precedence:
+
+1. Secrets backend
+2. Environment variable
+3. Set via the Airflow UI
+
+:::
+
+:::tip
+
+Setting Airflow connections via secrets requires knowledge of how to generate Airflow connection URIs. If you plan to store Airflow connections on your secrets backend, read the [Apache Airflow documentation](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html#connection-uri-format) for guidance on how to generate a connection URI.
+
+:::
 
 ## Hashicorp Vault
 
-In this section, we'll walk through how to use Vault as a secrets backend both locally and for your Airflow Deployment running on Astronomer.
+This topic provides steps for how to use [Hashicorp Vault](https://www.vaultproject.io/) as a secrets backend for both local development and on Astronomer Enterprise. To do this, you will:
+
+1. Create an AppRole which grants Astronomer minimal required permissions.
+2. Write a test Airflow variable or connection as a secret to your Vault server.
+3. Configure your Astronomer project to pull the secret from Vault.
+4. Test the backend in a local environment.
+5. Deploy your changes to Astronomer Cloud.
 
 ### Prerequisites
 
-To use this feature, you'll need the following:
+To use this feature, you need:
 
-- "Admin" access to an Airflow Deployment on Astronomer
-- [The Astro CLI](cli-quickstart.md)
-- A running Hashicorp Vault server
-- [The Vault CLI](https://www.vaultproject.io/docs/install)
-- Your Vault server's [Root Token](https://www.vaultproject.io/docs/concepts/tokens#root-tokens)
-- Your Vault Server's URL (if you're planning on using a local server, this should be `http://127.0.0.1:8200/`)
+- A [Deployment](configure-deployment.md) on Astronomer.
+- [The Astronomer CLI](cli-quickstart.md).
+- A [Hashicorp Vault server](https://learn.hashicorp.com/tutorials/vault/getting-started-dev-server?in=vault/getting-started).
+- An [Astronomer project](create-project.md).
+- [The Vault CLI](https://www.vaultproject.io/docs/install).
+- Your Vault Server's URL. If you're using a local server, this should be `http://127.0.0.1:8200/`.
 
-If you do not already have a Vault server deployed but would like to test this feature, we'd recommend either:
+If you do not already have a Vault server deployed but would like to test this feature, we recommend that you either:
 
-1. Deploying a light-weight server using [this Heroku Element](https://elements.heroku.com/buttons/pallavkothari/vault)
-2. Deploying a local server via the instructions in [our Airflow and Vault guide](https://www.astronomer.io/guides/airflow-and-hashicorp-vault)
+- Sign up for a Vault trial on [Hashicorp Cloud Platform (HCP)](https://cloud.hashicorp.com/products/vault) or
+- Deploy a local Vault server via the instructions in [our Airflow Guide](https://www.astronomer.io/guides/airflow-and-hashicorp-vault).
 
-### Write a Connection to Vault
+### Step 1: Configure Vault
 
-To start, you'll need to write an [Airflow connection URI](https://airflow.apache.org/docs/stable/howto/connection/index.html#generating-connection-uri) to your Vault server.
+To use Vault as a secrets backend, we recommend configuring a Vault role with a policy that grants only the minimum necessary permissions for Astronomer. To do this:
 
-To write the connection to your Vault server as a key/value pair, run:
+1. [Create a Vault policy](https://www.vaultproject.io/docs/concepts/policies) with the following permissions:
+
+    ```hcl
+    path "secret/variables/*" {
+      capabilities = ["read", "list"]
+    }
+
+    path "secret/connections/*" {
+      capabilities = ["read", "list"]
+    }
+    ```
+
+2. [Create a Vault AppRole](https://www.vaultproject.io/docs/auth/approle) and attach the policy you just created to it.
+3. Retrieve the `role-id` and `secret-id` for your AppRole by running the following commands:
+
+    ```sh
+    vault read auth/approle/role/<your-approle>/role-id
+    vault write -f auth/approle/role/<your-approle>/secret-id
+    ```
+
+    Save these values for Step 3.
+
+### Step 2: Write an Airflow Variable or Connection to Vault
+
+To test whether your Vault server is set up properly, create a test Airflow variable or connection to store as a secret.
+
+To store an Airflow variable in Vault as a secret, run the following Vault CLI command with your own values:
+
+```sh
+vault kv put secret/variables/<your-variable-key> value=<your-variable-value>
+```
+
+To store a connection in Vault as a secret, run the following Vault CLI command with your own values:
+
+```sh
+vault kv put secret/connections/<your-connection-id> conn_uri=<connection-type>://<connection-login>:<connection-password>@<connection-host>:5432
+```
+
+To confirm that your secret was written to Vault successfully, run:
+
+```sh
+# For variables
+$ vault kv get secret/variables/<your-variable-key>
+# For connections
+$ vault kv get secret/connections/<your-connection-id>
+```
+
+### Step 3: Set Up Vault Locally
+
+In your Astronomer project, add the [Hashicorp Airflow provider](https://airflow.apache.org/docs/apache-airflow-providers-hashicorp/stable/index.html) to your project by adding the following to your `requirements.txt` file:
 
 ```
-vault kv put secret/connections/<your-connection> conn_uri=my-conn-type://my-login:my-password@my-host:5432
+apache-airflow-providers-hashicorp
 ```
 
-This methodology should apply to any secret that is expressed as a Connection URI. For an SMTP connection, for example, this would look like the following:
+Then, add the following environment variables to your `Dockerfile`:
 
-```
-vault kv put secret/connections/smtp_default conn_uri=smtps://user:host@relay.example.com:465
-```
-
-> **Note:** We recommend setting the path to `secret/connections/<your-connection>` to keep all of your Airflow connections organized in the `connections` directory of the mount point.
-
-#### Confirm your secret was written successfully
-
-To confirm that the secret was written successfully for the example above, run the following:
-
-```
-vault kv gt secret/connections/<your-connection>
+```text
+# Make sure to replace `<your-approle-id>` and `<your-approle-secret>` with your own values.
+ENV AIRFLOW__SECRETS__BACKEND="airflow.contrib.secrets.hashicorp_vault.VaultBackend"
+ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_path": "airflow/connections", "variables_path": null, "config_path": null, "url": "https://vault.vault.svc.cluster.local:8200", "auth_type": "approle", "role_id":"<your-approle-id>", "secret_id":"<your-approle-secret>"}'
 ```
 
-For the SMTP example anove, the output would be:
+This tells Airflow to look for variable and connection information at the `secret/variables/*` and `secret/connections/*` paths in your Vault server. In the next step, you'll test this configuration in a local Airflow environment.
 
-    vault kv get secret/connections/smtp_default
-    ====== Metadata ======
-    Key              Value
-    ---              -----
-    created_time     2020-03-26T14:43:50.819791Z
-    deletion_time    n/a
-    destroyed        false
-    version          1
+:::warning
 
-    ====== Data ======
-    Key         Value
-    ---         -----
-    conn_uri    smtps://user:host@relay.example.com:465
+If you want to deploy your project to a hosted Git repository before deploying to Astronomer, be sure to save `<your-approle-id>` and `<your-approle-secret>` securely. We recommend adding them to your project's [`.env` file](develop-project.md#set-environment-variables-via-env-local-development-only) and specifying this file in `.gitignore`.
 
-### Set your Connection Locally
+When you deploy to Astronomer Enterprise in Step 4, you can set these values as secrets via the Astronomer UI.
 
-Now that you have a running Vault server with your secret injected, the next step is to configure your `Dockerfile` to use this Vault server as the default secrets backend for your local Airflow instance. Following this section, we'll set these variables on an Airflow Deployment running on Astronomer.
+:::
 
-To set this configuration up, follow the steps below.
+:::info
+By default, Airflow uses `"kv_engine_version": 2`, but we've written this secret using v1. You can change this to accommodate how you write and read your secrets.
+:::
 
-1. Add the following Environment Variables to the `.env` file in your project directory to be used locally:
+For more information on the Airflow provider for Hashicorp Vault and how to further customize your integration, read the [Apache Airflow documentation](https://airflow.apache.org/docs/apache-airflow-providers-hashicorp/stable/_api/airflow/providers/hashicorp/hooks/vault/index.html).
 
-        VAULT__ROOT_TOKEN="YOUR-ROOT-TOKEN"
-        VAULT__URL="YOUR-VAULT-URL"
+### Step 4: Run an Example DAG to Test Vault Locally
 
-   This will keep your connection to the Vault server secure. Be sure to keep your `.env` in your `.gitignore` when you deploy these changes to your project if they contain sensitive credentials. We'll set these variables separately on Astronomer.
+To test Vault, write a simple DAG which calls your test secret and add this DAG to your project's `dags` directory. For example, you can use the following DAG to print the value of a variable to your task logs:
 
-2. Add the following lines to your `Dockerfile` to instantiate those vault-specific Environment Variables and use them in the context of Airflow's `AIRFLOW__SECRETS__BACKEND` configuration:
-
-        ENV VAULT__ROOT_TOKEN=$VAULT__ROOT_TOKEN
-        ENV VAULT__URL=$VAULT__URL
-        ENV AIRFLOW__SECRETS__BACKEND="airflow.contrib.secrets.hashicorp_vault.VaultBackend"
-        ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"url":$VAULT__URL,"token": $VAULT__ROOT_TOKEN,"connections_path": "connections","variables_path": "variables","kv_engine_version":1}'
-
-   This tells Airflow to look for connection information at the `secret/connections/*` path in your Vault server.
-
-> **Note:** By default, Airflow uses `"kv_engine_version": 2`, but we've written this secret using v1. You're welcome to change this to accommodate how you write and read your secrets.
-
-If you'd like to further customize what the interaction between Airflow and Vault server will look like, you read [the full list of available kwargs for this integration](https://airflow.apache.org/docs/stable/_api/airflow/contrib/secrets/hashicorp_vault/index.html).
-
-### Test Your Connection
-
-To test your connection to Vault locally, add the code below as a new DAG in your `/dags` directory. This will print your connection information to the task logs and confirm that your connection has been established successfully.
-
-```python
+```py
 from airflow import DAG
 from airflow.operators.python_operator import PythonOperator
 from datetime import datetime
 from airflow.hooks.base_hook import BaseHook
 
+def print_var():
+    my_var = Variable.get("<your-variable-key>")
+    print(f'My variable is: {my_var}')
 
-def get_secrets(**kwargs):
-    conn = BaseHook.get_connection(kwargs['my_conn_id'])
-    print(f"Password: {conn.password}, Login: {conn.login}, URI: {conn.get_uri()}, Host: {conn.host}")
+with DAG('example_secrets_dags', start_date=datetime(2022, 1, 1), schedule_interval=None) as dag:
 
-with DAG('example_secrets_dags', start_date=datetime(2020, 1, 1), schedule_interval=None) as dag:
-
-
-    test_task = PythonOperator(
-        task_id='test-task',
-        python_callable=get_secrets,
-        op_kwargs={'my_conn_id': 'smtp_default'},
- )
+  test_task = PythonOperator(
+      task_id='test-task',
+      python_callable=print_var,
+)
 ```
 
 Once you've added this DAG to your project:
 
-1. Run `$ astro dev stop` and `$astro dev start`  to rebuild your image locally
-2. Trigger your new DAG (`example_secrets_dags`) via the Airflow UI at http://localhost:8080/admin/
-3. Click on `test-task` > `View Logs`
-4. Confirm your `smtp_default` connection information is being printed in the task logs.
+1. Run `astro dev stop` followed by `astro dev start` to push your changes to your local Airflow environment.
+2. In the Airflow UI (`http://localhost:8080/admin/`), trigger your new DAG.
+3. Click on `test-task` > **View Logs**.  If you ran the example DAG above, you should should see the contents of your secret in the task logs:
 
-![Airflow Logs for Vault](https://assets2.astronomer.io/main/docs/secrets-backends/logs.png)
+    ```text
+    {logging_mixin.py:109} INFO - My variable is: my-test-variable
+    ```
 
-This works because we set the `connections_path` in our `AIRFLOW__SECRETS__BACKEND_KWARGS` to be `connections`. You are welcome to change this path name if you'd prefer to access Variables from a different Vault directory.
+Once you confirm that the setup was successful, you can delete this example DAG.
 
-> **Note:** If you've written other secrets to your Vault server's `/connections` path, you should be able to test those here as well just by changing the `my_conn_id` value in the DAG code above.
+### Step 5: Deploy on Astronomer Enterprise
 
-### Use Vault Secrets in your DAGs
+Once you've confirmed that the integration with Vault works locally, you can complete a similar set up with a Deployment on Astronomer Enterprise.
 
-Once you've established that your connection is working, you can leverage the `BaseHook.get_connection(kwargs['conn_id'])` method to use your connections in your own DAG code.
+1. In the Astronomer UI, add the same environment variables found in your `Dockerfile` to your Deployment [environment variables](environment-variables.md). Specify `AIRFLOW__SECRETS__BACKEND_KWARGS` as **secret** to ensure that your Vault credentials are stored securely.
 
-You can also pass the `conn_id` of your secret directly to most Airflow operators, which will take care of instantiating the connection using a pre-built hook.
+  :::warning
 
-### Deploy to Astronomer
+  Make sure to strip the quotations (`"`) from your environment variable values. If you add these values with the quotation marks included in your Dockerfile, your configuration will not work on Astronomer Enterprise.
 
-Once you've confirmed that your connections are being imported correctly locally, you're ready to set your Environment Variables on Astronomer.
+  :::
 
-1. Navigate to `Deployment > Configure > Environment Variables` section of the Astronomer UI
-2. Set your `VAULT__ROOT_TOKEN` and `VAULT__URL` as you did above
-3. Click `Deploy Changes` to save and publish your changes
-4. Deploy to Astronomer by running `$ astro deploy`
+2. In your Astronomer project, delete the environment variables from your `Dockerfile`.
+3. [Deploy your changes](deploy-cli.md) to Astronomer Enterprise.
 
-You now should be able to see your connection information being pulled from Vault on Astronomer! If you're interested in pulling Airflow Variables, read below.
+Now, any Airflow variable or connection that you write to your Vault server can be successfully accessed and pulled by any DAG in your Deployment on Astronomer Enterprise.
 
-### Pulling Variables from Vault
+## AWS Systems Manager Parameter Store
 
-While the above section required that you add your connection information as a `conn_uri` to Vault, you can also pull Airflow Variables from Vault. To do so, you'll need to add your variable to vault via the following syntax:
-
-```console
-vault kv put airflow/variables/hello value=world
-```
-
-This works because we set the `variables_path` in our `AIRFLOW__SECRETS__BACKEND_KWARGS` to be `variables`. You are welcome to change this path name if you'd prefer to access variables from a different Vault directory.
-
-Now, if you print `Variables.get('hello')` in Airflow, it will print the value of that variable. In our case, that's `world`.
-
-## AWS SSM Parameter Store
-
-In this section, we'll walk through how to use AWS SSM Parameter Store as a secrets backend for your Airflow Deployment running on Astronomer.
-
-For the purpose of this doc, we'll assume you already have an SSM Parameter Store instance running.
+In this section, we'll walk through how to use [AWS Systems Manager (SSM) Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) as a secrets backend on Astronomer Enterprise.
 
 ### Prerequisites
 
-To use this feature, you'll need the following:
+To use this feature, you need:
 
-- "Admin" access to an Airflow Deployment on Astronomer
-- The [Astro CLI](cli-quickstart.md)
-- A running AWS SSM Parameter Store instance
-- A valid AWS Access Key ID and Secret Access Key
+- A [Deployment](configure-deployment.md).
+- The [Astronomer CLI](cli-quickstart.md).
+- An [Astronomer project](create-project.md).
+- Access to AWS SSM Parameter Store.
+- A valid AWS Access Key ID and Secret Access Key.
 
-### Add Secrets to Parameter Store
+### Step 1: Write an Airflow Variable or Connection to AWS Parameter Store
 
-To start, ensure that you have an Airflow Connection or Variable added to Parameter Store for testing.
+To start, add an Airflow variable or connection as a secret to Parameter Store for testing. For instructions, read AWS documentation on how to do so via the [AWS Systems Manager Console](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-create-console.html), the [AWS CLI](https://docs.aws.amazon.com/systems-manager/latest/userguide/param-create-cli.html), or [Tools for Windows PowerShell](https://docs.aws.amazon.com/systems-manager/latest/userguide/param-create-ps.html).
 
-Those should live at `/airflow/connections` and `/airflow/variables`, respectively. If you're using a secret with a connection id of `smtp_default`, it should exist at `/airflow/connections/smtp_default`, for example.
+Variables and connections should live at `/airflow/variables` and `/airflow/connections`, respectively. For example, if you're setting a secret variable with the key `my_secret`, it should exist at `/airflow/connections/my_secret`.
 
-> **Note:** The connection you add _must_ exist as a string representing an Airflow `connection_uri`. [Here is an example](https://godatadriven.com/blog/highlights-of-the-apache-airflow-1-10-10-release/) to help get you started. You can read up on generating a `connection_uri` [in the Airflow docs here](https://airflow.apache.org/docs/stable/howto/connection/index.html#generating-connection-uri).
+### Step 2: Set Up AWS Parameter Store Locally
 
-### Set your Connection Locally
+To test AWS Parameter Store locally, configure it as a secrets backend in your Astronomer project.
 
-Now that you have a Connection saved, the next step is to configure your `Dockerfile` on Astronomer to use this AWS SSM Parameter Store instance server as the default secrets backend for your local Airflow instance.
+First, install the [Airflow provider for Amazon](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/index.html) by adding the following to your project's `requirements.txt` file:
 
-To do so, follow the steps below.
+```
+apache-airflow-providers-amazon
+```
 
-1. Add the following environment variables to the `.env` file in your project directory to be used in your _local_ Airflow instance:
+Then, add the following environment variables to your project's `Dockerfile`:
 
-        AWS_ACCESS_KEY_ID="YOUR-AWS-KEY"
-        AWS_SECRET_ACCESS_KEY="YOUR-AWS-SECRET-KEY"
+```text
+# Make sure to replace `<your-aws-key>` and `<your-aws-secret-key>` with your own values.
+ENV AWS_ACCESS_KEY_ID="<your-aws-key>"
+ENV AWS_SECRET_ACCESS_KEY="<your-aws-secret-key>"
+ENV AIRFLOW__SECRETS__BACKEND="airflow.contrib.secrets.aws_systems_manager.SystemsManagerParameterStoreBackend"
+ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_prefix": "/airflow/connections", "variables_prefix": "/airflow/variables"}'
+```
 
-   This will keep our connection to the SSM server secure, though make sure to keep your `.env` file in `.gitignore` when you deploy these changes to your project. We'll set these variables separately on Astronomer.
+In the next step, you'll test that this configuration is valid locally.
 
-2. Add the following lines to your `Dockerfile` to instantiate those SSM-specific Environment Variables and use them in the context of Airflow's `AIRFLOW__SECRETS__BACKEND` configuration:
+:::warning
 
-        ENV AWS_ACCESS_KEY_ID $AWS_ACCESS_KEY_ID
-        ENV AWS_SECRET_ACCESS_KEY $AWS_SECRET_ACCESS_KEY
-        ENV AIRFLOW__SECRETS__BACKEND="airflow.contrib.secrets.aws_systems_manager.SystemsManagerParameterStoreBackend"
-        ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_prefix": "/airflow/connections", "variables_prefix": "/airflow/variables"}'
+If you want to deploy your project to a hosted Git repository before deploying to Astronomer, be sure to save `<your-aws-key>` and `<your-aws-secret-key>` in a secure manner. When you deploy to Astronomer, you should set these values as secrets via the Astronomer UI.
 
-This tells Airflow to look for connection information at the `airflow/connections/*` path in your SSM instance.
+:::
 
-If you're interested in further customizing what the interaction between Airflow and your SSM server looks like, learn more by reading [the full list of available kwargs for this integration](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/_api/airflow/providers/amazon/aws/secrets/systems_manager/index.html).
+:::tip
 
-> **Note:** If you'd like to reference an AWS profile instead of connecting via Environment Variables, you can also [add the `profile` param to your kwargs](https://airflow.apache.org/docs/1.10.10/howto/use-alternative-secrets-backend.html).
+If you'd like to reference an AWS profile, you can also add the `profile` param to `ENV AIRFLOW__SECRETS__BACKEND_KWARGS`.
 
-### Test Your Connection
+To further customize the integration between Airflow and AWS SSM Parameter Store, reference Airflow documentation with the [full list of available kwargs](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/_api/airflow/providers/amazon/aws/secrets/systems_manager/index.html).
 
-Test the connection to AWS SSM Parameter Store by calling the `get_conn_uri` method and passing it the `conn_id` of the secret you uploaded to your parameter store. If you followed our example, this would be `smtp_default`.
+:::
 
-### Deploy to Astronomer
+### Step 3: Run an Example DAG to Test AWS Parameter Store Locally
 
-Once you've confirmed that your connections are being imported correctly locally, you're ready to set your Environment Variables on Astronomer.
+To test Parameter Store, write a simple DAG which calls your secret and add this DAG to your Astronomer project's `dags` directory.
 
-1. Navigate to `Deployment > Configure > Environment Variables` section of our UI
-2. Set your `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as you did above in your `Dockerfile`
-3. Click "Deploy Changes" to save and publish your changes
-4. Deploy to Astronomer by running `$ astro deploy`.
+For example, you can use the following DAG to print the value of an Airflow variable to your task logs:
 
-You now should be able to see your connection information being pulled from AWS SSM Parameter Store on Astronomer!
+```py
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+from datetime import datetime
+from airflow.hooks.base_hook import BaseHook
+
+def print_var():
+    my_var = Variable.get("<your-variable-key>")
+    print(f'My variable is: {my_var}')
+
+with DAG('example_secrets_dags', start_date=datetime(2022, 1, 1), schedule_interval=None) as dag:
+
+  test_task = PythonOperator(
+      task_id='test-task',
+      python_callable=print_var,
+)
+```
+
+You can do the same for any Airflow connection.
+
+To test your changes:
+
+1. Run `astro dev stop` followed by `astro dev start` to push your changes to your local Airflow environment.
+2. In the Airflow UI (`http://localhost:8080/admin/`), trigger your new DAG.
+3. Click on `test-task` > **View Logs**. If you ran the example DAG above, you should should see the contents of your secret in the task logs:
+
+    ```text
+    {logging_mixin.py:109} INFO - My variable is: my-test-variable
+    ```
+
+### Step 4: Deploy to Astronomer Enterprise
+
+Once you've confirmed that the integration with AWS SSM Parameter Store works locally, you can complete a similar set up with a Deployment on Astronomer Enterprise.
+
+1. In the Astronomer UI, add the same environment variables found in your `Dockerfile` to your Deployment [environment variables](environment-variables.md). Specify both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as **secret** ensure that your credentials are stored securely.
+
+  :::warning
+
+  Make sure to strip the quotations (`"`) from your environment variable values. If you add these values with the quotation marks included in your Dockerfile, your configuration will not work on Astronomer Enterprise.
+
+  :::
+
+2. In your Astronomer project, delete the environment variables from your `Dockerfile`.
+3. [Deploy your changes](deploy-cli.md) to Astronomer Enterprise.
+
+Now, any Airflow variable or connection that you write to AWS SSM Parameter Store can be automatically pulled by any DAG in your Deployment on Astronomer Enterprise.
 
 ## Google Cloud Secret Manager
 
-This setup assumes that you already have a Google Cloud project with [Secret Manager configured](https://cloud.google.com/secret-manager/docs/configuring-secret-manager). To use Google Cloud Secrets Manager as your secrets backend for an Airflow Deployment on Astronomer:
+This topic provides setup steps for configuring [Google Cloud Secret Manager](https://cloud.google.com/secret-manager/docs/configuring-secret-manager) as a secrets backend on Astronomer Enterprise.
 
-1. [Create a service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts) with the appropriate permissions on Google Cloud.
-2. Add the [Secret Manager Secret Accessor](https://cloud.google.com/secret-manager/docs/access-control) role to the service account.
-3. Create and download a [JSON service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys) for the service account.
-4. In the Astronomer UI, set the following [environment variables](environment-variables.md) in your Airflow Deployment, making sure to paste the entire JSON key file in place of `<your-key-file>`:
+### Prerequisites
 
-    ```sh
-    AIRFLOW__SECRETS__BACKEND=airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend
-    AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_prefix": "airflow-connections", "variables_prefix": "airflow-variables", "gcp_keyfile_dict": <your-key-file>}'
+To use Google Cloud Secret Manager as your Airflow secrets backend, you need:
+
+- A [Deployment](configure-deployment.md).
+- The [Astronomer CLI](cli-quickstart.md).
+- An [Astronomer project](create-project.md).
+- [Cloud SDK](https://cloud.google.com/sdk/gcloud).
+- A Google Cloud environment with [Secret Manager](https://cloud.google.com/secret-manager/docs/configuring-secret-manager) configured.
+- A [service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts) with the [Secret Manager Secret Accessor](https://cloud.google.com/secret-manager/docs/access-control) role on Google Cloud.
+- A [JSON service account key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys) for the service account.
+
+### Step 1: Write an Airflow Variable or Connection to Google Cloud Secret Manager
+
+To start, add an Airflow variable or connection as a secret to Google Cloud Secret Manager. You can do so via the Cloud Console or the gcloud CLI.
+
+Secrets must be formatted such that:
+- Airflow variables are set as `airflow-variables-<variable-key>`.
+- Airflow connections are set as `airflow-connections-<connection-id>`.
+
+For example, to add an Airflow variable with a key `my-secret-variable`, you would run the following gcloud CLI command:
+
+```sh
+gcloud secrets create airflow-variables-<my-secret-variable> \
+    --replication-policy="automatic"
+```
+
+For more information on creating secrets in Google Cloud Secret Manager, read the [Google Cloud documentation](https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets#create).
+
+### Step 2: Set Up Secret Manager Locally
+
+To test Google Secret Manager locally, configure it as a secrets backend in your Astronomer project.
+
+First, install the [Airflow provider for Google](https://airflow.apache.org/docs/apache-airflow-providers-google/stable/index.html) by adding the following to your project's `requirements.txt` file:
+
+```
+apache-airflow-providers-google
+```
+
+Then, add the following environment variables to your project's Dockerfile:
+
+```sh
+ENV AIRFLOW__SECRETS__BACKEND=airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend
+ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_prefix": "airflow-connections", "variables_prefix": "airflow-variables", "gcp_keyfile_dict": <your-key-file>}'
+```
+
+Make sure to paste your entire JSON service account key in place of `<your-key-file>`. In the next step, you'll test that this configuration is valid locally.
+
+:::warning
+
+If you want to deploy your project to a hosted Git repository before deploying to Astronomer, be sure to save `<your-key-file>` securely. We recommend adding it to your project's [`.env` file](develop-project.md#set-environment-variables-via-env-local-development-only) and specifying this file in `.gitignore`. When you deploy to Astronomer, you should set these values as secrets via the Astronomer UI.
+
+:::
+
+### Step 3: Run an Example DAG to Test Secret Manager Locally
+
+To test Secret Manager, [create a secret](https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets#create) containing either an Airflow variable or connection for testing.
+
+Once you create a test secret, write a simple DAG which calls the secret and add this DAG to your project's `dags` directory. For example, you can use the following DAG to print the value of a variable to your task logs:
+
+```py
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+from datetime import datetime
+from airflow.hooks.base_hook import BaseHook
+
+def print_var():
+    my_var = Variable.get("<your-variable-key>")
+    print(f'My variable is: {my_var}')
+
+with DAG('example_secrets_dags', start_date=datetime(2022, 1, 1), schedule_interval=None) as dag:
+
+  test_task = PythonOperator(
+
+      task_id='test-task',
+      python_callable=print_var,
+)
+```
+
+To test your changes:
+
+1. Run `astro dev stop` followed by `astro dev start` to push your changes to your local Airflow environment.
+2. In the Airflow UI (`http://localhost:8080/admin/`), trigger your new DAG.
+3. Click on `test-task` > **View Logs**. If you ran the example DAG above, you should should see the contents of your secret in the task logs:
+
+    ```text
+    {logging_mixin.py:109} INFO - My variable is: my-test-variable
     ```
 
-    We recommend marking the `AIRFLOW__SECRETS__BACKEND_KWARGS` environment variable as "Secret" because it contains sensitive information about Secrets Manager.
+Once you confirm that the setup was successful, you can delete this DAG.
+
+### Step 4: Deploy to Astronomer Enterprise
+
+Once you've confirmed that the integration with Google Cloud Secret Manager works locally, you can complete a similar set up with a Deployment on Astronomer Enterprise.
+
+1. In the Astronomer UI, add the same environment variables found in your `Dockerfile` to your Deployment [environment variables](environment-variables.md). Specify both `AIRFLOW__SECRETS__BACKEND` and `AIRFLOW__SECRETS__BACKEND_KWARGS` as **Secret** to ensure that your credentials are stored securely.
+
+  :::warning
+
+  Make sure to strip the quotations (`"`) from your environment variable values. If you add these values with the quotation marks included in your Dockerfile, your configuration will not work on Astronomer Enterprise.
+
+  :::
+
+2. In your Astronomer project, delete the environment variables from your `Dockerfile`.
+3. [Deploy your changes](deploy-cli.md) to Astronomer Enterprise.
+
+You now should be able to see your secret information being pulled from Secret Manager on Astronomer. From here, you can store any Airflow variables or connections as secrets on Secret Manager and use them in your project.
+
+## Microsoft Azure Key Vault
+
+This topic provides setup steps for configuring [Azure Key Vault](https://cloud.google.com/secret-manager/docs/configuring-secret-manager) as a secrets backend on Astronomer Enterprise.
+
+### Prerequisites
+
+To use Azure Key Vault as a secrets backend, you need:
+
+- A [Deployment](configure-deployment.md).
+- The [Astronomer CLI](cli-quickstart.md).
+- An [Astronomer project](create-project.md).
+- An existing Azure Key Vault linked to a resource group.
+- Your Key Vault URL. To find this, go to your Key Vault overview page > **Vault URI**.
+
+If you do not already have Key Vault configured, read [Microsoft Azure documentation](https://docs.microsoft.com/en-us/azure/key-vault/general/quick-create-portal).
+
+### Step 1: Register Astronomer as an App on Azure
+
+Follow the [Microsoft Azure documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-credentials) to register a new application for Astronomer.
+
+At a minimum, you need to add a [secret](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-credentials) that Astronomer can use to authenticate to Key Vault.
+
+Note the value of the application's client ID and secret for Step 3.
+
+### Step 2: Create an Access Policy
+
+Follow the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-credentials) to create a new access policy for the application that you just registered. The settings you need to configure for your policy are:
+
+- **Configure from template**: Select `Key, Secret, & Certificate Management`.
+- **Select principal**: Select the name of the application that you registered in Step 1.
+
+### Step 3: Set Up Key Vault Locally
+
+In your Astronomer project, add the following line to your `requirements.txt` file:
+
+```text
+apache-airflow-providers-microsoft-azure
+```
+
+In your `Dockerfile`, add the following environment variables with your own values:
+
+```yaml
+ENV AZURE_CLIENT_ID="<your-client-id>" # Found on App page > 'Application (Client) ID'
+ENV AZURE_TENANT_ID="<your-tenant-id>" # Found on Properties > 'Tenant ID'
+ENV AZURE_CLIENT_SECRET="<your-client-secret>" # Found on App Registration Page > Certificates and Secrets > Client Secrets > 'Value'
+ENV AIRFLOW__SECRETS__BACKEND="airflow.providers.microsoft.azure.secrets.azure_key_vault.AzureKeyVaultBackend"
+ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_prefix": "airflow-connections", "variables_prefix": "airflow-variables", "vault_url": "<your-vault-url>"}'
+```
+
+This tells Airflow to look for variable information at the `airflow/variables/*` path in Azure Key Vault and connection information at the `airflow/connections/*` path. In the next step, you'll run an example DAG to test this configuration locally.
+
+:::tip
+By default, this setup requires that you prefix any secret names in Key Vault with `airflow-connections` or `airflow-variables`. If you don't want to use prefixes in your Key Vault secret names, replace the values for `"connections_prefix"` and `"connections_prefix"` with `""`.
+:::
+
+:::warning
+
+If you want to deploy your project to a hosted Git repository before deploying to Astronomer, be sure to save `<your-client-id>`, `<your-tenant-id>`, and `<your-client-secret>`  in a secure manner. When you deploy to Astronomer, you should set these values as secrets via the Astronomer UI.
+
+:::
+
+### Step 4: Test Key Vault Locally
+
+To test your Key Vault setup on Astronomer locally, [create a new secret](https://docs.microsoft.com/en-us/azure/key-vault/secrets/quick-create-portal#add-a-secret-to-key-vault) in Key Vault containing either a variable or a connection.
+
+Once you create a test secret, write a simple DAG which calls the secret and add this DAG to your project's `dags` directory. For example, you can use the following DAG to print the value of a variable to your task logs:
+
+```py
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+from datetime import datetime
+from airflow.hooks.base_hook import BaseHook
+
+def print_var():
+    my_var = Variable.get("<your-variable-key>")
+    print(f'My variable is: {my_var}')
+
+with DAG('example_secrets_dags', start_date=datetime(2022, 1, 1), schedule_interval=None) as dag:
+
+  test_task = PythonOperator(
+      task_id='test-task',
+      python_callable=print_var,
+)
+```
+
+To test your changes:
+
+1. Run `astro dev stop` followed by `astro dev start` to push your changes to your local Airflow environment.
+2. In the Airflow UI (`http://localhost:8080/admin/`), trigger your new DAG.
+3. Click on `test-task` > **View Logs**. If you ran the example DAG above, you should should see the contents of your secret in the task logs:
+
+    ```text
+    {logging_mixin.py:109} INFO - My variable is: my-test-variable
+    ```
+
+Once you confirm that the setup was successful, you can delete this DAG.
+
+### Step 5: Push Changes to Astronomer
+
+Once you've confirmed that your secrets are being imported correctly to your local environment, you're ready to configure the same feature in a Deployment on Astronomer Enterprise.
+
+1. In the Astronomer UI, add the same environment variables found in your `Dockerfile` to your Deployment [environment variables](environment-variables.md). Specify the `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_CLIENT_SECRET` variables as **Secret** to ensure that your credentials are stored securely.
+
+  :::warning
+
+  Make sure to strip the quotations (`"`) from your environment variable values. If you add these values with the quotation marks included in your Dockerfile, your configuration will not work on Astronomer Enterprise.
+
+  :::
+
+2. In your Astronomer project, delete the environment variables from your `Dockerfile`.
+3. [Deploy your changes](deploy-cli.md) to Astronomer Enterprise.
+
+From here, you can store any Airflow variables or connections as secrets on Key Vault and use them in your project.


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/347
Resolves https://github.com/astronomer/docs/issues/345

2-in-1 PR for Secrets Backend-related changes. The only new content is the updated Hashicorp Vault instruction. The only other changes are porting the Cloud content over to Enterprise and reformatting it accordingly. 