### PR TITLE
Change Google Analytics to Main Site Tracking

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -188,7 +188,7 @@ module.exports = {
           },
         },
         gtag: {
-          trackingID: 'G-W97HK48NPT',
+          trackingID: 'G-DKTB1B78FV',
           anonymizeIP: true,
         },
         theme: {


### PR DESCRIPTION
Updating Google Analytics to track in the consolidated property, alongside the marketing site and Forum.