### PR TITLE
Update robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Disallow: /src/
+Disallow: /assets/
 Disallow: /software_versioned_docs/
 Disallow: /software_versioned_sidebars/
 Disallow: /README.md


### PR DESCRIPTION
Seeing a number of 404 requests against /assets/* in Netlify, presumably from robots. Attempting to disallow that from indexing, but let me know if I did it wrong.