### PR TITLE
Update ci-cd.md for GitLab - incorrect pipeline

### DIFF
--- a/astro/ci-cd.md
+++ b/astro/ci-cd.md
@@ -459,7 +459,7 @@ To automate code deploys to a Deployment using [GitLab](https://gitlab.com/), co
 2. Go to the Editor option in your project's CI/CD section and commit the following:
 
    <pre><code parentName="pre">{`---
-      astro_deploy:
+    astro_deploy:
       stage: deploy
       image: docker:latest
       services:


### PR DESCRIPTION
The pipeline is invalid for the single branch GitLab.