### PR TITLE
Astro library documentation

### DIFF
--- a/astro/install-astro-sdk.md
+++ b/astro/install-astro-sdk.md
@@ -24,11 +24,23 @@ To start using the Astro SDK:
     - Run `pip install astro-projects`.
     - Add `astro-projects` to the `requirements.txt` file of an Astro project.
 
-2. Set the following environment variable either in the `.env` of your Astro project or in a Deployment on Astro:  
+2. Set the following environment variable in a way that's accessible to your project:  
 
     ```
     AIRFLOW__CORE__ENABLE_XCOM_PICKLING=True
     ```
+
+### Set a Temporary Schema
+
+When processing SQL-based DAGs, Astro creates temporary tables so that SQL table outputs can be inherited by other tasks and inspected for data quality.
+
+To better manage the cleanup of these tables, Astro stores all of these tables in a temporary schema that a database admin can delete with a single command. By default, the name of the temporary schema is “tmp_astro”.
+
+You can change the name of this schema to match the needs of your Airflow application. To do so, set the following environment variable:
+
+```text
+AIRFLOW__ASTRO__SQL_SCHEMA="<schema-name>"
+```
 
 ## Next Steps
 

--- a/astro/install-astro-sdk.md
+++ b/astro/install-astro-sdk.md
@@ -29,3 +29,7 @@ To begin using the Astro SDK:
     ```
     AIRFLOW__CORE__ENABLE_XCOM_PICKLING=True
     ```
+
+## Next Steps
+
+Once your environment is fully configured to use the Astro library, you can start writing DAGs using the [Python SDK](python-sdk.md).

--- a/astro/install-astro-sdk.md
+++ b/astro/install-astro-sdk.md
@@ -17,7 +17,7 @@ While not an explicit requirement for using the Astro SDK, we recommend download
 
 ## Setup
 
-To begin using the Astro SDK:
+To start using the Astro SDK:
 
 1. Install the library in one of the following ways:
 

--- a/astro/install-astro-sdk.md
+++ b/astro/install-astro-sdk.md
@@ -30,6 +30,12 @@ To start using the Astro SDK:
     AIRFLOW__CORE__ENABLE_XCOM_PICKLING=True
     ```
 
+:::tip
+
+Astro SDK uses XComs behind the scenes to transfer database metadata between tasks. If you intend to use the Astro SDK to work with large dataframes, we recommend implementing a custom XCom backend that can manage your additional data. For more information about this setup, read the [Custom XCom Backends Airflow Guide](https://www.astronomer.io/guides/custom-xcom-backends).
+
+:::
+
 ### Set a Temporary Schema
 
 When processing SQL-based DAGs, Astro creates temporary tables so that SQL table outputs can be inherited by other tasks and inspected for data quality.

--- a/astro/install-astro-sdk.md
+++ b/astro/install-astro-sdk.md
@@ -1,0 +1,31 @@
+---
+sidebar_label: 'Astro SDK'
+title: "Install the Astro SDK"
+id: install-astro-sdk
+description: Learn how to set up your environment to begin using the Astro SDK.
+---
+
+## Overview
+
+This document explains how to set up your environment to begin using the Astro SDK.
+
+The Astro SDK is a suite of tools for writing ETL and ELT workflows in Airflow. By simplifying data transformations between different environments, the library enables you to focus on data engineering instead of configuration. By design, `astro` modules automatically pass database contexts to your tasks, meaning that you can focus on writing code and leave metadata definitions for load time.
+
+## Prerequisites
+
+While not an explicit requirement for using the Astro SDK, we recommend downloading the [Astro CLI](install-cli.md) and [creating an Astro project](create-project.md) for use with this documentation. These tools make it easier to configure your environment and deploy code that utilizes the SDK. The following setup assumes that you are using an Astro project structure.
+
+## Setup
+
+To begin using the Astro SDK:
+
+1. Install the library in one of the following ways:
+
+    - Run `pip install astro-projects`.
+    - Add `astro-projects` to the `requirements.txt` file of an Astro project.
+
+2. Set the following environment variable either in the `.env` of your Astro project or in a Deployment on Astro:  
+
+    ```
+    AIRFLOW__CORE__ENABLE_XCOM_PICKLING=True
+    ```

--- a/astro/python-sdk.md
+++ b/astro/python-sdk.md
@@ -7,7 +7,7 @@ description: Learn how to use the Astro Python SDK.
 
 ## Overview
 
-The Python SDK simplifies ETL pipelines for Python engineers working in Airflow by treating SQL tables as Python objects. Using decorators, SQL tables can be manipulated, joined, templatized, and turned into dataframes using Python.
+The Python SDK simplifies ETL pipelines for Python engineers working in Airflow by treating SQL tables as Python objects. Using decorators, SQL tables can be manipulated, joined, templatized, and turned into DataFrames using Python.
 
 For each step of your pipeline, the SDK automatically passes database context, dependencies, and formatting so that you can focus on writing Python over database configuration.
 
@@ -58,7 +58,7 @@ At a minimum, a `Table` can have the following arguments:
 
 The most important utility of a `Table` is that it can be passed into various `astro` functions as either an `input_table` or an `output_table`. An `output_table` automatically inherits the context of an `input_table`, meaning that you can create downstream data processing tasks using chains of `input_tables` and `output_tables`.
 
-In the following example, a SQL table is imported as a `Table` in the DAG instantiation. This `Table` can then be automatically passed to any `astro` function, including for processing as a dataframe, without any additional configuration.
+In the following example, a SQL table is imported as a `Table` in the DAG instantiation. This `Table` can then be automatically passed to any `astro` function, including for processing as a DataFrame, without any additional configuration.
 
 ```python {10-12}
 from astro import sql as aql
@@ -107,7 +107,7 @@ with dag:
 
 ## Loading Data from Storage
 
-You can import data from a variety of data sources with the `load_file` function. The result of this function can be either a `Table` or a dataframe. For a full list of supported file locations and file types, see the [Astro README](https://github.com/astro-projects/astro#supported-technologies).
+You can import data from a variety of data sources with the `load_file` function. The result of this function can be either a `Table` or a DataFrame. For a full list of supported file locations and file types, see the [Astro README](https://github.com/astro-projects/astro#supported-technologies).
 
 In the following example, data is loaded from S3 by specifying the path and connection ID for an S3 database using `aql.load_file`. The result of this load is stored in a `Table` that can be used as an input table in later transformations:
 
@@ -191,13 +191,13 @@ def drop_table(table_to_drop):
     return "DROP TABLE IF EXISTS {{table_to_drop}}"
 ```
 
-## Working with Dataframes
+## Working with DataFrames
 
-You can use the `astro.dataframe` function to complete data analysis on a pandas dataframe. This function takes a `Table` as an argument and will treat it as a dataframe without any additional configuration, meaning that you can automatically complete data processing in a Pythonic context.
+You can use the `astro.dataframe` function to complete data analysis on a pandas DataFrame. This function takes a `Table` as an argument and will treat it as a DataFrame without any additional configuration, meaning that you can automatically complete data processing in a Pythonic context.
 
-You can also convert a dataframe back into a SQL table by passing this function a `Table` or `TempTable` in the `output_table` argument.
+You can also convert a DataFrame back into a SQL table by passing this function a `Table` or `TempTable` in the `output_table` argument.
 
-In the following example, the `actor` SQL table is automatically passed to `astro.dataframe` as a dataframe. The contents of the dataframe are printed, and then the dataframe is converted back into a SQL table using the `output_table` argument:
+In the following example, the `actor` SQL table is automatically passed to `astro.dataframe` as a DataFrame. The contents of the DataFrame are printed, and then the DataFrame is converted back into a SQL table using the `output_table` argument:
 
 ```python {14-16,22}
 import os

--- a/astro/python-sdk.md
+++ b/astro/python-sdk.md
@@ -55,9 +55,9 @@ Regardless of how you load in your table, all database contexts must first be de
 
 ### The Table class
 
-To instantiate a table or bring in a table from a database into the `astro` ecosystem, you can pass a `Table` object into your DAG. The `Table` object contains all of the metadata that's necessary for handling table creation between Airflow tasks. After you define a `Table's` metadata in the beginning of your pipeline, `astro` can automatically pass that metadata along to downstream tasks.
+To create or import a SQL table in the `astro` ecosystem, you can create a `Table` object. The `Table` object contains all of the metadata that's necessary for handling SQL table creation between Airflow tasks. `astro` can automatically pass metadata from a `Table` to downstream tasks, meaning that you only need to define your database context once at the start of your DAG.
 
-In the following example, your SQL table is defined in the DAG instantiation. In each subsequent task, you only pass in an input table argument because `astro` automatically passes in the additional context from your original `input_table` parameter.
+In the following example, a SQL table is defined in the DAG instantiation. In each subsequent task, you only need to pass in an input table. This is because `astro` automatically passes in the additional context from the original `input_table` parameter.
 
 ```python {10-12}
 from astro import sql as aql
@@ -76,7 +76,7 @@ with dag:
 
 ### The TempTable Class
 
-If you want to ensure that the output of your task is a table that can be deleted at any time for garbage collection, you can declare it as a nameless `TempTable`. This places the output into your `temp` schema, which can be later bulk deleted. By default, all `aql.transform` functions will output to a `TempTable` unless a `Table` object is used in the `output_table` argument.
+If you want to ensure that the output of your task is a table that can be deleted at any time for garbage collection, you can declare it as a nameless `TempTable`. This places the output into your `temp` schema, which can then be bulk deleted. By default, all `aql.transform` functions will output to a `TempTable` unless a `Table` object is used in the `output_table` argument.
 
 The following example DAG sets `output_table` to a nameless `TempTable`, meaning that any output from this DAG will be deleted once the DAG completes. If you wanted to keep your output, you would simply update the parameter to instantiate a `Table` instead.
 
@@ -106,7 +106,7 @@ with dag:
 
 ### Loading Data from Storage as a Table
 
-You can import data from a variety of data sources with the `load_file` function. The result of this function can be used as an input table in your DAG. For a full list of supported file locations and file types, see the [Astro README](https://github.com/astro-projects/astro#supported-technologies).
+You can import data from a variety of data sources with the `load_file` function. The result of this function can be either an `Table` or a dataframe. For a full list of supported file locations and file types, see the [Astro README](https://github.com/astro-projects/astro#supported-technologies).
 
 In the following example, data is loaded from S3 by specifying the path and connection ID for an S3 database using `aql.load_file`. The result of this load is stored in a `Table` that can be used as an input table in later transformations:
 
@@ -190,13 +190,13 @@ def drop_table(table_to_drop):
     return "DROP TABLE IF EXISTS {{table_to_drop}}"
 ```
 
-## Creating Dataframes
+## Working with Dataframes
 
-To create a dataframe, you can pass a SQL table into the `astro.dataframe` function. This function converts SQL tables into dataframes without any additional configuration, meaning that you can automatically finish your data processing in a Pythonic context.
+You can use the `astro.dataframe` function to complete data analysis on a pandas dataframe. This function takes a `Table` as an argument and will treat it as a dataframe without any additional configuration, meaning that you can automatically complete data processing in a Pythonic context.
 
 You can also convert a dataframe back into a SQL table by passing this function a `Table` or `TempTable` in the `output_table` argument.
 
-In the following example, the `actor` SQL table is automatically passed to `astro.dataframe` as a dataframe. The contents of the datafram are printed, and then the dataframe is converted back into a SQL table using the `output_table` argument:
+In the following example, the `actor` SQL table is automatically passed to `astro.dataframe` as a dataframe. The contents of the dataframe are printed, and then the dataframe is converted back into a SQL table using the `output_table` argument:
 
 ```python {14-16,22}
 import os

--- a/astro/python-sdk.md
+++ b/astro/python-sdk.md
@@ -253,7 +253,7 @@ Your project
 │   │   ├── test_inheritance.sql
 ```
 
-In this example, your DAG should run the `test_astro` query first, followed by `test_inheritance`. This time, however, all database context and dependencies will be defined directly in the `sql` query files.
+In this example, the DAG should run the `test_astro` query first, followed by `test_inheritance`. This time, however, all database context and dependencies will be defined directly in the `sql` query files.
 
 To define a database context in a `.sql` file, you can use the `conn_id` and `database` frontmatter options. For example, the following frontmatter defines the database context for `test_astro.sql`:
 

--- a/astro/python-sdk.md
+++ b/astro/python-sdk.md
@@ -46,7 +46,15 @@ To set up the pagila dataset on your local machine:
 
 ## The Table class
 
-To create or import a SQL table in the `astro` ecosystem, you can create a `Table` object. The `Table` object contains all of the metadata that's necessary for handling SQL table creation between Airflow tasks. `astro` can automatically pass metadata from a `Table` to downstream tasks, meaning that you only need to define your database context once at the start of your DAG.
+To create or import a SQL table in the `astro` ecosystem, you can create a `Table`. The `Table` object contains all of the metadata that's necessary for handling SQL table creation between Airflow tasks. `astro` can automatically pass metadata from a `Table` to downstream tasks, meaning that you only need to define your database context once at the start of your DAG.
+
+At a minimum, a `Table` can have the following arguments:
+
+- `conn_id` (_required_): The Airflow connection ID for the database
+- `name`: The name of the table
+- `database`: The database where this table is stored or should be stored
+
+### Input Tables and Output Tables
 
 The most important utility of a `Table` is that it can be passed into various `astro` functions as either an `input_table` or an `output_table`. An `output_table` automatically inherits the context of an `input_table`, meaning that you can create downstream data processing tasks using chains of `input_tables` and `output_tables`.
 
@@ -69,7 +77,7 @@ with dag:
 
 ### The TempTable Class
 
-If you want to ensure that the output of your task is a table that can be deleted at any time for garbage collection, you can declare it as a nameless `TempTable`. This places the output into your `temp` schema, which can then be bulk deleted. By default, all `aql.transform` functions will output to a `TempTable` unless a `Table` object is used in the `output_table` argument.
+If you want to ensure that the output of your task is a table that can be deleted at any time for garbage collection, you can declare it as a nameless `TempTable`. This places the output into your `temp` schema, which can then be bulk deleted. By default, all `aql.transform` functions will output to a `TempTable` unless you define a specific `output_table`.
 
 The following example DAG sets `output_table` to a nameless `TempTable`, meaning that any output from this DAG will be deleted once the DAG completes. If you wanted to keep your output, you would simply update the parameter to instantiate a `Table` instead.
 
@@ -99,7 +107,7 @@ with dag:
 
 ## Loading Data from Storage
 
-You can import data from a variety of data sources with the `load_file` function. The result of this function can be either an `Table` or a dataframe. For a full list of supported file locations and file types, see the [Astro README](https://github.com/astro-projects/astro#supported-technologies).
+You can import data from a variety of data sources with the `load_file` function. The result of this function can be either a `Table` or a dataframe. For a full list of supported file locations and file types, see the [Astro README](https://github.com/astro-projects/astro#supported-technologies).
 
 In the following example, data is loaded from S3 by specifying the path and connection ID for an S3 database using `aql.load_file`. The result of this load is stored in a `Table` that can be used as an input table in later transformations:
 
@@ -129,7 +137,7 @@ To interact with any external storage services, you need to first configure them
 
 ## Transforming Data
 
-After loading tables into your DAG, you can transform them. The `aql.transform` function serves as the "T" of the ETL system. By default, the result of this function is a `TempTable` generated from your `SELECT` statement, but you can also define a specific `output_table` to load the result of your transformation into. Tasks can pass these tables as if they were native Python objects.
+After loading tables into your DAG, you can transform them. The `aql.transform` function serves as the "T" of the ETL system. By default, the result of this function is a `TempTable` generated from your `SELECT` statement, but you can also define a specific `output_table` to load the result of your transformation into.
 
 The following example DAG shows how you can quickly pass tables between tasks when completing a data transformation:
 

--- a/astro/python-sdk.md
+++ b/astro/python-sdk.md
@@ -44,20 +44,13 @@ To set up the pagila dataset on your local machine:
         --conn-port '5433'
     ```
 
-## Creating Input and Output Tables
-
-Before you can complete any data transformations, you need to define input and output tables for Airflow. You can do this in either of the following ways:
-
-- Pass input tables as arguments when you call an `aql.transform` function.
-- Load data from a storage system into a new table.
-
-Regardless of how you load in your table, all database contexts must first be defined as [Airflow connections](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html).
-
-### The Table class
+## The Table class
 
 To create or import a SQL table in the `astro` ecosystem, you can create a `Table` object. The `Table` object contains all of the metadata that's necessary for handling SQL table creation between Airflow tasks. `astro` can automatically pass metadata from a `Table` to downstream tasks, meaning that you only need to define your database context once at the start of your DAG.
 
-In the following example, a SQL table is defined in the DAG instantiation. In each subsequent task, you only need to pass in an input table. This is because `astro` automatically passes in the additional context from the original `input_table` parameter.
+The most important utility of a `Table` is that it can be passed into various `astro` functions as either an `input_table` or an `output_table`. An `output_table` automatically inherits the context of an `input_table`, meaning that you can create downstream data processing tasks using chains of `input_tables` and `output_tables`.
+
+In the following example, a SQL table is imported as a `Table` in the DAG instantiation. This `Table` can then be automatically passed to any `astro` function, including for processing as a dataframe, without any additional configuration.
 
 ```python {10-12}
 from astro import sql as aql
@@ -104,7 +97,7 @@ with dag:
     my_second_sql_transformation(input_table_2=my_table)
 ```
 
-### Loading Data from Storage as a Table
+## Loading Data from Storage
 
 You can import data from a variety of data sources with the `load_file` function. The result of this function can be either an `Table` or a dataframe. For a full list of supported file locations and file types, see the [Astro README](https://github.com/astro-projects/astro#supported-technologies).
 
@@ -136,7 +129,7 @@ To interact with any external storage services, you need to first configure them
 
 ## Transforming Data
 
-After loading tables into your DAG, you can transform them. The `aql.transform` function serves as the "T" of the ETL system. Each use of the function creates a new output table from the `SELECT` statement. Tasks can pass these tables as if they were native Python objects.
+After loading tables into your DAG, you can transform them. The `aql.transform` function serves as the "T" of the ETL system. By default, the result of this function is a `TempTable` generated from your `SELECT` statement, but you can also define a specific `output_table` to load the result of your transformation into. Tasks can pass these tables as if they were native Python objects.
 
 The following example DAG shows how you can quickly pass tables between tasks when completing a data transformation:
 

--- a/astro/python-sdk.md
+++ b/astro/python-sdk.md
@@ -11,6 +11,12 @@ The Python SDK simplifies ETL pipelines for Python engineers working in Airflow 
 
 For each step of your pipeline, the SDK automatically passes database context, dependencies, and formatting so that you can focus on writing Python over database configuration.
 
+:::caution
+
+The Python SDK is still in alpha, meaning that breaking changes are likely in its next few releases. Consider avoiding using the SDK in production-level code until it is more stable.
+
+:::
+
 ## Prerequisites
 
 To use the Python SDK, you must first install the Astro SDK as described in [Setup the Astro SDK](install-astro-sdk).
@@ -77,7 +83,19 @@ with dag:
 
 ### The TempTable Class
 
-If you want to ensure that the output of your task is a table that can be deleted at any time for garbage collection, you can declare it as a nameless `TempTable`. This places the output into your `temp` schema, which can then be bulk deleted. By default, all `aql.transform` functions will output to a `TempTable` unless you define a specific `output_table`.
+If you want to ensure that the output of your task is a table that can be deleted at any time for garbage collection, you can declare it as a nameless `TempTable`. All `TempTables` are stored in your `temp` schema, which can then be bulk-cleaned by a database administrator using the following query:
+
+```SQL
+DROP SCHEMA tmp_astro CASCADE; CREATE SCHEMA tmp_astro;
+```
+
+:::info
+
+Automatic `TempTable` deletion is in active development and coming soon.
+
+:::
+
+By default, all `aql.transform` functions will output to a `TempTable` unless you define a specific `output_table`.
 
 The following example DAG sets `output_table` to a nameless `TempTable`, meaning that any output from this DAG will be deleted once the DAG completes. If you wanted to keep your output, you would simply update the parameter to instantiate a `Table` instead.
 

--- a/astro/python-sdk.md
+++ b/astro/python-sdk.md
@@ -97,7 +97,7 @@ Automatic `TempTable` deletion is in active development and coming soon.
 
 By default, all `aql.transform` functions will output to a `TempTable` unless you define a specific `output_table`.
 
-The following example DAG sets `output_table` to a nameless `TempTable`, meaning that any output from this DAG will be deleted once the DAG completes. If you wanted to keep your output, you would simply update the parameter to instantiate a `Table` instead.
+The following example DAG sets `output_table` to a nameless `TempTable`, meaning that any output from this DAG can be deleted once the DAG completes. If you wanted to keep your output, you would simply update the parameter to instantiate a `Table` instead.
 
 
 ```python {18}

--- a/astro/python-sdk.md
+++ b/astro/python-sdk.md
@@ -59,7 +59,7 @@ To instantiate a table or bring in a table from a database into the `astro` ecos
 
 In the following example, your SQL table is defined in the DAG instantiation. In each subsequent task, you only pass in an input table argument because `astro` automatically passes in the additional context from your original `input_table` parameter.
 
-```python
+```python {10-12}
 from astro import sql as aql
 from astro.sql.table import Table
 
@@ -81,7 +81,7 @@ If you want to ensure that the output of your task is a table that can be delete
 The following example DAG sets `output_table` to a nameless `TempTable`, meaning that any output from this DAG will be deleted once the DAG completes. If you wanted to keep your output, you would simply update the parameter to instantiate a `Table` instead.
 
 
-```python
+```python {18}
 from astro import sql as aql
 from astro.sql.table import Table, TempTable
 
@@ -110,7 +110,7 @@ You can load CSV or parquet data from either local, S3, or GCS storage into a SQ
 
 In the following example, data is loaded from S3 by specifying the path and connection ID for an S3 database using `aql.load_file`. The result of this load is stored in a `Table` that can be used as an input table in later transformations:
 
-```python
+```python {10-14}
 from astro import sql as aql
 from astro.sql.table import Table
 
@@ -199,7 +199,7 @@ To create a dataframe, you can pass a SQL table into the `adf` function. This fu
 
 In the following example, the `actor` SQL table is automatically passed  to `adf` as a dataframe:
 
-```python
+```python {14-16,22}
 import os
 from datetime import datetime, timedelta
 
@@ -265,7 +265,7 @@ In this example, your DAG should run the `test_astro` query first, followed by `
 
 To define a database context in a `.sql` file, you can use the `conn_id` and `database` frontmatter options. For example, the following frontmatter defines the database context for `test_astro.sql`:
 
-```SQL
+```SQL title="/dags/models/test_astro.sql" {1-4}
 ---
 conn_id: postgres_conn
 database: pagila
@@ -277,7 +277,7 @@ This context will be automatically passed to any downstream queries.
 
 To define a downstream query, specify the upstream table in the downstream query's frontmatter as an object in the `template_vars` frontmatter. For example, the following frontmatter would define the input table for `test_inheritance.sql` as the results of `test_astro.sql`:
 
-```sql
+```SQL title="/dags/models/test_inheritance.sql" {1-4}
 ---
 template_vars:
    my_astro_table: test_astro
@@ -287,7 +287,7 @@ SELECT * FROM my_astro_table;
 
 Because all database contexts and dependencies are defined in your `.sql` files, you only need to run `aql.render` once to execute your queries as successive Airflow tasks.
 
-```Python
+```Python title="/dags/astro_dag.py" {15}
 import os
 from datetime import datetime, timedelta
 

--- a/astro/python-sdk.md
+++ b/astro/python-sdk.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: 'SQL SDK'
-title: 'Using the Astro SQL SDK'
+sidebar_label: 'Python SDK'
+title: 'Using the Astro Python SDK'
 id: python-sdk
 description: Learn how to use the Astro Python SDK.
 ---

--- a/astro/python-sdk.md
+++ b/astro/python-sdk.md
@@ -1,0 +1,263 @@
+---
+sidebar_label: 'SQL SDK'
+title: 'Using the Astro SQL SDK'
+id: python-sdk
+description: Learn how to use the Astro Python SDK.
+---
+
+## Overview
+
+The Python SDK simplifies the experience of using SQL for Python engineers working in Airflow. It allows you to treat SQL tables as if they're Python objects. Using decorators, SQL tables can be manipulates, joined, templatized, and turned into dataframes using Python.
+
+## Prerequisites
+
+To use the Python SDK, you must:
+
+- Install the Astro SDK as described in [Setup the Astro SDK](install-astro-sdk).
+
+## Input and Output Tables
+
+Before you can complete any data transformations, you need to define input and output tables for Airflow. You can do this in either of the following ways:
+
+- Using an existing table, define `input_table` and `output_table` with `Table` or `TempTable` objects in the parameters of your DAG instantiations.
+- Load data from storage into a new table.
+
+### The Table class
+
+To instantiate a table or bring in a table from a database into the `astro` ecosystem, you can pass a `Table` object into your DAG. The `Table` object contains all of the metadata that's necessary for handling table creation between tasks. After you define a `Table's` metadata in the beginning of your pipeline, `astro` can automatically pass that metadata along to downstream tasks.
+
+In the following example, your SQL table is defined in the DAG instantiation. In each subsequent task, you only pass in an input table argument because `astro` automatically passes in the additional context from your original `input_table` parameter.
+
+```python
+from astro import sql as aql
+from astro.sql.table import Table
+
+@aql.transform
+def my_first_sql_transformation(input_table: Table):
+    return "SELECT * FROM {{input_table}}"
+
+@aql.transform
+def my_second_sql_transformation(input_table_2: Table):
+    return "SELECT * FROM {{input_table_2}}"
+
+with dag:
+    my_table = my_first_sql_transformation(
+        input_table=Table(table_name="foo", database="bar", conn_id="postgres_conn")
+    )
+    my_second_sql_transformation(my_table)
+```
+
+### The TempTable Class
+
+If you want to ensure that the output of your task is a table that can be deleted at any time for garbage collection, you can declare it as a nameless `TempTable`. This places the output into your `temp` schema, which can be later bulk deleted. By default, all `aql.transform` functions will output to TempTables unless a `Table` object is used in the `output_table` argument.
+
+The following example DAG sets the `output_table` to a nameless `TempTable`, meaning that any output from this DAG will be deleted once the DAG completes. If you wanted to keep your output, you would simply update the parameter to instantiate a `Table` instead.
+
+
+```python
+from astro import sql as aql
+from astro.sql.table import Table, TempTable
+
+@aql.transform
+def my_first_sql_transformation(input_table: Table):
+    return "SELECT * FROM {{input_table}}"
+
+@aql.transform
+def my_second_sql_transformation(input_table_2: Table):
+    return "SELECT * FROM {{input_table_2}}"
+
+with dag:
+    my_table = my_first_sql_transformation(
+        # Table will persist after DAG finishes
+        input_table=Table(table_name="foo", database="bar", conn_id="postgres_conn"),
+        # TempTable will not persist after DAG finishes
+        output_table=TempTable(database="bar", conn_id="postgres_conn"),
+    )
+    my_second_sql_transformation(my_table)
+```
+
+### Loading Data from Storage as a Table
+
+You can load CSV or parquet data from either local, S3, or GCS storage into a SQL database with the `load_file` function. The result of this function can be used as an input table in your DAG.
+
+In the following example, data is loaded from S3 by specifying the path and connection ID for an S3 database using `aql.load_file`. The result of this load is stored in a `Table` that can be used as an input table in later transformations:
+
+```python
+from astro import sql as aql
+from astro.sql.table import Table
+
+with dag:
+
+    raw_orders = aql.load_file(
+        path="s3://my/s3/path.csv",
+        file_conn_id="my_s3_conn",
+        output_table=Table(table_name="my_table", conn_id="postgres_conn"),
+    )
+```
+
+:::info
+
+To interact with S3, you must first set an S3 Airflow connection in the `AIRFLOW__ASTRO__CONN_AWS_DEFAULT` environment variable.
+
+:::
+
+## Transform
+
+The `transform` function of the SQL decorator serves as the "T" of the ELT system. Each step of the transform pipeline creates a new table from the `SELECT` statement. Tasks can pass these tables as if they were native Python objects.
+
+The following example DAG shows how you can quickly pass tables between tasks when completing a data transformation:
+
+```python
+#
+@aql.transform
+def get_orders():
+    ...
+
+@aql.transform
+def get_customers():
+    ...
+
+@aql.transform
+def join_orders_and_customers(orders_table: Table, customer_table: Table):
+    """Join `orders_table` and `customers_table` to create a simple 'feature' dataset."""
+    return """SELECT c.customer_id, c.source, c.region, c.member_since,
+        CASE WHEN purchase_count IS NULL THEN 0 ELSE 1 END AS recent_purchase
+        FROM {orders_table} c LEFT OUTER JOIN {customer_table} p ON c.customer_id = p.customer_id"""
+
+with dag:
+    orders = get_orders()
+    customers = get_customers()
+    join_orders_and_customers(orders, customers)
+```
+
+Note that the functions in this example use a templating system that's specific to the Python SDK. Wrapping a value in single brackets (like `{customer_table}`) indicates the value needs to be rendered as a SQL table. The SQL decorator also treats values in double brackets as Airflow jinja templates.
+
+Please note that the SQL expression should not be an F-string. F-strings in SQL formatting risk security breaches via SQL injections.
+
+For security, users must explicitly identify tables in the function parameters by typing a value as a `Table`. Only then can the SQL decorator treat the value as a table.
+
+### Transform File
+
+Instead of defining your SQL queries in your DAG code, you can use the `transform_file` function to pass an external SQL file to your DAG.
+
+```python
+with self.dag:
+    f = aql.transform_file(
+        sql=str(cwd) + "/my_sql_function.sql",
+        conn_id="postgres_conn",
+        database="pagila",
+        parameters={
+            "actor": Table("actor"),
+            "film_actor_join": Table("film_actor"),
+            "unsafe_parameter": "G%%",
+        },
+        output_table=Table("my_table_from_file"),
+    )
+```
+
+### Raw SQL
+
+Most ETL use cases can be addressed by cross-sharing task outputs, as shown with the example of `@aql.transform`.
+
+If you need to perform a SQL operation that doesn't return a table but might require a table as an argument, you can use `@aql.run_raw_sql`.
+
+```python
+@aql.run_raw_sql
+def drop_table(table_to_drop):
+    return "DROP TABLE IF EXISTS {{table_to_drop}}"
+```
+
+## Complete Example DAG
+
+The following is a full example DAG of a SQL + Python workflow using `astro`. It pulls data from S3, runs SQL transformations to merge the pulled data with existing data, and moves the result of that merge into a dataframe so that you can complete complex work on it using Python / ML.
+
+This DAG also showcases the different ways you can set contexts using the Astro library. For example, `get_customers` has its database context set in the SQL decorator, while `aggregate_orders` has its context set in the DAG instantiation. Both of these syntaxes are valid and can coexist with the help of the Astro library.
+
+```python
+from datetime import datetime, timedelta
+
+from airflow.models import DAG
+from pandas import DataFrame
+
+from astro import sql as aql
+from astro import dataframe as df
+
+from astro.sql.table import Table
+
+default_args = {
+    "owner": "airflow",
+    "retries": 1,
+    "retry_delay": 0,
+}
+
+dag = DAG(
+    dag_id="astro_example_dag",
+    start_date=datetime(2019, 1, 1),
+    max_active_runs=3,
+    schedule_interval=timedelta(minutes=30),
+    default_args=default_args,
+)
+
+@aql.transform
+def aggregate_orders(orders_table: Table):
+    """Basic clean-up of an existing table."""
+    return """SELECT customer_id, count(*) AS purchase_count FROM {orders_table}
+        WHERE purchase_date >= DATEADD(day, -7, '{{ execution_date }}')"""
+
+@aql.transform(conn_id="postgres_conn", database="pagila")
+def get_customers(customer_table: Table = Table("customer")):
+    """Basic clean-up of an existing table."""
+    return """SELECT customer_id, source, region, member_since
+        FROM {[customer_table}} WHERE NOT is_deleted"""
+
+@aql.transform
+def join_orders_and_customers(orders_table: Table, customer_table: Table):
+    """Join two tables together to create a very simple 'feature' dataset."""
+    return """SELECT c.customer_id, c.source, c.region, c.member_since,
+        CASE WHEN purchase_count IS NULL THEN 0 ELSE 1 END AS recent_purchase
+        FROM {{orders_table}} c LEFT OUTER JOIN {{customer_table}} p ON c.customer_id = p.customer_id"""
+
+@df
+def perform_dataframe_transformation(df: DataFrame):
+    """Train model with Python. You can import any python library you like and treat this as you would a normal
+    dataframe.
+    """
+    recent_purchases_dataframe = df.loc[:, "recent_purchase"]
+    return recent_purchases_dataframe
+
+@df
+def dataframe_action_to_sql(df: DataFrame):
+    """
+    This function gives us an example of a dataframe function that we intend to put back into SQL. The only thing we need to keep in mind for a SQL return function is that the result has to be a dataframe. Any non-dataframe return will result in an error, as there's no way for us to know how to upload the object to SQL.
+    """  
+    return df
+
+SOURCE_TABLE = "source_finance_table"
+
+s3_path = (
+    f"s3://astronomer-galaxy-stage-dev/thanos/{SOURCE_TABLE}/"
+    "{{ execution_date.year }}/"
+    "{{ execution_date.month }}/"
+    "{{ execution_date.day}}/"
+    f"{SOURCE_TABLE}_"
+    "{{ ts_nodash }}.csv"
+)
+
+with dag:
+    """Structure DAG dependencies.
+    """
+
+    raw_orders = aql.load_file(
+        path="s3://my/s3/path.csv",
+        file_conn_id="my_s3_conn",
+        output_table=Table(table_name="foo", conn_id="postgres_conn"),
+    )
+    agg_orders = aggregate_orders(raw_orders)
+    customers = get_customers()
+    features = join_orders_and_customers(customers, agg_orders)
+    simple_df = perform_dataframe_transformation(df=features)
+    # By defining the output_table in the invocation, we are telling astro where to put the result dataframe
+    dataframe_action_to_sql(
+        simple_df, output_table=Table(table_name="result", conn_id="postgres_conn")
+    )
+```

--- a/astro/python-sdk.md
+++ b/astro/python-sdk.md
@@ -48,7 +48,7 @@ To set up the pagila dataset on your local machine:
 
 Before you can complete any data transformations, you need to define input and output tables for Airflow. You can do this in either of the following ways:
 
-- Define input and output tables as arguments when you call an `aql.transform` function.
+- Pass input tables as arguments when you call an `aql.transform` function.
 - Load data from a storage system into a new table.
 
 Regardless of how you load in your table, all database contexts must first be defined as [Airflow connections](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html).
@@ -98,7 +98,7 @@ with dag:
     my_table = my_first_sql_transformation(
         # Table will persist after DAG finishes
         input_table=Table(table_name="actor", database="pagila", conn_id="postgres_conn"),
-        # TempTable will not persist after DAG finishes
+        # TempTable will not persist after DBA cleans temp schema
         output_table=TempTable(database="pagila", conn_id="postgres_conn"),
     )
     my_second_sql_transformation(input_table_2=my_table)
@@ -106,7 +106,7 @@ with dag:
 
 ### Loading Data from Storage as a Table
 
-You can a variety of data sources from either local, S3, or GCS storage into a SQL database with the `load_file` function. The result of this function can be used as an input table in your DAG. For a full list of supported file locations and file types, see the [Astro README](https://github.com/astro-projects/astro#supported-technologies).
+You can import data from a variety of data sources with the `load_file` function. The result of this function can be used as an input table in your DAG. For a full list of supported file locations and file types, see the [Astro README](https://github.com/astro-projects/astro#supported-technologies).
 
 In the following example, data is loaded from S3 by specifying the path and connection ID for an S3 database using `aql.load_file`. The result of this load is stored in a `Table` that can be used as an input table in later transformations:
 
@@ -130,13 +130,13 @@ with dag:
 
 :::info
 
-To interact with S3, you must first set an S3 Airflow connection in the `AIRFLOW__ASTRO__CONN_AWS_DEFAULT` environment variable.
+To interact with any external storage services, you need to first configure them as Airflow connections. For example, to interact with S3, you must first set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables in your project.
 
 :::
 
 ## Transforming Data
 
-After loading tables into your DAG, you can transform them. The `aql.transform` function serves as the "T" of the ETL system. Each step of the transform pipeline creates a new table from the `SELECT` statement. Tasks can pass these tables as if they were native Python objects.
+After loading tables into your DAG, you can transform them. The `aql.transform` function serves as the "T" of the ETL system. Each use of the function creates a new output table from the `SELECT` statement. Tasks can pass these tables as if they were native Python objects.
 
 The following example DAG shows how you can quickly pass tables between tasks when completing a data transformation:
 

--- a/astro/python-sdk.md
+++ b/astro/python-sdk.md
@@ -106,7 +106,7 @@ with dag:
 
 ### Loading Data from Storage as a Table
 
-You can load CSV or parquet data from either local, S3, or GCS storage into a SQL database with the `load_file` function. The result of this function can be used as an input table in your DAG.
+You can a variety of data sources from either local, S3, or GCS storage into a SQL database with the `load_file` function. The result of this function can be used as an input table in your DAG. For a full list of supported file locations and file types, see the [Astro README](https://github.com/astro-projects/astro#supported-technologies).
 
 In the following example, data is loaded from S3 by specifying the path and connection ID for an S3 database using `aql.load_file`. The result of this load is stored in a `Table` that can be used as an input table in later transformations:
 
@@ -195,9 +195,9 @@ def drop_table(table_to_drop):
 
 ## Creating Dataframes
 
-To create a dataframe, you can pass a SQL table into the `adf` function. This function converts SQL tables into dataframes without any additional configuration, meaning that you can automatically finish your data processing in a Pythonic context.
+To create a dataframe, you can pass a SQL table into the `aql.dataframe` function. This function converts SQL tables into dataframes without any additional configuration, meaning that you can automatically finish your data processing in a Pythonic context.
 
-In the following example, the `actor` SQL table is automatically passed  to `adf` as a dataframe:
+In the following example, the `actor` SQL table is automatically passed  to `aql.dataframe` as a dataframe:
 
 ```python {14-16,22}
 import os
@@ -206,14 +206,14 @@ from datetime import datetime, timedelta
 from airflow.models import DAG
 
 from astro import sql as aql
-from astro.dataframe import dataframe as adf
+from astro.dataframe import dataframe
 import pandas as pd
 
 dag = DAG(
    ...
 )
 
-@adf
+@aql.dataframe
 def my_dataframe_func(df: pd.DataFrame):
    print(df.to_string)
 

--- a/astro/python-sdk.md
+++ b/astro/python-sdk.md
@@ -174,8 +174,8 @@ with dag:
 
 The functions in this example use a templating system that's specific to the Python SDK:
 
-- Wrapping a value in single brackets (like `{customer_table}`) indicates the value needs to be rendered as a SQL table.
-- Wrapping a value in double brackets (like `{{ execution_date }}`) indicates that the value needs to be rendered as an Airflow jinja templates.
+- Wrapping a value in single brackets (like `{customer_table}`) indicates the value will be rendered as a SQL table.
+- Wrapping a value in double brackets (like `{{ execution_date }}`) indicates that the value will be rendered as an Airflow jinja template.
 
 Please note that the SQL expression should not be an F-string. F-strings in SQL formatting risk security breaches via SQL injections.
 

--- a/sidebarsAstro.js
+++ b/sidebarsAstro.js
@@ -33,6 +33,14 @@ module.exports = {
         'airflow-alerts',
         'kubernetespodoperator',
         'deferrable-operators',
+        {
+          type: 'category',
+          label: 'Astro SDK',
+          items: [
+            'install-astro-sdk',
+            'python-sdk',
+          ],
+        },
         'test-and-troubleshoot-locally',
       ],
     },


### PR DESCRIPTION
As a minimum viable docset, I’m planning to host two docs on Astro:

- **Install Astro SDK**: A doc explaining how to set up your project to run Astro, basically the first two pages of this doc: https://docs.google.com/document/d/1bZuwyG6oG95d_obdPd70whCFZzXLZH15EB57tHqcHRo/edit#. This will be slightly repetitive to the README
- **Python SDK**: A doc explaining how to use the key components of the Python SDK, much of this content will be taken from the old README. SQL SDK doc will follow

These docs will live under the Develop tab on [docs.astronomer.io](http://docs.astronomer.io/)

This is still WIP pending on some product naming decisions. Please ignore specific names of items for now - let's focus on nailing the technical reference and making the code examples as useful as we can