### PR TITLE
New doc: "Migrate to Astro"

### DIFF
--- a/astro/migrate-to-astro.md
+++ b/astro/migrate-to-astro.md
@@ -1,0 +1,51 @@
+---
+sidebar_label: 'Migrate to Astro'
+title: "Migrate DAGs to Astro"
+id: migrate-to-astro
+---
+
+## Overview
+
+This guide explains how to migrate existing DAGs to Astro.
+
+To provide a differentiated experience of Airflow, Astro projects use specific formatting and versions for DAGs and dependencies. Whether you are migrating DAGs from open source Airflow, Astornomer Software, or another commercial offering, you can follow this guide to start running your DAGs either locally or on Astro.
+
+## Step 1: Upgrade to Airflow 2.0/2.1.1
+
+If you have already upgraded all DAGs to Airflow 2.0+, you can skip this step.
+
+Astro Runtime, which is Astro's Airflow runtime environment, only supports Airflow 2.1.1+. To run any existing DAGs on Airflow 1.10.15 or less, you must first upgrade to Airflow 2.0 and then upgrade to a subsequent minor release. Follow the instructions in this step to manage the 2.0 ugprade process with limited disruption to your existing project.
+
+### a. Upgrade to Airflow 1.10.15
+
+[Airflow 1.10.14](https://github.com/apache/airflow/releases/tag/1.10.14) was built to make the migration and testing process as easy as possible. [Airflow 1.10.15](https://github.com/apache/airflow/releases/tag/1.10.15) was subsequently released with additional bug fixes and improvements. We recommend upgrading your existing Airflow environment to at least 1.10.15 before upgrading to Airflow 2.0+.
+
+### b. Run the Upgrade Check Script
+
+Apache Airflow released an [Upgrade Check Script](https://airflow.apache.org/docs/apache-airflow/2.1.3/upgrade-check.html) that scans your project and detects instances of code that need to be updated for Airflow 2.0. Run this script in your existing Airflow environment to determine the scope of the changes you need to complete for your upgrade.
+
+> **Note:** In the upgrade check output above, you can ignore the `Fernet is enabled by default` and `Check versions of PostgreSQL, MySQL, and SQLite to ease upgrade to Airflow 2.0` tests. All of these details are handled by Astro. You can also ignore the and `Users must set a kubernetes.pod_template_file value` test even if you are running the Kubernetes Executor.
+
+The following topics explain some of the changes that you might need to complete for this upgrade.
+
+#### Import Operators from Backport Providers
+
+All Airflow 2.0 Operators and Extras are backwards compatible with both Airflow 1.10.14 and Airflow 1.10.15. To transition to using these providers, refer to [1.10.15 Backport Providers](https://airflow.apache.org/docs/apache-airflow/1.10.15/backport-providers.html) in Apache Airflow documentation or reference the collection of [Backport Providers in PyPi](https://pypi.org/search/?q=apache-airflow-backport-providers&o=).
+
+#### Modify Airflow DAGs
+
+Depending on how your DAGs are written, you'll likely need to modify your code to be 2.0-compatible. This could include:
+
+- Changes to undefined variable handling in templates
+- Changes to the KubernetesPodOperator
+- Changes to the default value for `dag_run_conf_overrides_params`
+
+For more information, refer to [Step 5: Upgrade Airflow DAGs](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/upgrading-to-2.html#step-5-upgrade-airflow-dags) in Apache Airflow documentation.
+
+## Step 2: Install the Astro CLI
+
+The Astro CLI is the primary tool for managing, running, and deploying DAGs on Astro. The rest of this migration guide makes extensive use of the CLI. To install it, follow the steps in [Install the Astro CLI](install-cli.md).
+
+## Step 3: Create an Astro Project
+
+Astro uses a specific project structure that can be bundled into a Docker image and pushed to an Astro Deployment.

--- a/astro/migrate-to-astro.md
+++ b/astro/migrate-to-astro.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: 'Migrate to Astro'
+sidebar_label: 'Migrate DAGs to Astro'
 title: "Migrate DAGs to Astro"
 id: migrate-to-astro
 ---
@@ -12,9 +12,9 @@ To provide a differentiated experience of Airflow, Astro projects use specific f
 
 ## Step 1: Upgrade to Airflow 2.1.1
 
-If you have already upgraded all of your DAGs to Airflow 2.1.1+, you can skip this step.
+If all of your existing DAGs are on Airflow 2.1.1+, you can skip this step.
 
-Astro Runtime, which is Astro's Airflow runtime environment, only supports Airflow 2.1.1+. To run any existing DAGs on Airflow 1.10.15 or less, you must first upgrade to at least Airflow 2.1 and then upgrade to a subsequent minor release. For a full guide on upgrading from Airflow 1.10.x to 2.0+, see the [Apache Airflow documentation](https://airflow.apache.org/docs/apache-airflow/stable/upgrading-from-1-10/index.html).
+Astro Runtime, which is Astro's Airflow runtime environment, only supports Airflow 2.1.1+. To migrate any existing DAGs on Airflow 1.10.15 or less, you must first complete the major upgrade to Airflow 2.11. For a full guide on upgrading from Airflow 1.10.x to 2.0+, see the [Apache Airflow documentation](https://airflow.apache.org/docs/apache-airflow/stable/upgrading-from-1-10/index.html).
 
 :::info
 
@@ -33,8 +33,6 @@ Airflow 2.0+ was built to be fast, reliable, and scalable. Most notably, Airflow
 - Simplified KubernetesExecutor for flexibility in configuration.
 - [UI/UX Improvements](https://github.com/apache/airflow/pull/11195) including a new Airflow UI and auto-refresh button in the **Graph** view.
 
-Airflow 2.1.0 was a follow-up release to Airflow 2.0. If you're not running on Airflow 2.0+ yet, we recommend upgrading from Airflow 1.10.15 to Airflow 2.1 directly. For more information on the release, refer to the [Apache Airflow Changelog](https://airflow.apache.org/docs/apache-airflow/2.1.0/changelog.html) and the [Astronomer Certified Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.1.0/CHANGELOG.md).
-
 ## Step 2: Install the Astro CLI
 
 The Astro CLI is the primary tool for managing, running, and deploying DAGs on Astro. To install it, follow the steps in [Install the Astro CLI](install-cli.md).
@@ -52,9 +50,19 @@ Astro uses a specific project structure that can be bundled into a Docker image 
     - Custom or community Airflow plugins: move to `plugins`
     - Any other project files: move to `include`
 
+:::info Migrating to Astro Runtime
+
+Astro projects run Airflow using a Docker image built and published by Astronomer called Astro Runtime. Runtime extends the Apache Airflow project to provide a differentiated Airflow experience and includes additional bug fixes and features which are not available in the open source project.
+
+When you create a new Astro project, the latest version of Runtime is automatically included in your project's `Dockerfile`. If you upgraded to the minimum required version of Airflow for your version of Runtime, then you can run existing project code on Runtime without any additional changes.
+
+When you run your new Astro project, you might notice differences in the Airflow UI compared to your non-Astro projects. For a full list of changes which are unique to Runtime, see [Runtime Release Notes](runtime-release-notes.md).
+
+:::
+
 ## Step 4: Test Your New Project Locally
 
-Because migrating to Astro can result in changes to your project code, especially if you upgraded from Airflow 1.10.x, we recommend testing your new project in a local Airflow environment using the Astro CLI. For more information about how to test and troubleshoot using the Astro CLI, see [Test and Troubleshoot Locally](test-and-troubleshoot-locally.md).
+Because migrating to Astro can result in changes to your project code, especially if you upgraded from Airflow 1.10.x, we recommend testing your new project in a local Airflow environment using the Astro CLI. For more information about how to test your project using the Astro CLI, see [Test and Troubleshoot Locally](test-and-troubleshoot-locally.md).
 
 :::tip
 
@@ -66,9 +74,9 @@ To test your code in as close to a production environment as possible, you can c
 
 Once you confirm that your project works as expected in a local environment, you can push your project to a Deployment on Astro. For more information, see [Deploy Code](deploy-code.md).
 
-## Step 5: Create Deployment-Level Configurations
+## Step 5: Migrate Production-Level Configurations
 
-Depending on the function and context of your existing project, you might need to configure additional Astro settings to fully migrate your project to a production Astro Deployment. Read the following docs to learn more about how to configure your project on Astro:
+Depending on the function and context of your existing project, you might need to configure additional Astro settings to fully migrate your project to a production-level Astro Deployment. Read the following docs to learn more about how to configure your project on Astro:
 
 - [Environment Variables](environment-variables.md)
 - [Configure a Secrets Backend](secrets-backend.md)

--- a/astro/migrate-to-astro.md
+++ b/astro/migrate-to-astro.md
@@ -10,42 +10,67 @@ This guide explains how to migrate existing DAGs to Astro.
 
 To provide a differentiated experience of Airflow, Astro projects use specific formatting and versions for DAGs and dependencies. Whether you are migrating DAGs from open source Airflow, Astornomer Software, or another commercial offering, you can follow this guide to start running your DAGs either locally or on Astro.
 
-## Step 1: Upgrade to Airflow 2.0/2.1.1
+## Step 1: Upgrade to Airflow 2.1.1
 
-If you have already upgraded all DAGs to Airflow 2.0+, you can skip this step.
+If you have already upgraded all of your DAGs to Airflow 2.1.1+, you can skip this step.
 
-Astro Runtime, which is Astro's Airflow runtime environment, only supports Airflow 2.1.1+. To run any existing DAGs on Airflow 1.10.15 or less, you must first upgrade to Airflow 2.0 and then upgrade to a subsequent minor release. Follow the instructions in this step to manage the 2.0 ugprade process with limited disruption to your existing project.
+Astro Runtime, which is Astro's Airflow runtime environment, only supports Airflow 2.1.1+. To run any existing DAGs on Airflow 1.10.15 or less, you must first upgrade to at least Airflow 2.1 and then upgrade to a subsequent minor release. For a full guide on upgrading from Airflow 1.10.x to 2.0+, see the [Apache Airflow documentation](https://airflow.apache.org/docs/apache-airflow/stable/upgrading-from-1-10/index.html).
 
-### a. Upgrade to Airflow 1.10.15
+:::info
 
-[Airflow 1.10.14](https://github.com/apache/airflow/releases/tag/1.10.14) was built to make the migration and testing process as easy as possible. [Airflow 1.10.15](https://github.com/apache/airflow/releases/tag/1.10.15) was subsequently released with additional bug fixes and improvements. We recommend upgrading your existing Airflow environment to at least 1.10.15 before upgrading to Airflow 2.0+.
+In the output of Apache Airflow's [upgrade check script](https://airflow.apache.org/docs/apache-airflow/stable/upgrading-from-1-10/index.html#step-3-run-the-upgrade-check-scripts), you can ignore `Fernet is enabled by default` and `Check versions of PostgreSQL, MySQL, and SQLite to ease upgrade to Airflow 2.0 tests`. All of these details are handled automatically in Astro. You can also ignore the `Users must set a kubernetes.pod_template_file value` test even if you are running the Kubernetes Executor.
 
-### b. Run the Upgrade Check Script
+:::
 
-Apache Airflow released an [Upgrade Check Script](https://airflow.apache.org/docs/apache-airflow/2.1.3/upgrade-check.html) that scans your project and detects instances of code that need to be updated for Airflow 2.0. Run this script in your existing Airflow environment to determine the scope of the changes you need to complete for your upgrade.
+### Why Airflow 2.0+?
 
-> **Note:** In the upgrade check output above, you can ignore the `Fernet is enabled by default` and `Check versions of PostgreSQL, MySQL, and SQLite to ease upgrade to Airflow 2.0` tests. All of these details are handled by Astro. You can also ignore the and `Users must set a kubernetes.pod_template_file value` test even if you are running the Kubernetes Executor.
+Airflow 2.0+ was built to be fast, reliable, and scalable. Most notably, Airflow 2.0+ includes:
 
-The following topics explain some of the changes that you might need to complete for this upgrade.
+- [Refactored Airflow Scheduler](https://airflow.apache.org/docs/apache-airflow/stable/scheduler.html#running-more-than-one-scheduler) for enhanced performance and high-availability.
+- [Full REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html) that enables more opportunities for automation.
+- [TaskFlow API](https://airflow.apache.org/docs/apache-airflow/stable/concepts.html#taskflow-api) for a simpler way to pass information between tasks.
+- [Independent Providers](https://github.com/apache/airflow/tree/master/airflow/providers) for improved usability and a more agile release cadence.
+- Simplified KubernetesExecutor for flexibility in configuration.
+- [UI/UX Improvements](https://github.com/apache/airflow/pull/11195) including a new Airflow UI and auto-refresh button in the **Graph** view.
 
-#### Import Operators from Backport Providers
-
-All Airflow 2.0 Operators and Extras are backwards compatible with both Airflow 1.10.14 and Airflow 1.10.15. To transition to using these providers, refer to [1.10.15 Backport Providers](https://airflow.apache.org/docs/apache-airflow/1.10.15/backport-providers.html) in Apache Airflow documentation or reference the collection of [Backport Providers in PyPi](https://pypi.org/search/?q=apache-airflow-backport-providers&o=).
-
-#### Modify Airflow DAGs
-
-Depending on how your DAGs are written, you'll likely need to modify your code to be 2.0-compatible. This could include:
-
-- Changes to undefined variable handling in templates
-- Changes to the KubernetesPodOperator
-- Changes to the default value for `dag_run_conf_overrides_params`
-
-For more information, refer to [Step 5: Upgrade Airflow DAGs](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/upgrading-to-2.html#step-5-upgrade-airflow-dags) in Apache Airflow documentation.
+Airflow 2.1.0 was a follow-up release to Airflow 2.0. If you're not running on Airflow 2.0+ yet, we recommend upgrading from Airflow 1.10.15 to Airflow 2.1 directly. For more information on the release, refer to the [Apache Airflow Changelog](https://airflow.apache.org/docs/apache-airflow/2.1.0/changelog.html) and the [Astronomer Certified Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.1.0/CHANGELOG.md).
 
 ## Step 2: Install the Astro CLI
 
-The Astro CLI is the primary tool for managing, running, and deploying DAGs on Astro. The rest of this migration guide makes extensive use of the CLI. To install it, follow the steps in [Install the Astro CLI](install-cli.md).
+The Astro CLI is the primary tool for managing, running, and deploying DAGs on Astro. To install it, follow the steps in [Install the Astro CLI](install-cli.md).
 
-## Step 3: Create an Astro Project
+## Step 3: Migrate Project Code to a New Astro Project
 
-Astro uses a specific project structure that can be bundled into a Docker image and pushed to an Astro Deployment.
+Astro uses a specific project structure that can be bundled into a Docker image and pushed to an Astro Deployment. To migrate your existing code to a locally hosted Astro project:
+
+1. Follow the steps in [Create a Project](create-project.md) to create a new Astro project.
+2. Migrate your existing code to the following locations in your new project:
+
+    - DAG files: move to `dags`
+    - Python-level dependencies: list dependencies in `requirements.txt`
+    - OS-level dependencies: list dependencies in `packages.txt`
+    - Custom or community Airflow plugins: move to `plugins`
+    - Any other project files: move to `include`
+
+## Step 4: Test Your New Project Locally
+
+Because migrating to Astro can result in changes to your project code, especially if you upgraded from Airflow 1.10.x, we recommend testing your new project in a local Airflow environment using the Astro CLI. For more information about how to test and troubleshoot using the Astro CLI, see [Test and Troubleshoot Locally](test-and-troubleshoot-locally.md).
+
+:::tip
+
+To test your code in as close to a production environment as possible, you can configure environment variables, Airflow Connections, and Airflow Variables directly in your Astro project for local use only. For more information, see [Configure `airflow_settings.yaml`](develop-project.md#configure-airflow_settingsyaml-local-development-only) and [Set Environment Variables via `.env`](develop-project.md#set-environment-variables-via-env-local-development-only).
+
+:::
+
+## Step 4: Deploy to Astro
+
+Once you confirm that your project works as expected in a local environment, you can push your project to a Deployment on Astro. For more information, see [Deploy Code](deploy-code.md).
+
+## Step 5: Create Deployment-Level Configurations
+
+Depending on the function and context of your existing project, you might need to configure additional Astro settings to fully migrate your project to a production Astro Deployment. Read the following docs to learn more about how to configure your project on Astro:
+
+- [Environment Variables](environment-variables.md)
+- [Configure a Secrets Backend](secrets-backend.md)
+- [Deployment API Keys](api-keys.md)
+- [Deploy via CI/CD](ci-cd.md)

--- a/sidebarsAstro.js
+++ b/sidebarsAstro.js
@@ -20,6 +20,7 @@ module.exports = {
       items: [
         'install-cli',
         'create-project',
+        'migrate-to-astro',
       ],
     },
     {


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/436 sort of

I'm creating a new "Migrate to Astro" doc that serves as a jump-off point for DAG authors who are coming from other Airflow environments and are new to Astro. This guide should help you migrate any existing DAG code to new Astronomer deployments after you join Astro. 

Part of this is explaining that all DAGs need to be upgraded to Airflow 2.0 before they can run on Astro. I actually don't think our "[Upgrade to Airflow 2.0](https://nebula.astronomer.io/upgrade-to-airflow-2/)" doc has aged super well compared to the [OSS doc](https://airflow.apache.org/docs/apache-airflow/stable/upgrading-from-1-10/index.html). There's a lot more information in there, and I'm not sure how well supported our Software CLI - based "upgrade check" has been maintained. We should find a place for this info in Software, but I'm not sure it should be in its own dedicated doc. Currently, I'm leaning towards including a brief note in [Upgrade Airflow](https://docs.astronomer.io/software/manage-airflow-versions) which links out to the OSS doc. 