### PR TITLE
Update Role Permissions on Data Plane Activation Doc

### DIFF
--- a/astro/data-plane-activation.md
+++ b/astro/data-plane-activation.md
@@ -22,7 +22,15 @@ By default, the Astronomer account has no access to your data services. We’ll 
 ### Pre-Flight Checklist
 When you arrive at your data plane activation appointment, please ensure you have:
 - [ ] [Astro CLI](install-cli.md) installed for any users who will develop pipelines
-- [ ] Clean AWS Account created, which you have CreateRole permissions on
+- [ ] Clean AWS Account created, which you have the following permissions on:
+    - `cloudformation:*`
+    - `GetRole`
+    - `GetRolePolicy`
+    - `CreateRole`
+    - `DeleteRolePolicy`
+    - `PutRolePolicy`
+    - `ListRoles`
+    - `UpdateAssumeRolePolicy`
 - [ ] Desired region for Astro Cluster deployment identified, from the list of [supported regions](resource-reference-aws.md#aws-region)
 - [ ] _If peering VPCs_, preferred subnet CIDR range identified (no smaller than a /19 range)
 

--- a/astro/data-plane-activation.md
+++ b/astro/data-plane-activation.md
@@ -23,14 +23,14 @@ By default, the Astronomer account has no access to your data services. We’ll 
 When you arrive at your data plane activation appointment, please ensure you have:
 - [ ] [Astro CLI](install-cli.md) installed for any users who will develop pipelines
 - [ ] Clean AWS Account created, which you have the following permissions on:
-    - `cloudformation:*`
-    - `GetRole`
-    - `GetRolePolicy`
-    - `CreateRole`
-    - `DeleteRolePolicy`
-    - `PutRolePolicy`
-    - `ListRoles`
-    - `UpdateAssumeRolePolicy`
+  * `cloudformation:*`
+  * `GetRole`
+  * `GetRolePolicy`
+  * `CreateRole`
+  * `DeleteRolePolicy`
+  * `PutRolePolicy`
+  * `ListRoles`
+  * `UpdateAssumeRolePolicy`
 - [ ] Desired region for Astro Cluster deployment identified, from the list of [supported regions](resource-reference-aws.md#aws-region)
 - [ ] _If peering VPCs_, preferred subnet CIDR range identified (no smaller than a /19 range)
 

--- a/astro/data-plane-activation.md
+++ b/astro/data-plane-activation.md
@@ -22,15 +22,15 @@ By default, the Astronomer account has no access to your data services. We’ll 
 ### Pre-Flight Checklist
 When you arrive at your data plane activation appointment, please ensure you have:
 - [ ] [Astro CLI](install-cli.md) installed for any users who will develop pipelines
-- [ ] Clean AWS Account created, which you have the following permissions on:
-  * `cloudformation:*`
-  * `GetRole`
-  * `GetRolePolicy`
-  * `CreateRole`
-  * `DeleteRolePolicy`
-  * `PutRolePolicy`
-  * `ListRoles`
-  * `UpdateAssumeRolePolicy`
+- [ ] Clean AWS Account created, which you have the following permissions on:  
+  `cloudformation:*`
+  - `GetRole`
+  - `GetRolePolicy`
+  - `CreateRole`
+  - `DeleteRolePolicy`
+  - `PutRolePolicy`
+  - `ListRoles`
+  - `UpdateAssumeRolePolicy`
 - [ ] Desired region for Astro Cluster deployment identified, from the list of [supported regions](resource-reference-aws.md#aws-region)
 - [ ] _If peering VPCs_, preferred subnet CIDR range identified (no smaller than a /19 range)
 

--- a/astro/data-plane-activation.md
+++ b/astro/data-plane-activation.md
@@ -23,7 +23,7 @@ By default, the Astronomer account has no access to your data services. We’ll 
 When you arrive at your data plane activation appointment, please ensure you have:
 - [ ] [Astro CLI](install-cli.md) installed for any users who will develop pipelines
 - [ ] Clean AWS Account created, which you have the following permissions on:  
-  `cloudformation:*`
+  - `cloudformation:*`
   - `GetRole`
   - `GetRolePolicy`
   - `CreateRole`

--- a/astro/data-plane-activation.md
+++ b/astro/data-plane-activation.md
@@ -22,7 +22,8 @@ By default, the Astronomer account has no access to your data services. We’ll 
 ### Pre-Flight Checklist
 When you arrive at your data plane activation appointment, please ensure you have:
 - [ ] [Astro CLI](install-cli.md) installed for any users who will develop pipelines
-- [ ] Clean AWS Account created, which you have the following permissions on:  
+- [ ] A clean AWS Account
+- [ ] A user with the following permissions to that AWS account:
   - `cloudformation:*`
   - `GetRole`
   - `GetRolePolicy`


### PR DESCRIPTION
Correcting role permissions to reflect those required when executing via CloudFormation (rather than AWS CLI)