### PR TITLE
add dash to flags

### DIFF
--- a/astro/cli-reference/astrocloud-deploy.md
+++ b/astro/cli-reference/astrocloud-deploy.md
@@ -28,10 +28,10 @@ astrocloud deploy <options>
 | `<deployment-id>`         | Specify the Deployment to deploy to, bypass Deployment selection prompt                                                                             | Any valid Deployment ID           |
 | `-e`,`--env`              | Location of the file containing environment variables for Pytests. By default, this is `.env`.                                 | Any valid filepath to an `.env` file     |
 | `-f`,`--force`            | Force deploy even if your project contains errors or uncommitted changes                                                               | ``                                       |
-| `p`,`--prompt`            | Force the Deployment selection prompt even if a Deployment ID is specified                           | ``                                       |
+| `-p`,`--prompt`            | Force the Deployment selection prompt even if a Deployment ID is specified                           | ``                                       |
 | `--pytest`                | Deploy code to Astro only if the specified Pytests are passed                                                     | ``                                       |
-| `s`,`--save`              | Save the current Deployment and working directory combination for future deploys                                              | ``                                       |
-| `t`,`--test`              | The filepath to an alternative pytest file or directory | Valid filepath within your Astro project |
+| `-s`,`--save`              | Save the current Deployment and working directory combination for future deploys                                              | ``                                       |
+| `-t`,`--test`              | The filepath to an alternative pytest file or directory | Valid filepath within your Astro project |
 | `--workspace-id <string>` | In the prompt to select a Deployment, only show Deployments within this Workspace                                                                             | Any valid Workspace ID                                |
 
 ## Examples


### PR DESCRIPTION

Adds a `-` to the flags in the deployment create reference guide and fixes this issue: