### PR TITLE
Add footer link to Privacy Policy

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -144,6 +144,10 @@ module.exports = {
               label: 'Astronomer Registry',
               to: 'https://registry.astronomer.io/',
             },
+            {
+              label: 'Privacy Policy',
+              to: 'https://www.astronomer.io/privacy/',
+            },
           ],
         },
         {
@@ -208,12 +212,12 @@ module.exports = {
         path: 'software',
         lastVersion: 'current',
         versions: {
-        current: {
-          label: '0.28',
-          path: '',
-          banner: 'none',
-         },
-       },
+          current: {
+            label: '0.28',
+            path: '',
+            banner: 'none',
+          },
+        },
       },
     ],
   ],


### PR DESCRIPTION
This small PR adds a link to our Privacy Policy in the footer. https://www.astronomer.io/privacy/