### PR TITLE
Add "Upgrade to Airflow 2" docs to Astro

### DIFF
--- a/astro/data-plane-activation.md
+++ b/astro/data-plane-activation.md
@@ -27,7 +27,7 @@ This model allows us to get you started quickly, providing cloud-grade reliabili
 
 By default, the Astronomer account has no access to your data services. We’ll guide you through how to make these connections securely, whether peering VPCs or making direct connections.
 
-If you want to test an existing Airflow project on Astro, ensure that the project has been upgraded to Airflow 2.
+To test an existing Airflow project on Astro, your Airflow code needs to be compatible with Airflow 2. For a complete guide on how to migrate an open source Airflow project running 1.10.15 or lower to Astro, see [Upgrade to Airflow 2.0+](upgrade-to-airflow-2.md).
 
 ### Pre-Flight Checklist
 

--- a/astro/data-plane-activation.md
+++ b/astro/data-plane-activation.md
@@ -20,9 +20,14 @@ We’re excited to get you started with Astro! Getting your data plane activated
 When you meet with one of our engineers to activate your data plane, **expect it to take about an hour**. By the end of the session, you should have your **first pipeline deployed in your own Astro environment**!
 
 ### What to Bring and Know
+
 Your data plane will be deployed into a clean, dedicated AWS account or GCP project. With our fully managed service, we’ll take complete responsibility for the operations of this account, as described in our [Shared Responsibility Model](shared-responsibility-model.md).
+
 This model allows us to get you started quickly, providing cloud-grade reliability and seamless connection to all of your data services. If you decide not to proceed with Astro, this account can be deleted in its entirety.
+
 By default, the Astronomer account has no access to your data services. We’ll guide you through how to make these connections securely, whether peering VPCs or making direct connections.
+
+If you want to test an existing Airflow project on Astro, ensure that the project has been upgraded to Airflow 2.
 
 ### Pre-Flight Checklist
 

--- a/astro/upgrade-to-airflow-2.md
+++ b/astro/upgrade-to-airflow-2.md
@@ -1,0 +1,120 @@
+---
+title: "Upgrade to Airflow 2"
+sidebar_label: "Upgrade to Airflow 2"
+id: upgrade-to-airflow-2
+description: "Prepare for and upgrade to Airflow 2.0+ on Astronomer."
+---
+
+This guide explains how to upgrade an Airflow project from 1.10.15 to 2.3 and migrate it to Astro.
+
+As a follow up to Airflow 2.0, Airflow 2.3 was released in May 2022 with new features like dynamic task mapping and a Grid view in the Airflow UI. Given the significance of this release, Astronomer is providing full support for Airflow 2.3 until October 2023.
+
+Astronomer strongly recommends upgrading any Astronomer Software Deployments currently running Airflow 1.10.15 to Airflow 2.3.
+
+## The benefits of Airflow 2.0+
+
+Airflow 2.0 was built to be fast, reliable, and infinitely scalable. Among the hundreds of new features both large and small, Airflow 2.0 includes:
+
+- [Refactored Airflow Scheduler](https://airflow.apache.org/docs/apache-airflow/stable/scheduler.html#running-more-than-one-scheduler) for enhanced performance and high-availability.
+- [Full REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html) that enables more opportunities for automation.
+- [Smart Sensors](https://airflow.apache.org/docs/apache-airflow/stable/smart-sensor.html) that execute as single, long-running tasks.
+- [TaskFlow API](https://airflow.apache.org/docs/apache-airflow/stable/concepts.html#taskflow-api) for a simpler way to pass information between tasks.
+- [Independent Providers](https://github.com/apache/airflow/tree/master/airflow/providers) for improved usability and a more agile release cadence.
+- Simplified KubernetesExecutor for ultimate flexibility in configuration.
+- [UI/UX Improvements](https://github.com/apache/airflow/pull/11195) including a new Airflow UI and auto-refresh button in the **Graph** view.
+
+Airflow 2.3 subsequently introduced several powerful features, the most notable of which is [dynamic task mapping](https://airflow.apache.org/docs/apache-airflow/2.3.0/concepts/dynamic-task-mapping.html). For more information on Airflow 2.3, see ["Apache Airflow 2.3.0 is here"](https://airflow.apache.org/blog/airflow-2.3.0/) and the [Airflow 2.3.0 changelog](https://airflow.apache.org/docs/apache-airflow/2.3.0/release_notes.html#airflow-2-3-0-2022-04-30).
+
+## Prerequisites
+
+This setup requires:
+
+- The latest version of the [Astro CLI](configure-cli.md).
+- An Airflow project running Airflow 1.10.15.
+
+## Step 1: Migrate your Airflow code to an Astro project
+
+An Astro project structure is required for deploying code to Astro. To migrate an existing Airflow project to an Astro project:
+
+1. [Create an Astro project](create-project.md) using the Astro CLI.
+2. Delete the example DAGs included in the project.
+3. Move DAGs from your open source project to the `dags` folder in your Astro project.
+4. In your Astro project's `Dockerfile`, replace the `FROM` line with:
+
+    ```dockerfile
+    FROM quay.io/astronomer/ap-airflow:1.10.15-buster-onbuild
+    ```
+
+    This image serves as a bridge between your open source Airflow project and Airflow 2.3.
+
+5. Move OS-level dependencies from your open source project to the `packages.txt` file in your Astro project.
+6. Move OS-level dependencies from your open source project to the `requirements.txt` file in your Astro project.
+7. Open your Astro project and run `astro dev start` to your code in a local Airflow environment.
+
+## Step 2: Run the Airflow upgrade check script
+
+Most Airflow 1.10.15 DAGs will work in Airflow 2.0, though not all. The Airflow 2.0 upgrade check script can check for compatibility issues in your DAG code.
+
+To run the Airflow 2.0 upgrade check script, open your Astro project and run the following command:
+
+```shell
+astro dev upgrade-check
+```
+
+This command installs the latest version of the `apache-airflow-upgrade-check` package at runtime and outputs results from the corresponding Airflow CLI command.
+
+In the upgrade check output, you can ignore the `Fernet is enabled by default` and `Check versions of PostgreSQL, MySQL, and SQLite to ease upgrade to Airflow 2.0` tests. All of these details are handled by Astronomer. You can also ignore the and `Users must set a kubernetes.pod_template_file value` test even if you are running the Kubernetes executor.
+
+For more information on upgrade check functionality, see [Upgrade Check Script](https://airflow.apache.org/docs/apache-airflow/2.1.3/upgrade-check.html) in Apache Airflow documentation.
+
+## Step 3: Prepare Airflow 2.0 DAGs
+
+The next step is to review the results from Airflow's upgrade check script and make all necessary changes to your import statements, DAGs, and configurations.
+
+### a. Import operators from backport providers
+
+All Airflow 2.0 operators and extras are backwards compatible with both Airflow 1.10.14 and Airflow 1.10.15. To use these providers:
+
+1. Add all necessary providers in your `requirements.txt` file
+2. Modify your import statements
+3. Add any extras if needed
+
+For more information, see [1.10.15 Backport Providers](https://airflow.apache.org/docs/apache-airflow/1.10.15/backport-providers.html) in Apache Airflow documentation, or see the collection of [Backport Providers in PyPi](https://pypi.org/search/?q=apache-airflow-backport-providers&o=).
+
+### b. Modify Airflow DAGs
+
+Depending on your DAGs, you might need to modify your code to be 2.0-compatible. This can include:
+
+- Changes to undefined variable handling in templates.
+- Changes to the KubernetesPodOperator.
+- Changing the default value for `dag_run_conf_overrides_params`.
+
+For more compatibility considerations, see [Step 5: Upgrade Airflow DAGs](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/upgrading-to-2.html#step-5-upgrade-airflow-dags) in Apache Airflow documentation.
+
+## Step 4: Upgrade to Airflow 2.3
+
+If your DAGs and configurations pass the upgrade check script above, you're ready to officially upgrade to Airflow 2.3.0. The upgrade process itself is the same as any other on Astronomer.
+
+To upgrade to Airflow 2.3.0:
+
+1. Replace the `FROM` line in your Astro project's `Dockerfile` with the following:
+
+    ```dockerfile
+    FROM quay.io/astronomer/astro-runtime:5.0.4
+    ```
+
+2. Modify all backport providers and replace them with fully supported [provider packages](https://airflow.apache.org/docs/apache-airflow-providers/index.html). For example, if you were using the [Mongo backport provider](https://pypi.org/project/apache-airflow-backport-providers-mongo/), replace `apache-airflow-backport-providers-mongo` with `apache-airflow-providers-mongo` in your `requirements.txt` file. For more information, see [Airflow documentation on provider packages](https://airflow.apache.org/docs/apache-airflow-providers/index.html).
+3. Restart your local environment and open the Airflow UI to confirm that your upgrade was successful.
+
+### Upgrade considerations
+
+Apache Airflow 2.3 includes changes to the schema of the Airflow metadata database. When you first upgrade to Runtime 2.3, consider the following:
+
+- Upgrading to Airflow 2.3 can take 10 to 30 minutes or more depending on the number of task instances that have been recorded in the metadata database throughout the lifetime of your Deployment. During the upgrade, scheduled tasks will continue to execute but new tasks will not be scheduled.
+- Once you upgrade successfully to Airflow 2.3, you might see errors in the Airflow UI that warn you of incompatible data in certain tables of the database. For example:
+
+    ```
+    Airflow found incompatible data in the `dangling_rendered_task_instance_fields` table in your metadata database, and moved...
+    ```
+
+    These warnings have no impact on your tasks or DAGs and can be ignored. If you want to remove these warning messages from the Airflow UI, reach out to [Astronomer Support](https://support.astronomer.io). If requested, Astronomer can drop incompatible tables from your metadata database.


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/436

This is a really tricky one that might not need to be merged. This doc makes the following assumptions:

- The reader is a new user to Astro
- The reader has an existing 1.0.15 Airflow project from a non-Astronomer product (read as: this doc does not cover Software migrations _at all_)
- The reader only wants to migrate their project for the purposes of running it in Astro. They are not interested in exploring Astro / Runtime features yet.

Based on these assumptions, I made the following changes to the Nebula doc:

- Step one now instructs readers to migrate their Airflow code to an Astro project running AC 1.10.15. They will change this image later in the setup.
- The doc is unindexed, with only a few links to it scattered throughout our other docs. I don't want Software users to think that this is for them, or to use this as a migration doc to Astro. 