### PR TITLE
change `branch` to `branches`

### DIFF
--- a/software/ci-cd.md
+++ b/software/ci-cd.md
@@ -191,7 +191,7 @@ The following setup is an example implementation of CI/CD using GitHub Actions. 
     name: CI
     on:
       push:
-        branch: [dev, main]
+        branches: [dev, main]
     jobs:
       dev-push:
         runs-on: ubuntu-latest


### PR DESCRIPTION
github gives an error if branch is not plural