### PR TITLE
Fix Typos in Hashicorp Vault Secrets Backend Setup

### DIFF
--- a/software/secrets-backend.md
+++ b/software/secrets-backend.md
@@ -133,7 +133,7 @@ Then, add the following environment variables to your `Dockerfile`:
 ```text
 # Make sure to replace `<your-approle-id>` and `<your-approle-secret>` with your own values.
 ENV AIRFLOW__SECRETS__BACKEND="airflow.contrib.secrets.hashicorp_vault.VaultBackend"
-ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_path": "onnections", "variables_path": variables, "config_path": null, "url": "https://vault.vault.svc.cluster.local:8200", "auth_type": "approle", "role_id":"<your-approle-id>", "secret_id":"<your-approle-secret>"}'
+ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_path": "connections", "variables_path": "variables", "config_path": null, "url": "https://vault.vault.svc.cluster.local:8200", "auth_type": "approle", "role_id":"<your-approle-id>", "secret_id":"<your-approle-secret>"}'
 ```
 
 This tells Airflow to look for variable and connection information at the `secret/variables/*` and `secret/connections/*` paths in your Vault server. In the next step, you'll test this configuration in a local Airflow environment.
@@ -194,7 +194,7 @@ Once you've confirmed that the integration with Vault works locally, you can com
 
   :::warning
 
-  Make sure to strip the quotations (`"`) from your environment variable values. If you add these values with the quotation marks included in your Dockerfile, your configuration will not work on Astronomer Software.
+  Make sure to strip the single-quotation marks (`''`) from your environment variable value for KWARGS. If you add these values with the quotation marks included in your Dockerfile, your configuration will not work on Astronomer Software.
 
   :::
 


### PR DESCRIPTION
This PR fixes the following:

1. Typo in Dockerfile example for Hashicorp Vault where `variables` should be in double quotes.
2. Fix the spelling of `connections` in Dockerfile
3. Edit the warning to talk about removal of single quotes (`''`) in `KWARGS` not double quotes (`"`)