### PR TITLE
correct software BYO registry config structure for airgap users

### DIFF
--- a/software/custom-image-registry.md
+++ b/software/custom-image-registry.md
@@ -62,17 +62,17 @@ Deploying code changes to a custom image registry requires triggering a GraphQL 
 
     ```yaml
     astronomer:
-    	houston:
-         config:
+      houston:
+        config:
           deployments:
             enableUpdateDeploymentImageEndpoint: true
-        	  registry:
-        	    protectedCustomRegistry:
-        	      enabled: true
-        	      updateRegistry:
-        	        enabled: true
-        	        host: <your-airflow-image-repo>
-        	        secretName: <name-of-secret>
+	  registry:
+	    protectedCustomRegistry:
+	      enabled: true
+	      updateRegistry:
+		enabled: true
+		host: <your-airflow-image-repo>
+		secretName: <name-of-secret>
     ```
 
   :::info
@@ -128,23 +128,24 @@ Deploying code changes to a custom image registry requires triggering a GraphQL 
       houston:
         config:
           deployments:
+            enableUpdateDeploymentImageEndpoint: true
             helm:
               airflow:
                 defaultAirflowRepository: <airflow-image-repo>
                 images:
                   airflow:
                     repository: <airflow-image-repo>
-      registry:
-        protectedCustomRegistry:
-          enabled: true
-          baseRegistry:
-            enabled: true
-            host: <airflow-image-repo>
-            secretName: <name-of-secret-containing-image-repo-creds>
-          updateRegistry:
-            enabled: true
-            host: <airflow-image-repo>
-            secretName: <name-of-secret-containing-image-repo-creds>
+	  registry:
+	    protectedCustomRegistry:
+	      enabled: true
+	      baseRegistry:
+		enabled: true
+		host: <airflow-image-repo>
+		secretName: <name-of-secret-containing-image-repo-creds>
+	      updateRegistry:
+		enabled: true
+		host: <airflow-image-repo>
+		secretName: <name-of-secret-containing-image-repo-creds>
     ```
 
   :::info

--- a/software/custom-image-registry.md
+++ b/software/custom-image-registry.md
@@ -66,13 +66,13 @@ Deploying code changes to a custom image registry requires triggering a GraphQL 
         config:
           deployments:
             enableUpdateDeploymentImageEndpoint: true
-	  registry:
-	    protectedCustomRegistry:
-	      enabled: true
-	      updateRegistry:
-		enabled: true
-		host: <your-airflow-image-repo>
-		secretName: <name-of-secret>
+          registry:
+            protectedCustomRegistry:
+              enabled: true
+              updateRegistry:
+                enabled: true
+                host: <your-airflow-image-repo>
+                secretName: <name-of-secret>
     ```
 
   :::info
@@ -135,17 +135,17 @@ Deploying code changes to a custom image registry requires triggering a GraphQL 
                 images:
                   airflow:
                     repository: <airflow-image-repo>
-	  registry:
-	    protectedCustomRegistry:
-	      enabled: true
-	      baseRegistry:
-		enabled: true
-		host: <airflow-image-repo>
-		secretName: <name-of-secret-containing-image-repo-creds>
-	      updateRegistry:
-		enabled: true
-		host: <airflow-image-repo>
-		secretName: <name-of-secret-containing-image-repo-creds>
+          registry:
+            protectedCustomRegistry:
+              enabled: true
+              baseRegistry:
+                enabled: true
+                host: <airflow-image-repo>
+                secretName: <name-of-secret-containing-image-repo-creds>
+              updateRegistry:
+                enabled: true
+                host: <airflow-image-repo>
+                secretName: <name-of-secret-containing-image-repo-creds>
     ```
 
   :::info
@@ -171,14 +171,14 @@ After pushing images for your Astro project to your private registry, you can ru
 
 ```graphql
 mutation updateDeploymentImage {
-	updateDeploymentImage(
-		releaseName: "<deployment-release-name>", # for example "analytics-dev"
-		image: "<host>/<image-name>:<tag>",  # for example docker.io/cmart123/ap-airflow:test4
-		airflowVersion: "<airflow-version-number>" # for example "2.2.5"
-	)
-	{
-		id
-	}
+        updateDeploymentImage(
+                releaseName: "<deployment-release-name>", # for example "analytics-dev"
+                image: "<host>/<image-name>:<tag>",  # for example docker.io/cmart123/ap-airflow:test4
+                airflowVersion: "<airflow-version-number>" # for example "2.2.5"
+        )
+        {
+                id
+        }
 }
 ```
 

--- a/software/custom-image-registry.md
+++ b/software/custom-image-registry.md
@@ -48,7 +48,7 @@ Deploying code changes to a custom image registry requires triggering a GraphQL 
     To have Astronomer Software sync the registry credentials to all Deployment namespaces, add the following annotation:
 
     ```bash
-    kubectl -n <release-namespace> annotate secret <name-of-secret> "astronomer.io/commander-sync"="platform=astronomer"
+    kubectl -n <astronomer-platform-namespace> annotate secret <name-of-secret> "astronomer.io/commander-sync"="platform=astronomer"
     ```
 
   :::info
@@ -85,7 +85,7 @@ Deploying code changes to a custom image registry requires triggering a GraphQL 
 5. For any existing Deployments, run the following command to sync the registry credentials.
 
     ```bash
-    kubectl create job -n <release-namespace> --from=cronjob/astronomer-config-syncer upgrade-config-synchronization
+    kubectl create job -n <astronomer-platform-namespace> --from=cronjob/astronomer-config-syncer upgrade-config-synchronization
     ```
 
     :::info
@@ -109,7 +109,7 @@ Deploying code changes to a custom image registry requires triggering a GraphQL 
     To have Astronomer Software sync the registry credentials to all Deployment namespaces, add the following annotation:
 
     ```bash
-    kubectl -n <release-namespace> annotate secret <name-of-secret> "astronomer.io/commander-sync"="platform=astronomer"
+    kubectl -n <astronomer-platform-namespace> annotate secret <name-of-secret> "astronomer.io/commander-sync"="platform=astronomer"
     ```
 
   :::info
@@ -157,7 +157,7 @@ Deploying code changes to a custom image registry requires triggering a GraphQL 
 5. For any existing Deployments, run the following command to sync the registry credentials. If you're using different registries for each Deployment, you can skip this step.
 
     ```bash
-    kubectl create job -n <release-namespace> --from=cronjob/astronomer-config-syncer upgrade-config-synchronization
+    kubectl create job -n <astronomer-platform-namespace> --from=cronjob/astronomer-config-syncer upgrade-config-synchronization
     ```
 
 


### PR DESCRIPTION
The config sections weren't nested correctly in the example, I think same tabs got turned into spaces somewhere along the way, this should sort things out.

Also, the airgap example was missing the feature flag that actually enabled the feature, so I added it.