### PR TITLE
removeContradictoryExampleYaml

### DIFF
--- a/software/integrate-auth-system.md
+++ b/software/integrate-auth-system.md
@@ -302,7 +302,6 @@ To use a custom Oauth authorization code flow:
         enabled: true
 
       openidConnect:
-        # Valid values are "code" and "implicit"
         flow: "code"
     ```
 

--- a/software_versioned_docs/version-0.27/integrate-auth-system.md
+++ b/software_versioned_docs/version-0.27/integrate-auth-system.md
@@ -304,7 +304,6 @@ To use a custom Oauth authorization code flow:
         enabled: true
 
       openidConnect:
-        # Valid values are "code" and "implicit"
         flow: "code"
     ```
 

--- a/software_versioned_docs/version-0.28/integrate-auth-system.md
+++ b/software_versioned_docs/version-0.28/integrate-auth-system.md
@@ -304,7 +304,6 @@ To use a custom Oauth authorization code flow:
         enabled: true
 
       openidConnect:
-        # Valid values are "code" and "implicit"
         flow: "code"
     ```
 


### PR DESCRIPTION
Description: the example yaml in these sections makes it seem like implicit is a valid value when using teams when it is not.