### PR TITLE
Update REST API link

### DIFF
--- a/astro/airflow-api.md
+++ b/astro/airflow-api.md
@@ -37,7 +37,7 @@ To retrieve your Deployment URL, open your Deployment in the Cloud UI and click 
 
 ## Step 2: Make an Airflow API Request
 
-With the information from Step 1, you can now run `GET` or `POST` requests to any supported endpoints in Airflow's [Rest API Reference](https://airflow.apache.org/docs/stable/rest-api-ref.html). For example, to retrieve a list of all DAGs in a Deployment, you can run:
+With the information from Step 1, you can now run `GET` or `POST` requests to any supported endpoints in Airflow's [Rest API Reference](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html). For example, to retrieve a list of all DAGs in a Deployment, you can run:
 
 ```sh
 curl -X GET <deployment-url>/api/v1/dags -H 'Accept: application/json' -H 'Cache-Control: no-cache' -H "Authorization: Bearer <access-token>"


### PR DESCRIPTION
The URL pointed to in Step 2 is different to the URL pointed to in the Overview. This old URL (https://airflow.apache.org/docs/stable/rest-api-ref.html) actually redirects to the deprecated API doc (https://airflow.apache.org/docs/apache-airflow/stable/deprecated-rest-api-ref.html). This change updates that URL to point to the current API doc.