### PR TITLE
remove postgres flag

### DIFF
--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -96,7 +96,7 @@ By default, running `astrocloud dev logs` shows logs for all Airflow components.
 
 - `--scheduler`
 - `--webserver`
-- `--postgres`
+- `--triggerer`
 
 To continue monitoring logs, run `astrocloud dev logs --follow`. The `--follow` flag ensures that the latest logs continue to appear in your terminal window. For more information about this command, see [CLI Command Reference](cli-reference/astrocloud-dev-logs.md)
 


### PR DESCRIPTION
The postgres flag is depreciated for now and the triggerer flag is new. Only updated this doc because the astrocloud reference guide appears to up to date