### PR TITLE
Add note on how to view ENV Var/config settings

### DIFF
--- a/software/environment-variables.md
+++ b/software/environment-variables.md
@@ -55,7 +55,7 @@ AIRFLOW__CORE__DAG_CONCURRENCY=5
 
 #### Confirm your Environment Variables were Applied
 
-By default, the Airflow Configuration values are hidden in localhost Airflow UIs. In order to view these settings in the Airflow UI, set `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` in either your Dockerfile or `.env` file (local only).
+By default, Airflow environment variables are hidden in the Airflow UI for local environments. To confirm your environment variables in the Airflow UI for a local environment, set `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` in either your Dockerfile or `.env` file (local only).
 
 Alternatively, to confirm that the Environment Variables you just set were applied to your Airflow Deployment locally, first run:
 

--- a/software/environment-variables.md
+++ b/software/environment-variables.md
@@ -55,7 +55,9 @@ AIRFLOW__CORE__DAG_CONCURRENCY=5
 
 #### Confirm your Environment Variables were Applied
 
-To confirm that the Environment Variables you just set were applied to your Airflow Deployment locally, first run:
+By default, the Airflow Configuration values are hidden in localhost Airflow UIs. In order to view these settings in the Airflow UI, set `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` in either your Dockerfile or `.env` file (local only).
+
+Alternatively, to confirm that the Environment Variables you just set were applied to your Airflow Deployment locally, first run:
 
 ```
 docker ps

--- a/software/environment-variables.md
+++ b/software/environment-variables.md
@@ -57,7 +57,7 @@ AIRFLOW__CORE__DAG_CONCURRENCY=5
 
 By default, Airflow environment variables are hidden in the Airflow UI for local environments. To confirm your environment variables in the Airflow UI for a local environment, set `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` in either your Dockerfile or `.env` file (local only).
 
-Alternatively, to confirm that the Environment Variables you just set were applied to your Airflow Deployment locally, first run:
+Alternatively, you can run:
 
 ```
 docker ps


### PR DESCRIPTION
Similar to this PR for Astro: https://github.com/astronomer/docs/pull/536
However, on Software, the config settings are viewable by default in deployments, but not in localhost instances.