### PR TITLE
Fix AWS instal prerequisites and clarify permissions for AWS CLI usage

### DIFF
--- a/astro/install-aws.md
+++ b/astro/install-aws.md
@@ -23,7 +23,15 @@ For a complete list of the AWS resources that our team will provision in your AW
 Before completing this setup, make sure that you have:
 
 - A dedicated AWS account with minimum EC2 service quotas.
-- A user with `CreateRole` and `cloudformation:*` privileges.
+- A user with the following permissions:
+    - `cloudformation:*`
+    - `GetRole`
+    - `GetRolePolicy`
+    - `CreateRole`
+    - `DeleteRolePolicy`
+    - `PutRolePolicy`
+    - `ListRoles`
+    - `UpdateAssumeRolePolicy`
 - A subscription to the [Astro Status Page](https://cloud-status.astronomer.io/). This will ensure that you're alerted in the case of an incident or scheduled maintenance.
 
 Astro requires a clean AWS account with a minimum set of EC2 service quotas. For security reasons, the install process is not currently supported on an AWS account that has other tooling running in it. For instructions on creating a new AWS account, follow [AWS documentation](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/).
@@ -98,7 +106,7 @@ Then, click the link below to create an [cross-account admin IAM role](https://d
 
 - [Create cross-account IAM Role](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?templateURL=https://astro-cross-account-role-template.s3.us-east-2.amazonaws.com/customer-account.yaml&stackName=AstroCrossAccountIAMRole&param_AstroAccountId=406882777402)
 
-Alternatively, if you only have `CreateRole` permissions, you can create a cross-account IAM Role by running the following AWS CLI command:
+Using this CloudFormation link is the recommended way to create an IAM role for Astro. Alternatively, you can create a cross-account IAM Role by running the following AWS CLI commands:
 
 ```bash
 $ aws iam create-role --role-name astronomer-remote-management --assume-role-policy-document "{

--- a/astro/install-aws.md
+++ b/astro/install-aws.md
@@ -23,10 +23,10 @@ For a complete list of the AWS resources that our team will provision in your AW
 Before completing this setup, make sure that you have:
 
 - A dedicated AWS account with minimum EC2 service quotas.
-- A user that has `CreateRole` permissions on that account.
-- Subscribed to the [Astro Status Page](https://cloud-status.astronomer.io/). This will ensure that you're alerted in the case of an incident or scheduled maintenance.
+- A user with `CreateRole` and `cloudformation:*` privileges.
+- A subscription to the [Astro Status Page](https://cloud-status.astronomer.io/). This will ensure that you're alerted in the case of an incident or scheduled maintenance.
 
-Astro requires a dedicated AWS account with a minimum set of EC2 service quotas. For security reasons, the install process is not currently supported on an AWS account that has other tooling running in it. For instructions on creating a new AWS account, follow [AWS documentation](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/).
+Astro requires a clean AWS account with a minimum set of EC2 service quotas. For security reasons, the install process is not currently supported on an AWS account that has other tooling running in it. For instructions on creating a new AWS account, follow [AWS documentation](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/).
 
 The required [EC2 service quotas](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html) are:
 
@@ -90,7 +90,7 @@ If not specified, Astronomer will create a Cluster with two `m5.xlarge` nodes in
 
 From here, our team will provision an Astro Cluster according to the specifications you provided.
 
-## Step 3: Create a cross-account IAM Role for Astro
+## Step 3: Create a Cross-Account IAM Role for Astro
 
 Once your Astro Cluster has been created, an Astronomer team member will provide you with an [External ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html) that will allow Astronomer to connect to your AWS account. Save the External ID as a secret or in an otherwise secure format for use in the AWS CLI.
 
@@ -98,7 +98,7 @@ Then, click the link below to create an [cross-account admin IAM role](https://d
 
 - [Create cross-account IAM Role](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/quickcreate?templateURL=https://astro-cross-account-role-template.s3.us-east-2.amazonaws.com/customer-account.yaml&stackName=AstroCrossAccountIAMRole&param_AstroAccountId=406882777402)
 
-Alternatively, run the following AWS CLI command:
+Alternatively, if you only have `CreateRole` permissions, you can create a cross-account IAM Role by running the following AWS CLI command:
 
 ```bash
 $ aws iam create-role --role-name astronomer-remote-management --assume-role-policy-document "{


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/438

Added the appropriate base prerequisites for running our CloudFormation script to create a new role (I think!).

Remaining question here is, now that the permissions are different, would we prefer that people create the role using the CloudFormation link or the AWS CLI? Seems like the AWS CLI option is more compelling now because it requires less permissions. 