### PR TITLE
Enterprise 0.28 release notes and minor doc changes

### DIFF
--- a/enterprise/cli-reference.md
+++ b/enterprise/cli-reference.md
@@ -315,7 +315,7 @@ Generates a list of Airflow Deployments in your current Astronomer Workspace.
 
 ## astro deployment logs
 
-Returns logs from your Airflow Deployment's Scheduler, Webserver, and Celery Workers.
+Returns logs from your Airflow Deployment's Scheduler, Webserver, Triggerer, and Celery Workers.
 
 ### Usage
 
@@ -324,6 +324,7 @@ You can run any of the following commands depending on which logs you want to st
 - `astro deployment logs scheduler [flags]`
 - `astro deployment logs webserver [flags]`
 - `astro deployment logs workers [flags]`
+- `astro deployment logs triggerer [flags]`
 
 ### Flags
 

--- a/enterprise/cli-release-notes.md
+++ b/enterprise/cli-release-notes.md
@@ -7,44 +7,21 @@ description: Release notes for the Astronomer CLI.
 
 ## Overview
 
-This document provides a summary of all changes made to the [Astronomer CLI](cli-quickstart.md). For general product release notes, go to [Astronomer Enterprise Release Notes](release-notes.md).
+This document provides a summary of all changes made to the [Astronomer CLI](cli-quickstart.md) for the v0.28.x series of Astronomer Enterprise. For general product release notes, go to [Astronomer Enterprise Release Notes](release-notes.md).
 
 If you have any questions or a bug to report, don't hesitate to reach out to us via Slack or Intercom. We're here to help.
 
-## 0.27.2
+## 0.28.0
 
-Release date: January 21, 2022
-
-### Improvements to the Local Development Experience
-
-:::danger Breaking Change
-
-The latest version of the Astronomer CLI uses Docker engine `1.13.1` to run Airflow locally via `astro dev`. If you haven't done so already, ensure that your version of Docker Engine is at least `1.13.1` before upgrading the Astronomer CLI to v0.27.2. If your Docker Engine version is `<1.13.1`, then `astro dev` commands will not work on your local machine.
-
-:::
-
-Astronomer CLI v0.27.2 includes several improvements to the local development experience:
-
-- You can now run `astro dev start` with Docker Buildkit enabled. This resolves a [common issue](https://forum.astronomer.io/t/buildkit-not-supported-by-daemon-error-command-docker-build-t-airflow-astro-bcb837-airflow-latest-failed-failed-to-execute-cmd-exit-status-1/857) where users with Docker Buildkit enabled experienced an error that prevented them from running this command.
-- You can now run a Triggerer in a local Airflow environment. This means that you can test DAGs that use [deferrable operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html) locally before pushing them to a Deployment on Astronomer. Triggerer logs appear alongside Webserver and Scheduler logs when you run `astro dev logs`. Note that the Triggerer can run only in environments running Astronomer Certified 2.2.0+.
-- The Docker containers for the Scheduler, Webserver, and Triggerer now have standard names that persist after restarting your environment. You can check the names of these containers in your local Airflow environment by running `astro dev ps`:
-
-    ```sh
-    $ astro dev ps
-
-    Name				State		Ports
-    webserver			running		8080
-    triggerer			running		
-    scheduler			running		
-    0.27.2_a64c1a-postgres-1	running		5432
-    ```
-
-    To change the default names of these containers, run `astro config set <airflow-component>.container_name <new-component-container-name>`.
+Release date: February 15, 2022
 
 ### Additional Improvements
 
-- The Astronomer CLI can now be [installed](cli-quickstart.md) on machines with an [Apple M1 chip](https://www.apple.com/newsroom/2020/11/apple-unleashes-m1/) via both curl and Homebrew.
+- If you run `astro deployment create` when [Deployment validation webhooks](release-notes.md#apply-validation-webhooks-to-deployment-creation) are enabled, then the CLI now prompts you to specify a namespace for your new Deployment.
+- After successfully pushing code to a Deployment via `astro deploy`, the CLI now provides a URL that you can use to directly access that Deployment via the UI.
+- You can now retrieve Triggerer logs using `astro deployment logs triggerer`.
 
 ### Bug Fixes
 
-- Fixed an issue where you could not run an Astronomer project via `astro dev init/ astro dev start` in a directory with certain characters in the directory name
+- Fixed an issue where some objects specified in `airflow_settings.yaml` were not rendered after running `astro dev start`
+- Fixed an issue where environment variables in `docker-compose.override.yml` were unresolved after running `astro dev start`

--- a/enterprise/cli-release-notes.md
+++ b/enterprise/cli-release-notes.md
@@ -17,7 +17,6 @@ Release date: February 15, 2022
 
 ### Additional Improvements
 
-- If you run `astro deployment create` when [Deployment validation webhooks](release-notes.md#apply-validation-webhooks-to-deployment-creation) are enabled, then the CLI now prompts you to specify a namespace for your new Deployment.
 - After successfully pushing code to a Deployment via `astro deploy`, the CLI now provides a URL that you can use to directly access that Deployment via the UI.
 - You can now retrieve Triggerer logs using `astro deployment logs triggerer`.
 

--- a/enterprise/cli-release-notes.md
+++ b/enterprise/cli-release-notes.md
@@ -24,4 +24,4 @@ Release date: February 15, 2022
 ### Bug Fixes
 
 - Fixed an issue where some objects specified in `airflow_settings.yaml` were not rendered after running `astro dev start`
-- Fixed an issue where environment variables in `docker-compose.override.yml` were unresolved after running `astro dev start`
+- Fixed an issue where environment variables in `docker-compose.override.yml` were not correctly applied after running `astro dev start`

--- a/enterprise/deploy-git-sync.md
+++ b/enterprise/deploy-git-sync.md
@@ -55,13 +55,13 @@ Workspace editors can configure a new or existing Airflow Deployment to use a gi
 
     - **Repository URL**: The URL for the Git repository that hosts your Astronomer project
     - **Branch Name**: The name of the Git branch that you want to sync with your Deployment
-    - **Sync Interval**: The time interval between checks for updates in your Git repository, in seconds. A sync is only performed when an update is detected. We recommend a 1 second interval.
-    - **DAGs Directory:** The directory in your Git repository that hosts your DAGs. Specify the directory's path as relative to the repository's root directory. To use your root directory as your DAGs directory, specify this value as `./`. Other changes outside the DAGs directory in your Git repository must be deployed using `astro deploy`.
+    - **Sync Interval**: The time interval between checks for updates in your Git repository, in seconds. A sync is only performed when an update is detected. We recommend a 1 second interval
+    - **DAGs Directory:** The directory in your Git repository that hosts your DAGs. Specify the directory's path as relative to the repository's root directory. To use your root directory as your DAGs directory, specify this value as `./`. Other changes outside the DAGs directory in your Git repository must be deployed using `astro deploy`
     - **Rev**: The commit reference of the branch that you want to sync with your Deployment
     - **Ssh Key**: The SSH private key for your Git repository
     - **Known Hosts**: The known_hosts for your Git provider, formatted as: `<host1>,<ip1> <public_key>`
-    - **Ephemeral Storage Overwrite Gigabytes**: The storage limit for your Git repository. If your Git repo is larger than 2GB, we recommend setting this slider to your repo size + 1 Gi.
-    - **Sync Timeout**: The maximum amount of seconds allowed for a sync. We recommend increasing this value if your repo is larger than 1GB.
+    - **Ephemeral Storage Overwrite Gigabytes**: The storage limit for your Git repository. If your Git repo is larger than 2GB, we recommend setting this slider to your repo size + 1 Gi
+    - **Sync Timeout**: The maximum amount of seconds allowed for a sync. We recommend increasing this value if your repo is larger than 1GB
 
 5. Save your changes.
 

--- a/enterprise/deploy-git-sync.md
+++ b/enterprise/deploy-git-sync.md
@@ -60,6 +60,8 @@ Workspace editors can configure a new or existing Airflow Deployment to use a gi
     - **Rev**: The commit reference of the branch that you want to sync with your Deployment
     - **Ssh Key**: The SSH private key for your Git repository
     - **Known Hosts**: The known_hosts for your Git provider, formatted as: `<host1>,<ip1> <public_key>`
+    - **Ephemeral Storage Overwrite Gigabytes**: The storage limit for your Git repository. If your Git repo is larger than 2GB, we recommend setting this slider to your repo size + 1 Gi.
+    - **Sync Timeout**: The maximum amount of seconds allowed for a sync. We recommend increasing this value if your repo is larger than 1GB.
 
 5. Save your changes.
 

--- a/enterprise/install-azure-standard.md
+++ b/enterprise/install-azure-standard.md
@@ -20,6 +20,13 @@ To install Astronomer on AKS, you'll need access to the following tools and perm
 * Permission to create and modify resources on AKS
 * Permission to generate a certificate (not self-signed) that covers a defined set of subdomains
 
+:::caution
+
+Because of a Kubernetes version incompatibility, Astronomer Enterprise 0.28.x cannot be installed directly on [Microsoft Azure Red Hat OpenShift](https://cloud.redhat.com/products/azure-openshift?intcmp=701f2000000tjyaAAA). Instead, you must [install Enterprise 0.27.x](https://docs.astronomer.io/enterprise/0.27/install-azure) and then [upgrade to 0.28.x](upgrade-astronomer-stable.md).
+
+:::
+
+
 ## Step 1: Choose a Base Domain
 
 All Astronomer services will be tied to a base domain of your choice, under which you will need the ability to add and edit DNS records.

--- a/enterprise/release-notes.md
+++ b/enterprise/release-notes.md
@@ -17,7 +17,7 @@ We're committed to testing all Astronomer Enterprise versions for scale, reliabi
 
 ## v0.28.0
 
-Release date: February 10, 2022
+Release date: February 11, 2022
 
 ### Import Identity Provider User Groups as Teams
 
@@ -58,7 +58,7 @@ For example, a validation webhook can reject Deployment creation for any of the 
 - Removed root user permissions for authSidecar
 - Added AWS RDS certificates to list of trusted certificates
 - Removed support for Kubernetes 1.18
-- Fixed some confusing behavior the Git-Sync **SSH Key** field in the UI  
+- Fixed some confusing behavior with the Git-Sync **SSH Key** field in the UI  
 - Fixed an issue where the Astronomer platform and Airflow could not communicate in environments where inter-namespace communication is disabled
 - Fixed an issue where users would frequently get 502 errors when logging in to the Astronomer UI
 - Fixed an issue where users would get timeout issues when attempting to log in to an Astronomer installation on OpenShift

--- a/enterprise/release-notes.md
+++ b/enterprise/release-notes.md
@@ -48,7 +48,6 @@ For example, a validation webhook can reject Deployment creation for any of the 
 ### Additional Improvements
 
 - Astronomer now supports `prefer` and `require` SSL modes for connecting to PGBouncer. You can set this SSL mode via the `global.ssl.mode` value in your `config.yaml` file. Note that in v0.28.0, this feature works only with AWS and Azure.
-- All metrics dashboards have been upgraded to Grafana 8.
 - You can now set [Grafana environment variables](https://grafana.com/docs/grafana/latest/administration/configuration/#override-configuration-with-environment-variables) using the `grafana.extraEnvVars` setting in your `config.yaml` file.
 - Added a new **Ephemeral Storage Overwrite Gigabytes** slider to the Git Sync configuration screen. You can configure this slider to allocate more memory for syncing larger Git repos.
 - Added a new **Sync Timeout** slider to the Git Sync configuration screen. You can configure this slider to set a maximum allowed length of time for syncing a Git repo.

--- a/enterprise/release-notes.md
+++ b/enterprise/release-notes.md
@@ -17,7 +17,7 @@ We're committed to testing all Astronomer Enterprise versions for scale, reliabi
 
 ## v0.28.0
 
-Release date: February 11, 2022
+Release date: February 15, 2022
 
 ### Import Identity Provider User Groups as Teams
 

--- a/enterprise/release-notes.md
+++ b/enterprise/release-notes.md
@@ -39,7 +39,7 @@ houston:
     preDeploymentValidationHookTimeout: 30000 # 30 sec
 ```
 
-For example, you can a validation webhook can reject Deployment creation for any of the following reasons:
+For example, a validation webhook can reject Deployment creation for any of the following reasons:
 
 - The namespace for the a Deployment is already in use.
 - The namespace for the a Deployment is in an incorrect format.

--- a/enterprise/release-notes.md
+++ b/enterprise/release-notes.md
@@ -61,4 +61,4 @@ For example, a validation webhook can reject Deployment creation for any of the 
 - Fixed some confusing behavior the Git-Sync **SSH Key** field in the UI  
 - Fixed an issue where the Astronomer platform and Airflow could not communicate in environments where inter-namespace communication is disabled
 - Fixed an issue where users would frequently get 502 errors when logging in to the Astronomer UI
-- Fixed an issue users would get timeout issues when attempting to log in to an Astronomer installation on OpenShift
+- Fixed an issue where users would get timeout issues when attempting to log in to an Astronomer installation on OpenShift

--- a/enterprise/release-notes.md
+++ b/enterprise/release-notes.md
@@ -43,7 +43,7 @@ For example, a validation webhook can reject Deployment creation for any of the 
 
 - The namespace for a Deployment is already in use.
 - The namespace for a Deployment is in an incorrect format.
-- The user creating the Deployment is unauthorized to complete this action.
+- The user creating a Deployment is unauthorized to complete this action.
 
 ### Additional Improvements
 

--- a/enterprise/release-notes.md
+++ b/enterprise/release-notes.md
@@ -14,3 +14,51 @@ This document includes all release notes for Astronomer Enterprise v0.28.
 Astronomer v0.28 is the latest Stable version of Astronomer Enterprise, while v0.25 remains the latest long-term support (LTS) version. To upgrade to Astronomer v0.28 from v0.26+, read [Upgrade to a Stable Version](upgrade-astronomer-stable.md). For more information about Enterprise release channels, read [Release and Lifecycle Policies](release-lifecycle-policy.md). To read release notes specifically for the Astronomer CLI, see [Astronomer CLI Release Notes](cli-release-notes.md).
 
 We're committed to testing all Astronomer Enterprise versions for scale, reliability and security on Amazon EKS, Google GKE and Azure AKS. If you have any questions or an issue to report, don't hesitate to [reach out to us](https://support.astronomer.io).
+
+## v0.28.0
+
+Release date: February 10, 2022
+
+### Import Identity Provider User Groups as Teams
+
+You now can import existing identity provider (IDP) groups into Astronomer Enterprise as Teams, which are groups of Astronomer users that have the same set of permissions to a given Workspace or Deployment. Importing existing IDP groups as Teams enables swift onboarding to Astronomer and better control over multiple user permissions.
+
+For more information about configuring this feature, read [Import IDP Groups](import-idp-groups.md). To learn more about adding and setting permissions for Teams via the Astronomer UI, read [User Permissions](workspace-permissions.md#via-teams).
+
+### Apply Validation Webhooks to Deployment Creation
+
+You can now configure Astronomer to apply a custom validation webhook whenever a user attempts to create a new Astronomer Deployment.
+
+This feature can be configured in the following section of your `config.yaml` file:
+
+```yaml
+houston:
+  deployments:
+    namespaceFreeFormEntry: true #true|false
+    preDeploymentValidationHook: http://my-provision-hook.com/prod-us
+    preDeploymentValidationHookTimeout: 30000 # 30 sec
+```
+
+For example, you can a validation webhook can reject Deployment creation for any of the following reasons:
+
+- The namespace for the a Deployment is already in use.
+- The namespace for the a Deployment is in an incorrect format.
+- The user creating the Deployment is unauthorized to complete this action.
+
+### Additional Improvements
+
+- Astronomer now supports `prefer` and `require` SSL modes for connecting to PGBouncer. You can set this SSL mode via the `global.ssl.mode` value in your `config.yaml` file. Note that in v0.28.0, this feature works only with AWS and Azure.
+- All metrics dashboards have been upgraded to Grafana 8.
+- You can now set [Grafana environment variables](https://grafana.com/docs/grafana/latest/administration/configuration/#override-configuration-with-environment-variables) using the `grafana.extraEnvVars` setting in your `config.yaml` file.
+- Added a new **Ephemeral Storage Overwrite Gigabytes** slider to the Git Sync configuration screen. You can configure this slider to allocate more memory for syncing larger Git repos.
+- Added a new **Sync Timeout** slider to the Git Sync configuration screen. You can configure this slider to set a maximum allowed length of time for syncing a Git repo.
+
+### Bug Fixes
+
+- Removed root user permissions for authSidecar
+- Added AWS RDS certificates to list of trusted certificates
+- Removed support for Kubernetes 1.18
+- Fixed some confusing behavior the Git-Sync **SSH Key** field in the UI  
+- Fixed an issue where the Astronomer platform and Airflow could not communicate in environments where inter-namespace communication is disabled
+- Fixed an issue where users would frequently get 502 errors when logging in to the Astronomer UI
+- Fixed an issue users would get timeout issues when attempting to log in to an Astronomer installation on OpenShift

--- a/enterprise/release-notes.md
+++ b/enterprise/release-notes.md
@@ -41,8 +41,8 @@ houston:
 
 For example, a validation webhook can reject Deployment creation for any of the following reasons:
 
-- The namespace for the a Deployment is already in use.
-- The namespace for the a Deployment is in an incorrect format.
+- The namespace for a Deployment is already in use.
+- The namespace for a Deployment is in an incorrect format.
 - The user creating the Deployment is unauthorized to complete this action.
 
 ### Additional Improvements

--- a/enterprise/version-compatibility-reference.md
+++ b/enterprise/version-compatibility-reference.md
@@ -21,7 +21,7 @@ While the tables below reference the minimum compatible versions, we typically r
 | v0.25               | 1.17, 1.18, 1.19, 1.20, 1.21 | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.25.x         | All                  |
 | v0.26               | 1.17, 1.18, 1.19, 1.20, 1.21 | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.26.x         | All                  |
 | v0.27               | 1.18, 1.19, 1.20, 1.21       | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.27.x         | All                  |
-| v0.28               | 1.19, 1.20, 1.21       | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.27.x         | All                  |
+| v0.28               | 1.19, 1.20, 1.21       | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.28.x         | All                  |
 
 For more detail on changes between Enterprise versions, refer to [Astronomer Enterprise Release Notes](release-notes.md).
 

--- a/enterprise/version-compatibility-reference.md
+++ b/enterprise/version-compatibility-reference.md
@@ -21,7 +21,7 @@ While the tables below reference the minimum compatible versions, we typically r
 | v0.25               | 1.17, 1.18, 1.19, 1.20, 1.21 | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.25.x         | All                  |
 | v0.26               | 1.17, 1.18, 1.19, 1.20, 1.21 | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.26.x         | All                  |
 | v0.27               | 1.18, 1.19, 1.20, 1.21       | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.27.x         | All                  |
-| v0.28               | 1.18, 1.19, 1.20, 1.21       | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.27.x         | All                  |
+| v0.28               | 1.19, 1.20, 1.21       | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.27.x         | All                  |
 
 For more detail on changes between Enterprise versions, refer to [Astronomer Enterprise Release Notes](release-notes.md).
 

--- a/enterprise_versioned_docs/version-0.27/cli-release-notes.md
+++ b/enterprise_versioned_docs/version-0.27/cli-release-notes.md
@@ -11,6 +11,14 @@ This document provides a summary of all changes made to the [Astronomer CLI](cli
 
 If you have any questions or a bug to report, don't hesitate to reach out to us via Slack or Intercom. We're here to help.
 
+## 0.27.3
+
+Release date: February 15, 2022
+
+### Bug Fixes
+
+- Fixed an issue where environment variables in `docker-compose.override.yml` were not correctly applied after running `astro dev start`
+
 ## 0.27.2
 
 Release date: January 21, 2022


### PR DESCRIPTION
This PR contains release notes and minor doc updates only. Blocked by https://github.com/astronomer/docs/pull/361

Release notes are based on this thread: https://astronomer.slack.com/archives/C03070QJML4/p1644350706448959

If a change didn't have a clear user impact, I opted not to include it. This includes the CVE fixes and a few of the bug fixes. Most importantly, I'm not documenting BYO Registry capabilities yet. I think we need more time to develop docs and explain how to use this feature - currently, there's not even internal documentation related to its implementation.