### PR TITLE
quick fix of docs

### DIFF
--- a/astro/ci-cd.md
+++ b/astro/ci-cd.md
@@ -47,7 +47,7 @@ $ export ASTRONOMER_KEY_SECRET="<your-api-key-secret>"
 $ brew install astronomer/tap/astro
 
 # Build your Astro project into a Docker image and push the image to your Deployment
-$ astro deploy <your-deployment-id>
+$ astro deploy <your-deployment-id> -f
 ```
 
 :::info
@@ -90,7 +90,7 @@ To automate code deploys to a Deployment using [GitHub Actions](https://github.c
         - name: Deploy to Astro
           run: |
             brew install astronomer/tap/astro
-            astro deploy ${{ secrets.ASTRONOMER_DEPLOYMENT_ID }}
+            astro deploy ${{ secrets.ASTRONOMER_DEPLOYMENT_ID }} -f
     ```
 
 ### GitHub Actions (Multiple Branches)
@@ -141,7 +141,7 @@ This setup assumes the following prerequisites:
         - name: Deploy to Astro
           run: |
             brew install astronomer/tap/astro
-            astro deploy ${{ secrets.DEV_ASTRONOMER_DEPLOYMENT_ID }}
+            astro deploy ${{ secrets.DEV_ASTRONOMER_DEPLOYMENT_ID }} -f
       prod-push:
         if: github.event.action == 'closed' && github.event.pull_request.merged == true
         env:
@@ -155,7 +155,7 @@ This setup assumes the following prerequisites:
         - name: Deploy to Astro
           run: |
             brew install astronomer/tap/astro
-            astro deploy ${{ secrets.PROD_ASTRONOMER_DEPLOYMENT_ID }}
+            astro deploy ${{ secrets.PROD_ASTRONOMER_DEPLOYMENT_ID }} -f
     ```
 
 ### Jenkins

--- a/software_versioned_sidebars/version-0.28-sidebars.json
+++ b/software_versioned_sidebars/version-0.28-sidebars.json
@@ -65,7 +65,7 @@
             "registry-backend",
             "renew-tls-cert",
             "namespace-pools",
-            "third-party-ingress-controllers",
+            "third-party-ingress-controllers"
           ]
         },
         {
@@ -76,7 +76,7 @@
             "upgrade-astronomer-stable",
             "houston-api",
             "configure-platform-resources",
-            "upgrade-to-0-28",
+            "upgrade-to-0-28"
           ]
         },
         {


### PR DESCRIPTION
This issue https://github.com/astronomer/astro-cli/issues/585 is making it so the current CI/CD pipeline is failing in github actions. This PR updates the CI/CD pipeline to use `astro deploy -f` instead of `astro deploy` so the parse stage of the pipeline is skipped until we figure out what is causing the problem