### PR TITLE
Update connect-external-services.md

### DIFF
--- a/astro/connect-external-services.md
+++ b/astro/connect-external-services.md
@@ -82,7 +82,7 @@ astro-nuclear-science-2730@astronomer-prod.iam.gserviceaccount.com
 
 :::info
 
-GCP has a 30 character limit for service account names. For Deployment namespaces which are longer than 24 characters, use only the first 24 characters for the service account name. For example, if your Google cloud project was called `astronomer-prod` and your Deployment namespace was `nuclear-scintillation-2730`, your service account would be:
+GCP has a 30 character limit for service account names. For Deployment namespaces which are longer than 24 characters, use only the first 24 characters when determining your service account name. For example, if your GCP project was called `astronomer-prod` and your Deployment namespace was `nuclear-scintillation-2730`, your service account would be:
 
 ```text
 astro-nuclear-scintillation-27@astronomer-pmm.iam.gserviceaccount.com

--- a/astro/connect-external-services.md
+++ b/astro/connect-external-services.md
@@ -66,7 +66,7 @@ To grant a Deployment on Astro access to GCP services such as BigQuery, you must
 - Add the Kubernetes service account for your Astro Deployment to the principal of that Google Cloud project
 - Bind the service account to a role that has access to your external data service
 
-Kubernetes service accounts for Astro Deployments are formatted as follows:
+Kubernetes service accounts for Astro Deployments are formatted as follows: 
 
 ```text
 astro-<deployment-namespace>@<gcp-project-name>.iam.gserviceaccount.com
@@ -74,10 +74,10 @@ astro-<deployment-namespace>@<gcp-project-name>.iam.gserviceaccount.com
 
 To find the namespace of your Deployment, go to your Deployment page in the Cloud UI and copy paste the value in the **Namespace** field.
 
-For a Google Cloud project called `astronomer-prod-deployment` and a Deployment namespace called `geometrical-gyroscope-9932`, for example, the service account for the Deployment would be:
+For a Google Cloud project called `astronomer-prod` and a Deployment namespace called `nuclear-science-2730`, for example, the service account for the Deployment would be:
 
 ```text
-astro-geometrical-gyroscope-9932@astronomer-prod-deployment.iam.gserviceaccount.com
+astro-nuclear-science-2730@astronomer-prod.iam.gserviceaccount.com
 ```
 
 For more information about configuring service accounts on GCP, see [GCP documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).

--- a/astro/connect-external-services.md
+++ b/astro/connect-external-services.md
@@ -62,11 +62,11 @@ If your target VPC resolves DNS hostnames using [private hosted zones](https://d
 
 To grant a Deployment on Astro access to GCP services such as BigQuery, you must:
 
-- Go to the Google Cloud project in which your external data service is hosted 
+- Go to the Google Cloud project in which your external data service is hosted
 - Add the Kubernetes service account for your Astro Deployment to the principal of that Google Cloud project
 - Bind the service account to a role that has access to your external data service
 
-Kubernetes service accounts for Astro Deployments are formatted as follows: 
+Kubernetes service accounts for Astro Deployments are formatted as follows:
 
 ```text
 astro-<deployment-namespace>@<gcp-project-name>.iam.gserviceaccount.com
@@ -80,10 +80,14 @@ For a Google Cloud project called `astronomer-prod` and a Deployment namespace c
 astro-nuclear-science-2730@astronomer-prod.iam.gserviceaccount.com
 ```
 
-:::info 
+:::info
 
 GCP has a 30 character limit for service account names. For Deployment namespaces which are longer than 24 characters, use only the first 24 characters for the service account name. For example, if your Google cloud project was called `astronomer-prod` and your Deployment namespace was `nuclear-scintillation-2730`, your service account would be:
 
 ```text
 astro-nuclear-scintillation-27@astronomer-pmm.iam.gserviceaccount.com
+```
+
+:::
+
 For more information about configuring service accounts on GCP, see [GCP documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).

--- a/astro/connect-external-services.md
+++ b/astro/connect-external-services.md
@@ -80,4 +80,10 @@ For a Google Cloud project called `astronomer-prod` and a Deployment namespace c
 astro-nuclear-science-2730@astronomer-prod.iam.gserviceaccount.com
 ```
 
+:::info 
+
+GCP has a 30 character limit for service account names. For Deployment namespaces which are longer than 24 characters, use only the first 24 characters for the service account name. For example, if your Google cloud project was called `astronomer-prod` and your Deployment namespace was `nuclear-scintillation-2730`, your service account would be:
+
+```text
+astro-nuclear-scintillation-27@astronomer-pmm.iam.gserviceaccount.com
 For more information about configuring service accounts on GCP, see [GCP documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).


### PR DESCRIPTION
Fixed the example because the one I had was made up and wouldn't have worked - Google service accounts are truncated at 30 characters (I was trying to be cute, it backfired)

This is just a band-aid until we figure out how to deal with this issue in the product itself, but I didn't want an incorrect example in the docs until then.