### PR TITLE
Bump Runtime version to 4.2.4

### DIFF
--- a/astro/release-notes.md
+++ b/astro/release-notes.md
@@ -12,7 +12,7 @@ Astronomer is committed to continuous delivery of both features and bug fixes to
 
 If you have any questions or a bug to report, don't hesitate to reach out to [Astronomer support](https://support.astronomer.io).
 
-**Latest Runtime Version**: 4.2.2 ([Release notes](runtime-release-notes.md))
+**Latest Runtime Version**: 4.2.4 ([Release notes](runtime-release-notes.md))
 
 **Latest CLI Version**: 1.3.3 ([Release notes](cli-release-notes.md))
 

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -11,9 +11,9 @@ Astro Runtime is a Docker image built and published by Astronomer that extends t
 
 For instructions on how to upgrade, read [Upgrade Astro Runtime](upgrade-runtime.md). For general product release notes, go to [Astro Release Notes](release-notes.md). If you have any questions or a bug to report, reach out to [Astronomer Support](https://support.astronomer.io).
 
-## Astro Runtime 4.2.2
+## Astro Runtime 4.2.4
 
-- Release date: April 4, 2022
+- Release date: April 6, 2022
 - Airflow version: 2.2.5
 
 ### Support for Airflow 2.2.5

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,6 +1,6 @@
 export const siteVariables = {
   cliVersion: '1.3.3',
-  runtimeVersion: '4.2.2',
+  runtimeVersion: '4.2.4',
   // Hacky variable so that we can use env var fromatting in CI/CD templates
   deploymentid: '${ASTRONOMER_DEPLOYMENT_ID}',
   keyid: '${ASTRONOMER_KEY_ID}',


### PR DESCRIPTION
Removed `4.2.2` and added `4.2.4` to Runtime release notes, as the last three patch versions are really just one version that needed fixes to changes that didn't exist in prior versions. This seems like a good policy for any other "hotfix" versions in the future, as only the latest patch will ever be available in the Cloud UI

However, if there's more than a week between hotfixes, we should consider how to handle situations where someone might be on an "in between" version of Runtime. Should we contact those customers directly, or add a note in release notes like we did with the [Astro CLI](https://docs.astronomer.io/astro/cli-release-notes#v132)? 