### PR TITLE
Airgap Doc Improvements

### DIFF
--- a/software/install-airgapped.md
+++ b/software/install-airgapped.md
@@ -41,7 +41,7 @@ You can also set up your own registry using a dedicated registry service such as
 ## Step 2: Fetch Images from Astronomer's Helm Template
 **Note**: Astronomer recommends creating a YAML configuration file before completing this task. Sample `config.yaml` files are available here: [AWS](install-aws-standard.md), [Azure](install-azure-standard.md), [GCP](install-gcp-standard.md).
 
-**Note**: If you utilize other features such as [third party ingress controllers](./third-party-ingress-controllers.md), you made need to synchronize other images not listed with this snippet
+**Note**: If you utilize features such as [third party ingress controllers](./third-party-ingress-controllers.md), you may need to synchronize other images not listed here.
 
 The images and tags which are required for your Software installation depend on the version of Astronomer you're installing. 
 Image tags are subject to change, even within existing versions, for example to resolve critical security issues, and therefore not listed here. 

--- a/software/install-airgapped.md
+++ b/software/install-airgapped.md
@@ -267,7 +267,7 @@ Before completing this step, double-check that the following statements are true
 - You made Astronomer's Docker images, Airflow Helm chart, and updates JSON accessible inside your network.
 - You completed Steps 1 through 8 in the [AWS](install-aws-standard.md), [Azure](install-azure-standard.md), or [GCP](install-gcp-standard.md) install guide.
 
-After this check, you can install the Astronomer Helm chart by running the following commands, making sure to replace <your-image-tag> with the version of Astronomer that you want to install:
+After this check, you can install the Astronomer Helm chart by running the following commands, making sure to replace `<your-image-tag>` with the version of Astronomer that you want to install:
 
 ```bash
 curl -L https://github.com/astronomer/astronomer/archive/v<your-image-tag>.tar.gz -o astronomer.tgz

--- a/software/install-airgapped.md
+++ b/software/install-airgapped.md
@@ -39,7 +39,7 @@ Astronomer's Docker images are hosted on a public registry which isn't accessibl
 You can also set up your own registry using a dedicated registry service such as [JFrog Artifactory](https://jfrog.com/artifactory/). Regardless of which service you use, follow the product documentation to configure a private registry according to your organization's security requirements.
 
 ## Step 2: Fetch Images from Astronomer's Helm Template
-**Note**: You should set up a `config.yaml` before running the below steps. Example `config.yaml` files are in the [AWS](install-aws-standard.md), [Azure](install-azure-standard.md), or [GCP](install-gcp-standard.md) install guides
+**Note**: Astronomer recommends creating a YAML configuration file before completing this task. Sample `config.yaml` files are available here: [AWS](install-aws-standard.md), [Azure](install-azure-standard.md), [GCP](install-gcp-standard.md).
 
 **Note**: If you utilize other features such as [third party ingress controllers](./third-party-ingress-controllers.md), you made need to synchronize other images not listed with this snippet
 

--- a/software/install-airgapped.md
+++ b/software/install-airgapped.md
@@ -44,7 +44,7 @@ You can also set up your own registry using a dedicated registry service such as
 **Note**: If you utilize features such as [third party ingress controllers](./third-party-ingress-controllers.md), you may need to synchronize other images not listed here.
 
 The images and tags which are required for your Software installation depend on the version of Astronomer you're installing. 
-Image tags are subject to change, even within existing versions, for example to resolve critical security issues, and therefore not listed here. 
+Image tags are subject to change, even within existing versions. 
 To gather a list of exact images and tags required for your Astronomer Helm chart version, you can template the Helm chart and fetch the rendered image tags:
 
 ```bash

--- a/software/third-party-ingress-controllers.md
+++ b/software/third-party-ingress-controllers.md
@@ -99,6 +99,7 @@ global:
   authSidecar:  
     enabled: true
     repository: nginxinc/nginx-unprivileged # In airgapped installations, change this to specify your private registry
+    tag: stable
 ```
 
 If you use a Traefik or Contour ingress controller, you need to configure additional values in your chart. For more information, read the following subsections.


### PR DESCRIPTION
- remove old versions (0.27) from airgap bash commands in documentation
- add better image tag fetching bash snippets (utilize the `config.yaml` to better get the list of images, add `airflow`)
- add required tag to third-party-ingress