### PR TITLE
Update outdated code in KubernetesPodOperator docs

### DIFF
--- a/astro/kubernetespodoperator.md
+++ b/astro/kubernetespodoperator.md
@@ -30,14 +30,13 @@ To use the KubernetesPodOperator, you need:
 To use the KubernetesPodOperator in a DAG, add the following import statements and instantiation to your DAG file:
 
 ```python
-from airflow.contrib.operators.kubernetes_pod_operator import kubernetes_pod_operator
+from airflow.configuration import conf
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 
-# Pulls environment information from Astro
-from airflow import configuration as conf
-...
 
-namespace = conf.get('kubernetes', 'NAMESPACE')
-k = kubernetes_pod_operator.KubernetesPodOperator(
+namespace = conf.get("kubernetes", "NAMESPACE")
+
+KubernetesPodOperator(
     namespace=namespace,
     image="<your-docker-image>",
     cmds=["<commands-for-image>"],
@@ -47,12 +46,13 @@ k = kubernetes_pod_operator.KubernetesPodOperator(
     is_delete_operator_pod=True,
     in_cluster=True,
     task_id="<task-name>",
-    get_logs=True)
+    get_logs=True,
+)
 ```
 
 For each instantiation of the KubernetesPodOperator, you must specify the following values:
 
-- `namespace = conf.get('kubernetes', 'NAMESPACE')`: Every Deployment runs on its own Kubernetes namespace within a Cluster. Information about this namespace can be programmatically imported as long as you set this variable.
+- `namespace = conf.get("kubernetes", "NAMESPACE")`: Every Deployment runs on its own Kubernetes namespace within a Cluster. Information about this namespace can be programmatically imported as long as you set this variable.
 - `image`: This is the Docker image that the operator will use to run its defined task, commands, and arguments. The value you specify is assumed to be an image tag that's publicly available on [Docker Hub](https://hub.docker.com/). To pull an image from a private registry, read [Pull Images from a Private Registry](kubernetespodoperator.md#run-images-from-a-private-registry).
 - `in_cluster=True`: When this value is set, your task will run within the Cluster from which it's instantiated on Astro. This ensures that the Kubernetes Pod running your task has the correct permissions within the Cluster.
 - `is_delete_operator_pod=True`: This setting ensures that once a KubernetesPodOperator task is complete, the Kubernetes Pod that ran that task is terminated. This ensures that there are no unused pods in your Cluster taking up resources.
@@ -63,33 +63,35 @@ This is the minimum configuration required to run tasks with the KubernetesPodOp
 
 Astro automatically allocates resources to Pods created by the KubernetesPodOperator. Resources used by the KubernetesPodOperator are not technically limited, meaning that the operator could theoretically use any CPU and memory that's available in your Cluster to complete a task. Because of this, we recommend specifying [compute resource requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) per task.
 
-To do so, define a dictionary of compute resources in your DAG. For example, applying the following dictionary to a task would ensure that a Pod runs that task with exactly 800m of CPU and 3Gi of memory at all times:
+To do so, define a `kubernetes.client.models.V1ResourceRequirements` object and provide that to the `resources` argument of the KubernetesPodOperator:
 
-```python
-compute_resources = \
-  {'request_cpu': '800m',
-  'request_memory': '3Gi',
-  'limit_cpu': '800m',
-  'limit_memory': '3Gi'}
+```python {20}
+from airflow.configuration import conf
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from kubernetes.client import models as k8s
+
+compute_resources = k8s.V1ResourceRequirements(
+    limits={"cpu": "800m", "memory": "3Gi"}, requests={"cpu": "800m", "memory": "3Gi"}
+)
+
+namespace = conf.get("kubernetes", "NAMESPACE")
+
+KubernetesPodOperator(
+    namespace=namespace,
+    image="<your-docker-image>",
+    cmds=["<commands-for-image>"],
+    arguments=["<arguments-for-image>"],
+    labels={"<pod-label>": "<label-name>"},
+    name="<pod-name>",
+    is_delete_operator_pod=True,
+    in_cluster=True,
+    resources=compute_resources,
+    task_id="<task-name>",
+    get_logs=True,
+)
 ```
 
-To use a dictionary, specify the `resources` variable in your instantiation of the KubernetesPodOperator:
-
-```python {11}
-namespace = conf.get('kubernetes', 'NAMESPACE')
-with dag:
-    k = KubernetesPodOperator(
-        namespace=namespace,
-        image="<your-docker-image>",
-        labels={"<pod-label>": "<label-name>"},
-        name="<pod-name>",
-        task_id="<task-name>",
-        in_cluster=True,
-        cluster_context='docker-for-desktop',
-        resources=compute_resources,
-        is_delete_operator_pod=True,
-        get_logs=True)
-```
+Applying the code above ensures that Kubernetes allocates exactly 800m of CPU and 3Gi of memory to your task's Pod at all times.
 
 ## Run Images from a Private Registry
 
@@ -122,9 +124,9 @@ From here, you can run images from your private registry by importing `models` f
 ```python {1,5}
 from kubernetes.client import models as k8s
 
-k = kubernetes_pod_operator.KubernetesPodOperator(
+KubernetesPodOperator(
     namespace=namespace,
-    image_pull_secrets=[k8s.V1LocalObjectReference('<your-secret-name>')],
+    image_pull_secrets=[k8s.V1LocalObjectReference("<your-secret-name>")],
     image="<your-docker-image>",
     cmds=["<commands-for-image>"],
     arguments=["<arguments-for-image>"],
@@ -133,5 +135,6 @@ k = kubernetes_pod_operator.KubernetesPodOperator(
     is_delete_operator_pod=True,
     in_cluster=True,
     task_id="<task-name>",
-    get_logs=True)
+    get_logs=True,
+)
 ```

--- a/astro/kubernetespodoperator.md
+++ b/astro/kubernetespodoperator.md
@@ -71,7 +71,8 @@ from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import Kubernete
 from kubernetes.client import models as k8s
 
 compute_resources = k8s.V1ResourceRequirements(
-    limits={"cpu": "800m", "memory": "3Gi"}, requests={"cpu": "800m", "memory": "3Gi"}
+    limits={"cpu": "800m", "memory": "3Gi"},
+    requests={"cpu": "800m", "memory": "3Gi"}
 )
 
 namespace = conf.get("kubernetes", "NAMESPACE")

--- a/astro/kubernetespodoperator.md
+++ b/astro/kubernetespodoperator.md
@@ -91,7 +91,7 @@ KubernetesPodOperator(
 )
 ```
 
-Applying the code above ensures that Kubernetes allocates exactly 800m of CPU and 3Gi of memory to your task's Pod at all times.
+Applying the code above ensures that when this DAG runs, it will launch a Kubernetes Pod with exactly 800m of CPU and 3Gi of memory as long as that infrastructure is available in your Cluster. Once the task finishes, the Pod will terminate gracefully.
 
 ## Run Images from a Private Registry
 

--- a/software/kubepodoperator-local.md
+++ b/software/kubepodoperator-local.md
@@ -36,10 +36,11 @@ microk8s.config > /include/.kube/config
 The `config_file` is pointing to the `/include/.kube/config` file you just edited. Run `astro dev start` to build this config into your image.
 
 ```python
-from airflow import DAG
 from datetime import datetime, timedelta
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
-from airflow import configuration as conf
+
+from airflow import DAG
+from airflow.configuration import conf
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 
 default_args = {
     'owner': 'airflow',
@@ -57,29 +58,27 @@ namespace = conf.get('kubernetes', 'NAMESPACE')
 # environment namespace when deployed to Astronomer.
 if namespace =='default':
     config_file = '/usr/local/airflow/include/.kube/config'
-    in_cluster=False
+    in_cluster = False
 else:
-    in_cluster=True
-    config_file=None
+    in_cluster = True
+    config_file = None
 
-dag = DAG('example_kubernetes_pod',
-          schedule_interval='@once',
-          default_args=default_args)
-
+dag = DAG('example_kubernetes_pod', schedule_interval='@once', default_args=default_args)
 
 
 with dag:
-    k = KubernetesPodOperator(
+    KubernetesPodOperator(
         namespace=namespace,
         image="hello-world",
         labels={"foo": "bar"},
         name="airflow-test-pod",
         task_id="task-one",
-        in_cluster=in_cluster, # if set to true, will look in the cluster, if false, looks for file
-        cluster_context='docker-desktop', # is ignored when in_cluster is set to True
+        in_cluster=in_cluster,  # if set to true, will look in the cluster, if false, looks for file
+        cluster_context="docker-desktop",  # is ignored when in_cluster is set to True
         config_file=config_file,
         is_delete_operator_pod=True,
-        get_logs=True)
+        get_logs=True,
+    )
 
 ```
 
@@ -100,4 +99,4 @@ Run the same commands as above prefixed with microk8s:
 microk8s.kubectl get pods -n $namespace
 ```
 
-When you are ready to deploy this up into Astronomer, follow the [KubePodOperator doc](kubepodoperator.md) to find a list of the necessary changes that will need to be made.
+When you are ready to deploy this up into Astronomer, follow the [KubernetesPodOperator doc](kubepodoperator.md) to find a list of the necessary changes that will need to be made.

--- a/software/kubepodoperator.md
+++ b/software/kubepodoperator.md
@@ -138,7 +138,8 @@ dag = DAG("example_kubernetes_pod", schedule_interval="@once", default_args=defa
 
 # This is where we define our desired resources.
 compute_resources = k8s.V1ResourceRequirements(
-    limits={"cpu": "800m", "memory": "3Gi"}, requests={"cpu": "800m", "memory": "3Gi"}
+    limits={"cpu": "800m", "memory": "3Gi"},
+    requests={"cpu": "800m", "memory": "3Gi"}
 )
 
 with dag:

--- a/software/kubepodoperator.md
+++ b/software/kubepodoperator.md
@@ -7,11 +7,11 @@ description: Run the KubernetesPodOperator on Astronomer Software.
 
 ## Overview
 
-A widely-used and performant alternative to Airflow's older DockerOperator, the [KubernetesPodOperator](https://github.com/apache/airflow/blob/v1-10-stable/airflow/contrib/operators/kubernetes_pod_operator.py) is able to natively launch a Kubernetes Pod to run an individual task - and terminate that pod when the task is completed. Similarly to the Kubernetes Executor, the operator uses the [Kube Python Client](https://github.com/kubernetes-client/python) to generate a Kubernetes API request that dynamically launches those individual pods.
+A widely-used and performant alternative to Airflow's older DockerOperator, the [KubernetesPodOperator](https://github.com/apache/airflow/blob/main/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py) is able to natively launch a Kubernetes Pod to run an individual task - and terminate that pod when the task is completed. Similarly to the Kubernetes Executor, the operator uses the [Kubernetes Python Client](https://github.com/kubernetes-client/python) to generate a Kubernetes API request that dynamically launches those individual pods.
 
 The KubernetesPodOperator enables task-level resource configuration and is optimal for those who have custom Python dependencies. Ultimately, it allows Airflow to act a job orchestrator - no matter the language those jobs are written in.
 
-At its core, the KubernetesPodOperator is built to run any docker image with Airflow regardless of the language it's written in. It's the next generation of the DockerOperator and is optimized to leverage Kubernetes functionality, allowing users to specify resource requests and pass Kubernetes specific parameters into the task.
+At its core, the KubernetesPodOperator is built to run any Docker image with Airflow regardless of the language it's written in. It's the next generation of the DockerOperator and is optimized to leverage Kubernetes functionality, allowing users to specify resource requests and pass Kubernetes specific parameters into the task.
 
 If you're using the Kubernetes Executor, you can also configure task-level Kubernetes resources using a pod template. For more information, read [Use a Pod Template in a Task](kubernetes-executor.md#use-a-pod-template-in-a-task).
 
@@ -22,16 +22,22 @@ To run the KubernetesPodOperator on Astronomer, make sure you:
 - Have a running Airflow Deployment on Astronomer Software
 - Run Astronomer Airflow 1.10+
 
-> **Note:** If you haven't already, we'd encourage you to first test the KubernetesPodOperator in your local environment. Follow our [Running KubePodOperator Locally](kubepodoperator-local.md) for guidelines.
+> **Note:** If you haven't already, we'd encourage you to first test the KubernetesPodOperator in your local environment. Follow our [Running KubernetesPodOperator Locally](kubepodoperator-local.md) for guidelines.
 
 ## The KubernetesPodOperator on Astronomer
 
 ### Import the Operator
 
-You can import the KubernetesPodOperator as you would any other plugin in its [GitHub Contrib Folder](https://github.com/apache/airflow/blob/v1-10-stable/airflow/contrib/operators/kubernetes_pod_operator.py).
+First ensure you have the `apache-airflow-providers-cncf-kubernetes` package installed:
+
+```bash
+pip install apache-airflow-providers-cncf-kubernetes
+```
+
+You can then import the KubernetesPodOperator:
 
 ```python
-from airflow.contrib.operators.kubernetes_pod_operator import kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 ```
 
 ### Specify Parameters
@@ -39,12 +45,13 @@ from airflow.contrib.operators.kubernetes_pod_operator import kubernetes_pod_ope
 From here, instantiate the operator based on your image and setup:
 
 ```python
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
-from airflow import configuration as conf
-...
+from airflow.configuration import conf
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 
-namespace = conf.get('kubernetes', 'NAMESPACE')
-k = kubernetes_pod_operator.KubernetesPodOperator(
+
+namespace = conf.get("kubernetes", "NAMESPACE")
+
+KubernetesPodOperator(
     namespace=namespace,
     image="ubuntu:16.04",
     cmds=["bash", "-cx"],
@@ -54,7 +61,8 @@ k = kubernetes_pod_operator.KubernetesPodOperator(
     is_delete_operator_pod=True,
     in_cluster=True,
     task_id="task-two",
-    get_logs=True)
+    get_logs=True,
+)
 ```
 
 To successfully instantiate the operator, you'll need to make note of a few parameters.
@@ -91,25 +99,19 @@ On Astronomer Software, the largest node a single pod can occupy is dependent on
 
 #### Define Resources per Task
 
-A notable advantage of leveraging Airflow's KubernetesPodOperator is that you can specify compute [resources](https://github.com/apache/airflow/blob/master/airflow/contrib/operators/kubernetes_pod_operator.py#L85) in the task definition.
+A notable advantage of leveraging Airflow's KubernetesPodOperator is that you can control compute resources in the task definition.
 
-```
-    :param resources: A dict containing resources requests and limits.
-        Possible keys are request_memory, request_cpu, limit_memory, limit_cpu,
-        and limit_gpu, which will be used to generate airflow.kubernetes.pod.Resources.
-        See also kubernetes.io/docs/concepts/configuration/manage-compute-resources-container
-    :type resources: dict
-```
-
-> **Note:** If you're using the KubernetesExecutor, note that this value is separate from the `executor_config` parameter. In this case, the `executor_config` would only define the Airflow worker that is launching your k8s task.
+> **Note:** If you're using the KubernetesExecutor, note that this value is separate from the `executor_config` parameter. In this case, the `executor_config` would only define the Airflow worker that is launching your Kubernetes task.
 
 ### Example Task Definition:
 
 ```python
-from airflow import DAG
 from datetime import datetime, timedelta
-from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
-from airflow import configuration as conf
+
+from airflow import DAG
+from airflow.configuration import conf
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from kubernetes.client import models as k8s
 
 default_args = {
     'owner': 'airflow',
@@ -127,56 +129,58 @@ namespace = conf.get('kubernetes', 'NAMESPACE')
 # environment namespace when deployed to Astronomer.
 if namespace =='default':
     config_file = '/usr/local/airflow/include/.kube/config'
-    in_cluster=False
+    in_cluster = False
 else:
-    in_cluster=True
-    config_file=None
+    in_cluster = True
+    config_file = None
 
-dag = DAG('example_kubernetes_pod',
-          schedule_interval='@once',
-          default_args=default_args)
+dag = DAG("example_kubernetes_pod", schedule_interval="@once", default_args=default_args)
 
 # This is where we define our desired resources.
-compute_resources = \
-  {'request_cpu': '800m',
-  'request_memory': '3Gi',
-  'limit_cpu': '800m',
-  'limit_memory': '3Gi'}
+compute_resources = k8s.V1ResourceRequirements(
+    limits={"cpu": "800m", "memory": "3Gi"}, requests={"cpu": "800m", "memory": "3Gi"}
+)
 
 with dag:
-    k = KubernetesPodOperator(
+    KubernetesPodOperator(
         namespace=namespace,
         image="hello-world",
         labels={"foo": "bar"},
         name="airflow-test-pod",
         task_id="task-one",
-        in_cluster=in_cluster, # if set to true, will look in the cluster, if false, looks for file
-        cluster_context='docker-for-desktop', # is ignored when in_cluster is set to True
+        in_cluster=in_cluster,  # if set to true, will look in the cluster, if false, looks for file
+        cluster_context="docker-for-desktop",  # is ignored when in_cluster is set to True
         config_file=config_file,
         resources=compute_resources,
         is_delete_operator_pod=True,
-        get_logs=True)
+        get_logs=True,
+    )
 ```
 
-In the example above, we define resources by building the following dict:
+In the example above, we define resources by building the following `V1ResourceRequirements` object:
 
 ```python
-compute_resources = \
-  {'request_cpu': '800m',
-  'request_memory': '3Gi',
-  'limit_cpu': '800m',
-  'limit_memory': '3Gi'}
+from kubernetes.client import models as k8s
+
+compute_resources = k8s.V1ResourceRequirements(
+    limits={"cpu": "800m", "memory": "3Gi"},
+    requests={"cpu": "800m", "memory": "3Gi"}
+)
 ```
 
-Using this dict, users can set Memory and CPU requests and limits for any given pod. For more information, reference [Kubernetes Documentation on Requests and Limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits).
+Using this object, users can set Memory and CPU requests and limits for any given pod. For more information, reference [Kubernetes Documentation on Requests and Limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits).
 
-Once you've created the object, simply apply it to the `resources` parameter of the task. When this DAG runs, it will launch a pod that runs the `hello-world` image, pulled from DockerHub, in your Airflow Deployment's namespace with the resource request specified above. Once it finishes running, it will delete the pod.
+Once you've created the object, apply it to the `resources` parameter of the task. When this DAG runs, it will launch a pod that runs the `hello-world` image, pulled from Docker Hub, in your Airflow Deployment's namespace with the resource request specified above. Once the container finishes, the pod will be removed.
 
-> **Note:** On Astronomer, the equivalent of 1AU is: `"request_cpu": "100m", "request_memory": "384Mi", "limit_cpu": "100m", "limit_memory": "384Mi"}`
+:::info 
+
+On Astronomer, the equivalent of 1AU is: `requests={"cpu": "100m", "memory": "384Mi"}, limits={"cpu": "100m", "memory": "384Mi"}`.
+
+:::
 
 ## Pulling Images from a Private Registry
 
-By default, the KubernetesPodOperator will look for images hosted publicly on [Dockerhub](https://hub.docker.com/). If you want to pull images from a private registry, you may do so.
+By default, the KubernetesPodOperator will look for images hosted publicly on [Docker Hub](https://hub.docker.com/). If you want to pull images from a private registry, you may do so.
 
 > **Note:** The KubernetesPodOperator doesn't support passing in `image_pull_secrets` until [Airflow 1.10.2](https://github.com/apache/airflow/blob/master/CHANGELOG.txt#L526).
 
@@ -201,9 +205,9 @@ To pull images from a private registry on Astronomer Software:
     ```python {1,5}
     from kubernetes.client import models as k8s
 
-    k = kubernetes_pod_operator.KubernetesPodOperator(
+    KubernetesPodOperator(
         namespace=namespace,
-        image_pull_secrets=[k8s.V1LocalObjectReference('<your-secret-name>')],
+        image_pull_secrets=[k8s.V1LocalObjectReference("<your-secret-name>")],
         image="<your-docker-image>",
         cmds=["<commands-for-image>"],
         arguments=["<arguments-for-image>"],
@@ -212,11 +216,12 @@ To pull images from a private registry on Astronomer Software:
         is_delete_operator_pod=True,
         in_cluster=True,
         task_id="<task-name>",
-        get_logs=True)
+        get_logs=True,
+    )
     ```
 
 ## Local Testing
 
-Follow our [CLI doc](kubepodoperator-local.md/) on using [Microk8s](https://microk8s.io/) or [Docker for Kubernetes](https://matthewpalmer.net/kubernetes-app-developer/articles/how-to-run-local-kubernetes-docker-for-mac.html) to run tasks with the KubernetesPodOperator locally.
+Follow our [Local KubernetesPodOperator](kubepodoperator-local.md/) on using [MicroK8s](https://microk8s.io/) or [Docker for Kubernetes](https://matthewpalmer.net/kubernetes-app-developer/articles/how-to-run-local-kubernetes-docker-for-mac.html) to run tasks with the KubernetesPodOperator locally.
 
 > **Note:** To pull images from a private registry locally, you'll have to create a secret in your local namespace and similarly call it in your operator following the guidelines above.

--- a/software/kubepodoperator.md
+++ b/software/kubepodoperator.md
@@ -168,9 +168,9 @@ compute_resources = k8s.V1ResourceRequirements(
 )
 ```
 
-Using this object, users can set Memory and CPU requests and limits for any given pod. For more information, reference [Kubernetes Documentation on Requests and Limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits).
+This object allows you to specify Memory and CPU requests and limits for any given task and its correspond Kubernetes Pod. For more information, read [Kubernetes Documentation on Requests and Limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits).
 
-Once you've created the object, apply it to the `resources` parameter of the task. When this DAG runs, it will launch a pod that runs the `hello-world` image, pulled from Docker Hub, in your Airflow Deployment's namespace with the resource request specified above. Once the container finishes, the pod will be removed.
+Once you've created the object, apply it to the `resources` parameter of the task. When this DAG runs, it will launch a Pod that runs the `hello-world` image, which is pulled from Docker Hub, in your Airflow Deployment's namespace with the resource requests defined above. Once the task finishes, the Pod will be gracefully terminate.
 
 :::info 
 
@@ -222,6 +222,6 @@ To pull images from a private registry on Astronomer Software:
 
 ## Local Testing
 
-Follow our [Local KubernetesPodOperator](kubepodoperator-local.md/) on using [MicroK8s](https://microk8s.io/) or [Docker for Kubernetes](https://matthewpalmer.net/kubernetes-app-developer/articles/how-to-run-local-kubernetes-docker-for-mac.html) to run tasks with the KubernetesPodOperator locally.
+We recommend testing your DAGs locally before pushing them to a Deployment on Astronomer. For more information, read [How to Run the KubernetesPodOperator Locally](kubepodoperator-local.md/). That guide provides information on how to use [MicroK8s](https://microk8s.io/) or [Docker for Kubernetes](https://matthewpalmer.net/kubernetes-app-developer/articles/how-to-run-local-kubernetes-docker-for-mac.html) to run tasks with the KubernetesPodOperator in a local environment.
 
 > **Note:** To pull images from a private registry locally, you'll have to create a secret in your local namespace and similarly call it in your operator following the guidelines above.

--- a/software/kubepodoperator.md
+++ b/software/kubepodoperator.md
@@ -168,7 +168,7 @@ compute_resources = k8s.V1ResourceRequirements(
 )
 ```
 
-This object allows you to specify Memory and CPU requests and limits for any given task and its correspond Kubernetes Pod. For more information, read [Kubernetes Documentation on Requests and Limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits).
+This object allows you to specify Memory and CPU requests and limits for any given task and its corresponding Kubernetes Pod. For more information, read [Kubernetes Documentation on Requests and Limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits).
 
 Once you've created the object, apply it to the `resources` parameter of the task. When this DAG runs, it will launch a Pod that runs the `hello-world` image, which is pulled from Docker Hub, in your Airflow Deployment's namespace with the resource requests defined above. Once the task finishes, the Pod will be gracefully terminate.
 


### PR DESCRIPTION
Had a customer call about the KubernetesPodOperator and it turned out the code in our KubernetesPodOperator docs is outdated (code samples are for Airflow 1). This PR updates all code for Airflow 2 and fixes several inconsistencies.