### PR TITLE
Add dns APIs to the setup script

### DIFF
--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -82,6 +82,7 @@ To activate the Data Plane on your GCP project:
     $ gcloud services enable cloudkms.googleapis.com
     $ gcloud services enable sqladmin.googleapis.com
     $ gcloud services enable servicenetworking.googleapis.com
+    $ gcloud services enable dns.googleapis.com
     $ curl \
     https://storage.googleapis.com/storage/v1/projects/$GOOGLE_CLOUD_PROJECT/serviceAccount \
     --header "Authorization: Bearer `gcloud auth application-default print-access-token`"   \


### PR DESCRIPTION
We added a feature to update DNS for Private Services Connect, which requires the DNS apis to be enabled.  The feature will be out on Thursday 5/26 or Friday 5/27, but having this line in early won't hurt one bit.