### PR TITLE
Update airflow-api.md for Software

### DIFF
--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -82,7 +82,7 @@ POST /dags/<dag-id>/dagRuns
 
 #### cURL
 ```
-curl -v -X POST https://deployments.<BASE-DOMAIN>/<DEPLOYMENT-NAME>/airflow/api/v1/dags/<DAG-ID>/dagRuns \
+curl -v -X POST https://deployments.<BASE-DOMAIN>/<DEPLOYMENT-RELEASE-NAME>/airflow/api/v1/dags/<DAG-ID>/dagRuns \
   -H 'Authorization: <API-KEY>' \
   -H 'Cache-Control: no-cache' \
   -H 'content-type: application/json' -d '{}'

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -223,6 +223,3 @@ curl -X GET \
   -H 'Cache-Control: no-cache'
 ```
 
-- `<BASE-DOMAIN>`: Use your base domain name, i.e. the domain name used when authenticating to the `astro` cli
-- `<DEPLOYMENT-NAME>`: Use the name of your deployment release name
-- `<API-KEY>`: API Key from your Service Account

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -62,7 +62,7 @@ To create a Deployment-level Service Account via the Astronomer CLI:
 
 ## Step 2: Make an Airflow REST API Request
 
-Now that you've created a Service Account, you're free to generate REST API requests to any supported endpoints in Airflow's [Rest API Reference](https://airflow.apache.org/docs/stable/rest-api-ref.html) via the following base URL:
+With the information from Step 1, you can now run `GET` or `POST` requests to any supported endpoints in Airflow's [Rest API Reference](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html) via the following base URL:
 
 ```
 https://deployments.<BASE-DOMAIN>/<DEPLOYMENT-NAME>/airflow/api/v1

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -214,7 +214,7 @@ Here, your cURL request would look like the following:
 
 ```
 curl -X GET \
-  https://deployments.<BASE-DOMAIN>/<DEPLOYMENT-NAME>/api/v1/config \
+  https://deployments.<BASE-DOMAIN>/<DEPLOYMENT-RELEASE-NAME>/api/v1/config \
   -H 'Authorization: <API-KEY>' \
   -H 'Cache-Control: no-cache'
 ```

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -68,13 +68,15 @@ With the information from Step 1, you can now run `GET` or `POST` requests to an
 https://deployments.<BASE-DOMAIN>/<DEPLOYMENT-NAME>/airflow/api/v1
 ```
 
-In the examples below, you'll replace the following values with your own:
+## Example API Calls
+
+In the following examples, you'll replace the following values with your own:
 
 - `<BASE-DOMAIN>`: The base domain for your organization on Astronomer Software. For example: `mycompany.astronomer.io`.
 - `<DEPLOYMENT-RELEASE-NAME>`: The release name of your Deployment. For example: `galactic-stars-1234`.
 - `<API-KEY>`: The API key for your Deployment Service Account.
 
-You can make requests via the method of your choosing. Below, we'll share example requests via cURL and Python to Airflow's "Trigger DAG" and "Get all Pools" endpoints. In all cases, your request will have the same permissions as the role of the Service Account you created on Astronomer.
+The following example calls are made via cURL and Python, but you can make requests via any standard method. In all cases, your request will have the same permissions as the role of the Service Account you created on Astronomer.
 
 ### Trigger DAG
 
@@ -109,8 +111,6 @@ resp = requests.post(
 print(resp.json())
 # {'conf': {}, 'dag_id': 'example_dag', 'dag_run_id': 'manual__2022-04-26T21:57:23.572567+00:00', 'end_date': None, 'execution_date': '2022-04-26T21:57:23.572567+00:00', 'external_trigger': True, 'logical_date': '2022-04-26T21:57:23.572567+00:00', 'start_date': None, 'state': 'queued'}
 ```
-
-To run this, replace the following placeholder values:
 
 - `<DAG-ID>`: Name of your DAG (_case-sensitive_)
 
@@ -179,12 +179,8 @@ print(resp.json())
 # {'pools': [{'name': 'default_pool', 'occupied_slots': 0, 'open_slots': 128, 'queued_slots': 0, 'running_slots': 0, 'slots': 128}], 'total_entries': 1}
 ```
 
-To run this, replace the following placeholder values:
 
-
-## A Note on Airflow 2 Stable REST API
-
-### What's new
+## Notes on Airflow 2.0's Stable REST API
 
 As of its momentous [2.0 release](https://www.astronomer.io/blog/introducing-airflow-2-0), the Apache Airflow project now supports an official and more robust Stable REST API. Among other things, Airflow's new REST API:
 

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -94,6 +94,7 @@ curl -v -X POST https://deployments.<BASE-DOMAIN>/<DEPLOYMENT-RELEASE-NAME>/airf
 ```
 
 #### Python
+
 ```python
 import requests
 

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -169,7 +169,7 @@ import requests
 
 token = "<API-KEY>"
 base_domain = "<BASE-DOMAIN>"
-deployment_name = "<DEPLOYMENT-NAME>"
+deployment_name = "<DEPLOYMENT-RELEASE-NAME>"
 resp = requests.get(
     url=f"https://deployments.{base_domain}/{deployment_name}/airflow/api/v1/pools",
     headers={"Authorization": token, "Content-Type": "application/json"},

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -81,6 +81,7 @@ POST /dags/<dag-id>/dagRuns
 ```
 
 #### cURL
+
 ```
 curl -v -X POST https://deployments.<BASE-DOMAIN>/<DEPLOYMENT-RELEASE-NAME>/airflow/api/v1/dags/<DAG-ID>/dagRuns \
   -H 'Authorization: <API-KEY>' \

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -94,7 +94,7 @@ import requests
 
 token = "<API-KEY>"
 base_domain = "<BASE-DOMAIN>"
-deployment_name = "<DEPLOYMENT-NAME>"
+deployment_name = "<DEPLOYMENT-RELEASE-NAME>"
 resp = requests.post(
     url=f"https://deployments.{base_domain}/{deployment_name}/airflow/api/v1/dags/example_dag/dagRuns",
     headers={"Authorization": token, "Content-Type": "application/json"},

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -181,9 +181,6 @@ print(resp.json())
 
 To run this, replace the following placeholder values:
 
-- `<API-KEY>`: API Key from your Service Account
-- `<BASE-DOMAIN>`: Use your base domain name, i.e. the domain name used when authenticating to the `astro` cli
-- `<DEPLOYMENT-NAME>`: Use the name of your deployment release name
 
 ## A Note on Airflow 2 Stable REST API
 

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -137,7 +137,7 @@ For example:
 Here, your request becomes:
 
 ```
-curl -v -X POST https://deployments.<AIRFLOW_DOMAIN>/airflow/api/v1/dags/<DAG-ID>/dagRuns \
+curl -v -X POST https://deployments.<BASE-DOMAIN>/<DEPLOYMENT-RELEASE-NAME>/airflow/api/v1/dags/<DAG-ID>/dagRuns \
   -H 'Authorization: <API-KEY>' \
   -H 'Cache-Control: no-cache' \
   -H 'content-type: application/json' -d '{"execution_date":"2019-11-16T11:34:00"}'

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -187,7 +187,7 @@ To run this, replace the following placeholder values:
 - `<BASE-DOMAIN>`: Use your base domain name, i.e. the domain name used when authenticating to the `astro` cli
 - `<DEPLOYMENT-NAME>`: Use the name of your deployment release name
 
-## A Note on Airflow 2.x Stable REST API
+## A Note on Airflow 2 Stable REST API
 
 ### What's new
 

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -112,8 +112,6 @@ print(resp.json())
 
 To run this, replace the following placeholder values:
 
-- `<BASE-DOMAIN>`: Use your base domain name, i.e. the domain name used when authenticating to the `astro` cli
-- `<DEPLOYMENT-NAME>`: Use the name of your deployment release name
 - `<DAG-ID>`: Name of your DAG (_case-sensitive_)
 - `<API-KEY>`: API Key from your Service Account
 

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -113,7 +113,6 @@ print(resp.json())
 To run this, replace the following placeholder values:
 
 - `<DAG-ID>`: Name of your DAG (_case-sensitive_)
-- `<API-KEY>`: API Key from your Service Account
 
 This will trigger a DAG run for your desired DAG with a `execution_date` value of `NOW()`, which is equivalent to clicking the "Play" button in the main "DAGs" view of the Airflow UI.
 

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -158,7 +158,7 @@ GET /pools
 ```
 #### cURL
 ```
-curl -X GET https://deployments.<BASE-DOMAIN>/<DEPLOYMENT-NAME>/airflow/api/v1/pools \
+curl -X GET https://deployments.<BASE-DOMAIN>/<DEPLOYMENT-RELEASE-NAME>/airflow/api/v1/pools \
   -H 'Authorization: <API-KEY>'
 ```
 #### Python

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -68,7 +68,11 @@ With the information from Step 1, you can now run `GET` or `POST` requests to an
 https://deployments.<BASE-DOMAIN>/<DEPLOYMENT-NAME>/airflow/api/v1
 ```
 
-In the examples below, you'll replace `<BASE-DOMAIN>` (e.g. `mycompany.astronomer.io`) and `<DEPLOYMENT-NAME>` (e.g. `galactic-stars-1234`) with your own.
+In the examples below, you'll replace the following values with your own:
+
+- `<BASE-DOMAIN>`: The base domain for your organization on Astronomer Software. For example: `mycompany.astronomer.io`.
+- `<DEPLOYMENT-RELEASE-NAME>`: The release name of your Deployment. For example: `galactic-stars-1234`.
+- `<API-KEY>`: The API key for your Deployment Service Account.
 
 You can make requests via the method of your choosing. Below, we'll share example requests via cURL and Python to Airflow's "Trigger DAG" and "Get all Pools" endpoints. In all cases, your request will have the same permissions as the role of the Service Account you created on Astronomer.
 

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -223,8 +223,6 @@ curl -X GET \
   -H 'Cache-Control: no-cache'
 ```
 
-To run this, update the following placeholder values:
-
 - `<BASE-DOMAIN>`: Use your base domain name, i.e. the domain name used when authenticating to the `astro` cli
 - `<DEPLOYMENT-NAME>`: Use the name of your deployment release name
 - `<API-KEY>`: API Key from your Service Account


### PR DESCRIPTION
Change summary
* Add `app.` prefix for url for temporary token generation
* Fix syntax errors in curl commands
* Indents in curl commands for readability
* I'm not sure if it's a unique DNS issue for me, but I need the URL to be prefixed with `deployments`, e.g. `https://deployments.mydomain.com/deployment/airflow/api/v1...`
* On a related note, I need to include "airflow" between my deployment name and "api" in the URL, e.g. `https://deployments.mydomain.com/deployment/airflow/api/v1...`
* fix `python` being at the top of the python API request example for `GET /pools`
* Use f-strings in URLs in python requests
* Distinguish between deployment name and the base domain by converting `<AIRFLOW-DOMAIN>` into `<BASE-DOMAIN>` and `<DEPLOYMENT-NAME>`
* Add Python example for triggering DAGs


Additional issues
* When I try to specify an `execution_date` or `logical_date` for triggering a dagrun, I get the error "Naive datetime is disallowed", so I mostly left this section alone for now.

Curious to hear what you think! Happy to go back and forth a bit if only some of this makes sense.