### PR TITLE
Add info about how to override default ports on the Astro CLI

### DIFF
--- a/astro/create-project.md
+++ b/astro/create-project.md
@@ -117,7 +117,7 @@ The default credentials are admin:admin
 
 :::info
 
-By default, the Astro CLI uses port `8080` for Airflow's Webserver and port `5432` for Airflow's metadata database. If these ports are already in use on your local machine, you can change the ports for these components using the following steps:
+By default, the Astro CLI uses port `8080` for Airflow's Webserver and port `5432` for Airflow's metadata database. If these ports are already in use on your local machine, you can change the default ports for these components using the following steps:
 
 1. In your Astro project directory, open `.astrocloud/config.yaml`. This file might be hidden in graphical file browsers. You can show hidden files using `⌘ + Shift + .` on Mac or by selecting **View** > **Hidden items** in Windows file explorer.
 2. Specify alternative ports for your Webserver and/or metadata database in `config.yaml`. For example, to use `8081` for your Webserver port and `5435` for your database port, you would specify the following:

--- a/astro/create-project.md
+++ b/astro/create-project.md
@@ -131,7 +131,7 @@ By default, the Astro CLI uses port `8080` for Airflow's Webserver and port `543
       port: 5435
     ```
 
-3. Run `astro dev restart` to rebuild and rerun your project.
+3. Run `astrocloud dev restart` to rebuild and rerun your project.
 
 :::
 

--- a/astro/create-project.md
+++ b/astro/create-project.md
@@ -115,6 +115,26 @@ Postgres Database: localhost:5432/postgres
 The default credentials are admin:admin
 `}</code></pre>
 
+:::info
+
+By default, the Astro CLI uses port `8080` for Airflow's Webserver and port `5432` for Airflow's metadata database. If these ports are already in use on your local machine, you can change the ports for these components using the following steps:
+
+1. In your Astro project directory, open `.astrocloud/config.yaml`. This file might be hidden in graphical file browsers. You can show hidden files using `⌘ + Shift + .` on Mac or by selecting **View** > **Hidden items** in Windows file explorer.
+2. Specify alternative ports for your Webserver and/or metadata database in `config.yaml`. For example, to use `8081` for your Webserver port and `5435` for your database port, you would specify the following:
+
+    ```yaml
+    project:
+      name: <your-directory-name>
+    webserver:
+      port: 8081
+    postgres:
+      port: 5435
+    ```
+
+3. Run `astro dev restart` to rebuild and rerun your project.
+
+:::
+
 ## Step 3: Access the Airflow UI
 
 Once your project builds successfully, you can access the Airflow UI by going to `http://localhost:8080/` and logging in with `admin` for both your username and password.

--- a/astro/create-project.md
+++ b/astro/create-project.md
@@ -117,7 +117,7 @@ The default credentials are admin:admin
 
 :::info
 
-By default, the Astro CLI uses port `8080` for Airflow's Webserver and port `5432` for Airflow's metadata database. If these ports are already in use on your local machine, you can change the default ports for these components using the following steps:
+By default, the Astro CLI uses port `8080` for Airflow's Webserver and port `5432` for Airflow's metadata database. If these ports are already in use on your local machine, you can change the default ports for these components by following these steps:
 
 1. In your Astro project directory, open `.astrocloud/config.yaml`. This file might be hidden in graphical file browsers. You can show hidden files using `⌘ + Shift + .` on Mac or by selecting **View** > **Hidden items** in Windows file explorer.
 2. Specify alternative ports for your Webserver and/or metadata database in `config.yaml`. For example, to use `8081` for your Webserver port and `5435` for your database port, you would specify the following:

--- a/astro/create-project.md
+++ b/astro/create-project.md
@@ -117,7 +117,7 @@ The default credentials are admin:admin
 
 :::info
 
-By default, the Astro CLI uses port `8080` for Airflow's Webserver and port `5432` for Airflow's metadata database. If these ports are already in use on your local machine, you can change the default ports for these components by following these steps:
+By default, the Astro CLI uses port `8080` for the Airflow Webserver and port `5432` for the Airflow metadata database. If these ports are already in use on your local machine, you can change the default ports for these components by following these steps:
 
 1. In your Astro project directory, open `.astrocloud/config.yaml`. This file might be hidden in graphical file browsers. You can show hidden files using `⌘ + Shift + .` on Mac or by selecting **View** > **Hidden items** in Windows file explorer.
 2. Specify alternative ports for your Webserver and/or metadata database in `config.yaml`. For example, to use `8081` for your Webserver port and `5435` for your database port, you would specify the following:

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -160,7 +160,7 @@ To do this:
     │   └── helper.py
     ├── include
     ├── tests
-     │   └── test_dag_integrity.py
+    │   └── test_dag_integrity.py
     ├── packages.txt
     ├── plugins
     │   └── example-plugin.py

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -246,7 +246,6 @@ The Astro CLI is built on top of [Docker Compose](https://docs.docker.com/compos
 
 To see what values you can override, reference the CLI's [Docker Compose file](https://github.com/astronomer/astro-cli/blob/main/airflow/include/composeyml.go). The linked file is for the original Astro CLI, but the values here are identical to those used in the Astro CLI. Common use cases for Docker Compose overrides include:
 
-- Modifying the ports at which the Airflow Webserver or Postgres database start on if another service is already running on those same ports (8080 and 5432, respectively). You can override this default and point your containers to a different port.
 - Adding extra containers to mimic services that your Airflow environment needs to interact with locally, such as an SFTP server.
 - Change the volumes mounted to any of your local containers.
 
@@ -298,7 +297,7 @@ If your environment variables contain sensitive information or credentials that 
 
 ### Confirm your environment variables were applied
 
-By default, Airflow environment variables are hidden in the Airflow UI for both local environments and Astro Deployments. To confirm your environment variables via the Airflow UI, set `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` in either your Dockerfile or `.env` file. 
+By default, Airflow environment variables are hidden in the Airflow UI for both local environments and Astro Deployments. To confirm your environment variables via the Airflow UI, set `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True` in either your Dockerfile or `.env` file.
 
 Alternatively, you can run:
 

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -108,7 +108,7 @@ To run [Apache Airflow CLI](https://airflow.apache.org/docs/apache-airflow/stabl
 astrocloud dev run <airflow-cli-command>
 ```
 
-For example, the Airflow CLI command for viewing the values of your `airflow.cfg` file is `airflow config list`. To run this command with the Astro CLI, you would run `astrocloud dev run config list` instead. 
+For example, the Airflow CLI command for viewing the values of your `airflow.cfg` file is `airflow config list`. To run this command with the Astro CLI, you would run `astrocloud dev run config list` instead.
 
 In practice, running `astro dev run` is the equivalent of running `docker exec` in local containers and then running an Airflow CLI command within those containers.
 


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/337

The original issue discussed having this information in "Develop project" but I think we should only include it there once we have more to say about `config.yaml` in general. In the meantime, I think this content is better suited in "Create a Project", since a user would run into this issue when first starting to run a project locally. This could also theoretically live under a new "Troubleshooting" section in "Test and Troubleshoot locally" since that doc is a lot more test-y than troubleshoot-y