### PR TITLE
Add AC 2.2.5 info and remove Alpine info

### DIFF
--- a/software/ac-support-policy.md
+++ b/software/ac-support-policy.md
@@ -114,6 +114,8 @@ Maintenance is discontinued the last day of the month for a given version. For e
 
 ## Astronomer Certified Lifecycle Schedule
 
+<!--- Version-specific -->
+
 The following tables contain the exact lifecycle for each published version of Astronomer Certified. These timelines are based on the LTS and Stable release channel maintenance policies.
 
 ### Stable Releases

--- a/software/image-architecture.md
+++ b/software/image-architecture.md
@@ -30,6 +30,7 @@ The Astronomer Certified Docker image is built from the Python wheel and incorpo
 
 Every supported version of the Astronomer Certified Python wheel is available at [pip.astronomer.io](https://pip.astronomer.io/simple/astronomer-certified/). The Dockerfiles for all supported Astronomer Certified images can be found in [Astronomer's `ap-airflow` GitHub repository](https://github.com/astronomer/ap-airflow):
 
+- [Airflow 2.2.5](https://github.com/astronomer/ap-airflow/blob/master/2.2.5/bullseye/Dockerfile)
 - [Airflow 2.2.4](https://github.com/astronomer/ap-airflow/blob/master/2.2.4/bullseye/Dockerfile)
 - [Airflow 2.2.3](https://github.com/astronomer/ap-airflow/blob/master/2.2.3/bullseye/Dockerfile)
 - [Airflow 2.2.2](https://github.com/astronomer/ap-airflow/blob/master/2.2.2/bullseye/Dockerfile)
@@ -40,8 +41,6 @@ Every supported version of the Astronomer Certified Python wheel is available at
 - [Airflow 2.0.0](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/buster/Dockerfile)
 - [Airflow 1.10.15](https://github.com/astronomer/ap-airflow/blob/master/1.10.15/buster/Dockerfile)
 - [Airflow 1.10.14](https://github.com/astronomer/ap-airflow/blob/master/1.10.14/buster/Dockerfile)
-- [Airflow 1.10.12](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/buster/Dockerfile)
-- [Airflow 1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/buster/Dockerfile)
 
 ## Image Requirements
 
@@ -100,6 +99,8 @@ Starting in version 2.0.0, the Astronomer Certified image includes provider pack
 |**2.2.2**|1!2.3.0|1!3.3.0|1!2.1.0|1!2.1.0|1!2.1.0|1!2.0.1|1!6.1.0|1!2.0.1|1!2.0.1|1!2.1.1|1!2.3.0|1!2.0.1|1!4.1.0|1!2.0.1|1!2.3.0|
 |**2.2.3**|1!2.3.0|1!3.3.0|1!2.1.0|1!2.1.0|1!2.1.0|1!2.0.1|1!6.1.0|1!2.0.1|1!2.0.1|1!2.1.1|1!2.3.0|1!2.0.1|1!4.1.0|1!2.0.1|1!2.3.0|
 |**2.2.4**|1!3.0.0|1!3.6.0|1!2.1.0|1!3.0.2|1!2.2.0|1!2.0.1|1!6.4.0|1!2.0.3|1!2.2.0|1!2.2.0|1!3.0.0|1!2.0.1|1!4.2.0|1!2.1.0|1!2.4.0|
+|**2.2.5**|1!3.2.0|1!3.7.2|1!2.1.0|1!3.0.0|1!3.0.2|1!2.1.2|1!6.7.0|1!2.1.1|1!2.2.3|1!2.2.3|1!4.1.0|1!2.0.4|1!4.2.3|1!2.1.3|1!2.4.3|
+
 
 ## System Dependencies
 

--- a/software/image-architecture.md
+++ b/software/image-architecture.md
@@ -40,7 +40,6 @@ Every supported version of the Astronomer Certified Python wheel is available at
 - [Airflow 2.0.2](https://github.com/astronomer/ap-airflow/blob/master/2.0.2/buster/Dockerfile)
 - [Airflow 2.0.0](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/buster/Dockerfile)
 - [Airflow 1.10.15](https://github.com/astronomer/ap-airflow/blob/master/1.10.15/buster/Dockerfile)
-- [Airflow 1.10.14](https://github.com/astronomer/ap-airflow/blob/master/1.10.14/buster/Dockerfile)
 
 ## Image Requirements
 

--- a/software/manage-airflow-versions.md
+++ b/software/manage-airflow-versions.md
@@ -129,9 +129,6 @@ For our platform's full collection of Docker Images, reference [Astronomer on Qu
 
 | Airflow Version                                                                      | Debian-based Image                                        | Alpine-based Image                                            |
 | -------------------------------------------------------------------------------------| --------------------------------------------------------- | --------------------------------------------------------------|
-| [1.10.10](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.10-buster-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.10-alpine3.10-onbuild |
-| [1.10.12](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild | FROM quay.io/astronomer/ap-airflow:1.10.12-alpine3.10-onbuild |
-| [1.10.14](https://github.com/astronomer/ap-airflow/blob/master/1.10.14/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.14-buster-onbuild | N/A                                                           |
 | [1.10.15](https://github.com/astronomer/ap-airflow/blob/master/1.10.15/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.15-buster-onbuild | N/A                                                           |
 | [2.0.0](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild   | N/A                                                           |
 | [2.0.2](https://github.com/astronomer/ap-airflow/blob/master/2.0.2/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.2-buster-onbuild   | N/A                                                           |
@@ -143,6 +140,7 @@ For our platform's full collection of Docker Images, reference [Astronomer on Qu
 | [2.2.1](https://github.com/astronomer/ap-airflow/blob/master/2.2.1/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.1-onbuild   | N/A                                                           |
 | [2.2.2](https://github.com/astronomer/ap-airflow/blob/master/2.2.2/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.2-onbuild   | N/A      |
 | [2.2.4](https://github.com/astronomer/ap-airflow/blob/master/2.2.4/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.4-onbuild   | N/A      |
+| [2.2.5](https://github.com/astronomer/ap-airflow/blob/master/2.2.5/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.4-onbuild   | N/A      |
 
 > **Note:** In November of 2020, Astronomer migrated its Docker Registry from [Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow) to [Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags) due to a [change](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/) in Docker Hub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer/ap-airflow` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer (e.g. `toomanyrequests: You have reached your pull rate limit`).
 

--- a/software/manage-airflow-versions.md
+++ b/software/manage-airflow-versions.md
@@ -1,6 +1,6 @@
 ---
-title: 'Upgrade Apache Airflow on Astronomer Software'
-sidebar_label: 'Upgrade Airflow'
+title: "Upgrade Apache Airflow on Astronomer Software"
+sidebar_label: "Upgrade Airflow"
 id: manage-airflow-versions
 description: Adjust and upgrade Airflow versions on Astronomer Software.
 ---
@@ -27,11 +27,11 @@ Starting with Astronomer Software v0.23, new versions of Astronomer Certified ar
 
 > **Note:** If you don't want to wait for new versions of Astronomer Certified to appear on their own, you can manually trigger the cron job with the following Kubernetes command:
 >
->    ```sh    
->    kubectl create job --namespace astronomer --from=cronjob/astronomer-houston-update-airflow-check airflow-update-check-first-run
->    ```
+> ```sh
+> kubectl create job --namespace astronomer --from=cronjob/astronomer-houston-update-airflow-check airflow-update-check-first-run
+> ```
 >
->    If you get a message indicating that a job already exists, delete the job and rerun the command.
+> If you get a message indicating that a job already exists, delete the job and rerun the command.
 
 ## Step 1. Initialize the Upgrade Process
 
@@ -125,22 +125,22 @@ Depending on the Airflow version you'd like to run or upgrade to, copy one of th
 
 Once you upgrade Airflow versions, you CANNOT downgrade to an earlier version. The Airflow metadata database structurally changes with each release, making for backwards incompatibility across versions.
 
-For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags). For more information on Alpine and Debian as distinct system distributions, read the "Migrate from Alpine to Debian" section below.
+For our platform's full collection of Docker Images, reference [Astronomer on Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
 
-| Airflow Version                                                                      | Debian-based Image                                        | Alpine-based Image                                            |
-| -------------------------------------------------------------------------------------| --------------------------------------------------------- | --------------------------------------------------------------|
-| [1.10.15](https://github.com/astronomer/ap-airflow/blob/master/1.10.15/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.15-buster-onbuild | N/A                                                           |
-| [2.0.0](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild   | N/A                                                           |
-| [2.0.2](https://github.com/astronomer/ap-airflow/blob/master/2.0.2/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.2-buster-onbuild   | N/A                                                           |
-| [2.1.0](https://github.com/astronomer/ap-airflow/blob/master/2.1.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.1.0-buster-onbuild   | N/A                                                           |
-| [2.1.1](https://github.com/astronomer/ap-airflow/blob/master/2.1.1/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.1.1-buster-onbuild   | N/A                                                           |
-| [2.1.3](https://github.com/astronomer/ap-airflow/blob/master/2.1.3/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.1.3-buster-onbuild   | N/A                                                           |
-| [2.1.4](https://github.com/astronomer/ap-airflow/blob/master/2.1.4/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.1.4-buster-onbuild   | N/A                                                           |
-| [2.2.0](https://github.com/astronomer/ap-airflow/blob/master/2.2.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.0-buster-onbuild   | N/A                                                           |
-| [2.2.1](https://github.com/astronomer/ap-airflow/blob/master/2.2.1/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.1-onbuild   | N/A                                                           |
-| [2.2.2](https://github.com/astronomer/ap-airflow/blob/master/2.2.2/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.2-onbuild   | N/A      |
-| [2.2.4](https://github.com/astronomer/ap-airflow/blob/master/2.2.4/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.4-onbuild   | N/A      |
-| [2.2.5](https://github.com/astronomer/ap-airflow/blob/master/2.2.5/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.4-onbuild   | N/A      |
+| Airflow Version                                                                      | Debian-based Image                                        |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| [1.10.15](https://github.com/astronomer/ap-airflow/blob/master/1.10.15/CHANGELOG.md) | FROM quay.io/astronomer/ap-airflow:1.10.15-buster-onbuild |
+| [2.0.0](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.0-buster-onbuild   |
+| [2.0.2](https://github.com/astronomer/ap-airflow/blob/master/2.0.2/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.0.2-buster-onbuild   |
+| [2.1.0](https://github.com/astronomer/ap-airflow/blob/master/2.1.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.1.0-buster-onbuild   |
+| [2.1.1](https://github.com/astronomer/ap-airflow/blob/master/2.1.1/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.1.1-buster-onbuild   |
+| [2.1.3](https://github.com/astronomer/ap-airflow/blob/master/2.1.3/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.1.3-buster-onbuild   |
+| [2.1.4](https://github.com/astronomer/ap-airflow/blob/master/2.1.4/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.1.4-buster-onbuild   |
+| [2.2.0](https://github.com/astronomer/ap-airflow/blob/master/2.2.0/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.0-buster-onbuild   |
+| [2.2.1](https://github.com/astronomer/ap-airflow/blob/master/2.2.1/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.1-onbuild          |
+| [2.2.2](https://github.com/astronomer/ap-airflow/blob/master/2.2.2/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.2-onbuild          |
+| [2.2.4](https://github.com/astronomer/ap-airflow/blob/master/2.2.4/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.4-onbuild          |
+| [2.2.5](https://github.com/astronomer/ap-airflow/blob/master/2.2.5/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.4-onbuild          |
 
 > **Note:** In November of 2020, Astronomer migrated its Docker Registry from [Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow) to [Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags) due to a [change](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/) in Docker Hub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer/ap-airflow` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer (e.g. `toomanyrequests: You have reached your pull rate limit`).
 
@@ -161,6 +161,7 @@ If you're developing locally, make sure to save your changes and issue the follo
 ### On Astronomer
 
 If you don't need to test this locally and just want to push to your Astronomer Software installation, you can run:
+
 ```sh
 astro deploy
 ```
@@ -185,84 +186,6 @@ Once there, you should see your correct Airflow version listed.
 If you're on Astronomer Software, navigate to your Airflow Deployment page on the Software UI.
 
 > **Note:** In Airflow 2.0, the **Version** page referenced above will be deprecated. Check the footer of the Airflow UI to validate Airflow version instead.
-
-## Migrate from Alpine to Debian
-
-Astronomer exclusively builds [Debian Buster](https://www.debian.org/) Docker images, though we support [Alpine Linux](https://alpinelinux.org/) images for AC versions 1.10.5 - 1.10.12.
-
-In an effort to standardize our offering and optimize for reliability, Debian Buster proved most suitable to handle complex dependencies and integrate well with Machine Learning Python Libraries that are commonly used with Airflow.
-
-Aside from the initial Docker image build and deploy process, both base images offer the exact same Apache Airflow experience. For best practices on migrating from Alpine to Debian, read below.
-
-### Before you Begin
-
-To avoid unexpected impact to your Airflow Deployment, we strongly recommend two things as you prepare to migrate from Alpine to Debian:
-
-1. Do not upgrade Airflow versions simultaneously.
-2. Test your changes locally before you push a new image to Astronomer.
-
-If you're runnning an Alpine-based 1.10.12 image, for example, try the Debian-based AC 1.10.12 image locally *before* you push that image to Astronomer and before you upgrade to a higher version of Airflow.
-
-> **Note:** If your `packages.txt` file is empty, skip to step 3.
-
-### Step 1. Remove Packages
-
-Debian Buster has many common packages installed by default, which means that you should be able to remove some dependencies.
-
-If you have any packages installed primarily *because* they're native to another library  (e.g. `pandas`, `numpy`, `pyarrow`, `scipy`, `sci-kit learn`), we recommend that you remove those additional packages from your `requirements.txt` or `packages.txt` files and see if your image builds successfully.
-
-If you test a Debian-based image and encounter an error, you can always add packages back as needed.
-
-> **Note:** If you need a particular version of any package, make sure to pin it in your `requirements.txt` or `packages.txt` files (i.e. `<package-name>==<version>`). For Python packages that are pre-built into Astronomer's Debian image *and* listed in your `requirements.txt` file, the version of the package that's specified in `requirements.txt` will take precedence.
-
-### Step 2. Rename Existing Packages
-
-For the dependencies you *do* have installed, a primary concern in migrating from Alpine to Debian is that Python and OS-level packages may be named differently.
-
-To identify a difference in package names, refer to [Debian Buster Packages](https://packages.debian.org/stable/) and [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages) for a full breakdown of both collections.
-
-Modify your `requirements.txt` and `packages.txt` files as needed. If you include a package that does not exist or is named incorrectly, your image will fail to build.
-
-### Step 3. Modify your Dockerfile
-
-Now, try to build your Debian-based image via the Astronomer CLI locally. To do so, replace the Alpine image in your `Dockerfile` with an available Debian image.
-
-For AC 1.10.12, you would replace:
-
-```
-FROM quay.io/astronomer/ap-airflow:1.10.12-alpine3.10-onbuild
-```
-
-with:
-
-```
-FROM quay.io/astronomer/ap-airflow:1.10.12-buster-onbuild
-```
-
-For all available images, refer to the matrix above or [Astronomer's Docker Registry](https://quay.io/repository/astronomer/ap-airflow?tab=tags).
-
-### Step 4. Test your Image Locally
-
-Now, test your changes locally via the Astronomer CLI by running:
-
-1. `$ astro dev stop`, then
-2. `$ astro dev start`
-
-If your image does not build successfully, it's likely that you're either missing additional dependencies or one of your packages is not named properly. Add and modify as needed.
-
-For help from our team, reach out to [Astronomer Support](https://support.astronomer.io).
-
-### Step 5. Push to Astronomer
-
-If your image *does* build successfully, you're ready to push it to your Airflow Deployment Astronomer.
-
-To do so, trigger your [CI/CD process](ci-cd.md) or simply run:
-
-```bash
- astro deploy
- ```
-
- For more information on deploying to Astronomer, refer to [Deploy to Astronomer via the CLI](deploy-cli.md).
 
 ## Cancel Airflow Upgrade Initialization
 

--- a/software/manage-airflow-versions.md
+++ b/software/manage-airflow-versions.md
@@ -140,7 +140,7 @@ For our platform's full collection of Docker Images, reference [Astronomer on Qu
 | [2.2.1](https://github.com/astronomer/ap-airflow/blob/master/2.2.1/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.1-onbuild          |
 | [2.2.2](https://github.com/astronomer/ap-airflow/blob/master/2.2.2/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.2-onbuild          |
 | [2.2.4](https://github.com/astronomer/ap-airflow/blob/master/2.2.4/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.4-onbuild          |
-| [2.2.5](https://github.com/astronomer/ap-airflow/blob/master/2.2.5/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.4-onbuild          |
+| [2.2.5](https://github.com/astronomer/ap-airflow/blob/master/2.2.5/CHANGELOG.md)     | FROM quay.io/astronomer/ap-airflow:2.2.5-onbuild          |
 
 > **Note:** In November of 2020, Astronomer migrated its Docker Registry from [Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow) to [Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags) due to a [change](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/) in Docker Hub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer/ap-airflow` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer (e.g. `toomanyrequests: You have reached your pull rate limit`).
 

--- a/software/version-compatibility-reference.md
+++ b/software/version-compatibility-reference.md
@@ -63,6 +63,7 @@ For more information on upgrading Kubernetes versions, follow the guidelines off
 | 2.2.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
 | 2.2.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
 | 2.2.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
+| 2.2.5                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to [Upgrade Apache Airflow](manage-airflow-versions.md).
 

--- a/software/version-compatibility-reference.md
+++ b/software/version-compatibility-reference.md
@@ -15,13 +15,13 @@ While the tables below reference the minimum compatible versions, we typically r
 
 <!--- Version-specific -->
 
-| Astronomer Platform | Kubernetes                   | Helm | Terraform    | Postgres | Python                                    | Astronomer CLI | Astronomer Certified |
-| ------------------- | ---------------------------- | ---- | ------------ | -------- | ----------------------------------------- | -------------- | -------------------- |
-| v0.23               | 1.16, 1.17, 1.18             | 3    | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8                             | 0.23.x         | All                  |
-| v0.25               | 1.17, 1.18, 1.19, 1.20, 1.21 | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.25.x         | All                  |
-| v0.26               | 1.17, 1.18, 1.19, 1.20, 1.21 | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.26.x         | All                  |
-| v0.27               | 1.18, 1.19, 1.20, 1.21       | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.27.x         | All                  |
-| v0.28               | 1.19, 1.20, 1.21       | 3.6  | 0.13.5       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.28.x         | All                  |
+| Astronomer Platform | Kubernetes                   | Helm | Terraform | Postgres | Python                                    | Astronomer CLI | Astronomer Certified |
+| ------------------- | ---------------------------- | ---- | --------- | -------- | ----------------------------------------- | -------------- | -------------------- |
+| v0.23               | 1.16, 1.17, 1.18             | 3    | 0.13.5    | 9.6+     | 3.6, 3.7, 3.8                             | 0.23.x         | All                  |
+| v0.25               | 1.17, 1.18, 1.19, 1.20, 1.21 | 3.6  | 0.13.5    | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.25.x         | All                  |
+| v0.26               | 1.17, 1.18, 1.19, 1.20, 1.21 | 3.6  | 0.13.5    | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.26.x         | All                  |
+| v0.27               | 1.18, 1.19, 1.20, 1.21       | 3.6  | 0.13.5    | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.27.x         | All                  |
+| v0.28               | 1.19, 1.20, 1.21             | 3.6  | 0.13.5    | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.28.x         | All                  |
 
 For more detail on changes between Software versions, refer to [Astronomer Software Release Notes](release-notes.md).
 
@@ -44,26 +44,21 @@ For more information on upgrading Kubernetes versions, follow the guidelines off
 
 ## Astronomer Certified
 
-| Astronomer Certified | Postgres | MySQL     | Python                         | System Distribution             | Airflow Helm Chart |
-| -------------------- | -------- | --------- | ------------------------------ | ------------------------------- | ------------------ |
-| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | Any                |
-| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | Any                |
-| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.2.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.5                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
+| Astronomer Certified | Postgres | MySQL     | Python                         | System Distribution  | Airflow Helm Chart |
+| -------------------- | -------- | --------- | ------------------------------ | -------------------- | ------------------ |
+| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | Any                |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.2.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.5                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to [Upgrade Apache Airflow](manage-airflow-versions.md).
 

--- a/software_versioned_docs/version-0.23/version-compatibility-reference.md
+++ b/software_versioned_docs/version-0.23/version-compatibility-reference.md
@@ -44,25 +44,21 @@ For more information on upgrading Kubernetes versions, follow the guidelines off
 
 ## Astronomer Certified
 
-| Astronomer Certified | Postgres | MySQL     | Python                         | System Distribution             | Airflow Helm Chart |
-| -------------------- | -------- | --------- | ------------------------------ | ------------------------------- | ------------------ |
-| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | Any                |
-| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | Any                |
-| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.2.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
+| Astronomer Certified | Postgres | MySQL     | Python                         | System Distribution  | Airflow Helm Chart |
+| -------------------- | -------- | --------- | ------------------------------ | -------------------- | ------------------ |
+| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | Any                |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.2.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.5                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to [Upgrade Apache Airflow](manage-airflow-versions.md).
 

--- a/software_versioned_docs/version-0.25/version-compatibility-reference.md
+++ b/software_versioned_docs/version-0.25/version-compatibility-reference.md
@@ -44,25 +44,21 @@ For more information on upgrading Kubernetes versions, follow the guidelines off
 
 ## Astronomer Certified
 
-| Astronomer Certified | Postgres | MySQL     | Python                         | System Distribution             | Airflow Helm Chart |
-| -------------------- | -------- | --------- | ------------------------------ | ------------------------------- | ------------------ |
-| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | Any                |
-| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | Any                |
-| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.2.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
+| Astronomer Certified | Postgres | MySQL     | Python                         | System Distribution  | Airflow Helm Chart |
+| -------------------- | -------- | --------- | ------------------------------ | -------------------- | ------------------ |
+| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | Any                |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.2.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.5                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to [Upgrade Apache Airflow](manage-airflow-versions.md).
 

--- a/software_versioned_docs/version-0.26/version-compatibility-reference.md
+++ b/software_versioned_docs/version-0.26/version-compatibility-reference.md
@@ -44,25 +44,21 @@ For more information on upgrading Kubernetes versions, follow the guidelines off
 
 ## Astronomer Certified
 
-| Astronomer Certified | Postgres | MySQL     | Python                         | System Distribution             | Airflow Helm Chart |
-| -------------------- | -------- | --------- | ------------------------------ | ------------------------------- | ------------------ |
-| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | Any                |
-| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | Any                |
-| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.2.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
+| Astronomer Certified | Postgres | MySQL     | Python                         | System Distribution  | Airflow Helm Chart |
+| -------------------- | -------- | --------- | ------------------------------ | -------------------- | ------------------ |
+| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | Any                |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.2.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.5                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to [Upgrade Apache Airflow](manage-airflow-versions.md).
 

--- a/software_versioned_docs/version-0.27/version-compatibility-reference.md
+++ b/software_versioned_docs/version-0.27/version-compatibility-reference.md
@@ -44,25 +44,21 @@ For more information on upgrading Kubernetes versions, follow the guidelines off
 
 ## Astronomer Certified
 
-| Astronomer Certified | Postgres | MySQL     | Python                         | System Distribution             | Airflow Helm Chart |
-| -------------------- | -------- | --------- | ------------------------------ | ------------------------------- | ------------------ |
-| 1.10.5               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.7               | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.10              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.12              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Alpine 3.10, Debian 10 (Buster) | Any                |
-| 1.10.14              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | Any                |
-| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | Any                |
-| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.1.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)              | 0.18.6+            |
-| 2.2.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
-| 2.2.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye)            | 0.18.6+            |
+| Astronomer Certified | Postgres | MySQL     | Python                         | System Distribution  | Airflow Helm Chart |
+| -------------------- | -------- | --------- | ------------------------------ | -------------------- | ------------------ |
+| 1.10.15              | 9.6+     | 5.7, 8.0+ | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | Any                |
+| 2.0.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.0.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8                  | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.1.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 10 (Buster)   | 0.18.6+            |
+| 2.2.0                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9             | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.1                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.2                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.3                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.4                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
+| 2.2.5                | 9.6+     | 8.0+      | 3.6, 3.7, 3.8, 3.9 (_Default_) | Debian 11 (Bullseye) | 0.18.6+            |
 
 For more detail on each version of Astronomer Certified and instructions on how to upgrade, refer to [Upgrade Apache Airflow](manage-airflow-versions.md).
 


### PR DESCRIPTION
Per our [Support Policy](https://docs.astronomer.io/software/ac-support-policy), using the opportunity of AC 2.2.5 to remove information about AC versions that have been unsupported for a couple of months. 

Sort of forcing the discussion of whether we can finally remove unsupported versions from our docs, if we don't want to do this now then I'd really like to figure out a policy for when we can remove them.