### PR TITLE
5.0.0 Upgrade Considerations/ Tidy Software Upgrade Doc

### DIFF
--- a/astro/upgrade-runtime.md
+++ b/astro/upgrade-runtime.md
@@ -37,3 +37,11 @@ To push your upgrade to Astro, run `astrocloud deploy` and select the Deployment
 3. In the Airflow UI, scroll to the bottom of any page. You should see your new Runtime version in the footer:
 
     ![Runtime Version banner](/img/docs/image-tag-airflow-ui.png)
+
+## Upgrade Considerations
+
+The following topic contains information about upgrading to specific versions of Runtime, including breaking changes and other upgrade considerations.
+
+### Runtime 5.0.0 (Airflow 2.3.0)
+
+When a Deployment has a large amount of data stored in its metadata database, upgrading it to Runtime 5.0.0 can take significantly longer than average. If you need to minimize the upgrade time for a given Deployment, reach out to [Astronomer Support](https://support.astornomer.io) and request for Astronomer to remove unnecessary records from your metadata DB.

--- a/astro/upgrade-runtime.md
+++ b/astro/upgrade-runtime.md
@@ -46,7 +46,7 @@ This topic contains information about upgrading to specific versions of Astro Ru
 
 Astro Runtime 5.0 includes changes to the schema of the Airflow metadata database. When you first upgrade to Runtime 5, consider that:
 
-- If a Deployment on Astro has a large amount of historical data stored in its metadata database, upgrading to Runtime 5.0 can take 10 to 30 minutes or more. During this time, scheduled tasks will continue to execute but new tasks will not be scheduled.
+- Upgrading to Runtime 5.0 can take 10 to 30 minutes or more depending on the number of task instances that have been recorded in the deployment's metadata database. During this time, scheduled tasks will continue to execute but new tasks will not be scheduled.
 - Once you upgrade successfully to Runtime 5.0, you might see errors in the Airflow UI that warn you of incompatible data in certain tables of the database. For example:
 
     ```Airflow found incompatible data in the `dangling_rendered_task_instance_fields` table in your metadata database, and moved...`.

--- a/astro/upgrade-runtime.md
+++ b/astro/upgrade-runtime.md
@@ -40,8 +40,18 @@ To push your upgrade to Astro, run `astrocloud deploy` and select the Deployment
 
 ## Upgrade Considerations
 
-The following topic contains information about upgrading to specific versions of Runtime, including breaking changes and other upgrade considerations.
+This topic contains information about upgrading to specific versions of Astro Runtime. This includes notes on breaking changes, database migrations, and other considerations that might depend on your use case.
 
-### Runtime 5.0.0 (Airflow 2.3.0)
+### Runtime 5.0.x (Airflow 2.3.x)
 
-When a Deployment has a large amount of data stored in its metadata database, upgrading it to Runtime 5.0.0 can take significantly longer than average. If you need to minimize the upgrade time for a given Deployment, reach out to [Astronomer Support](https://support.astornomer.io) and request for Astronomer to remove unnecessary records from your metadata DB.
+Astro Runtime 5.0 includes changes to the schema of the Airflow metadata database. When you first upgrade to Runtime 5, consider that:
+
+- If a Deployment on Astro has a large amount of historical data stored in its metadata database, upgrading to Runtime 5.0 can take 10 to 30 minutes or more. During this time, scheduled tasks will continue to execute but new tasks will not be scheduled.
+- Once you upgrade successfully to Runtime 5.0, you might see errors in the Airflow UI that warn you of incompatible data in certain tables of the database. For example:
+
+    ```Airflow found incompatible data in the `dangling_rendered_task_instance_fields` table in your metadata database, and moved...`.
+    ```
+
+    These warnings have no impact on your tasks or DAGs and can be ignored. If you want to remove these warning messages from the Airflow UI, reach out to [Astronomer Support](https://support.astronomer.io). If requested, Astronomer can drop incompatible tables from your metadata database.
+
+For more information on Airflow 2.3, see ["Apache Airflow 2.3.0 is here"](https://airflow.apache.org/blog/airflow-2.3.0/) or the [Airflow 2.3.0 changelog](https://airflow.apache.org/docs/apache-airflow/2.3.0/release_notes.html#airflow-2-3-0-2022-04-30).

--- a/software/manage-airflow-versions.md
+++ b/software/manage-airflow-versions.md
@@ -169,10 +169,9 @@ astro deploy
 
 :::caution
 
-Due to a schema change in the Airflow metadata database, upgrading a Software Deployment to [AC 2.3.0](https://github.com/astronomer/ap-airflow/blob/master/2.3.0/CHANGELOG.md) can take significantly longer than usual. Depending on the size of your metadata database, upgrades can take anywhere from 10 minutes to an hour. During this time, scheduled tasks will continue to execute but new tasks will not be scheduled.
+Due to a schema change in the Airflow metadata database, upgrading a Software Deployment to [AC 2.3.0](https://github.com/astronomer/ap-airflow/blob/master/2.3.0/CHANGELOG.md) can take significantly longer than usual. Depending on the size of your metadata database, upgrades can take anywhere from 10 minutes to an hour or longer depending on the number of task instances that have been recorded in the Airflow metadata database. During this time, scheduled tasks will continue to execute but new tasks will not be scheduled.
 
-If you need to minimize the upgrade time for a given Deployment, reach out to [Astronomer Support](https://support.astornomer.io) and request for Astronomer to remove unnecessary records from your metadata DB.
-
+If you need to minimize the upgrade time for a given Deployment, reach out to [Astronomer Support](https://support.astornomer.io).
 :::
 
 ### 5. Confirm your version in the Airflow UI

--- a/software/manage-airflow-versions.md
+++ b/software/manage-airflow-versions.md
@@ -161,7 +161,7 @@ $ astro dev start
 
 ### Step 4: Deploy to Astronomer
 
-To push your upgrade to your Astronomer Nebula Deployment, run:
+To push your upgrade to your Deployment, run:
 
 ```sh
 astro deploy
@@ -169,7 +169,7 @@ astro deploy
 
 :::caution
 
-Upgrading a Nebula Deployment to [AC 2.3.0](https://github.com/astronomer/ap-airflow/blob/master/2.3.0/CHANGELOG.md) can take significantly longer than normal, with some upgrades taking anywhere from 10 minutes to an hour. If you need to minimize the upgrade time for a given Deployment, reach out to [Astronomer Support](https://support.astornomer.io) and request for Astronomer to remove unnecessary records from your metadata DB.
+Upgrading a Software Deployment to [AC 2.3.0](https://github.com/astronomer/ap-airflow/blob/master/2.3.0/CHANGELOG.md) can take significantly longer than normal, with some upgrades taking anywhere from 10 minutes to an hour. If you need to minimize the upgrade time for a given Deployment, reach out to [Astronomer Support](https://support.astornomer.io) and request for Astronomer to remove unnecessary records from your metadata DB.
 
 :::
 

--- a/software/manage-airflow-versions.md
+++ b/software/manage-airflow-versions.md
@@ -145,7 +145,7 @@ For our platform's full collection of Docker Images, reference [Astronomer on Qu
 
 > **Note:** In November of 2020, Astronomer migrated its Docker Registry from [Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow) to [Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags) due to a [change](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/) in Docker Hub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer/ap-airflow` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer (e.g. `toomanyrequests: You have reached your pull rate limit`).
 
-### Step 3: Test Your Upgrade (_Optional_)
+### 3. Test Your Upgrade (_Optional_)
 
 To test your upgrade on your local machine, make sure to save your changes and run the following from your command line:
 
@@ -159,7 +159,7 @@ This will stop all 3 running Docker containers for each of the necessary Airflow
 $ astro dev start
 ```
 
-### Step 4: Deploy to Astronomer
+### 4. Deploy to Astronomer
 
 To push your upgrade to your Deployment, run:
 
@@ -173,7 +173,7 @@ Upgrading a Software Deployment to [AC 2.3.0](https://github.com/astronomer/ap-a
 
 :::
 
-### Step 4: Confirm your version in the Airflow UI
+### 5. Confirm your version in the Airflow UI
 
 Once you've issued that command, navigate to your Airflow UI to confirm that you're now running the correct Airflow version.
 

--- a/software/manage-airflow-versions.md
+++ b/software/manage-airflow-versions.md
@@ -145,15 +145,15 @@ For our platform's full collection of Docker Images, reference [Astronomer on Qu
 
 > **Note:** In November of 2020, Astronomer migrated its Docker Registry from [Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow) to [Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags) due to a [change](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/) in Docker Hub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer/ap-airflow` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer (e.g. `toomanyrequests: You have reached your pull rate limit`).
 
-### 3. Test Your Upgrade (_Optional_)
+### 3. Test Your Upgrade Locally (_Optional_)
 
-To test your upgrade on your local machine, make sure to save your changes and run the following from your command line:
+To test a new version of Astronomer Certified on your local machine, save all changes to your `Dockerfile` and run:
 
 ```sh
 $ astro dev stop
 ```
 
-This will stop all 3 running Docker containers for each of the necessary Airflow components (Webserver, Scheduler, Postgres). From here, you can apply your changes and deploy them locally by running the following:
+This will stop all 3 running Docker containers for each of the necessary Airflow components (Webserver, Scheduler, Postgres). Then, apply your changes locally by running:
 
 ```sh
 $ astro dev start
@@ -161,7 +161,7 @@ $ astro dev start
 
 ### 4. Deploy to Astronomer
 
-To push your upgrade to your Deployment, run:
+To push your upgrade to a Deployment on Astronomer Software, run:
 
 ```sh
 astro deploy
@@ -169,7 +169,9 @@ astro deploy
 
 :::caution
 
-Upgrading a Software Deployment to [AC 2.3.0](https://github.com/astronomer/ap-airflow/blob/master/2.3.0/CHANGELOG.md) can take significantly longer than normal, with some upgrades taking anywhere from 10 minutes to an hour. If you need to minimize the upgrade time for a given Deployment, reach out to [Astronomer Support](https://support.astornomer.io) and request for Astronomer to remove unnecessary records from your metadata DB.
+Due to a schema change in the Airflow metadata database, upgrading a Software Deployment to [AC 2.3.0](https://github.com/astronomer/ap-airflow/blob/master/2.3.0/CHANGELOG.md) can take significantly longer than usual. Depending on the size of your metadata database, upgrades can take anywhere from 10 minutes to an hour. During this time, scheduled tasks will continue to execute but new tasks will not be scheduled.
+
+If you need to minimize the upgrade time for a given Deployment, reach out to [Astronomer Support](https://support.astornomer.io) and request for Astronomer to remove unnecessary records from your metadata DB.
 
 :::
 

--- a/software/manage-airflow-versions.md
+++ b/software/manage-airflow-versions.md
@@ -145,33 +145,39 @@ For our platform's full collection of Docker Images, reference [Astronomer on Qu
 
 > **Note:** In November of 2020, Astronomer migrated its Docker Registry from [Docker Hub](https://hub.docker.com/r/astronomerinc/ap-airflow) to [Quay.io](https://quay.io/repository/astronomer/ap-airflow?tab=tags) due to a [change](https://www.docker.com/blog/what-you-need-to-know-about-upcoming-docker-hub-rate-limiting/) in Docker Hub's rate limit policy. If you're using a legacy `astronomerinc/ap-airflow` image, replace it with a corresponding `quay.io/astronomer/ap-airflow` image to avoid rate limiting errors from DockerHub when you deploy to Astronomer (e.g. `toomanyrequests: You have reached your pull rate limit`).
 
-## Step 3: Rebuild your Image
+### Step 3: Test Your Upgrade (_Optional_)
 
-### Local Development
+To test your upgrade on your local machine, make sure to save your changes and run the following from your command line:
 
-If you're developing locally, make sure to save your changes and issue the following from your command line:
+```sh
+$ astro dev stop
+```
 
-1. `$ astro dev stop`
+This will stop all 3 running Docker containers for each of the necessary Airflow components (Webserver, Scheduler, Postgres). From here, you can apply your changes and deploy them locally by running the following:
 
-   This will stop all 3 running Docker containers for each of the necessary Airflow components (Webserver, Scheduler, Postgres).
+```sh
+$ astro dev start
+```
 
-2. `$ astro dev start`
+### Step 4: Deploy to Astronomer
 
-   This will start those 3 Docker containers needed to run Airflow.
-
-### On Astronomer
-
-If you don't need to test this locally and just want to push to your Astronomer Software installation, you can run:
+To push your upgrade to your Astronomer Nebula Deployment, run:
 
 ```sh
 astro deploy
 ```
 
-## Step 4: Confirm your version in the Airflow UI
+:::caution
+
+Upgrading a Nebula Deployment to [AC 2.3.0](https://github.com/astronomer/ap-airflow/blob/master/2.3.0/CHANGELOG.md) can take significantly longer than normal, with some upgrades taking anywhere from 10 minutes to an hour. If you need to minimize the upgrade time for a given Deployment, reach out to [Astronomer Support](https://support.astornomer.io) and request for Astronomer to remove unnecessary records from your metadata DB.
+
+:::
+
+### Step 4: Confirm your version in the Airflow UI
 
 Once you've issued that command, navigate to your Airflow UI to confirm that you're now running the correct Airflow version.
 
-### Local Development
+#### Local Development
 
 If you're developing locally, you can:
 
@@ -182,7 +188,7 @@ Once there, you should see your correct Airflow version listed.
 
 > **Note:** The URL listed above assumes your Webserver is at Port 8080 (default). To change that default, read [this forum post](https://forum.astronomer.io/t/i-already-have-the-ports-that-the-cli-is-trying-to-use-8080-5432-occupied-can-i-change-the-ports-when-starting-a-project/48).
 
-### On Astronomer
+#### On Astronomer
 
 If you're on Astronomer Software, navigate to your Airflow Deployment page on the Software UI.
 

--- a/software/manage-airflow-versions.md
+++ b/software/manage-airflow-versions.md
@@ -171,7 +171,7 @@ astro deploy
 
 Due to a schema change in the Airflow metadata database, upgrading a Software Deployment to [AC 2.3.0](https://github.com/astronomer/ap-airflow/blob/master/2.3.0/CHANGELOG.md) can take significantly longer than usual. Depending on the size of your metadata database, upgrades can take anywhere from 10 minutes to an hour or longer depending on the number of task instances that have been recorded in the Airflow metadata database. During this time, scheduled tasks will continue to execute but new tasks will not be scheduled.
 
-If you need to minimize the upgrade time for a given Deployment, reach out to [Astronomer Support](https://support.astornomer.io).
+If you need to minimize the upgrade time for a given Deployment, reach out to [Astronomer Support](https://support.astronomer.io). Note that minimizing your upgrade time requires removing records from your metadata database. 
 :::
 
 ### 5. Confirm your version in the Airflow UI


### PR DESCRIPTION
The Upgrade considerations for Runtime 5.0.0/ AC 2.3.0 gave me a good excuse to update some of our upgrade docs. 

- For Astro, I added a new "Upgrade Considerations" topic that includes version-specific upgrade information
- For Software (and Nebula), I split the test/ deploy workflows into two separate steps and added a note about AC 2.3.0 as a cautionary note instead of a full consideration. 