### PR TITLE
`--deployment-id` flag missing in examples

### DIFF
--- a/astro/cli-reference/astrocloud-deployment-variable-create.md
+++ b/astro/cli-reference/astrocloud-deployment-variable-create.md
@@ -34,13 +34,13 @@ astrocloud deployment variable create
 
 ```sh
 # Create a new secret environment variable
-$ astrocloud deployment variable create cl03oiq7d80402nwn7fsl3dmv --key AIRFLOW__SECRETS__BACKEND_KWARGS --value <my-secret-value> --secret
+$ astrocloud deployment variable create --deployment-id cl03oiq7d80402nwn7fsl3dmv --key AIRFLOW__SECRETS__BACKEND_KWARGS --value <my-secret-value> --secret
 
 # Create multiple environment variables for a Deployment at once by loading them from a .env file
-$ astrocloud deployment variable create cl03oiq7d80402nwn7fsl3dmv --load --env .env.dev
+$ astrocloud deployment variable create --deployment-id cl03oiq7d80402nwn7fsl3dmv --load --env .env.dev
 
 # Update the value of an existing environment variable
-$ astrocloud deployment variable create cl03oiq7d80402nwn7fsl3dmv --update AIRFLOW__CORE__PARALLELISM --value <my-new-value>
+$ astrocloud deployment variable create --deployment-id cl03oiq7d80402nwn7fsl3dmv --update --key AIRFLOW__CORE__PARALLELISM --value <my-new-value>
 ```
 
 ## Related Commands

--- a/astro/cli-reference/astrocloud-deployment-variable-list.md
+++ b/astro/cli-reference/astrocloud-deployment-variable-list.md
@@ -33,10 +33,10 @@ astrocloud deployment variable list
 
 ```sh
 # Save all environment variables currently running on an Astro Deployment to the `.env` file in your current directory
-$ astrocloud deployment variable list cl03oiq7d80402nwn7fsl3dmv --save
+$ astrocloud deployment variable list --deployment-id cl03oiq7d80402nwn7fsl3dmv --save
 
 # Save only a single environment variable from a Deployment on Astro to a `.env` file that is outside of your current directory
-$ astrocloud deployment variable list cl03oiq7d80402nwn7fsl3dmv --key AIRFLOW__CORE__PARALLELISM --save --env /users/documents/my-astro-project/.env
+$ astrocloud deployment variable list --deployment-id cl03oiq7d80402nwn7fsl3dmv --key AIRFLOW__CORE__PARALLELISM --save --env /users/documents/my-astro-project/.env
 ```
 
 ## Related Commands


### PR DESCRIPTION
Examples with missing flag: 
- https://docs.astronomer.io/astro/cli-reference/astrocloud-deployment-variable-list#examples
- https://docs.astronomer.io/astro/cli-reference/astrocloud-deployment-variable-create#examples

