### PR TITLE
Update Deferrable Operators Doc with new Astronomer Providers Package Info

### DIFF
--- a/astro/deferrable-operators.md
+++ b/astro/deferrable-operators.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: 'Deferrable Operators'
-title: 'Deferrable Operators'
+sidebar_label: "Deferrable Operators"
+title: "Deferrable Operators"
 id: deferrable-operators
 description: Run Airflow's deferrable operators on Astro for improved performance and cost savings.
 ---
@@ -60,4 +60,26 @@ Some additional notes about using deferrable operators:
 
 Astronomer maintains [`astronomer-providers`](https://github.com/astronomer/astronomer-providers), which is an open source collection deferrable operators bundled as a provider package. This package is available by default on Astronomer Runtime and includes deferrable versions of popular operators such as `ExternalTaskSensor`, `DatabricksRunNowOperator`, and `SnowflakeOperator`.
 
-For more information about each available operator in the package, including import statements and example DAGs, see the [`astronomer-providers` documentation](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#100-2022-03-01).
+The following table contains information about each operator that's available in the package, including their import path and an example DAG. For more information about each available operator in the package, see the [`astronomer-providers` documentation](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#100-2022-03-01).
+
+
+| Operator/ Sensor Class     | Import Path                                                                                   | Example DAG                                                                                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RedshiftSQLOperatorAsync` | `from astronomer.providers.amazon.aws.operators.redshift_sql import RedshiftSQLOperatorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py) |
+| `RedshiftPauseClusterOperatorAsync` | `from astronomer.providers.amazon.aws.operators.redshift_cluster import RedshiftPauseClusterOperatorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py) |
+| `RedshiftResumeClusterOperatorAsync` | `from astronomer.providers.amazon.aws.operators.redshift_cluster import RedshiftResumeClusterOperatorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py) |
+| `RedshiftClusterSensorAsync` | `from astronomer.providers.amazon.aws.sensors.redshift_cluster import RedshiftClusterSensorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py) |
+| `S3KeySensorAsync` | `from astronomer.providers.amazon.aws.sensors.s3 import S3KeySensorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/amazon/aws/example_dags/example_s3.py) |
+| `KubernetesPodOperatorAsync` | `from astronomer_operators.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperatorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/amazon/aws/example_dags/example_s3.py) |
+| `ExternalTaskSensorAsync` | `from astronomer_operators.core.sensors.external_task import ExternalTaskSensorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/core/example_dags/example_external_task.py) |
+| `FileSensorAsync` | `from astronomer_operators.core.sensors.filesystem import FileSensorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/core/example_dags/example_file_sensor.py) |
+| `DatabricksRunNowOperatorAsync` | `from astronomer.providers.databricks.operators.databricks import DatabricksRunNowOperatorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/databricks/example_dags/example_databricks.py) |
+| `DatabricksSubmitRunOperatorAsync` | `from astronomer.providers.databricks.operators.databricks import DatabricksSubmitRunOperatorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/databricks/example_dags/example_databricks.py) |
+| `BigQueryCheckOperatorAsync` | `from astronomer.providers.google.cloud.operators.bigquery import BigQueryCheckOperatorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py) |
+| `BigQueryGetDataOperatorAsync` | `from astronomer.providers.google.cloud.operators.bigquery import BigQueryGetDataOperatorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py) |
+| `BigQueryInsertJobOperatorAsync` | `from astronomer.providers.google.cloud.operators.bigquery import  BigQueryInsertJobOperatorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py) |
+| `BigQueryIntervalCheckOperatorAsync` | `from astronomer.providers.google.cloud.operators.bigquery import BigQueryIntervalCheckOperatorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py) |
+| `BigQueryValueCheckOperatorAsync` | `from astronomer.providers.google.cloud.operators.bigquery import BigQueryValueCheckOperatorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py) |
+| `GCSObjectExistenceSensorAsync` | `from astronomer.providers.google.cloud.sensors.gcs import GCSObjectExistenceSensorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/google/cloud/example_dags/example_gcs.py) |
+| `HttpSensorAsync` | `from astronomer.providers.http.sensors.http import HttpSensorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/http/example_dags/example_http.py) |
+| `SnowflakeOperatorAsync` | `from astronomer.providers.snowflake.operators.snowflake import SnowflakeOperatorAsync` | [Example DAG](https://github.com/astronomer/astronomer-providers/blob/1.0.0/astronomer/providers/snowflake/example_dags/example_snowflake.py) |

--- a/astro/deferrable-operators.md
+++ b/astro/deferrable-operators.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: "Deferrable Operators"
-title: "Deferrable Operators"
+sidebar_label: 'Deferrable Operators'
+title: 'Deferrable Operators'
 id: deferrable-operators
 description: Run deferrable operators on Astro for improved performance and cost savings.
 ---

--- a/astro/deferrable-operators.md
+++ b/astro/deferrable-operators.md
@@ -2,7 +2,7 @@
 sidebar_label: "Deferrable Operators"
 title: "Deferrable Operators"
 id: deferrable-operators
-description: Run Airflow's deferrable operators on Astro for improved performance and cost savings.
+description: Run deferrable operators on Astro for improved performance and cost savings.
 ---
 
 ## Overview
@@ -11,9 +11,9 @@ This guide explains how deferrable operators work and how to implement them in y
 
 [Apache Airflow 2.2](https://airflow.apache.org/blog/airflow-2.2.0/) introduced [**deferrable operators**](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), a powerful type of Airflow operator that promises lower resource costs and improved performance.
 
-In Airflow, it's common to use [sensors](https://airflow.apache.org/docs/apache-airflow/stable/concepts/sensors.html) and some [operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/operators.html) to configure tasks that wait for some external condition to be met before executing or triggering another task. While tasks using standard operators and sensors take up a Worker or Scheduler slot when checking if an external condition has been met, deferrable operators suspend themselves during that process. This releases the Worker to take on other tasks. Using the deferrable versions of operators or sensors that typically spend a long time waiting for a condition to be met, such as the `S3Sensor`, the `HTTPSensor`, or the `DatabricksSubmitRunOperator`, can result in significant per-task cost savings and performance improvements.
+In Airflow, it's common to use [sensors](https://airflow.apache.org/docs/apache-airflow/stable/concepts/sensors.html) and some [operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/operators.html) to configure tasks that wait for some external condition to be met before executing or triggering another task. While tasks using standard operators and sensors take up a Worker slot when checking if an external condition has been met, deferrable operators, suspend themselves during that process. This releases the Worker to take on other tasks. Using the deferrable versions of operators or sensors that typically spend a long time waiting for a condition to be met, such as the `S3Sensor`, the `HTTPSensor`, or the `DatabricksSubmitRunOperator`, can result in significant per-task cost savings and performance improvements.
 
-Deferrable operators rely on a new Airflow component called the Triggerer. The Triggerer is highly available and entirely managed on Astro, meaning that you can start using deferrable operators in your DAGs as long as you're running Astro Runtime 4.0+.
+Deferrable operators rely on an Airflow component called the Triggerer. The Triggerer is highly available and entirely managed on Astro, meaning that you can start using deferrable operators in your DAGs as long as you're running Astro Runtime 4.0+.
 
 ### How It Works
 
@@ -34,7 +34,7 @@ For implementation details on deferrable operators, read the [Apache Airflow doc
 
 ## Prerequisites
 
-Deferrable operators are available by default on [Astro Runtime 4.1.1+](runtime-release-notes.md#astro-runtime-400). For more information on upgrading your Deployment's Runtime version, read [Upgrade Runtime](upgrade-runtime.md).
+To use Deferrable operators, you must have an [Astro project](create-project.md) running [Astro Runtime 4.2.0+](runtime-release-notes.md#astro-runtime-411). For more information on upgrading your Deployment's Runtime version, read [Upgrade Runtime](upgrade-runtime.md).
 
 ## Using Deferrable Operators
 
@@ -53,15 +53,14 @@ Some additional notes about using deferrable operators:
 
 - If you want to replace non-deferrable operators in an existing project with deferrable operators, we recommend importing the deferrable operator class as its non-deferrable class name. If you don't include this part of the import statement, you need to replace all instances of non-deferrable operators in your DAGs. In the above example, that would require replacing all instances of `TimeSensor` with `TimeSensorAsync`.
 - Currently, not all operators have a deferrable version. There are a few open source deferrable operators, plus additional operators designed and maintained by Astronomer.
-- If you're interested in the deferrable version of an operator that is not generally available, you can write your own and contribute these to the open source project. If you need help with writing a custom deferrable operator, reach out to Astronomer support.
+- If you're interested in the deferrable version of an operator that is not generally available, you can write your own and contribute these to the open source project. If you need help with writing a custom deferrable operator, reach out to [Astronomer support](https://support.astronomer.io).
 - There are some use cases where it can be more appropriate to use a traditional sensor instead of a deferrable operator. For example, if your task needs to wait only a few seconds for a condition to be met, we recommend using a Sensor in [`reschedule` mode](https://github.com/apache/airflow/blob/1.10.2/airflow/sensors/base_sensor_operator.py#L46-L56) to avoid unnecessary resource overhead.
 
 ## Astronomer's Deferrable Operators
 
-Astronomer maintains [`astronomer-providers`](https://github.com/astronomer/astronomer-providers), which is an open source collection deferrable operators bundled as a provider package. This package is available by default on Astronomer Runtime and includes deferrable versions of popular operators such as `ExternalTaskSensor`, `DatabricksRunNowOperator`, and `SnowflakeOperator`.
+Astronomer maintains [`astronomer-providers`](https://github.com/astronomer/astronomer-providers), which is an open source collection of deferrable operators bundled as a provider package. This package is installed on Astronomer Runtime by default and includes deferrable versions of popular operators such as `ExternalTaskSensor`, `DatabricksRunNowOperator`, and `SnowflakeOperator`.
 
-The following table contains information about each operator that's available in the package, including their import path and an example DAG. For more information about each available operator in the package, see the [`astronomer-providers` documentation](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#100-2022-03-01).
-
+The following table contains information about each operator that's available in the package, including their import path and an example DAG. For more information about each available operator in the package, see the [CHANGELOG in `astronomer-providers`](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#100-2022-03-01).
 
 | Operator/ Sensor Class     | Import Path                                                                                   | Example DAG                                                                                                                                       |
 | -------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/astro/deferrable-operators.md
+++ b/astro/deferrable-operators.md
@@ -9,9 +9,9 @@ description: Run deferrable operators on Astro for improved performance and cost
 
 This guide explains how deferrable operators work and how to implement them in your DAGs.
 
-[Apache Airflow 2.2](https://airflow.apache.org/blog/airflow-2.2.0/) introduced [**deferrable operators**](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), a powerful type of Airflow operator that's optimized for lower resource costs and improved performance.
+[Apache Airflow 2.2](https://airflow.apache.org/blog/airflow-2.2.0/) introduced [**deferrable operators**](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), a powerful type of Airflow operator that's optimized for lower resource costs and improved performance. In Airflow, it's common to use [sensors](https://airflow.apache.org/docs/apache-airflow/stable/concepts/sensors.html) and some [operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/operators.html) to configure tasks that wait for some external condition to be met before executing or triggering another task. While tasks using standard operators and sensors take up a worker slot when checking if an external condition has been met, deferrable operators suspend themselves during that process. This releases the worker to take on other tasks. 
 
-In Airflow, it's common to use [sensors](https://airflow.apache.org/docs/apache-airflow/stable/concepts/sensors.html) and some [operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/operators.html) to configure tasks that wait for some external condition to be met before executing or triggering another task. While tasks using standard operators and sensors take up a worker slot when checking if an external condition has been met, deferrable operators suspend themselves during that process. This releases the worker to take on other tasks. To do so, deferrable operators rely on a new Airflow component called the Triggerer. The Triggerer is highly available and built into all Deployments on Astro, which means that you can use deferrable operators in your DAGs with no additional configuration. To ensure that you can test your DAGs locally, the Triggerer is also built into the Astro CLI local development experience.
+Deferrable operators rely on a new Airflow component called the Triggerer. The Triggerer is highly available and built into all Deployments on Astro, which means that you can use deferrable operators in your DAGs with no additional configuration. To ensure that you can test your DAGs locally, the Triggerer is also built into the Astro CLI local development experience.
 
 Deferrable operators enable two primary benefits:
 
@@ -35,7 +35,7 @@ The process for running a task using a deferrable operator is as follows:
 3. The Triggerer runs the task's Trigger periodically to check whether the condition has been met.
 4. Once the Trigger condition succeeds, the task is again queued by the Scheduler. This time, when the task is picked up by a worker, it begins to complete its main function.
 
-For more information on how deferrable operators work and how to use them, read the [Airflow Guide for Deferrable Operators](https://www.astronomer.io/guides/deferrable-operators) or the [Apache Airflow documentation](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html).
+For more information on how deferrable operators work and how to use them, read our [Airflow Guide for Deferrable Operators](https://www.astronomer.io/guides/deferrable-operators) or the [Apache Airflow documentation](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html).
 
 ## Prerequisites
 

--- a/astro/deferrable-operators.md
+++ b/astro/deferrable-operators.md
@@ -34,7 +34,7 @@ For implementation details on deferrable operators, read the [Apache Airflow doc
 
 ## Prerequisites
 
-To use Deferrable operators, you must have an [Astro project](create-project.md) running [Astro Runtime 4.2.0+](runtime-release-notes.md#astro-runtime-411). For more information on upgrading your Deployment's Runtime version, read [Upgrade Runtime](upgrade-runtime.md).
+To use Deferrable operators, you must have an [Astro project](create-project.md) running [Astro Runtime 4.2.0+](runtime-release-notes.md#astro-runtime-420). For more information on upgrading your Deployment's Runtime version, read [Upgrade Runtime](upgrade-runtime.md).
 
 ## Using Deferrable Operators
 

--- a/astro/deferrable-operators.md
+++ b/astro/deferrable-operators.md
@@ -7,13 +7,13 @@ description: Run Airflow's deferrable operators on Astro for improved performanc
 
 ## Overview
 
-[Apache Airflow 2.2](https://airflow.apache.org/blog/airflow-2.2.0/) introduces [**deferrable operators**](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), a powerful type of Airflow operator that promises lower resource costs and improved performance.
+This guide explains how deferrable operators work and how to implement them in your DAGs.
+
+[Apache Airflow 2.2](https://airflow.apache.org/blog/airflow-2.2.0/) introduced [**deferrable operators**](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), a powerful type of Airflow operator that promises lower resource costs and improved performance.
 
 In Airflow, it's common to use [sensors](https://airflow.apache.org/docs/apache-airflow/stable/concepts/sensors.html) and some [operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/operators.html) to configure tasks that wait for some external condition to be met before executing or triggering another task. While tasks using standard operators and sensors take up a Worker or Scheduler slot when checking if an external condition has been met, deferrable operators suspend themselves during that process. This releases the Worker to take on other tasks. Using the deferrable versions of operators or sensors that typically spend a long time waiting for a condition to be met, such as the `S3Sensor`, the `HTTPSensor`, or the `DatabricksSubmitRunOperator`, can result in significant per-task cost savings and performance improvements.
 
-Deferrable operators rely on a new Airflow component called the Triggerer. The Triggerer is highly available and entirely managed on Astro, meaning that you can start using deferrable operators in your DAGs as long as you're running Astro Runtime 4.0+. As an Astronomer customer, you additionally have exclusive access to several deferrable versions of open source operators.
-
-This guide explains how deferrable operators work and how to implement them in your DAGs.
+Deferrable operators rely on a new Airflow component called the Triggerer. The Triggerer is highly available and entirely managed on Astro, meaning that you can start using deferrable operators in your DAGs as long as you're running Astro Runtime 4.0+.
 
 ### How It Works
 
@@ -34,15 +34,7 @@ For implementation details on deferrable operators, read the [Apache Airflow doc
 
 ## Prerequisites
 
-To use deferrable operators on Astro, you must deploy your code to a Deployment running [Astro Runtime 4.0+](runtime-release-notes.md#astro-runtime-400). For more information on upgrading your Deployment's Runtime version, read [Upgrade Runtime](upgrade-runtime.md).
-
-To use deferrable operators available exclusively on Astro Runtime, you must additionally add the `astronomer-operator-wrappers` package to the `packages.txt` file of your Astro project.
-
-:::info
-
-Support for the Triggerer in local Airflow environments running via the Astro CLI is coming soon. In the meantime, this means that you cannot test deferrable operator functionally locally. If you run a DAG locally that imports a deferrable operator, the DAG falls back to using the non-deferrable version of that operator.
-
-:::
+Deferrable operators are available by default on [Astro Runtime 4.1.1+](runtime-release-notes.md#astro-runtime-400). For more information on upgrading your Deployment's Runtime version, read [Upgrade Runtime](upgrade-runtime.md).
 
 ## Using Deferrable Operators
 
@@ -59,46 +51,13 @@ from airflow.sensors.time_sensor import TimeSensorAsync as TimeSensor
 
 Some additional notes about using deferrable operators:
 
-- For open source operators, we recommend importing the deferrable operator class as its non-deferrable class name. If you don't include this part of the import statement, you need to replace all instances of non-deferrable operators in your DAGs. In the above example, that would require replacing all instances of `TimeSensor` with `TimeSensorAsync`.
+- If you want to replace non-deferrable operators in an existing project with deferrable operators, we recommend importing the deferrable operator class as its non-deferrable class name. If you don't include this part of the import statement, you need to replace all instances of non-deferrable operators in your DAGs. In the above example, that would require replacing all instances of `TimeSensor` with `TimeSensorAsync`.
 - Currently, not all operators have a deferrable version. There are a few open source deferrable operators, plus additional operators designed and maintained by Astronomer.
-- If you're interested in the deferrable version of an operator that is not generally available, you can write your own and contribute these to the open source project. If you need help with writing a custom deferrable operator, reach out to your Astronomer representative.
+- If you're interested in the deferrable version of an operator that is not generally available, you can write your own and contribute these to the open source project. If you need help with writing a custom deferrable operator, reach out to Astronomer support.
 - There are some use cases where it can be more appropriate to use a traditional sensor instead of a deferrable operator. For example, if your task needs to wait only a few seconds for a condition to be met, we recommend using a Sensor in [`reschedule` mode](https://github.com/apache/airflow/blob/1.10.2/airflow/sensors/base_sensor_operator.py#L46-L56) to avoid unnecessary resource overhead.
 
 ## Astronomer's Deferrable Operators
 
-Astronomer maintains a collection of deferrable operators that are available exclusively on Astro Runtime. These operators are drop-in replacements for non-Deferrable operators, meaning that you only have to change the import statements in your DAGs to begin using them.
+Astronomer maintains [`astronomer-providers`](https://github.com/astronomer/astronomer-providers), which is an open source collection deferrable operators bundled as a provider package. This package is available by default on Astronomer Runtime and includes deferrable versions of popular operators such as `ExternalTaskSensor`, `DatabricksRunNowOperator`, and `SnowflakeOperator`.
 
-This section contains information and example import statements for all deferrable operators written by Astronomer.
-
-> **Note:** When you use deferrable operators in the `astronomer-operator-wrappers` package outside of an Astro Runtime environment, the package falls back to using the open source, non-deferrable versions of each operator.
-
-### Databricks operators
-
-Astro Runtime includes the following Databricks operators:
-
-- `DatabricksSubmitRunOperator`
-- `DatabricksRunNowOperator`
-
-Tasks using these operators remain in a deferred state while waiting for their respective Databricks job to complete.
-
-#### Import statement
-
-To run Astronomer's Databricks operators, use the following import statement:
-
-```python
-from astronomer.operators import DatabricksSubmitRunOperator, DatabricksRunNowOperator
-```
-
-### ExternalTaskSensor
-
-This is a drop-in replacement for [Airflow's `ExternalTaskSensor`](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/sensors/external_task/index.html#module-airflow.sensors.external_task). It defers itself while waiting for a given task or DAG to complete.
-
-> **Note:** There is a difference between the deferrable ExternalTaskSensor and the non-deferrable ExternalTaskSensor. If the Sensor is checking a task or DAG that fails, the deferrable Sensor also fails, whereas the non-deferrable Sensor freezes indefinitely.
-
-#### Import statement
-
-To run Astronomer's deferrable version of the ExternalTaskSensor, use the following import statement:
-
-```python
-from astronomer.operators import ExternalTaskSensor
-```
+For more information about each available operator in the package, including import statements and example DAGs, see the [`astronomer-providers` documentation](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#100-2022-03-01).

--- a/astro/disaster-recovery.md
+++ b/astro/disaster-recovery.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: 'Disaster Recovery'
-title: "Disaster Recovery"
+title: 'Disaster Recovery'
 id: disaster-recovery
 description: Learn how Astronomer handles disaster recovery scenarios and how to best prepare your environment.
 ---


### PR DESCRIPTION
We are changing our import statements and Runtime support for deferrable operators in https://github.com/astronomer/astro-runtime/pull/191. This PR includes updates related to that change, as well as updates for docs related to our open sourcing of deferrable operators.

This PR should not merge until the next version of Runtime is released. I'm going to draft release notes in a separate PR