### PR TITLE
Set Google Analytics siteSpeedSampleRate

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -186,6 +186,7 @@ module.exports = {
         googleAnalytics: {
           trackingID: 'UA-54102728-4',
           anonymizeIP: true,
+          siteSpeedSampleRate: 20,
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Increasing from default (1%) to 20% of sessions that will record site speed to get a better picture of performance in Google Analytics.