### PR TITLE
Update Docker Engine version requirements

### DIFF
--- a/astro/cli/configure-cli.md
+++ b/astro/cli/configure-cli.md
@@ -60,7 +60,7 @@ This is where you'll find information about installing the Astro CLI on a Window
 To use the Astro CLI on Windows, you must have:
 
 - [Docker Desktop](https://docs.docker.com/desktop/windows/install/) for Windows.
-- [Docker Engine](https://docs.docker.com/engine/install/) (v0.18.9 or higher).
+- [Docker Engine](https://docs.docker.com/engine/install/) (v1.13.1 or higher).
 - [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) enabled on your local machine.
 -  Windows 10 or Windows 11.
 
@@ -92,7 +92,7 @@ This is where you'll find information about installing the Astro CLI on Linux.
 
 To use the Astro CLI on Linux, you must have:
 
-- [Docker Engine](https://docs.docker.com/engine/install/) (v0.18.9 or higher).
+- [Docker Engine](https://docs.docker.com/engine/install/) (v1.13.1 or higher).
 
 #### Installation
 

--- a/astro/cli/get-started.md
+++ b/astro/cli/get-started.md
@@ -46,7 +46,7 @@ brew install astro
 To use the Astro CLI on Windows, you must have:
 
 - [Docker Desktop](https://docs.docker.com/desktop/windows/install/) for Windows.
-- [Docker Engine](https://docs.docker.com/engine/install/) (v0.18.9 or higher).
+- [Docker Engine](https://docs.docker.com/engine/install/) (v1.13.1 or higher).
 - [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) enabled on your local machine.
 -  Windows 10 or Windows 11.
 
@@ -74,7 +74,7 @@ To use the Astro CLI on Windows, you must have:
 
 To use the Astro CLI on Linux, you must have:
 
-- [Docker Engine](https://docs.docker.com/engine/install/) (v0.18.9 or higher).
+- [Docker Engine](https://docs.docker.com/engine/install/) (v1.13.1 or higher).
 
 #### Installation
 

--- a/software/install-cli.md
+++ b/software/install-cli.md
@@ -53,7 +53,7 @@ brew install astro
 To use the Astro CLI on Windows, you must have:
 
 - [Docker Desktop](https://docs.docker.com/desktop/windows/install/) for Windows.
-- [Docker Engine](https://docs.docker.com/engine/install/) (v0.13.1 or higher).
+- [Docker Engine](https://docs.docker.com/engine/install/) (v1.13.1 or higher).
 - [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) enabled on your local machine.
 -  Windows 10 or Windows 11.
 
@@ -81,7 +81,7 @@ To use the Astro CLI on Windows, you must have:
 
 To use the Astro CLI on Linux, you must have:
 
-- [Docker Engine](https://docs.docker.com/engine/install/) (v0.18.9 or higher).
+- [Docker Engine](https://docs.docker.com/engine/install/) (v1.13.1 or higher).
 
 #### Installation
 

--- a/software_versioned_docs/version-0.28/install-cli.md
+++ b/software_versioned_docs/version-0.28/install-cli.md
@@ -56,7 +56,7 @@ brew install astro@1.1
 To use the Astro CLI on Windows, you must have:
 
 - [Docker Desktop](https://docs.docker.com/desktop/windows/install/) for Windows.
-- [Docker Engine](https://docs.docker.com/engine/install/) (v0.13.1 or higher).
+- [Docker Engine](https://docs.docker.com/engine/install/) (v1.13.1 or higher).
 - [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) enabled on your local machine.
 -  Windows 10 or Windows 11.
 
@@ -84,7 +84,7 @@ To use the Astro CLI on Windows, you must have:
 
 To use the Astro CLI on Linux, you must have:
 
-- [Docker Engine](https://docs.docker.com/engine/install/) (v0.18.9 or higher).
+- [Docker Engine](https://docs.docker.com/engine/install/) (v1.13.1 or higher).
 
 #### Installation
 


### PR DESCRIPTION
We documented a breaking change to the Docker Engine in Software 0.27: https://docs.astronomer.io/software/0.27/cli-release-notes#improvements-to-the-local-development-experience. For the most part, we expect most users to be on a modern version of the engine and to not encounter problems with this change. 

However, we have some inaccurate version prerequisites for this in our CLI install guides (looks like I copied over the Desktop version instead of using the Engine version). This PR should fix those errors.

Resolves https://github.com/astronomer/docs/issues/268