### PR TITLE
Add Information About Upgrading Astronomer Software Before Kubernetes

### DIFF
--- a/software/upgrade-astronomer.md
+++ b/software/upgrade-astronomer.md
@@ -15,6 +15,12 @@ A few notes before you get started:
 - The upgrade process will not affect running Airflow tasks as long as `upgradeDeployments.enabled=false` is set in your upgrade script.
 - Updates will not cause any downtime to Astronomer services, including the Software UI, the Astro CLI, and the Houston API.
 
+:::tip
+
+To avoid service disruptions, Astronomer recommends upgrading Astronomer Software to a compatible version before you upgrade Kubernetes. To view Astronomer Software and Kubernetes compatibility information, see [Version compatibility reference for Astronomer Software](version-compatibility-reference.md#astronomer-software).
+
+:::
+
 ## Step 1: Review upgrade considerations
 
 The [Upgrade considerations](upgrade-astronomer.md#upgrade-considerations) section of this document contains upgrade information for specific Astronomer versions. Review these notes before starting the upgrade process.
@@ -137,6 +143,8 @@ Make changes as needed and rerun the upgrade command from Step 7. Do not continu
 ## Upgrade considerations
 
 This topic contains information about upgrading to specific versions of Astronomer Software. This includes notes on breaking changes, database migrations, and other considerations that might depend on your use case.
+
+To avoid service disruptions, Astronomer recommends upgrading Astronomer Software to a compatible version before you upgrade Kubernetes. To view Astronomer Software and Kubernetes compatibility information, see [Version compatibility reference for Astronomer Software](version-compatibility-reference.md#astronomer-software).
 
 ### Upgrading to 0.29
 


### PR DESCRIPTION
Resolves #864

@danielhoherd I have added text indicating that Astronomer Software should be upgraded _**before**_ Kubernetes is upgraded. I added the text in two locations to make sure it wasn't missed. Please review and provide your edits or approval. Thanks!