### PR TITLE
Add note on how to view ENV Var/config settings

### DIFF
--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -298,7 +298,7 @@ If your environment variables contain sensitive information or credentials that 
 
 ### Confirm your environment variables were applied
 
-By default, the Airflow Configuration values are hidden in both the localhost and Astro deployment Airflow UIs. In order to view these settings in the Airflow UI, set `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` in either your Dockerfile, Astro Deployment, or `.env` file (local only). 
+By default, Airflow environment variables are hidden in the Airflow UI for both local environments and Astro Deployments. To confirm your environment variables via the Airflow UI, set `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` in either your Dockerfile or `.env` file. 
 
 Alternatively, you can run:
 

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -298,7 +298,7 @@ If your environment variables contain sensitive information or credentials that 
 
 ### Confirm your environment variables were applied
 
-By default, the Airflow Configuration values are hidden in both the localhost and Astro deployment Airflow UIs. In order to view these settings in the Airflow UI, set `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` in either your Dockerfile, Astro Deployment, or `.env` (local only). 
+By default, the Airflow Configuration values are hidden in both the localhost and Astro deployment Airflow UIs. In order to view these settings in the Airflow UI, set `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` in either your Dockerfile, Astro Deployment, or `.env` file (local only). 
 
 Alternatively, to confirm that the environment variables you just set were applied in your local Airflow environment, first run:
 

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -298,7 +298,9 @@ If your environment variables contain sensitive information or credentials that 
 
 ### Confirm your environment variables were applied
 
-To confirm that the environment variables you just set were applied in your local Airflow environment, first run:
+By default, the Airflow Configuration values are hidden in both the localhost and Astro deployment Airflow UIs. In order to view these settings in the Airflow UI, set `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` in either your Dockerfile, Astro Deployment, or `.env` (local only). 
+
+Alternatively, to confirm that the environment variables you just set were applied in your local Airflow environment, first run:
 
 ```
 docker ps

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -300,7 +300,7 @@ If your environment variables contain sensitive information or credentials that 
 
 By default, the Airflow Configuration values are hidden in both the localhost and Astro deployment Airflow UIs. In order to view these settings in the Airflow UI, set `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` in either your Dockerfile, Astro Deployment, or `.env` file (local only). 
 
-Alternatively, to confirm that the environment variables you just set were applied in your local Airflow environment, first run:
+Alternatively, you can run:
 
 ```
 docker ps

--- a/astro/environment-variables.md
+++ b/astro/environment-variables.md
@@ -157,6 +157,12 @@ Here, the environment variable would read:
 ENV AIRFLOW_VAR_MY_VAR=2
 ```
 
+## View Environment Variables in the Airflow UI
+
+By default, Airflow environment variables are hidden in the Airflow UI for both local environments and Astro Deployments. To view a Deployment's current environment variables from the Airflow UI, you can set `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` either in your Dockerfile or the Cloud UI.
+
+You might want to turn on this setting if you want explicit confirmation that an environment variable change was correctly applied to a Deployment, or if you want anyone accessing the Deployment to have more convenient access to environment variable values when working in the Airflow UI.
+
 ## Environment Variable Priority
 
 On Astro, environment variables are applied and overridden in the following order:


### PR DESCRIPTION
We've recently had a few customers ask how to either show/hide Airflow Config/ENV vars in the Admin > Configurations screen in the Airflow UI. Instructions on how to expose these in the UI are not available in our UI. By default, localhost and Astro instances will hide the config settings. But in Software, the config settings are exposed by default in non-local deployments.

[Slack thread 1 - Everlane](https://astronomer.slack.com/archives/C01UA03TPV1/p1647978050281219)
[Slack thread 2 - Questrade](https://astronomer.slack.com/archives/C02PK95SKCZ/p1648127874216799)

This is likely the default for security concerns - if we feel it's too risky to allow customers to expose these values in their deployments we can close this out, or potentially only suggest making this change in their local-only `.env` files

Related to: https://astronomer.productboard.com/insights/notes/all-notes/notes/22595269