### PR TITLE
add instructions for mandatory openshift ingress controller settings

### DIFF
--- a/software/third-party-ingress-controllers.md
+++ b/software/third-party-ingress-controllers.md
@@ -180,12 +180,12 @@ This is typically done by labeling the namespace containing your ingress control
 kubectl label namespace/<ingress namespace> network.openshift.io/policy-group=ingress
 ```
 
-See [Openshift's Network Policy documentation](https://docs.openshift.com/container-platform/4.1/networking/configuring-networkpolicy.html) for more details.
+For more information, see the [Openshift Network Policy documentation](https://docs.openshift.com/container-platform/4.1/networking/configuring-networkpolicy.html).
 
-OpenShift's default route admission policy must be configured to allow traffic from multiple namespaces.
+Additionally, OpenShift's default route admission policy must be configured to allow traffic from multiple namespaces. To do so, run the following command:
 
 ```sh
 kubectl -n openshift-ingress-operator patch ingresscontroller/default --patch '{"spec":{"routeAdmission":{"namespaceOwnership":"InterNamespaceAllowed"}}}' --type=merge
 ```
 
-See [Openshift's Ingress Operator documentation](https://docs.openshift.com/container-platform/4.9/networking/ingress-operator.html) for more details and security-implications for multi-tenant clusters.
+For more information about security implications for multi-tenant clusters, see the [Openshift Ingress Operator documentation](https://docs.openshift.com/container-platform/4.9/networking/ingress-operator.html).

--- a/software/third-party-ingress-controllers.md
+++ b/software/third-party-ingress-controllers.md
@@ -182,7 +182,7 @@ kubectl label namespace/<ingress namespace> network.openshift.io/policy-group=in
 
 For more information, see the [OpenShift documentation](https://docs.openshift.com/container-platform/4.1/networking/configuring-networkpolicy.html) on configuring network policy.
 
-Additionally, OpenShift's default route admission policy must be configured to allow traffic from multiple namespaces. To do so, run the following command:
+To allow traffic from multiple namespaces, you must also configure OpenShift's default route admission policy. To do so, run the following command:
 
 ```sh
 kubectl -n openshift-ingress-operator patch ingresscontroller/default --patch '{"spec":{"routeAdmission":{"namespaceOwnership":"InterNamespaceAllowed"}}}' --type=merge

--- a/software/third-party-ingress-controllers.md
+++ b/software/third-party-ingress-controllers.md
@@ -181,3 +181,11 @@ kubectl label namespace/<ingress namespace> network.openshift.io/policy-group=in
 ```
 
 See [Openshift's Network Policy documentation](https://docs.openshift.com/container-platform/4.1/networking/configuring-networkpolicy.html) for more details.
+
+OpenShift's default route admission policy must be configured to allow traffic from multiple namespaces.
+
+```sh
+kubectl -n openshift-ingress-operator patch ingresscontroller/default --patch '{"spec":{"routeAdmission":{"namespaceOwnership":"InterNamespaceAllowed"}}}' --type=merge
+```
+
+See [Openshift's Ingress Operator documentation](https://docs.openshift.com/container-platform/4.9/networking/ingress-operator.html) for more details and security-implications for multi-tenant clusters.

--- a/software/third-party-ingress-controllers.md
+++ b/software/third-party-ingress-controllers.md
@@ -180,7 +180,7 @@ This is typically done by labeling the namespace containing your ingress control
 kubectl label namespace/<ingress namespace> network.openshift.io/policy-group=ingress
 ```
 
-For more information, see the [Openshift Network Policy documentation](https://docs.openshift.com/container-platform/4.1/networking/configuring-networkpolicy.html).
+For more information, see the [OpenShift documentation](https://docs.openshift.com/container-platform/4.1/networking/configuring-networkpolicy.html) on configuring network policy.
 
 Additionally, OpenShift's default route admission policy must be configured to allow traffic from multiple namespaces. To do so, run the following command:
 


### PR DESCRIPTION
OpenShift's default route admission policy must be configured to allow traffic from multiple namespaces - it's not required for customers using our built-in ingress controller but for customers choosing to use the built-in openshift ingress controller is a strict requirement.