### PR TITLE
Fixes spelling mistake in namespace pools documentation

### DIFF
--- a/software/namespace-pools.md
+++ b/software/namespace-pools.md
@@ -289,7 +289,7 @@ astronomer:
   commander:
     env:
       - name: "COMMANDER_MANUAL_NAMESPACE_NAMES"
-        value: tru
+        value: true
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
`tru -> true`