### PR TITLE
remove m5.large as supported node type

### DIFF
--- a/astro/resource-reference-aws.md
+++ b/astro/resource-reference-aws.md
@@ -59,7 +59,6 @@ For detailed information on each instance type, reference [AWS documentation](ht
 
 **m5**
 
-- m5.large
 - m5.xlarge (_default_)
 - m5.2xlarge
 - m5.4xlarge


### PR DESCRIPTION
m5.large is not supported currently. will be added back post Cluster upgrades to 3.x