### PR TITLE
Make font sizes a little smaller

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -23,10 +23,10 @@
   --font-size-0: 0.875rem;
   --font-size-1: 1rem;
   --font-size-1-25: 1.25rem;
-  --font-size-2: 1.5rem;
-  --font-size-3: 1.75rem;
-  --font-size-4: 2.5rem;
-  --font-size-5: 3.75rem;
+  --font-size-2: 1.25rem;
+  --font-size-3: 1.5rem;
+  --font-size-4: 1.75rem;
+  --font-size-5: 2.5rem;
   --font-size-body: 1.125rem;
 
   /* Colors */


### PR DESCRIPTION
Fixes #863 by tweaking the header fonts sizes to be a little smaller.

Before
<img width="1400" alt="Screen Shot 2022-06-29 at 3 54 41 PM" src="https://user-images.githubusercontent.com/96535736/176533128-223f5be4-22fe-4d9a-a31e-7f9faeccbaec.png">

After
<img width="1403" alt="Screen Shot 2022-06-29 at 3 54 30 PM" src="https://user-images.githubusercontent.com/96535736/176533180-32198da8-21a0-4f16-85a6-39e0a26db841.png">

