### PR TITLE
Create a "Supported Cluster Modifications" topic

### DIFF
--- a/astro/astro-support.md
+++ b/astro/astro-support.md
@@ -38,6 +38,7 @@ Examples:
 
 - The Airflow UI is unavailable.
 - You are unable to deploy code to your Deployment, but existing DAGs and tasks are running as expected.
+- You need to [modify a cluster setting](modify-cluster.md) to successfully run tasks.
 - Task logs are missing in the Airflow UI.
 
 **P3:** Medium impact. Service is partially impaired.
@@ -45,7 +46,7 @@ Examples:
 Examples:
 
 - There is a bug in the Software UI.
-- You need to [modify a cluster setting](modify-cluster.md) to improve how your cluster runs. 
+- You need to [modify a cluster setting](modify-cluster.md) to improve your cluster's performance.
 - Astro CLI usage is impaired (for example, there are incompatibility errors between installed packages).
 - There is an Airflow issue that has a code-based solution.
 - You received a log alert on Astronomer.

--- a/astro/astro-support.md
+++ b/astro/astro-support.md
@@ -10,7 +10,7 @@ In addition to product documentation, the following resources are available to h
 - [Astronomer Forum](https://forum.astronomer.io)
 - [Airflow Guides](https://www.astronomer.io/guides/)
 
-If you're experiencing an issue or have a question that requires Astronomer expertise, you can use one of the following methods to contact Astronomer support:
+If you're experiencing an issue or have a question that requires Astronomer expertise, or if you want to [modify a cluster configuration](modify-cluster.md), you can use one of the following methods to contact Astronomer support:
 
 - Submit a support request in the [Cloud UI](astro-support.md#submit-a-support-request-in-the-cloud-ui)
 - Submit a support request on the [Astronomer support portal](https://support.astronomer.io/hc/en-us)
@@ -45,6 +45,7 @@ Examples:
 Examples:
 
 - There is a bug in the Software UI.
+- You need to [modify a cluster setting](modify-cluster.md) to improve how your cluster runs. 
 - Astro CLI usage is impaired (for example, there are incompatibility errors between installed packages).
 - There is an Airflow issue that has a code-based solution.
 - You received a log alert on Astronomer.

--- a/astro/astro-support.md
+++ b/astro/astro-support.md
@@ -10,7 +10,7 @@ In addition to product documentation, the following resources are available to h
 - [Astronomer Forum](https://forum.astronomer.io)
 - [Airflow Guides](https://www.astronomer.io/guides/)
 
-If you're experiencing an issue or have a question that requires Astronomer expertise, or if you want to [modify a cluster configuration](modify-cluster.md), you can use one of the following methods to contact Astronomer support:
+If you're experiencing an issue or have a question that requires Astronomer expertise, or if you want to [modify a cluster configuration](modify-cluster.md), use one of the following methods to contact Astronomer support:
 
 - Submit a support request in the [Cloud UI](astro-support.md#submit-a-support-request-in-the-cloud-ui)
 - Submit a support request on the [Astronomer support portal](https://support.astronomer.io/hc/en-us)
@@ -38,7 +38,7 @@ Examples:
 
 - The Airflow UI is unavailable.
 - You are unable to deploy code to your Deployment, but existing DAGs and tasks are running as expected.
-- You need to [modify a cluster setting](modify-cluster.md) to successfully run tasks.
+- You need to [modify a cluster setting](modify-cluster.md) that is required for running tasks, such as adding a new worker instance type.
 - Task logs are missing in the Airflow UI.
 
 **P3:** Medium impact. Service is partially impaired.
@@ -46,7 +46,7 @@ Examples:
 Examples:
 
 - There is a bug in the Software UI.
-- You need to [modify a cluster setting](modify-cluster.md) to improve your cluster's performance.
+- You need to [modify a cluster setting](modify-cluster.md) that affects your cluster's performance but isn't required to run task, such as changing the size of your cluster's database or adding a new VPC peering connection.
 - Astro CLI usage is impaired (for example, there are incompatibility errors between installed packages).
 - There is an Airflow issue that has a code-based solution.
 - You received a log alert on Astronomer.

--- a/astro/kubernetespodoperator.md
+++ b/astro/kubernetespodoperator.md
@@ -111,7 +111,7 @@ To complete this setup, you need:
 To run Docker images from a private registry on Astro, you first need to create a Kubernetes secret that contains credentials to your registry. Astronomer will then inject that secret into your Deployment's namespace, which will give your tasks access to Docker images within your registry. To do this, complete the following setup:
 
 1. Log in to your Docker registry and follow the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#log-in-to-docker-hub) to produce a `/.docker/config.json` file.
-2. Reach out to [Astronomer support](https://support.astronomer.io) and include the namespace of the Deployment you want to use the KubernetesPodOperator with. A Deployment's namespace can be found in the Deployment view of the Astronomer UI.
+2. Reach out to [Astronomer support](https://support.astronomer.io) and provide the namespace of the Deployment you want to use the KubernetesPodOperator with. A Deployment's namespace can be found in the Deployment view of the Astronomer UI.
 
 From here, Astronomer Support will give you instructions on how to securely send the output of your `/.docker/config.json` file. Do not send this file via email, as it contains sensitive credentials to your registry.
 

--- a/astro/kubernetespodoperator.md
+++ b/astro/kubernetespodoperator.md
@@ -111,9 +111,11 @@ To complete this setup, you need:
 To run Docker images from a private registry on Astro, you first need to create a Kubernetes secret that contains credentials to your registry. Astronomer will then inject that secret into your Deployment's namespace, which will give your tasks access to Docker images within your registry. To do this, complete the following setup:
 
 1. Log in to your Docker registry and follow the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#log-in-to-docker-hub) to produce a `/.docker/config.json` file.
-2. Reach out to [Astronomer support](https://support.astronomer.io) and provide the namespace of the Deployment you want to use the KubernetesPodOperator with. A Deployment's namespace can be found in the Deployment view of the Astronomer UI.
+2. In the Cloud UI, select a Workspace and then select the Deployment you want to use the KubernetesPodOperator with.
+3. Copy the value in the **NAMESPACE** field.
+4. Reach out to [Astronomer support](https://support.astronomer.io) and provide the namespace of the Deployment.
 
-From here, Astronomer Support will give you instructions on how to securely send the output of your `/.docker/config.json` file. Do not send this file via email, as it contains sensitive credentials to your registry.
+Astronomer Support will give you instructions on how to securely send the output of your `/.docker/config.json` file. Do not send this file by email, as it contains sensitive credentials to your registry.
 
 ### Step 2: Specify the Kubernetes Secret in your DAG
 

--- a/astro/modify-cluster.md
+++ b/astro/modify-cluster.md
@@ -7,7 +7,7 @@ description: Request changes to an existing Astro cluster.
 
 Unless otherwise specified, new Clusters on Astro are created with a set of default configurations. Depending on your use case, you may decide that you want to modify an existing Cluster to run a different configuration.
 
-For example, if you have a new set of DAGs that require significantly more CPU and Memory than your existing workloads, you may be interested in modifying a cluster on AWS to run `m5.8xlarge` nodes instead of `m5.4xlarge` nodes. You might also want to modify a cluster's maximum node count from the default of 20 to better fit your expected workload.
+For example, if you have a new set of DAGs that require significantly more CPU and Memory than your existing workloads, you might be interested in modifying a cluster on AWS to run `m5.8xlarge` nodes instead of `m5.4xlarge` nodes. You might also want to modify a cluster's maximum node count from the default of 20 to better fit your expected workload.
 
 ## Prerequisites
 
@@ -27,3 +27,13 @@ To modify an existing cluster in your Organization, first verify that the change
 Once our team validates that the cluster configuration you requested is supported, we will let you know as soon as we are able to perform the change.
 
 Modifications to an existing cluster may take a few minutes to complete, but you can expect no downtime during the process. Astro is built to ensure a graceful rollover, which means that the Airflow and Cloud UIs will continue to be available and your Airflow tasks will not be affected.
+
+## Supported cluster modifications
+
+Some cluster and Deployment-level modifications can be completed only by Astronomer support. These include:
+
+- [Creating a new cluster](create-cluster.md).
+- Updating a cluster's worker instance type.
+- Updating the maximum node count of an existing cluster.
+- [Creating a VPC connection](connect-external-services.md#vpc-peering) between a cluster and a target VPC.
+- Running images from a private registry with the [KubernetesPodOperator](kubernetespodoperator#run-images-from-a-private-registry).

--- a/astro/modify-cluster.md
+++ b/astro/modify-cluster.md
@@ -18,16 +18,6 @@ To complete this setup, you need to have:
 
 If you don't have a cluster on Astro, follow the instructions to [Install Astro on AWS](install-aws.md) or [GCP](install-gcp.md). If you have an existing cluster and are interested in creating additional clusters, read [Create a cluster](create-cluster.md).
 
-## Step 1: Submit a Request to Astronomer
-
-To modify an existing cluster in your Organization, first verify that the change you want to make is supported by reading the resource reference documentation for either [AWS](resource-reference-aws.md) or [GCP](resource-reference-gcp.md). Then, reach out to [Astronomer support](https://support.astronomer.io).
-
-## Step 2: Confirm with Astronomer
-
-Once our team validates that the cluster configuration you requested is supported, we will let you know as soon as we are able to perform the change.
-
-Modifications to an existing cluster may take a few minutes to complete, but you can expect no downtime during the process. Astro is built to ensure a graceful rollover, which means that the Airflow and Cloud UIs will continue to be available and your Airflow tasks will not be affected.
-
 ## Supported cluster modifications
 
 Some cluster and Deployment-level modifications can be completed only by Astronomer support. These include:
@@ -37,3 +27,15 @@ Some cluster and Deployment-level modifications can be completed only by Astrono
 - Updating the maximum node count of an existing cluster.
 - [Creating a VPC connection](connect-external-services.md#vpc-peering) between a cluster and a target VPC.
 - Running images from a private registry with the [KubernetesPodOperator](kubernetespodoperator#run-images-from-a-private-registry).
+
+## Step 1: Submit a request to Astronomer
+
+To modify an existing cluster in your Organization, first verify that the change you want to make is supported by reading the resource reference documentation for either [AWS](resource-reference-aws.md) or [GCP](resource-reference-gcp.md). Then, reach out to [Astronomer support](https://support.astronomer.io).
+
+## Step 2: Confirm the modification
+
+If the modification you requested is supported, Astronomer will notify you as soon as it's possible to complete the modification.
+
+Modifications to an existing cluster might take a few minutes to complete, but you can expect no downtime during the process. Astro is built to ensure a graceful rollover, which means that the Airflow and Cloud UIs will continue to be available and your Airflow tasks will not be affected.
+
+To confirm that the modification was completed, open the **Clusters** tab in the Cloud UI. You should see the updated configuration in the table entry for your cluster. 

--- a/astro/modify-cluster.md
+++ b/astro/modify-cluster.md
@@ -20,14 +20,14 @@ If you don't have a cluster on Astro, follow the instructions to [Install Astro 
 
 ## Supported cluster modifications
 
-Some cluster and Deployment-level modifications can be completed only by Astronomer support. These include:
+Some cluster and Deployment-level modifications require Astronomer support and cannot be completed with the Cloud UI or CLI. These include requests to:
 
-- [Creating a new cluster](create-cluster.md).
-- Deleting a cluster.
-- Updating a cluster's worker instance type. See cloud resource references ([AWS](resource-reference-aws.md#deployment-worker-size-limits), [GCP](resource-reference-gcp.md#deployment-worker-size-limits)).
-- Updating the maximum node count of an existing cluster.
-- [Creating a VPC connection](connect-external-services.md#vpc-peering) between a cluster and a target VPC.
-- Running images from a private registry with the [KubernetesPodOperator](kubernetespodoperator#run-images-from-a-private-registry).
+- [Create a new cluster](create-cluster.md).
+- Delete a cluster.
+- Update a cluster's worker instance type. See cloud resource references ([AWS](resource-reference-aws.md#deployment-worker-size-limits), [GCP](resource-reference-gcp.md#deployment-worker-size-limits)).
+- Update the maximum node count of an existing cluster.
+- [Create a VPC connection](connect-external-services.md#vpc-peering) or a [transit gateway connection](connect-external-services.md#workload-identity-gcp-only) between a cluster and a target VPC.
+- Run Docker images from a private registry with the [KubernetesPodOperator](kubernetespodoperator#run-images-from-a-private-registry).
 
 ## Step 1: Submit a request to Astronomer
 
@@ -37,6 +37,8 @@ To modify an existing cluster in your Organization, first verify that the change
 
 If the modification you requested is supported, Astronomer will notify you as soon as it's possible to complete the modification.
 
-Modifications to an existing cluster might take a few minutes to complete, but you can expect no downtime during the process. Astro is built to ensure a graceful rollover, which means that the Airflow and Cloud UIs will continue to be available and your Airflow tasks will not be affected.
+Most modifications to an existing cluster take only a few minutes to complete and do not incur downtime. In these cases, the Airflow UI and Cloud UI continue to be available and your Airflow tasks are not interrupted.
+
+For modifications that do incur downtime, such as changing your cluster's node instance type, Astronomer support will inform you of the expected impact and ask you to confirm if you want to proceed.
 
 To confirm that the modification was completed, open the **Clusters** tab in the Cloud UI. You should see the updated configuration in the table entry for your cluster.

--- a/astro/modify-cluster.md
+++ b/astro/modify-cluster.md
@@ -23,7 +23,8 @@ If you don't have a cluster on Astro, follow the instructions to [Install Astro 
 Some cluster and Deployment-level modifications can be completed only by Astronomer support. These include:
 
 - [Creating a new cluster](create-cluster.md).
-- Updating a cluster's worker instance type.
+- Deleting a cluster.
+- Updating a cluster's worker instance type. See cloud resource references ([AWS](resource-reference-aws.md#deployment-worker-size-limits), [GCP](resource-reference-gcp.md#deployment-worker-size-limits)).
 - Updating the maximum node count of an existing cluster.
 - [Creating a VPC connection](connect-external-services.md#vpc-peering) between a cluster and a target VPC.
 - Running images from a private registry with the [KubernetesPodOperator](kubernetespodoperator#run-images-from-a-private-registry).
@@ -38,4 +39,4 @@ If the modification you requested is supported, Astronomer will notify you as so
 
 Modifications to an existing cluster might take a few minutes to complete, but you can expect no downtime during the process. Astro is built to ensure a graceful rollover, which means that the Airflow and Cloud UIs will continue to be available and your Airflow tasks will not be affected.
 
-To confirm that the modification was completed, open the **Clusters** tab in the Cloud UI. You should see the updated configuration in the table entry for your cluster. 
+To confirm that the modification was completed, open the **Clusters** tab in the Cloud UI. You should see the updated configuration in the table entry for your cluster.


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/894

We have "Reach out to Astronomer Support" statements scattered throughout the docs, but no central place where we maintain information about what modifications are supported and can only be completed by Astronomer support. @kwcanuck Especially interested in your thoughts on this sort of reference topic that doesn't provide any new info but simply compiles similar info from many disparate docs. 