### PR TITLE
Add Content Security Policy headers

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,7 @@
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  Access-Control-Allow-Origin: *
+  Referrer-Policy: no-referrer-when-downgrade
+  Permissions-Policy: geolocation=()
+  Content-Security-Policy: default-src https: blob: data: wss: 'self' 'unsafe-inline' 'unsafe-eval'; upgrade-insecure-requests; frame-ancestors 'self'; base-uri 'self';


### PR DESCRIPTION
This PR adds Content Security Policy and related headers to improve site security, primarily to prevent XSS attacks.
https://securityheaders.com/?q=https%3A%2F%2Fdocs.astronomer.io%2F&followRedirects=on