### PR TITLE
Quick Cleanup in Release Notes + CLI Docs

### DIFF
--- a/astro/cli-release-notes.md
+++ b/astro/cli-release-notes.md
@@ -17,11 +17,11 @@ Release date: March 3, 2022
 
 ### New Command to Parse DAGs for Errors
 
-`astrocloud dev parse` is a new Astro CLI command that allows you to run a basic test against your Astro project to ensure that essential aspects of your code are properly formatted. This includes the DAG integrity test that is run with `astro dev pytest`, which checks that your DAGs are written properly enough to render in the Airflow UI.
+`astrocloud dev parse` is a new Astro CLI command that allows you to run a basic test against your Astro project to ensure that essential aspects of your code are properly formatted. This includes the DAG integrity test that is run with `astrocloud dev pytest`, which checks that your DAGs are able to to render in the Airflow UI.
 
-This command was built to replace the need to constantly run `astrocloud dev restart` during troubleshooting to see if your DAGs render in the Airflow UI. Now, you can quickly run `astro dev parse` and see import and syntax errors directly in your terminal without having to restart all Airflow services locally. For more complex testing, we still recommend using `astrocloud dev pytest`, which allows you to run other custom tests in your project.
+This command was built to replace the need to constantly run `astrocloud dev restart` during troubleshooting to see if your DAGs render in the Airflow UI. Now, you can quickly run `astrocloud dev parse` and see import and syntax errors directly in your terminal without having to restart all Airflow services locally. For more complex testing, we still recommend using `astrocloud dev pytest`, which allows you to run other custom tests in your project.
 
-For more information about `astro dev parse`, see the [CLI Command Reference](cli-reference/astrocloud-dev-parse.md). For more guidance on testing DAGs locally, see [Test DAGs Locally](test-and-troubleshoot-locally.md#test-dags-locally).
+For more information about `astrocloud dev parse`, see the [CLI Command Reference](cli-reference/astrocloud-dev-parse.md). For more guidance on testing DAGs locally, see [Test DAGs Locally](test-and-troubleshoot-locally.md#test-dags-locally).
 
 ### `astrocloud deploy` Parses DAGs by Default
 

--- a/astro/cli-release-notes.md
+++ b/astro/cli-release-notes.md
@@ -17,28 +17,29 @@ Release date: March 3, 2022
 
 ### New Command to Parse DAGs for Errors
 
-`astrocloud dev parse` is a new Astro CLI command that allows you to run a basic test against your Astro project to ensure that essential aspects of your code are properly formatted.
+`astrocloud dev parse` is a new Astro CLI command that allows you to run a basic test against your Astro project to ensure that essential aspects of your code are properly formatted. This includes the DAG integrity test that is run with `astro dev pytest`, which checks that your DAGs are written properly enough to render properly in the Airflow UI.
 
-This includes the DAG integrity test that is run with `astro dev pytest` which checks that your DAGs will run on the Airflow Webserver.
+This command is meant to replace the need to run `astrocloud dev restart` consecutively during the DAG authoring or troubleshooting process to see if your DAGs became available in the Airflow UI. Now, you can quickly run `astro dev parse` and see DAG errors directly in your terminal without having to restart all Airflow services locally.
 
-We recommend using `astrocloud dev parse` to quickly test your DAGs for basic errors before running `astrocloud dev start`. For more complex or custom testing, we recommend using `astrocloud dev pytest`.
+For more complex or custom testing, we recommend using `astrocloud dev pytest`. For more information about `astro dev parse`, see the [CLI Command Reference](cli-reference/astrocloud-dev-parse.md). For more guidance on testing DAGs locally, see [Test DAGs Locally](test-and-troubleshoot-locally.md#test-dags-locally).
 
 ### `astrocloud deploy` Parses DAGs by Default
 
-
 To better protect your Deployments from unexpected errors, `astrocloud deploy` now automatically applies tests from `astrocloud dev parse` to your Astro project before completing the deploy process. If any of these tests fail, the CLI will not push your code to Astro.
+
+For more information about `astrocloud deploy`, see [CLI Command Reference](cli-reference/astrocloud-deploy.md).
 
 :::danger Breaking Change
 
-`astrocloud deploy` will no longer push code Deployments running Astro Runtime 4.1.0+ if your DAGs contain basic errors. If any of your Astro projects contain these errors, then certain deploys might stop working after you upgrade the CLI to 1.3.0.
+For Deployments running Astro Runtime 4.1.0+, `astrocloud deploy` will no longer complete the code push to your Deployment if your DAGs contain basic errors. If any files in your Astro project contain these errors, then certain deploys might stop working after you upgrade the Astro CLI to v1.3.0.
 
-To maintain the CLI's original behavior, use `astrocloud deploy --force` to force a deploy even if your Astro project might contain errors.
+To maintain the CLI's original behavior, use `astrocloud deploy --force`. This command forces a deploy even if errors are detected in your DAGs.
 
 :::
 
 ### New Command to Update Deployment Configurations
 
-You can now use `astrocloud deployment update` to update certain configurations for an existing Deployment on Astro directly from the Astro CLI. The configurations that you can update include:
+You can now use `astrocloud deployment update` to update certain configurations for an existing Astro Deployment directly from the Astro CLI. The configurations that you can update are:
 
 - Deployment name
 - Deployment description
@@ -46,7 +47,7 @@ You can now use `astrocloud deployment update` to update certain configurations 
 - Scheduler replicas
 - Worker resources
 
-This is the same set of configurations that you can modify via the **Edit Configuration** view in the Cloud UI. For more information on modifying a Deployment, see [Configure a Deployment](configure-deployment.md). For more information on this command, see [CLI Command Reference](cli-reference.md).
+This is the same set of configurations that you can modify via the **Edit Configuration** view in the Cloud UI. For more information on modifying a Deployment, see [Configure a Deployment](configure-deployment.md). For more information on this command, see [CLI Command Reference](cli-reference/astrocloud-deployment-update.md).
 
 ## v1.2.0
 
@@ -56,10 +57,10 @@ Release date: February 25, 2022
 
 You can now use [Deployment API keys](api-keys.md) to run `astrocloud deploy` either from the CLI directly or via a CI/CD script. This update simplifies deploying code to Astro via CI/CD.
 
-With an existing Deployment API key, you can set `ASTRONOMER_KEY_ID` and `ASTRONOMER_KEY_SECRET` as OS-level environment variables. From there, you can now configure a CI/CD pipeline that does the following:
+With an existing Deployment API key, you can set `ASTRONOMER_KEY_ID` and `ASTRONOMER_KEY_SECRET` as OS-level environment variables. From there, you can now configure a CI/CD pipeline that:
 
-- Installs the Astro CLI
-- Runs `astrocloud deploy`
+- Installs the Astro CLI.
+- Runs `astrocloud deploy`.
 
 When `astrocloud deploy` is run, the CLI will now automatically look for and use the Deployment API key credentials that were set as environment variables to authorize and complete a code push.
 

--- a/astro/cli-release-notes.md
+++ b/astro/cli-release-notes.md
@@ -17,11 +17,11 @@ Release date: March 3, 2022
 
 ### New Command to Parse DAGs for Errors
 
-`astrocloud dev parse` is a new Astro CLI command that allows you to run a basic test against your Astro project to ensure that essential aspects of your code are properly formatted. This includes the DAG integrity test that is run with `astro dev pytest`, which checks that your DAGs are written properly enough to render properly in the Airflow UI.
+`astrocloud dev parse` is a new Astro CLI command that allows you to run a basic test against your Astro project to ensure that essential aspects of your code are properly formatted. This includes the DAG integrity test that is run with `astro dev pytest`, which checks that your DAGs are written properly enough to render in the Airflow UI.
 
-This command is meant to replace the need to run `astrocloud dev restart` consecutively during the DAG authoring or troubleshooting process to see if your DAGs became available in the Airflow UI. Now, you can quickly run `astro dev parse` and see DAG errors directly in your terminal without having to restart all Airflow services locally.
+This command was built to replace the need to constantly run `astrocloud dev restart` during troubleshooting to see if your DAGs render in the Airflow UI. Now, you can quickly run `astro dev parse` and see import and syntax errors directly in your terminal without having to restart all Airflow services locally. For more complex testing, we still recommend using `astrocloud dev pytest`, which allows you to run other custom tests in your project.
 
-For more complex or custom testing, we recommend using `astrocloud dev pytest`. For more information about `astro dev parse`, see the [CLI Command Reference](cli-reference/astrocloud-dev-parse.md). For more guidance on testing DAGs locally, see [Test DAGs Locally](test-and-troubleshoot-locally.md#test-dags-locally).
+For more information about `astro dev parse`, see the [CLI Command Reference](cli-reference/astrocloud-dev-parse.md). For more guidance on testing DAGs locally, see [Test DAGs Locally](test-and-troubleshoot-locally.md#test-dags-locally).
 
 ### `astrocloud deploy` Parses DAGs by Default
 

--- a/astro/create-project.md
+++ b/astro/create-project.md
@@ -54,7 +54,7 @@ To create a new Astro project:
     ├── plugins # For any custom or community Airflow plugins
     |   └── example-plugin.py
     ├── tests # For any DAG unit test files to be run with pytest
-    |   └── test_dag_integrity.py
+    |   └── test_dag_integrity.py # Test that checks for basic errors in your DAGs
     ├── airflow_settings.yaml # For your Airflow Connections, Variables and Pools (local only)
     ├── packages.txt # For OS-level packages
     └── requirements.txt # For Python packages

--- a/astro/create-project.md
+++ b/astro/create-project.md
@@ -47,11 +47,14 @@ To create a new Astro project:
     ```
     .
     ├── dags # Where your DAGs go
-    │   └── example-dag.py # An example DAG that comes with the initialized project
+    │   └── example-dag-basic.py # Example DAG that showcases a simple ETL data pipeline
+    |   └── example-dag-advanced.py # Example DAG that showcases more advanced Airflow features, such as the TaskFlow API
     ├── Dockerfile # For the Astro Runtime Docker image, environment variables, and overrides
     ├── include # For any other files you'd like to include
     ├── plugins # For any custom or community Airflow plugins
+    |   └── example-plugin.py
     ├── tests # For any DAG unit test files to be run with pytest
+    |   └── test_dag_integrity.py
     ├── airflow_settings.yaml # For your Airflow Connections, Variables and Pools (local only)
     ├── packages.txt # For OS-level packages
     └── requirements.txt # For Python packages
@@ -81,7 +84,7 @@ This command builds your project and spins up 3 Docker containers on your machin
 - **Postgres:** Airflow's metadata database
 - **Webserver:** The Airflow component responsible for rendering the Airflow UI
 - **Scheduler:** The Airflow component responsible for monitoring and triggering tasks
-- **Triggerer:** The Airflow component responsible for running Triggers and signaling tasks to resume when their conditions have been met. The Triggerer is used exclusively for tasks that are run with [deferrable operators](deferrable-operators.md).
+- **Triggerer:** The Airflow component responsible for running Triggers and signaling tasks to resume when their conditions have been met. The Triggerer is used exclusively for tasks that are run with [deferrable operators](deferrable-operators.md)
 
 As your project builds locally, you should see the following output:
 
@@ -99,12 +102,14 @@ Step 1/1 : FROM quay.io/astronomer/astro-runtime:${siteVariables.runtimeVersion}
 ---> 5160cfd00623
 Successfully built 5160cfd00623
 Successfully tagged astro-trial_705330/airflow:latest
-INFO[0000] [0/3] [postgres]: Starting
-INFO[0002] [1/3] [postgres]: Started
-INFO[0002] [1/3] [scheduler]: Starting
-INFO[0003] [2/3] [scheduler]: Started
-INFO[0003] [2/3] [webserver]: Starting
-INFO[0004] [3/3] [webserver]: Started
+INFO[0000] [0/4] [postgres]: Starting
+INFO[0002] [1/4] [postgres]: Started
+INFO[0002] [1/4] [scheduler]: Starting
+INFO[0003] [2/4] [scheduler]: Started
+INFO[0003] [2/4] [webserver]: Starting
+INFO[0004] [3/4] [webserver]: Started
+INFO[0003] [3/4] [triggerer]: Starting
+INFO[0004] [4/4] [triggerer]: Started
 Airflow Webserver: http://localhost:8080
 Postgres Database: localhost:5432/postgres
 The default credentials are admin:admin

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -158,6 +158,7 @@ To do this:
     ├── helper_functions
     │   └── helper.py
     ├── include
+    ├── tests
     ├── packages.txt
     ├── plugins
     │   └── example-plugin.py

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -153,12 +153,14 @@ To do this:
     .
     ├── airflow_settings.yaml
     ├── dags
-    │   └── example-dag.py
+    │   └── example-dag-basic.py
+    │   └── example-dag-advanced.py
     ├── Dockerfile
     ├── helper_functions
     │   └── helper.py
     ├── include
     ├── tests
+     │   └── test_dag_integrity.py
     ├── packages.txt
     ├── plugins
     │   └── example-plugin.py

--- a/astro/release-notes.md
+++ b/astro/release-notes.md
@@ -20,20 +20,20 @@ If you have any questions or a bug to report, don't hesitate to reach out to [As
 
 ### Additional Improvements
 
-- The usage threshold for bars in the **Worker CPU** and **Worker Memory** charts to appear red has been reduced from 95% to 90%. This is to make sure that you get an earlier warning if your Workers are close to hitting their resource limits.
+- The threshold in order for bars in the **Worker CPU** and **Worker Memory** charts to appear red has been reduced from 95% to 90%. This is to make sure that you get an earlier warning if your workers are close to hitting their resource limits.
 
 ### Bug Fixes
 
-- Fixed an issue where malformed URLs prevented users from accessing the Airflow UI for Deployments
-- Fixed an issue where Astro Runtime 4.0.11 wasn't a selectable Runtime version in the Cloud UI
+- Fixed an issue where malformed URLs prevented users from accessing the Airflow UI of some Deployments on Astro
+- Fixed an issue where Astro Runtime 4.0.11 wasn't a selectable version in the **Astro Runtime** menu of the Deployment creation view in the Cloud UI
 
 ## February 24, 2022
 
-### Bug fixes
+### Bug Fixes
 
-- Removed the nonfunctional **Teams** tab from the Cloud UI
-- Fixed an issue where a user's Workspace membership count in the Organization view of the UI wasn't updated properly
-- Fixed an issue where updates to secret environment variable values were not applied to Deployments
+- Removed the **Teams** tab from the Cloud UI. This view was not yet functional but coming back soon
+- Fixed an issue where the number of users per Workspace displayed in the Organization view of the Cloud UI was incorrect
+- Fixed an issue where if a secret environment value was updated in the Cloud UI and no other values were modified, the change was not applied to the Deployment
 
 ## February 17, 2022
 
@@ -51,7 +51,7 @@ In addition to visual changes, we've renamed the following high-level Astro comp
 - **Astronomer UI** is now **Cloud UI**
 - **Astronomer Runtime** is now **Astro Runtime**
 
-A formal company announcement is coming soon. We're thrilled.
+We hope you find this exciting. We're thrilled.
 
 ### New Organization Roles for Users
 
@@ -71,7 +71,7 @@ All users can now create a new Workspace directly from the **Overview** tab of t
 
 When you create a new Workspace, you will automatically become a Workspace Admin within it and can create Deployments. For more information about managing Workspaces, see [Manage Workspaces](manage-workspaces.md).
 
-### Bug fixes
+### Bug Fixes
 
 - Fixed an issue where authentication tokens to Astro weren't properly applied when accessing the Airflow UI for a Deployment. This would result in an authenticated user seeing `Error: Cannot find this astro cloud user` in the Airflow UI.
 - Fixed an issue where long environment variable values would spill out of the **Value** column and onto the **Updated** column in the **Environment Variables** view of a Deployment in the Cloud UI.
@@ -270,7 +270,7 @@ For more information on this feature, read [Deployment Metrics](deployment-metri
 
 ## November 5, 2021
 
-### Bug fixes
+### Bug Fixes
 
 - Fixed an issue where a new user could not exit the Cloud UI "Welcome" screen if they hadn't yet been invited to a Workspace
 

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -30,7 +30,7 @@ astrocloud dev parse
 
 This command parses your DAGs to ensure that they don't contain any basic syntax or import errors and that they can successfully render in the Airflow UI.
 
-Generally speaking, `astrocloud dev parse` is a more convenient but less customizable version of `astro dev pytest`. If you don't have any specific test files that you want to run on your DAGs, then we recommend using `astrocloud dev parse` as your primary testing tool. For more information about this command, see the [CLI Command Reference](cli-reference/astrocloud-dev-parse.md).
+Generally speaking, `astrocloud dev parse` is a more convenient but less customizable version of `astrocloud dev pytest`. If you don't have any specific test files that you want to run on your DAGs, then we recommend using `astrocloud dev parse` as your primary testing tool. For more information about this command, see the [CLI Command Reference](cli-reference/astrocloud-dev-parse.md).
 
 ### Run Tests with Pytest
 

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -13,9 +13,47 @@ As you develop data pipelines on Astro, we strongly recommend running and testin
 
 Whenever you want to test your code, the first step is always to start a local Airflow environment. To run your project in a local Airflow environment, follow the steps in [Build and Run a Project](develop-project.md#build-and-run-a-project-locally).
 
+## Test DAGs with the Astro CLI
+
+To enhance the testing experience for data pipelines, Astro enables users to run DAG unit tests with two different Astro CLI commands:
+
+- `astrocloud dev parse`
+- `astrocloud dev pytest`
+
+### Parse DAGs
+
+To quickly parse your DAGs, you can run:
+
+```sh
+astrocloud dev parse
+```
+
+This command parses your DAGs to ensure that they don't contain any basic syntax or import errors and that they can successfully render in the Airflow UI.
+
+Generally speaking, `astrocloud dev parse` is a more convenient but less customizable version of `astro dev pytest`. If you don't have any specific test files that you want to run on your DAGs, then we recommend using `astrocloud dev parse` as your primary testing tool. For more information about this command, see the [CLI Command Reference](cli-reference/astrocloud-dev-parse.md).
+
+### Run Tests with Pytest
+
+To perform unit tests on your Astro project, you can run:
+
+```sh
+astrocloud dev pytest
+```
+
+This command runs all tests in your project's `tests` directory with [pytest](https://docs.pytest.org/en/7.0.x/index.html#), a testing framework for Python. With pytest, you can test custom Python code and operators locally without having to start a local Airflow environment.
+
+By default, the `tests` directory in your Astro project includes a default DAG integrity test called `test_dag_integrity.py`. This test checks that:
+
+- All Airflow tasks have required arguments.
+- DAG IDs are unique across the Astro project.
+- DAGs have no cycles.
+- There are no general import or syntax errors.
+
+`astrocloud dev pytest` runs this default test alongside any other custom tests that you add to the `tests` directory. For more information about this command, see the [CLI Command Reference](cli-reference/astrocloud-dev-pytest.md).
+
 ## View Airflow Task Logs
 
-You can view logs for individual tasks in the Airflow UI. This is useful if you want to troubleshoot why a specific task instance failed or retried.
+You can view logs for individual tasks in the Airflow UI. This is useful if you want to troubleshoot a specific task instance that failed or retried.
 
 To access these logs:
 
@@ -46,7 +84,7 @@ To access these logs:
 
 ## Access Airflow Component Logs
 
-To show logs for your Airflow Scheduler, Webserver, or Metadata DB locally, run the following command:
+To show logs for your Airflow Scheduler, Webserver, or metadata database locally, run the following command:
 
 ```sh
 astrocloud dev logs
@@ -60,7 +98,7 @@ By default, running `astrocloud dev logs` shows logs for all Airflow components.
 - `--webserver`
 - `--postgres`
 
-To continue monitoring logs, run `astrocloud dev logs --follow`. The `--follow` flag ensures that the latest logs continue to appear in your terminal window.
+To continue monitoring logs, run `astrocloud dev logs --follow`. The `--follow` flag ensures that the latest logs continue to appear in your terminal window. For more information about this command, see [CLI Command Reference](cli-reference/astrocloud-dev-logs.md)
 
 ## Run Airflow CLI Commands
 
@@ -72,47 +110,9 @@ astrocloud dev run <airflow-cli-command>
 
 For example, the Apache Airflow command for viewing your entire configuration is `airflow config list`. To run this command with the Astro CLI, you would run `astrocloud dev run config list` instead.
 
-## Run Tests with the Astro CLI
-
-To enhance the testing experience for data pipelines, Astro enables users to run DAG unit tests with two different Astro CLI commands:
-
-- `astrocloud dev parse`
-- `astrocloud dev pytest`
-
-### Parse DAGs
-
-To quickly parse your DAGs, you can run:
-
-```sh
-astrocloud dev parse
-```
-
-This command parses your DAGs to ensure that they don't contain any basic syntax or import errors and that they can successfully render in an Airflow Webserver.
-
-Generally speaking, `astrocloud dev parse` is a more convenient but less customizable version of `astro dev pytest`. If you don't have any specific test files that you want to run on your DAGs, then we recommend using `astrocloud dev parse` as your primary testing tool. For more information about this command, see the [CLI Command Reference](cli-reference/astrocloud-dev-parse.md).
-
-### Run Tests with Pytest
-
-To perform unit tests on your Astro project, you can run:
-
-```sh
-astrocloud dev pytest
-```
-
-This command runs all tests in your project's `tests` directory with [pytest](https://docs.pytest.org/en/7.0.x/index.html#). With pytest, you can test custom Python code and operators locally without having to start a local Airflow environment.
-
-By default, the `tests` directory in your Astro project includes a default DAG integrity test called `test_dag_integrity.py`. This test checks that:
-
-- All Airflow tasks have required arguments.
-- DAG IDs are unique across the Astro project.
-- DAGs have no cycles.
-- There are no general import or syntax errors.
-
-`astrocloud dev pytest` runs this default test alongside any other custom tests that you add to the `tests` directory. For more information about this command, see the [CLI Command Reference](cli-reference/astrocloud-dev-pytest.md).
-
 ## Hard Reset Your Local Environment
 
-In most cases, [restarting your local project](develop-project.md#restart-your-local-environment) is sufficient for testing and making changes to your project. However, it is sometimes necessary to kill your Docker containers and metadata DB for testing purposes. To do so, run the following command:
+In most cases, [restarting your local project](develop-project.md#restart-your-local-environment) is sufficient for testing and making changes to your project. However, it is sometimes necessary to kill your Docker containers and metadata database for testing purposes. To do so, run the following command:
 
 ```sh
 astrocloud dev kill


### PR DESCRIPTION
I just went through some of our release notes and docs changes from last week and made a few tweaks:

- Cleaned up Release Notes
   - Capitalized the f in `Bug Fixes`
   - Added explicit reference to CLI command reference/other docs
   - Fixed reference to Airflow Webserver
- For Test and Troubleshoot Locally doc
   - Modified title of Test DAGs Locally section
   - Brought up the test DAGs section to the top
   - Linked out to CLI command reference
 - Other
    - Cleaned up the tree directory of files in `Create a Project` to show new tests directory and default files
 
@jwitz Lemme know what you think.