### PR TITLE
Clarify value of createDeployment query in Software Houston API Doc

### DIFF
--- a/software/houston-api.md
+++ b/software/houston-api.md
@@ -154,7 +154,7 @@ mutation CreateDeployment {
   createDeployment(
     workspaceUuid: "<workspace-id>",
     type: "airflow",
-    label: "<deployment-label>",
+    label: "<deployment-name>",
     config: {executor:"<airflow-executor>"},
 
 


### PR DESCRIPTION
The createDeployment example shows a placeholder "deployment-label", but what value to enter is not explained and the term "deployment label" is not used anywhere in Astronomer. The user needs to enter the name of the deployment and since the term "name" is used in the UI, I suggest changing the placeholder to "deployment-name".