### PR TITLE
Limit concurrency for index actions

### DIFF
--- a/.github/workflows/reindex.yml
+++ b/.github/workflows/reindex.yml
@@ -1,4 +1,5 @@
 name: Reindex Algolia
+concurrency: algolia
 on:
   push:
     branches:


### PR DESCRIPTION
If two Reindex actions run at the same time, Algolia cannot handle the simultaneous API calls and it ends up messing with our index. 

Using [GitHub](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) concurrency settings, this PR attempts to limit concurrency of our reindex action.