### PR TITLE
config.yaml editing instructions should be consistent for each page

### DIFF
--- a/software/custom-image-registry.md
+++ b/software/custom-image-registry.md
@@ -59,14 +59,7 @@ Deploying code changes to a custom image registry requires triggering a GraphQL 
 
   :::
 
-2. Locate your `config.yaml` file. To retrieve it programmatically, run:
-
-    ```bash
-    # platform-release-name is usually "astronomer"
-    helm get values <your-platform-release-name> astronomer/astronomer -n astronomer
-    ```
-
-3. Add the following to your `config.yaml` file:
+2. Add the following to your `config.yaml` file:
 
     ```yaml
     astronomer:
@@ -89,8 +82,8 @@ Deploying code changes to a custom image registry requires triggering a GraphQL 
 
   :::
 
-4. Push the configuration change. See [Apply a Config Change](https://docs.astronomer.io/software/apply-platform-config).
-5. For any existing Deployments, run the following command to sync the registry credentials.
+3. Push the configuration change. See [Apply a Config Change](https://docs.astronomer.io/software/apply-platform-config).
+4. For any existing Deployments, run the following command to sync the registry credentials.
 
     ```bash
     kubectl create job -n <release-namespace> --from=cronjob/astronomer-config-syncer upgrade-config-synchronization

--- a/software/export-task-logs.md
+++ b/software/export-task-logs.md
@@ -51,14 +51,7 @@ With this implementation, the Vector sidecars each utilize 100m cpu and 384Mi me
 
 ### Configure Logging Sidecars
 
-1. Locate your Astronomer Software `config.yaml`. To retrieve it programatically, run the following:
-
-    ```bash
-    # platform-release-name is usually "astronomer"
-    helm get values <your-platform-release-name> astronomer/astronomer -n astronomer
-    ```
-
-2. Add the following entry to your `config.yaml:`
+1. Add the following entry to your `config.yaml:`
 
     ```yaml
     global:
@@ -70,7 +63,7 @@ With this implementation, the Vector sidecars each utilize 100m cpu and 384Mi me
         terminationEndpoint: http://localhost:8000/quitquitquit
     ```
 
-3. Push the configuration change. See [Apply a Config Change](https://docs.astronomer.io/software/apply-platform-config)
+2. Push the configuration change. See [Apply a Config Change](https://docs.astronomer.io/software/apply-platform-config)
 
 
 :::info


### PR DESCRIPTION
Most of the pages under **Platform Setup** give instructions in the same format: update config.yaml and then see the instructions in **Apply a Software Platform Configuration Change**.

These two pages are doubling up by also instructing the user how to retrieve the config.yaml, which is differs from the precedence. I would like to make all the change-config-instructions pages consistent. 