### PR TITLE
Only mention Helm major required version

### DIFF
--- a/software/install-aws-standard.md
+++ b/software/install-aws-standard.md
@@ -15,7 +15,7 @@ To install Astronomer on EKS, you'll need access to the following tools and perm
 * A compatible version of Kubernetes as described in Astronomer's [Version Compatibility Reference](version-compatibility-reference.md)
 * The [Kubernetes CLI (kubectl)](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 * The [OpenSSL CLI](https://www.openssl.org/docs/man1.0.2/man1/openssl.html)
-* [Helm v3.2.1](https://github.com/helm/helm/releases/tag/v3.2.1)
+* [Helm v3](https://helm.sh/docs/intro/install)
 * An SMTP Service & Credentials (e.g. Mailgun, Sendgrid, etc.)
 * Permission to create and modify resources on AWS
 * Permission to generate a certificate (not self-signed) that covers a defined set of subdomains

--- a/software/install-azure-standard.md
+++ b/software/install-azure-standard.md
@@ -15,7 +15,7 @@ To install Astronomer on AKS, you'll need access to the following tools and perm
 * [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
 * [Kubernetes CLI (kubectl)](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 * A compatible version of Kubernetes as described in Astronomer's [Version Compatibility Reference](version-compatibility-reference.md)
-* [Helm v3.2.1](https://github.com/helm/helm/releases/tag/v3.2.1)
+* [Helm v3](https://helm.sh/docs/intro/install)
 * SMTP Service & Credentials (e.g. Mailgun, Sendgrid, etc.)
 * Permission to create and modify resources on AKS
 * Permission to generate a certificate (not self-signed) that covers a defined set of subdomains

--- a/software/install-gcp-standard.md
+++ b/software/install-gcp-standard.md
@@ -15,7 +15,7 @@ To install Astronomer on GCP, you'll need access to the following tools and perm
 * [Google Cloud SDK](https://cloud.google.com/sdk/install)
 * A compatible version of Kubernetes as described in Astronomer's [Version Compatibility Reference](version-compatibility-reference.md)
 * [Kubernetes CLI (kubectl)](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-* [Helm v3.2.1](https://github.com/helm/helm/releases/tag/v3.2.1)
+* [Helm v3](https://helm.sh/docs/intro/install)
 * An SMTP Service & Credentials (e.g. Mailgun, Sendgrid, etc.)
 * Permission to create and modify resources on Google Cloud Platform
 * Permission to generate a certificate (not self-signed) that covers a defined set of subdomains


### PR DESCRIPTION
Currently, the Software install docs require Helm v3.2.1, but this is an old version. Any Helm 3 version will do, so I suggest only mentioning the major version.