### PR TITLE
(#391) Fix dark mdoe for Safari

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -134,7 +134,8 @@
 }
 
 html[data-theme="dark"] {
-  --ifm-font-color-base: var(--white);
+  :root {
+    --ifm-font-color-base: var(--white);
   --ifm-menu-color: var(--white);
   --ifm-heading-color: var(--white);
   --ifm-background-color: var(--gray-900);
@@ -158,6 +159,7 @@ html[data-theme="dark"] {
 
   --ifm-menu-color-background-hover: var(--gray-800);
   --ifm-menu-color-background-active: var(--gray-800);
+  }
 }
 
 h1,


### PR DESCRIPTION
This PR fixes dark mode for Safari by making a (very) minor adjustment to how theme values are loaded.