### PR TITLE
Fix wording around github package installation

### DIFF
--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -372,7 +372,8 @@ To build from a private repository, you need:
 
 - The [Astro CLI](install-cli.md).
 - An [Astro project](create-project.md).
-- One or more private GitHub repositories containing Python packages that can be installed by pip (see [PEP 516](https://peps.python.org/pep-0516/)).
+- Python packages that are [installable via pip](https://packaging.python.org/en/latest/tutorials/packaging-projects/).
+- Private GitHub repositories hosting code for each of your Python packages. 
 - An [SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) authorized to access your private GitHub repo.
 
 ### Step 1: Specify the Private Repository in Your Project

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -378,7 +378,9 @@ To build from a private repository, you need:
 
 ### Step 1: Specify the Private Repository in Your Project
 
-To add a Python package from a private repository to your Astro project, specify the URL in the format `git+ssh://git@github.com/<organization_name>/<repository>.git` in your project's `requirements.txt` file in conjunction with any other packages. For example, to install the packages `mypackage1` & `mypackage2` from `myorganization` as well as numpy version 1.22.1, your `requirements.txt` should contain:
+To add a Python package from a private repository to your Astro project, specify repository's SSH URL in your project's `requirements.txt` file. This URL should be formatted as `git+ssh://git@github.com/<organization-name>/<repository>.git`. 
+
+For example, to install the `mypackage1` & `mypackage2` from `myorganization`, as well as `numpy v 1.22.1`, you would add the following to `requirements.txt`:
 
 ```
 git+ssh://git@github.com/myorganization/mypackage1.git

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -372,8 +372,9 @@ To build from a private repository, you need:
 
 - The [Astro CLI](install-cli.md).
 - An [Astro project](create-project.md).
-- Private GitHub repositories hosting code for each of your Python packages that are [installable via pip](https://packaging.python.org/en/latest/tutorials/packaging-projects/). 
-- An [SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) authorized to access your private GitHub repo.
+- Custom Python packages that are [installable via pip](https://packaging.python.org/en/latest/tutorials/packaging-projects/).
+- A private GitHub repository for each of your custom Python packages.
+- An [SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) authorized to access your private GitHub repo(s).
 
 ### Step 1: Specify the Private Repository in Your Project
 

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -372,8 +372,7 @@ To build from a private repository, you need:
 
 - The [Astro CLI](install-cli.md).
 - An [Astro project](create-project.md).
-- Python packages that are [installable via pip](https://packaging.python.org/en/latest/tutorials/packaging-projects/).
-- Private GitHub repositories hosting code for each of your Python packages. 
+- Private GitHub repositories hosting code for each of your Python packages that are [installable via pip](https://packaging.python.org/en/latest/tutorials/packaging-projects/). 
 - An [SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) authorized to access your private GitHub repo.
 
 ### Step 1: Specify the Private Repository in Your Project

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -372,15 +372,17 @@ To build from a private repository, you need:
 
 - The [Astro CLI](install-cli.md).
 - An [Astro project](create-project.md).
-- A private GitHub repository with a directory of your Python packages.
+- One or more private GitHub repositories containing Python packages that can be installed by pip (see [PEP 516](https://peps.python.org/pep-0516/)).
 - An [SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) authorized to access your private GitHub repo.
 
 ### Step 1: Specify the Private Repository in Your Project
 
-To add Python packages from a private repository to your Astro project, specify the [SSH URL](https://docs.github.com/en/enterprise-server@3.1/get-started/getting-started-with-git/about-remote-repositories#cloning-with-ssh-urls) to your repository in your project's `requirements.txt` file. For example, to clone a private repository named `mypackages`, you would add the following line to `requirements.txt`
+To add a Python package from a private repository to your Astro project, specify the URL in the format `git+ssh://git@github.com/<organization_name>/<repository>.git` in your project's `requirements.txt` file in conjunction with any other packages. For example, to install the packages `mypackage1` & `mypackage2` from `myorganization` as well as numpy version 1.22.1, your `requirements.txt` should contain:
 
 ```
-git+git@github.com:myorganization/mypackages.git
+git+ssh://git@github.com/myorganization/mypackage1.git
+git+ssh://git@github.com/myorganization/mypackage2.git
+numpy==1.22.1
 ```
 
 ### Step 2: Create Dockerfile.build

--- a/software/customize-image.md
+++ b/software/customize-image.md
@@ -264,7 +264,7 @@ To build from a private repository, you need:
 
 ### Step 1: Specify the Private Repository in Your Project
 
-To add a Python package from a private repository to your Astro project, specify repository's SSH URL in your project's `requirements.txt` file. This URL should be formatted as `git+ssh://git@github.com/<organization-name>/<repository>.git`. 
+To add a Python package from a private repository to your Software project, specify repository's SSH URL in your project's `requirements.txt` file. This URL should be formatted as `git+ssh://git@github.com/<organization-name>/<repository>.git`. 
 
 For example, to install the `mypackage1` & `mypackage2` from `myorganization`, as well as `numpy v 1.22.1`, you would add the following to `requirements.txt`:
 

--- a/software/customize-image.md
+++ b/software/customize-image.md
@@ -257,8 +257,7 @@ To build from a private repository, you need:
 
 - The [Astronomer CLI](cli-quickstart.md).
 - A [Software project](create-project.md).
-- Python packages that are [installable via pip](https://packaging.python.org/en/latest/tutorials/packaging-projects/).
-- Private GitHub repositories hosting code for each of your Python packages. 
+- Private GitHub repositories hosting code for each of your Python packages that are [installable via pip](https://packaging.python.org/en/latest/tutorials/packaging-projects/). 
 - An [SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) authorized to access your private GitHub repo.
 
 

--- a/software/customize-image.md
+++ b/software/customize-image.md
@@ -263,7 +263,7 @@ To build from a private repository, you need:
 
 ### Step 1: Specify the Private Repository in Your Project
 
-To add a Python package from a private repository to your Astro project, specify the URL in the format `git+ssh://git@github.com/<organization_name>/<repository>.git` in your project's `requirements.txt` file in conjunction with any other packages. For example, to install the packages `mypackage1` & `mypackage2` from `myorganization` as well as numpy version 1.22.1, your `requirements.txt` should contain:
+To add a Python package from a private repository to your Software project, specify the URL in the format `git+ssh://git@github.com/<organization_name>/<repository>.git` in your project's `requirements.txt` file in conjunction with any other packages. For example, to install the packages `mypackage1` & `mypackage2` from `myorganization` as well as numpy version 1.22.1, your `requirements.txt` should contain:
 
 ```
 git+ssh://git@github.com/myorganization/mypackage1.git

--- a/software/customize-image.md
+++ b/software/customize-image.md
@@ -257,7 +257,8 @@ To build from a private repository, you need:
 
 - The [Astronomer CLI](cli-quickstart.md).
 - A [Software project](create-project.md).
-- One or more private GitHub repositories containing Python packages that can be installed by pip (see [PEP 516](https://peps.python.org/pep-0516/)).
+- Python packages that are [installable via pip](https://packaging.python.org/en/latest/tutorials/packaging-projects/).
+- Private GitHub repositories hosting code for each of your Python packages. 
 - An [SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) authorized to access your private GitHub repo.
 
 

--- a/software/customize-image.md
+++ b/software/customize-image.md
@@ -264,7 +264,9 @@ To build from a private repository, you need:
 
 ### Step 1: Specify the Private Repository in Your Project
 
-To add a Python package from a private repository to your Software project, specify the URL in the format `git+ssh://git@github.com/<organization_name>/<repository>.git` in your project's `requirements.txt` file in conjunction with any other packages. For example, to install the packages `mypackage1` & `mypackage2` from `myorganization` as well as numpy version 1.22.1, your `requirements.txt` should contain:
+To add a Python package from a private repository to your Astro project, specify repository's SSH URL in your project's `requirements.txt` file. This URL should be formatted as `git+ssh://git@github.com/<organization-name>/<repository>.git`. 
+
+For example, to install the `mypackage1` & `mypackage2` from `myorganization`, as well as `numpy v 1.22.1`, you would add the following to `requirements.txt`:
 
 ```
 git+ssh://git@github.com/myorganization/mypackage1.git

--- a/software/customize-image.md
+++ b/software/customize-image.md
@@ -257,16 +257,18 @@ To build from a private repository, you need:
 
 - The [Astronomer CLI](cli-quickstart.md).
 - A [Software project](create-project.md).
-- A private GitHub repository with a directory of your Python packages.
+- One or more private GitHub repositories containing Python packages that can be installed by pip (see [PEP 516](https://peps.python.org/pep-0516/)).
 - An [SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) authorized to access your private GitHub repo.
 
 
 ### Step 1: Specify the Private Repository in Your Project
 
-To add Python packages from a private repository to your Software project, specify the [SSH URL](https://docs.github.com/en/enterprise-server@3.1/get-started/getting-started-with-git/about-remote-repositories#cloning-with-ssh-urls) to your repository in your project's `requirements.txt` file. For example, to clone a private repository named `mypackages`, you would add the following line to `requirements.txt`
+To add a Python package from a private repository to your Astro project, specify the URL in the format `git+ssh://git@github.com/<organization_name>/<repository>.git` in your project's `requirements.txt` file in conjunction with any other packages. For example, to install the packages `mypackage1` & `mypackage2` from `myorganization` as well as numpy version 1.22.1, your `requirements.txt` should contain:
 
 ```
-git+git@github.com:myorganization/mypackages.git
+git+ssh://git@github.com/myorganization/mypackage1.git
+git+ssh://git@github.com/myorganization/mypackage2.git
+numpy==1.22.1
 ```
 
 ### Step 2. Create Dockerfile.build

--- a/software/customize-image.md
+++ b/software/customize-image.md
@@ -260,7 +260,6 @@ To build from a private repository, you need:
 - Custom Python packages that are [installable via pip](https://packaging.python.org/en/latest/tutorials/packaging-projects/).
 - A private GitHub repository for each of your custom Python packages.
 - An [SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) authorized to access your private GitHub repo(s).
-- An [SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) authorized to access your private GitHub repo.
 
 
 ### Step 1: Specify the Private Repository in Your Project

--- a/software/customize-image.md
+++ b/software/customize-image.md
@@ -257,7 +257,9 @@ To build from a private repository, you need:
 
 - The [Astronomer CLI](cli-quickstart.md).
 - A [Software project](create-project.md).
-- Private GitHub repositories hosting code for each of your Python packages that are [installable via pip](https://packaging.python.org/en/latest/tutorials/packaging-projects/). 
+- Custom Python packages that are [installable via pip](https://packaging.python.org/en/latest/tutorials/packaging-projects/).
+- A private GitHub repository for each of your custom Python packages.
+- An [SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) authorized to access your private GitHub repo(s).
 - An [SSH Key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) authorized to access your private GitHub repo.
 
 


### PR DESCRIPTION
Pip can only install one package from each repo, and the repo must be layed out according to PEP 516.