### PR TITLE
Fix Algolia search

### DIFF
--- a/src/theme/SearchBar/README.md
+++ b/src/theme/SearchBar/README.md
@@ -1,0 +1,11 @@
+## NOTE on custom SearchBar component
+
+This component was created using [Docusaurus swizzle eject](https://docusaurus.io/docs/swizzling#ejecting).
+
+This overwrites the SearchBar component so that we can use our custom `useAlgoliaContextualFacetFilters.js` search hook, which filters results based on the product being viewed (Astro vs Software).
+
+Previously, overwriting `useAlgoliaContextualFacetFilters` sufficed, but the original hook was moved into a different package so that stopped working.
+
+`swizzle eject` automatically created this entire directory for the SearchBar component, which is a copy of the original package(`theme-search-algolia`) component . The only file changed was `index.js`, where on line 17 we're importing our custom hook instead of the original hook.
+
+The caveat to all of this is that our custom component will prevent future changes from being applied. The original component can be [found here](node_modules/@docusaurus/theme-search-algolia/lib/theme/SearchBar) if we ever need to update our custom component. 

--- a/src/theme/SearchBar/index.d.ts
+++ b/src/theme/SearchBar/index.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+/// <reference types="react" />
+export default function SearchBar(): JSX.Element;

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {useState, useRef, useCallback, useMemo} from 'react';
+import {createPortal} from 'react-dom';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {useHistory} from '@docusaurus/router';
+import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
+import Link from '@docusaurus/Link';
+import Head from '@docusaurus/Head';
+import {isRegexpStringMatch, useSearchPage} from '@docusaurus/theme-common';
+import {DocSearchButton, useDocSearchKeyboardEvents} from '@docsearch/react';
+import useAlgoliaContextualFacetFilters from '../hooks/useAlgoliaContextualFacetFilters.js';
+// OUR CUSTOM HOOK ^^^^^^^^^^^^^^^
+import Translate, {translate} from '@docusaurus/Translate';
+import styles from './styles.module.css';
+let DocSearchModal = null;
+function Hit({hit, children}) {
+  return <Link to={hit.url}>{children}</Link>;
+}
+function ResultsFooter({state, onClose}) {
+  const {generateSearchPageLink} = useSearchPage();
+  return (
+    <Link to={generateSearchPageLink(state.query)} onClick={onClose}>
+      <Translate
+        id="theme.SearchBar.seeAll"
+        values={{count: state.context.nbHits}}>
+        {'See all {count} results'}
+      </Translate>
+    </Link>
+  );
+}
+function mergeFacetFilters(f1, f2) {
+  const normalize = (f) => (typeof f === 'string' ? [f] : f);
+  return [...normalize(f1), ...normalize(f2)];
+}
+function DocSearch({contextualSearch, externalUrlRegex, ...props}) {
+  var _a, _b;
+  const {siteMetadata} = useDocusaurusContext();
+  const contextualSearchFacetFilters = useAlgoliaContextualFacetFilters();
+  const configFacetFilters =
+    (_b =
+      (_a = props.searchParameters) === null || _a === void 0
+        ? void 0
+        : _a.facetFilters) !== null && _b !== void 0
+      ? _b
+      : [];
+  const facetFilters = contextualSearch
+    ? // Merge contextual search filters with config filters
+      mergeFacetFilters(contextualSearchFacetFilters, configFacetFilters)
+    : // ... or use config facetFilters
+      configFacetFilters;
+  // we let user override default searchParameters if he wants to
+  const searchParameters = {
+    ...props.searchParameters,
+    facetFilters,
+  };
+  const {withBaseUrl} = useBaseUrlUtils();
+  const history = useHistory();
+  const searchContainer = useRef(null);
+  const searchButtonRef = useRef(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [initialQuery, setInitialQuery] = useState(undefined);
+  const importDocSearchModalIfNeeded = useCallback(() => {
+    if (DocSearchModal) {
+      return Promise.resolve();
+    }
+    return Promise.all([
+      import('@docsearch/react/modal'),
+      import('@docsearch/react/style'),
+      import('./styles.css'),
+    ]).then(([{DocSearchModal: Modal}]) => {
+      DocSearchModal = Modal;
+    });
+  }, []);
+  const onOpen = useCallback(() => {
+    importDocSearchModalIfNeeded().then(() => {
+      searchContainer.current = document.createElement('div');
+      document.body.insertBefore(
+        searchContainer.current,
+        document.body.firstChild,
+      );
+      setIsOpen(true);
+    });
+  }, [importDocSearchModalIfNeeded, setIsOpen]);
+  const onClose = useCallback(() => {
+    var _a;
+    setIsOpen(false);
+    (_a = searchContainer.current) === null || _a === void 0
+      ? void 0
+      : _a.remove();
+  }, [setIsOpen]);
+  const onInput = useCallback(
+    (event) => {
+      importDocSearchModalIfNeeded().then(() => {
+        setIsOpen(true);
+        setInitialQuery(event.key);
+      });
+    },
+    [importDocSearchModalIfNeeded, setIsOpen, setInitialQuery],
+  );
+  const navigator = useRef({
+    navigate({itemUrl}) {
+      // Algolia results could contain URL's from other domains which cannot
+      // be served through history and should navigate with window.location
+      if (isRegexpStringMatch(externalUrlRegex, itemUrl)) {
+        window.location.href = itemUrl;
+      } else {
+        history.push(itemUrl);
+      }
+    },
+  }).current;
+  const transformItems = useRef((items) =>
+    items.map((item) => {
+      // If Algolia contains a external domain, we should navigate without
+      // relative URL
+      if (isRegexpStringMatch(externalUrlRegex, item.url)) {
+        return item;
+      }
+      // We transform the absolute URL into a relative URL.
+      const url = new URL(item.url);
+      return {
+        ...item,
+        url: withBaseUrl(`${url.pathname}${url.hash}`),
+      };
+    }),
+  ).current;
+  const resultsFooterComponent = useMemo(
+    () =>
+      // eslint-disable-next-line react/no-unstable-nested-components
+      (footerProps) =>
+        <ResultsFooter {...footerProps} onClose={onClose} />,
+    [onClose],
+  );
+  const transformSearchClient = useCallback(
+    (searchClient) => {
+      searchClient.addAlgoliaAgent(
+        'docusaurus',
+        siteMetadata.docusaurusVersion,
+      );
+      return searchClient;
+    },
+    [siteMetadata.docusaurusVersion],
+  );
+  useDocSearchKeyboardEvents({
+    isOpen,
+    onOpen,
+    onClose,
+    onInput,
+    searchButtonRef,
+  });
+  const translatedSearchLabel = translate({
+    id: 'theme.SearchBar.label',
+    message: 'Search',
+    description: 'The ARIA label and placeholder for search button',
+  });
+  return (
+    <>
+      <Head>
+        {/* This hints the browser that the website will load data from Algolia,
+        and allows it to preconnect to the DocSearch cluster. It makes the first
+        query faster, especially on mobile. */}
+        <link
+          rel="preconnect"
+          href={`https://${props.appId}-dsn.algolia.net`}
+          crossOrigin="anonymous"
+        />
+      </Head>
+
+      <div className={styles.searchBox}>
+        <DocSearchButton
+          onTouchStart={importDocSearchModalIfNeeded}
+          onFocus={importDocSearchModalIfNeeded}
+          onMouseOver={importDocSearchModalIfNeeded}
+          onClick={onOpen}
+          ref={searchButtonRef}
+          translations={{
+            buttonText: translatedSearchLabel,
+            buttonAriaLabel: translatedSearchLabel,
+          }}
+        />
+      </div>
+
+      {isOpen &&
+        DocSearchModal &&
+        searchContainer.current &&
+        createPortal(
+          <DocSearchModal
+            onClose={onClose}
+            initialScrollY={window.scrollY}
+            initialQuery={initialQuery}
+            navigator={navigator}
+            transformItems={transformItems}
+            hitComponent={Hit}
+            transformSearchClient={transformSearchClient}
+            {...(props.searchPagePath && {
+              resultsFooterComponent,
+            })}
+            {...props}
+            searchParameters={searchParameters}
+          />,
+          searchContainer.current,
+        )}
+    </>
+  );
+}
+export default function SearchBar() {
+  const {siteConfig} = useDocusaurusContext();
+  return <DocSearch {...siteConfig.themeConfig.algolia} />;
+}

--- a/src/theme/SearchBar/styles.css
+++ b/src/theme/SearchBar/styles.css
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+:root {
+  --docsearch-primary-color: var(--ifm-color-primary);
+  --docsearch-text-color: var(--ifm-font-color-base);
+}
+
+.DocSearch-Button {
+  margin: 0;
+  transition: all var(--ifm-transition-fast)
+    var(--ifm-transition-timing-default);
+}
+
+.DocSearch-Container {
+  z-index: calc(var(--ifm-z-index-fixed) + 1);
+}

--- a/src/theme/SearchBar/styles.module.css
+++ b/src/theme/SearchBar/styles.module.css
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@media (max-width: 996px) {
+  .searchBox {
+    position: absolute;
+    right: var(--ifm-navbar-padding-horizontal);
+  }
+}
+
+@media (min-width: 997px) {
+  .searchBox {
+    padding: var(--ifm-navbar-item-padding-vertical)
+      var(--ifm-navbar-item-padding-horizontal);
+  }
+}

--- a/src/theme/hooks/useAlgoliaContextualFacetFilters.js
+++ b/src/theme/hooks/useAlgoliaContextualFacetFilters.js
@@ -18,7 +18,7 @@ export default function useAlgoliaContextualFacetFilters() {
   // limit search results to current docset
  if (currentPath.includes('software')) {
   tagsFilter = [`docusaurus_tag:${currentSoftwareTag}`]
- } else if (currentPath.includes('cloud')) {
+} else if (currentPath.includes('astro')) {
   tagsFilter = ['docusaurus_tag:docs-default-current']
  }
 


### PR DESCRIPTION
When we rebranded, there were some leftover variables from our custom components which didn't get updated. This should make the appropriate updates to our search so that it once again filters based on a user's current docset.