### PR TITLE
Archive Software 0.26 and 0.27

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -83,16 +83,6 @@ module.exports = {
               activeBaseRegex: '(software\/0.28)+',
             },
             {
-              label: '0.27',
-              to: '/software/0.27/overview',
-              activeBaseRegex: '(software\/0.27)+',
-            },
-            {
-              label: '0.26',
-              to: '/software/0.26/overview',
-              activeBaseRegex: '(software\/0.26)+',
-            },
-            {
               label: '0.25',
               to: '/software/0.25/overview',
               activeBaseRegex: '(software\/0.25)+',

--- a/software/documentation-archive.md
+++ b/software/documentation-archive.md
@@ -37,10 +37,12 @@ This section contains links to documentation sets that correspond to all previou
 
 - [v0.28](https://docs.astronomer.io/software/0.28/overview)
 - [v0.27](https://docs.astronomer.io/software/0.27/overview)
-- [v0.26](https://docs.astronomer.io/software/0.26/overview)
-- [v0.25](https://docs.astronomer.io/software/0.25/overview)
 
 ### Unmaintained versions
 
+- [v0.26](https://docs.astronomer.io/software/0.26/overview)
+- [v0.25](https://docs.astronomer.io/software/0.25/overview)
 - [v0.23](https://docs.astronomer.io/software/0.23/overview)
 - [v0.16](https://docs.astronomer.io/software/0.16/overview)
+- [v0.26](https://docs.astronomer.io/software/0.26/overview)
+- [v0.25](https://docs.astronomer.io/software/0.25/overview)

--- a/software/release-lifecycle-policy.md
+++ b/software/release-lifecycle-policy.md
@@ -91,9 +91,7 @@ The following tables contain the exact lifecycle for each published version of A
 
 | Software Version | Release Date     | End of Maintenance Date |
 | ---------------- | ---------------- | ----------------------- |
-| 0.25             | May 11, 2021     | December 2022*         |
-| 0.26             | Nov 23, 2021     | May 2022                |
-| 0.27             | Dec 21, 2021     | June 2022               |
+| 0.25             | May 11, 2021     | December 2022*          |
 | 0.28             | Feb 15, 2022     | February 2023           |
 | 0.29             | June 1, 2022     | December 2022           |
 
@@ -101,7 +99,7 @@ The following tables contain the exact lifecycle for each published version of A
 
 | Software Version | Release Date     | End of Maintenance Date |
 | ---------------- | ---------------- | ----------------------- |
-| 0.25             | May 11, 2021     | December 2022*         |
+| 0.25             | May 11, 2021     | December 2022*          |
 | 0.28             | Feb 15, 2022     | February 2023           |
 
 > *Given the wide usage of Astronomer Software v0.25, Astronomer has extended the maintenance period for this version through December 2022.

--- a/software/version-compatibility-reference.md
+++ b/software/version-compatibility-reference.md
@@ -18,8 +18,6 @@ While the tables below reference the minimum compatible versions, we typically r
 | Astronomer Platform | Kubernetes                   |  Postgres | Python                                    | Astro CLI | Astronomer Certified / Runtime | Helm|
 | ------------------- | ---------------------------- |  -------- | ----------------------------------------- | -------------- | -------------------- |---|
 | v0.25               | 1.17, 1.18, 1.19, 1.20, 1.21 | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.25.x         | All Certified versions                  |3.6|
-| v0.26               | 1.17, 1.18, 1.19, 1.20, 1.21 |  9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.26.x         | All Certified versions                  |3.6|
-| v0.27               | 1.18, 1.19, 1.20, 1.21       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 0.27.x         | All Certified versions                  |3.6|
 | v0.28               | 1.19, 1.20, 1.21             |  9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 1.0.x, 1.1.x        | All Certified versions                  |3.6|
 | v0.29               | 1.19, 1.20, 1.21, 1.22        | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | 1.2.x         | All Certified and Runtime versions    | 3.6|
 


### PR DESCRIPTION
Software 0.26 and 0.27 are no longer maintained. Per our policies, we should archive the docsets for those versions.