### PR TITLE
Add a little more info to Airflow CLI command section in "Test and Troubleshoot Locally"

### DIFF
--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -108,7 +108,13 @@ To run [Apache Airflow CLI](https://airflow.apache.org/docs/apache-airflow/stabl
 astrocloud dev run <airflow-cli-command>
 ```
 
-For example, the Apache Airflow command for viewing your entire configuration is `airflow config list`. To run this command with the Astro CLI, you would run `astrocloud dev run config list` instead.
+For example, the Airflow CLI command for viewing the values of your `airflow.cfg` file is `airflow config list`. To run this command with the Astro CLI, you would run `astrocloud dev run config list` instead. In practice, `astro dev run` does the equivalent of running `docker exec` in local containers and then running the Airflow CLI command within those containers.
+
+:::tip
+
+Airflow CLI commands can only be run locally via the Astro CLI and cannot be run against a Deployment on Astro. To automate actions in Airflow on Astro, we recommend making requests to the [Airflow REST API](airflow-api.md). For example, you can make a request to the [`dagRuns` endpoint](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#operation/post_dag_run) to automate triggering a DAG instead of running the `airflow dags trigger` Airflow CLI command.
+
+:::
 
 ## Test the KubernetesPodOperator Locally
 

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -108,11 +108,13 @@ To run [Apache Airflow CLI](https://airflow.apache.org/docs/apache-airflow/stabl
 astrocloud dev run <airflow-cli-command>
 ```
 
-For example, the Airflow CLI command for viewing the values of your `airflow.cfg` file is `airflow config list`. To run this command with the Astro CLI, you would run `astrocloud dev run config list` instead. In practice, `astro dev run` does the equivalent of running `docker exec` in local containers and then running the Airflow CLI command within those containers.
+For example, the Airflow CLI command for viewing the values of your `airflow.cfg` file is `airflow config list`. To run this command with the Astro CLI, you would run `astrocloud dev run config list` instead. 
+
+In practice, running `astro dev run` is the equivalent of running `docker exec` in local containers and then running an Airflow CLI command within those containers.
 
 :::tip
 
-Airflow CLI commands can only be run locally via the Astro CLI and cannot be run against a Deployment on Astro. To automate actions in Airflow on Astro, we recommend making requests to the [Airflow REST API](airflow-api.md). For example, you can make a request to the [`dagRuns` endpoint](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#operation/post_dag_run) to automate triggering a DAG instead of running the `airflow dags trigger` Airflow CLI command.
+You can only use `astro dev run` in a local Airflow environment. To automate Airflow actions on Astro, you can use the [Airflow REST API](airflow-api.md). For example, you can make a request to the [`dagRuns` endpoint](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#operation/post_dag_run) to trigger a DAG run programmatically, which is equivalent to running `airflow dags trigger` via the Airflow CLI.
 
 :::
 


### PR DESCRIPTION
Based on this Slack conversation: https://astronomer.slack.com/archives/CGQSYG25V/p1648575633921599

I added a little more context on `astro dev run` to our "Test and Troubleshoot Locally" doc:

- Descriptor of what `astro dev run` does behind the scenes
- Added a tip that recommends that people make requests to Airflow REST API when they want to automate Airflow actions on Astro

@jwitz @sunkickr LMK what you think. Is the statement on what `astro dev run` does in practice useful here? I thought about just adding it to the command reference too.