### PR TITLE
Provide Additional Clarity About Runtime Vulnerability Fixes

### DIFF
--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -74,7 +74,7 @@ Occasionally, Astronomer might deviate from the defined response policy and back
 
 ### The Quay Common Vulnerabilities and Exposures Report
 
-Astronomer is aware of the Quay Common Vulnerabilities and Exposures (CVE) report and monitors it frequently. Many of the medium and low-level vulnerabilities identified in the report pose no risk to Astronomer customers. Some high-level vulnerabilities identified in the report must be corrected by vendors and Astronomer adds the fixes to stable and LTS releases as soon as they are available. All vulnerabilities that are the responsibility of Astronomer are addressed quickly and fixes are provided regularly. 
+Astronomer is aware of the Quay Common Vulnerabilities and Exposures (CVE) report and monitors it frequently to reduce or eliminate customer exposure to high-level threats. Many of the medium and low-level vulnerabilities identified in the report pose no risk to Astronomer customers. Some high-level vulnerabilities identified in the report must be corrected by vendors. Astronomer adds the fixes provided by vendors to stable and LTS releases as soon as they are available. All vulnerabilities that are the responsibility of Astronomer are addressed quickly and fixes are released regularly. If there is a high-level vulnerability in the CVE report that is causing concern for your organization, contact [Astronomer Support](https://support.astronomer.io/).
 
 
 ## Astro Runtime Maintenance Policy

--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -66,7 +66,7 @@ For the smoothest, out-of-the-box Airflow experience, we strongly recommend and 
 
 ## Backport Policy for Bug and Security Fixes
 
-When Astronomer identifies a significant Astro Runtime bug, a fix is backported to all Long Term Support (LTS) versions and the latest stable version. Astronomer recommends that you upgrade Astro Runtime if you are not using the latest, stable version. The timely implementation of bug fixes is recommended to avoid task scheduling delays and data loss.
+When Astronomer identifies a significant bug in Astro Runtime, a fix is backported to all Long Term Support (LTS) versions and the latest stable version. To avoid the impact of previously identified bugs, Astronomer recommends that you upgrade Astro Runtime if you are not using the latest stable version.
 
 When Astronomer identifies a significant Astro Runtime security vulnerability, a fix is backported and made available as a patch version for all stable and LTS versions in maintenance. A significant security issue is defined as an issue with significant impact and exploitability.
 

--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -74,7 +74,7 @@ Occasionally, Astronomer might deviate from the defined response policy and back
 
 ### The Quay Common Vulnerabilities and Exposures Report
 
-Astronomer is aware of the Quay Common Vulnerabilities and Exposures (CVE) report and monitors it frequently to identify high-level threats. Many of the medium and low-level vulnerabilities identified in the report pose no risk to Astronomer customers. Some high-level vulnerabilities identified in the report must be corrected by vendors. Astronomer adds the fixes provided by vendors to stable and LTS releases as soon as they are available. All vulnerabilities that are the responsibility of Astronomer are addressed quickly and fixes are released regularly. If there is a high-level vulnerability in the CVE report that is causing concern for your organization, contact [Astronomer Support](https://support.astronomer.io/).
+Astronomer is aware of the Quay Common Vulnerabilities and Exposures (CVE) report and monitors it frequently to determine if the vulnerabilities identified in the report pose a risk to organizations using Astro Runtime images. Astronomer works with vendors to correct vulnerabilities and regularly adds fixes to stable and LTS releases. If there is a high-level vulnerability in the CVE report that is causing concern for your organization, contact [Astronomer Support](https://support.astronomer.io/).
 
 
 ## Astro Runtime Maintenance Policy

--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -68,7 +68,7 @@ For the smoothest, out-of-the-box Airflow experience, we strongly recommend and 
 
 When Astronomer identifies a significant bug in Astro Runtime, a fix is backported to all Long Term Support (LTS) versions and the latest stable version. To avoid the impact of previously identified bugs, Astronomer recommends that you upgrade Astro Runtime if you are not using the latest stable version.
 
-When Astronomer identifies a significant Astro Runtime security vulnerability, a fix is backported and made available as a patch version for all stable and LTS versions in maintenance. A significant security issue is defined as an issue with significant impact and exploitability.
+When Astronomer identifies a significant security vulnerability in Astro Runtime, a fix is backported and made available as a patch version for all stable and LTS versions in maintenance. A significant security issue is defined as an issue with significant impact and exploitability.
 
 Occasionally, Astronomer might deviate from the defined response policy and backport a bug or security fix to releases other than the latest stable and LTS versions. To request a fix for a specific bug, contact your customer success manager.
 

--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -66,11 +66,16 @@ For the smoothest, out-of-the-box Airflow experience, we strongly recommend and 
 
 ## Backport Policy for Bug and Security Fixes
 
-If a major stability bug in Astro Runtime is identified by Astronomer, a fix will be backported to all LTS versions and only the latest stable version. For users on a stable version that is not latest, our team will recommend that you upgrade. Major issues in this category may result in significant delays in task scheduling as well as potential data loss.
+When Astronomer identifies a significant Astro Runtime bug, a fix is backported to all Long Term Support (LTS) versions and the latest stable version. Astronomer recommends that you upgrade Astro Runtime if you are not using the latest, stable version. The timely implementation of bug fixes is recommended to avoid task scheduling delays and data loss.
 
-If a major security issue is identified, a fix will be backported and made available as a new Runtime patch version for all stable and LTS releases in maintenance. Major issues in this category are classified by a combination of impact and exploitability.
+When Astronomer identifies a significant Astro Runtime security vulnerability, a fix is backported and made available as a patch version for all stable and LTS versions in maintenance. A significant security issue is defined as an issue with significant impact and exploitability.
 
-In rare instances, the Astronomer team may make an exception and backport a bug or security fix to a release that is beyond the commitment stated above. To submit a request for consideration, please reach out to your customer success manager.
+Occasionally, Astronomer might deviate from the defined response policy and backport a bug or security fix to releases other than the latest stable and LTS versions. To request a fix for a specific bug, contact your customer success manager.
+
+### The Quay Common Vulnerabilities and Exposures Report
+
+Astronomer is aware of the Quay Common Vulnerabilities and Exposures (CVE) report and monitors it frequently. Many of the medium and low-level vulnerabilities identified in the report pose no risk to Astronomer customers. Some high-level vulnerabilities identified in the report must be corrected by vendors and Astronomer adds the fixes to stable and LTS releases as soon as they are available. All vulnerabilities that are the responsibility of Astronomer are addressed quickly and fixes are provided regularly. 
+
 
 ## Astro Runtime Maintenance Policy
 

--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -74,7 +74,7 @@ Occasionally, Astronomer might deviate from the defined response policy and back
 
 ### The Quay Common Vulnerabilities and Exposures Report
 
-Astronomer is aware of the Quay Common Vulnerabilities and Exposures (CVE) report and monitors it frequently to reduce or eliminate customer exposure to high-level threats. Many of the medium and low-level vulnerabilities identified in the report pose no risk to Astronomer customers. Some high-level vulnerabilities identified in the report must be corrected by vendors. Astronomer adds the fixes provided by vendors to stable and LTS releases as soon as they are available. All vulnerabilities that are the responsibility of Astronomer are addressed quickly and fixes are released regularly. If there is a high-level vulnerability in the CVE report that is causing concern for your organization, contact [Astronomer Support](https://support.astronomer.io/).
+Astronomer is aware of the Quay Common Vulnerabilities and Exposures (CVE) report and monitors it frequently to identify high-level threats. Many of the medium and low-level vulnerabilities identified in the report pose no risk to Astronomer customers. Some high-level vulnerabilities identified in the report must be corrected by vendors. Astronomer adds the fixes provided by vendors to stable and LTS releases as soon as they are available. All vulnerabilities that are the responsibility of Astronomer are addressed quickly and fixes are released regularly. If there is a high-level vulnerability in the CVE report that is causing concern for your organization, contact [Astronomer Support](https://support.astronomer.io/).
 
 
 ## Astro Runtime Maintenance Policy


### PR DESCRIPTION
Resolves #769.

To resolve issue 769, I added a new section titled _The Quay Common Vulnerabilities and Exposures Report_ to the existing section _Backport Policy for Bug and Security Fixes_ in _[Astro Runtime Versioning and Lifecycle Policy](https://docs.astronomer.io/astro/runtime-version-lifecycle-policy)_. This seemed the simplest solution.  