### PR TITLE
Cleanup "Connect to External Services"

### DIFF
--- a/astro/connect-external-services.md
+++ b/astro/connect-external-services.md
@@ -5,10 +5,12 @@ id: connect-external-services
 description: Learn how to connect your Astro data plane to different types of external data services.
 ---
 
-Before you can run pipelines on Astro with real data, you first need to make your data services accessible to your Data Plane and the Deployments running within it. This guide explains how to securely connect Astro to external data services using the following methods:
+Before you can run pipelines on Astro with real data, you first need to make your data services accessible to your data plane and the Deployments running within it. This guide explains how to securely connect Astro to external data services using the following methods:
 
-- Public Endpoints
-- Virtual Private Cloud (VPC) Peering
+- Public endpoints
+- Virtual Private Cloud (VPC) peering
+- AWS Transit Gateway
+- AWS IAM roles
 - Workload Identity (_GCP only_)
 
 If you need to connect to a type of data service that requires a connectivity method that is not documented here, reach out to [Astronomer support](https://support.astronomer.io).
@@ -24,110 +26,83 @@ These endpoints can be configured by:
 
 Public connection traffic moves directly between your data plane and the external data service's API endpoint. This means that the data in this traffic never reaches the control plane, which is managed by Astronomer.
 
-### IP allowlist
+### Allowlist Astro IPs
 
-Some data services, including Snowflake and Databricks, provide an additional layer of security by requiring you to allowlist a specific IP address before you can access the service.
+Some data services, including Snowflake and Databricks, require that you identify and allowlist any IP addresses reponsible for outbound traffic before you can access their services from an external network. This provides an additional layer of security.
 
-On Astro, each cluster has a pair of unique external IP address that will persist throughout the lifetime of the cluster. These IP addresses are assigned for network address translation, which means that they are responsible for all outbound traffic from your Astro cluster to the internet. To retrieve the IP addresses for a given cluster, open a ticket with [Astronomer support](https://support.astronomer.io) and request it. If you have more than one cluster, you will need to allowlist each cluster individually on your data service provider.
+On Astro, each cluster has two unique external IP address that persist throughout the lifetime of the cluster. These IP addresses are assigned for network address translation, which means that they are responsible for all outbound traffic from your Astro cluster to the internet.
+
+To retrieve the IP addresses of an Astro cluster, contact [Astronomer support](https://support.astronomer.io) and request them. Then, allowlist these IP addresses in your data service provider. If you have more than one cluster, you will need to allowlist each cluster individually.
 
 ## VPC peering
 
-Each cluster on Astro runs in a dedicated VPC. To set up private connectivity between an Astro VPC and another VPC, you can set up a VPC peering connection. Peered VPCs provide additional security by ensuring private connectivity, reduced network transit costs, and simplified network layouts.
+Each cluster on Astro runs in a dedicated Virtual Private Network (VPC). To set up private connectivity between an Astro VPC and another VPC, you can set up a VPC peering connection. VPC peering ensures private and secure connectivity, reduced network transit costs, and simplified network layouts.
 
-To create a VPC peering connection between an Astro cluster's VPC and a target VPC, reach out to [Astronomer support](https://support.astronomer.io) and provide the following information:
+To create a VPC peering connection between an Astro VPC and a target VPC, reach out to [Astronomer support](https://support.astronomer.io) and provide the following information:
 
-- Astro cluster ID and Name
-- Amazon Web Services (AWS) Account ID or Google Cloud Platform (GCP) Project ID of the target VPC
+- Astro cluster ID and name
+- AWS Account ID or GCP Project ID of the target VPC
 - Region of the target VPC (_AWS only_)
 - VPC ID of the target VPC
 - CIDR of the target VPC
 
-From there, Astronomer will initiate a peering request. To connect successfully, this peering request must be accepted by the owner of the target VPC.
+From there, Astronomer initiates a peering request. To connect successfully, this peering request must be accepted by the owner of the target VPC in your organization.
 
-Once peering is set up, the owner of the target VPC can expect to continue to work with our team to update the routing tables of both VPCs to direct traffic to each other.
+Once the VPC peering connection is established, the owner of the target VPC will continue to work with our team to update the routing tables of both VPCs to direct traffic to each other.
 
-### DNS considerations with VPC peering (_AWS only_)
+### DNS considerations for VPC peering (_AWS only_)
 
-To resolve DNS hostnames from your target VPC, your cluster VPC has **DNS Hostnames**, **DNS Resolutions**, and **Requester DNS Resolution** enabled. See AWS [Peering Connection settings](https://docs.aws.amazon.com/vpc/latest/peering/modify-peering-connections.html).  
+To resolve DNS hostnames from your target VPC, every Astro VPC has **DNS Hostnames**, **DNS Resolutions**, and **Requester DNS Resolution** enabled. See AWS [Peering Connection settings](https://docs.aws.amazon.com/vpc/latest/peering/modify-peering-connections.html).
 
-If your target VPC resolves DNS hostnames using **DNS Hostnames** and **DNS Resolution**, you must also enable the **Accepter DNS Resolution** setting. This allows the data plane to resolve the public DNS hostnames of the target VPC to its private IP addresses. To configure this option, see [AWS Documentation](https://docs.aws.amazon.com/vpc/latest/peering/modify-peering-connections.html).
+If your target VPC resolves DNS hostnames using **DNS Hostnames** and **DNS Resolution**, you must also enable the **Accepter DNS Resolution** setting on AWS. This allows the data plane to resolve the public DNS hostnames of the target VPC to its private IP addresses. To configure this option, see [AWS Documentation](https://docs.aws.amazon.com/vpc/latest/peering/modify-peering-connections.html).
 
-If your target VPC resolves DNS hostnames using [private hosted zones](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html), then you must associate your Route53 private hosted zone with the Astronomer VPC using instructions provided in [AWS Documentation](https://aws.amazon.com/premiumsupport/knowledge-center/route53-private-hosted-zone/). You can retrieve the ID of the Astronomer VPC by contacting [Astronomer support](https://support.astronomer.io).
+If your target VPC resolves DNS hostnames using [private hosted zones](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html), then you must associate your Route53 private hosted zone with the Astro VPC using instructions provided in [AWS Documentation](https://aws.amazon.com/premiumsupport/knowledge-center/route53-private-hosted-zone/).
+
+To retrieve the ID of any Astro VPC, contact [Astronomer support](https://support.astronomer.io). If you have more than one Astro cluster, request the VPC ID of each cluster.
 
 ## AWS Transit Gateway
 
-Use AWS Transit Gateways to connect your Astro clusters to your VPCs and on-premises networks.
+Use AWS Transit Gateway to connect one or more Astro clusters to other VPCs, AWS accounts, and on-premises networks supported by your organization.
+
+AWS Transit Gateway is an alternative to VPC Peering on AWS. Instead of having to establish a direct connection between two VPCs, you can attach over 5,000 networks to a central transit gateway that has a single VPN connection to your corporate network.
+
+While it can be more costly, AWS Transit Gateway requires less configuration and is often recommended for organizations connecting a larger number of VPCs. For more information, see [AWS Transit Gateway](https://aws.amazon.com/transit-gateway/).
 
 ### Prerequisites
 
 - An Astro cluster
-- A transit gateway in the same region as your Astro cluster
+- An existing transit gateway in the same region as your Astro cluster
 - Permission to share resources using AWS Resource Access Manager (RAM)
 
 :::info
 
-If your transit gateway is in a different region than your Astro cluster, contact [Astronomer support](https://support.astronomer.io). Astronomer can create a new transit gateway and set up cross-region peering with your existing transit gateway. With this configuration your organization can incur AWS charges for a new transit gateway hosted in the Astro account, as well as inter-region transfer costs.
+If your transit gateway is in a different region than your Astro cluster, contact [Astronomer support](https://support.astronomer.io). Astronomer can create a new transit gateway in your AWS account for Astro and set up a cross-region peering connection with your existing transit gateway.
+
+If Astronomer creates a new transit gateway in your AWS account for Astro, keep in mind that your organization will incur additional AWS charges for the new transit gateway as well as the inter-region transfer costs.
+
 :::
 
 ### Setup
 
-1. In the Cloud UI, click the **Clusters** tab and copy the **Account ID** for the cluster.
-2. Create a resource share in AWS RAM. See [Creating a resource share in AWS RAM](https://docs.aws.amazon.com/ram/latest/userguide/working-with-sharing-create.html)  The account ID that you need to share with is the value that you copied in Step 1.
-3. Contact [Astronomer support](https://support.astronomer.io) and provide the destination CIDR block of the VPC or on-premises network that should be routed through the transit gateway. From here, Astronomer approves the resource sharing request and creates a transit gateway peering attachment request to your on-premises network.
-4. Accept the Transit Gateway peering attachment request from your on-premises network. See [Accept or reject a peering attachment request](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-peering.html#tgw-peering-accept-reject).
+1. In the Cloud UI, click the **Clusters** tab and copy the **Account ID** for your Astro cluster. This is an AWS account ID.
+2. Create a resource share in AWS RAM with the account ID from step 1. See [Creating a resource share in AWS RAM](https://docs.aws.amazon.com/ram/latest/userguide/working-with-sharing-create.html).
+3. Contact [Astronomer support](https://support.astronomer.io) and provide the CIDR block of the target VPC or on-premises network that you want to connect your Astro cluster with. From here, Astronomer approves the resource sharing request and creates a transit gateway peering attachment request to your network.
+4. Accept the transit gateway peering attachment request from your network. See [Accept or reject a peering attachment request](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-peering.html#tgw-peering-accept-reject).
 5. Create a static route from your CIDR block to the transit gateway. See [Add a route to the transit gateway route table](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-peering.html#tgw-peering-add-route).
-6. Contact [Astronomer support](https://support.astronomer.io) to confirm that you have created the static route. From here, Astronomer updates the routing table of the Astro cluster's VPC to send traffic from your CIDR block through the transit gateway.
+6. Contact [Astronomer support](https://support.astronomer.io) to confirm that you have created the static route. From here, Astronomer updates the routing table of the Astro VPC to send traffic from your CIDR block through the transit gateway.
 
-## Workload Identity (_GCP only_)
+Complete the steps for each Astro cluster that you want to connect to your transit gateway.
 
-[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) is recommended by Google as the best way for data pipelines running on GCP to access Google Cloud services in a secure and manageable way. All Astro clusters on GCP have Workload Identity enabled by default. Each Astro Deployment is associated with a Kubernetes service account that's created by Astronomer and is bound to an identity from your Google Cloud project's fixed workload identity pool.
-
-To grant a Deployment on Astro access to GCP services such as BigQuery, you must:
-
-- Go to the Google Cloud project in which your external data service is hosted
-- Add the Kubernetes service account for your Astro Deployment to the principal of that Google Cloud project
-- Bind the service account to a role that has access to your external data service
-
-Kubernetes service accounts for Astro Deployments are formatted as follows:
-
-```text
-astro-<deployment-namespace>@<gcp-project-name>.iam.gserviceaccount.com
-```
-
-To find the namespace of your Deployment, go to your Deployment page in the Cloud UI and copy paste the value in the **Namespace** field.
-
-For a Google Cloud project called `astronomer-prod` and a Deployment namespace called `nuclear-science-2730`, for example, the service account for the Deployment would be:
-
-```text
-astro-nuclear-science-2730@astronomer-prod.iam.gserviceaccount.com
-```
-
-:::info
-
-GCP has a 30 character limit for service account names. For Deployment namespaces which are longer than 24 characters, use only the first 24 characters when determining your service account name. For example, if your GCP project was called `astronomer-prod` and your Deployment namespace was `nuclear-scintillation-2730`, your service account would be:
-
-```text
-astro-nuclear-scintillation-27@astronomer-pmm.iam.gserviceaccount.com
-```
-
-:::
-
-For more information about configuring service accounts on GCP, see [GCP documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
-
-## Use AWS IAM roles to authorize access to Astro
+## AWS IAM roles
 
 To grant an Astro cluster access to a service that is running in an AWS account not managed by Astronomer, use AWS IAM roles. IAM roles on AWS are often used to manage the level of access a specific user, object, or group of users has to a resource. This includes an Amazon S3 bucket, Redshift instance, or secrets backend.
 
 1. In the Cloud UI, click **Clusters** and then copy the value displayed in the **Cluster ID** column for the Astro cluster that needs access to AWS service resources.
-
 2. Create an IAM role in the AWS account that contains your AWS service. See [Creating a role to delegate permissions to an AWS service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html).
 
 3. In the AWS Management Console, go to the Identity and Access Management (IAM) dashboard.
-
-4. Click **Roles** and in the **Role name** column select the role you created in step 2.
-
+4. Click **Roles**. In the **Role name** column, select the role you created in step 2.
 5. Click the **Trust relationships** tab.
-
 6. Click **Edit trust policy** and update the `arn` value:
 
 ```text {8}
@@ -147,5 +122,44 @@ To grant an Astro cluster access to a service that is running in an AWS account 
 }
 ```
 7. Click **Update policy**.
+8. In the Airflow UI or as an environment variable on Astro, create an Airflow connection to AWS for each Deployment that requires the resources you connected. See [Managing connections to Apache Airflow](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html).
 
-8. Create an Airflow connection to AWS for each Deployment that requires the resources you connected. See [Managing connections to Apache Airflow](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html).
+Complete these steps for each Astro cluster that requires access to external data services on AWS.
+
+## Workload Identity (_GCP only_)
+
+[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) is recommended by Google as the best way for data pipelines running on Google Cloud Platform (GCP) to access Google Cloud services in a secure and manageable way. All Astro clusters on GCP have Workload Identity enabled by default. Each Astro Deployment is associated with a Kubernetes service account that's created by Astronomer and is bound to an identity from your Google Cloud project's fixed workload identity pool.
+
+To grant a Deployment on Astro access to external data services on GCP, such as BigQuery:
+
+1. In the Cloud UI, go to your Deployment and copy paste the value under **Namespace**.
+2. Use your Deployment's namespace and the name of your Google Cloud project for Astro to identify the Kubernetes service account for your Deployment.
+    
+    Kubernetes service accounts for Astro Deployments are formatted as follows:
+
+    ```text
+    astro-<deployment-namespace>@<gcp-project-name>.iam.gserviceaccount.com
+    ```
+    
+    For a Google Cloud project called `astronomer-prod` and a Deployment namespace defined as `nuclear-science-2730`, for example, the service account for the Deployment would be:
+
+    ```text
+    astro-nuclear-science-2730@astronomer-prod.iam.gserviceaccount.com
+    ```
+3. Go to the Google Cloud project in which your external data service is hosted.
+4. Add the Kubernetes service account for your Astro Deployment to the principal of that Google Cloud project. See [GCP documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
+5. Bind the service account to a role that has access to your external data service.
+
+Complete these steps for every Astro Deployment that requires access to external data services on GCP.
+
+:::info
+
+GCP has a 30 character limit for service account names. For Deployment namespaces which are longer than 24 characters, use only the first 24 characters when determining your service account name.
+
+For example, if your GCP project was called `astronomer-prod` and your Deployment namespace was `nuclear-scintillation-2730`, your service account would be:
+
+```text
+astro-nuclear-scintillation-27@astronomer-pmm.iam.gserviceaccount.com
+```
+
+:::

--- a/astro/connect-external-services.md
+++ b/astro/connect-external-services.md
@@ -9,9 +9,9 @@ Before you can run pipelines on Astro with real data, you first need to make you
 
 - Public endpoints
 - Virtual Private Cloud (VPC) peering
-- AWS Transit Gateway
+- Amazon Web Services (AWS) Transit Gateway
 - AWS IAM roles
-- Workload Identity (_GCP only_)
+- Workload Identity (_Google Cloud Platform (GCP) only_)
 
 If you need to connect to a type of data service that requires a connectivity method that is not documented here, reach out to [Astronomer support](https://support.astronomer.io).
 
@@ -41,7 +41,7 @@ Each cluster on Astro runs in a dedicated Virtual Private Network (VPC). To set 
 To create a VPC peering connection between an Astro VPC and a target VPC, reach out to [Astronomer support](https://support.astronomer.io) and provide the following information:
 
 - Astro cluster ID and name
-- AWS Account ID or GCP Project ID of the target VPC
+- AWS Account ID or Google Cloud project ID of the target VPC
 - Region of the target VPC (_AWS only_)
 - VPC ID of the target VPC
 - CIDR of the target VPC
@@ -90,8 +90,7 @@ If Astronomer creates a new transit gateway in your AWS account for Astro, keep 
 4. Accept the transit gateway peering attachment request from your network. See [Accept or reject a peering attachment request](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-peering.html#tgw-peering-accept-reject).
 5. Create a static route from your CIDR block to the transit gateway. See [Add a route to the transit gateway route table](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-peering.html#tgw-peering-add-route).
 6. Contact [Astronomer support](https://support.astronomer.io) to confirm that you have created the static route. Astronomer support will update the Astro VPC routing table to send traffic from your CIDR block through the transit gateway.
-
-Complete the steps for each Astro cluster that you want to connect to your transit gateway.
+7. Optional. Complete the steps for each Astro cluster that you want to connect to your transit gateway.
 
 ## AWS IAM roles
 
@@ -123,12 +122,11 @@ To grant an Astro cluster access to a service that is running in an AWS account 
 ```
 7. Click **Update policy**.
 8. In the Airflow UI or as an environment variable on Astro, create an Airflow connection to AWS for each Deployment that requires the resources you connected. See [Managing connections to Apache Airflow](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html).
-
-Complete these steps for each Astro cluster that requires access to external data services on AWS.
+8. Optional. Complete these steps for each Astro cluster that requires access to external data services on AWS.
 
 ## Workload Identity (_GCP only_)
 
-[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) is recommended by Google as the best way for data pipelines running on Google Cloud Platform (GCP) to access Google Cloud services in a secure and manageable way. All Astro clusters on GCP have Workload Identity enabled by default. Each Astro Deployment is associated with a Kubernetes service account that's created by Astronomer and is bound to an identity from your Google Cloud project's fixed workload identity pool.
+[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) is recommended by Google as the best way for data pipelines running on GCP to access Google Cloud services in a secure and manageable way. All Astro clusters on GCP have Workload Identity enabled by default. Each Astro Deployment is associated with a Kubernetes service account that's created by Astronomer and is bound to an identity from your Google Cloud project's fixed workload identity pool.
 
 To grant a Deployment on Astro access to external data services on GCP, such as BigQuery:
 
@@ -147,10 +145,9 @@ To grant a Deployment on Astro access to external data services on GCP, such as 
     astro-nuclear-science-2730@astronomer-prod.iam.gserviceaccount.com
     ```
 3. Go to the Google Cloud project in which your external data service is hosted.
-4. Add the Kubernetes service account for your Astro Deployment to the principal of that Google Cloud project. See [GCP documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
+4. Add the Kubernetes service account for your Astro Deployment to the principal of that Google Cloud project. See [Configure applications to use Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
 5. Bind the service account to a role that has access to your external data service.
-
-Complete these steps for every Astro Deployment that requires access to external data services on GCP.
+6. Optional. Complete these steps for every Astro Deployment that requires access to external data services on GCP.
 
 :::info
 

--- a/astro/connect-external-services.md
+++ b/astro/connect-external-services.md
@@ -76,7 +76,7 @@ While it can be more costly, AWS Transit Gateway requires less configuration and
 
 :::info
 
-If your transit gateway is in a different region than your Astro cluster, contact [Astronomer support](https://support.astronomer.io). Astronomer can create a new transit gateway in your AWS account for Astro and set up a cross-region peering connection with your existing transit gateway.
+If your transit gateway is in a different region than your Astro cluster, contact [Astronomer support](https://support.astronomer.io). Astronomer support can create a new transit gateway in your AWS account for Astro and set up a cross-region peering connection with your existing transit gateway.
 
 If Astronomer creates a new transit gateway in your AWS account for Astro, keep in mind that your organization will incur additional AWS charges for the new transit gateway as well as the inter-region transfer costs.
 
@@ -89,7 +89,7 @@ If Astronomer creates a new transit gateway in your AWS account for Astro, keep 
 3. Contact [Astronomer support](https://support.astronomer.io) and provide the CIDR block of the target VPC or on-premises network that you want to connect your Astro cluster with. From here, Astronomer approves the resource sharing request and creates a transit gateway peering attachment request to your network.
 4. Accept the transit gateway peering attachment request from your network. See [Accept or reject a peering attachment request](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-peering.html#tgw-peering-accept-reject).
 5. Create a static route from your CIDR block to the transit gateway. See [Add a route to the transit gateway route table](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-peering.html#tgw-peering-add-route).
-6. Contact [Astronomer support](https://support.astronomer.io) to confirm that you have created the static route. From here, Astronomer updates the routing table of the Astro VPC to send traffic from your CIDR block through the transit gateway.
+6. Contact [Astronomer support](https://support.astronomer.io) to confirm that you have created the static route. Astronomer support will update the Astro VPC routing table to send traffic from your CIDR block through the transit gateway.
 
 Complete the steps for each Astro cluster that you want to connect to your transit gateway.
 
@@ -101,7 +101,7 @@ To grant an Astro cluster access to a service that is running in an AWS account 
 2. Create an IAM role in the AWS account that contains your AWS service. See [Creating a role to delegate permissions to an AWS service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html).
 
 3. In the AWS Management Console, go to the Identity and Access Management (IAM) dashboard.
-4. Click **Roles**. In the **Role name** column, select the role you created in step 2.
+4. Click **Roles** and in the **Role name** column, select the role you created in step 2.
 5. Click the **Trust relationships** tab.
 6. Click **Edit trust policy** and update the `arn` value:
 
@@ -132,8 +132,8 @@ Complete these steps for each Astro cluster that requires access to external dat
 
 To grant a Deployment on Astro access to external data services on GCP, such as BigQuery:
 
-1. In the Cloud UI, go to your Deployment and copy paste the value under **Namespace**.
-2. Use your Deployment's namespace and the name of your Google Cloud project for Astro to identify the Kubernetes service account for your Deployment.
+1. In the Cloud UI, select a Deployment and then copy the value in the **Namespace** field.
+2. Use the Deployment namespace value and the name of your GCP project to identify the Kubernetes service account for your Deployment.
     
     Kubernetes service accounts for Astro Deployments are formatted as follows:
 
@@ -141,7 +141,7 @@ To grant a Deployment on Astro access to external data services on GCP, such as 
     astro-<deployment-namespace>@<gcp-project-name>.iam.gserviceaccount.com
     ```
     
-    For a Google Cloud project called `astronomer-prod` and a Deployment namespace defined as `nuclear-science-2730`, for example, the service account for the Deployment would be:
+    For a Google Cloud project named `astronomer-prod` and a Deployment namespace defined as `nuclear-science-2730`, for example, the service account for the Deployment would be:
 
     ```text
     astro-nuclear-science-2730@astronomer-prod.iam.gserviceaccount.com
@@ -156,7 +156,7 @@ Complete these steps for every Astro Deployment that requires access to external
 
 GCP has a 30 character limit for service account names. For Deployment namespaces which are longer than 24 characters, use only the first 24 characters when determining your service account name.
 
-For example, if your GCP project was called `astronomer-prod` and your Deployment namespace was `nuclear-scintillation-2730`, your service account would be:
+For example, if your GCP project is named `astronomer-prod` and your Deployment namespace is `nuclear-scintillation-2730`, the service account name is:
 
 ```text
 astro-nuclear-scintillation-27@astronomer-pmm.iam.gserviceaccount.com

--- a/astro/connect-external-services.md
+++ b/astro/connect-external-services.md
@@ -90,7 +90,7 @@ If Astronomer creates a new transit gateway in your AWS account for Astro, keep 
 4. Accept the transit gateway peering attachment request from your network. See [Accept or reject a peering attachment request](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-peering.html#tgw-peering-accept-reject).
 5. Create a static route from your CIDR block to the transit gateway. See [Add a route to the transit gateway route table](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-peering.html#tgw-peering-add-route).
 6. Contact [Astronomer support](https://support.astronomer.io) to confirm that you have created the static route. Astronomer support will update the Astro VPC routing table to send traffic from your CIDR block through the transit gateway.
-7. Optional. Complete the steps for each Astro cluster that you want to connect to your transit gateway.
+7. Optional. Repeat the steps for each Astro cluster that you want to connect to your transit gateway.
 
 ## AWS IAM roles
 
@@ -122,7 +122,7 @@ To grant an Astro cluster access to a service that is running in an AWS account 
 ```
 7. Click **Update policy**.
 8. In the Airflow UI or as an environment variable on Astro, create an Airflow connection to AWS for each Deployment that requires the resources you connected. See [Managing connections to Apache Airflow](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html).
-8. Optional. Complete these steps for each Astro cluster that requires access to external data services on AWS.
+8. Optional. Repeat these steps for each Astro cluster that requires access to external data services on AWS.
 
 ## Workload Identity (_GCP only_)
 
@@ -147,7 +147,7 @@ To grant a Deployment on Astro access to external data services on GCP, such as 
 3. Go to the Google Cloud project in which your external data service is hosted.
 4. Add the Kubernetes service account for your Astro Deployment to the principal of that Google Cloud project. See [Configure applications to use Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
 5. Bind the service account to a role that has access to your external data service.
-6. Optional. Complete these steps for every Astro Deployment that requires access to external data services on GCP.
+6. Optional. Repeat these steps for every Astro Deployment that requires access to external data services on GCP.
 
 :::info
 

--- a/astro/create-cluster.md
+++ b/astro/create-cluster.md
@@ -34,7 +34,7 @@ To create an Astro cluster, you need to have:
 
 #### Step 1: Submit a request to Astronomer
 
-To create a new Astro cluster on AWS for your Organization, you must first reach out to your Astronomer representative. For each new cluster that you want to provision, provide our team with the following information:
+To create a new Astro cluster on AWS for your Organization, submit a [support request](astro-support.md). In your support request, provide the following information for every new cluster that you want to provision:
 
 - Your AWS Account ID
 - Your preferred Astro cluster name
@@ -42,9 +42,9 @@ To create a new Astro cluster on AWS for your Organization, you must first reach
 - Your preferred node instance type
 - Your preferred max node count
 
-If not specified, Astronomer will create a cluster with two `m5.xlarge` nodes and a maximum node count of 20 in `us-east-1`. For information on all supported regions, configurations, and defaults, see [AWS resource reference](resource-reference-aws.md).
+If you don't specify configuration preferences for your new cluster, Astronomer creates a cluster with two `m5.xlarge` nodes and a maximum node count of 20 in `us-east-1`. For information on all supported regions, configurations, and defaults, see [AWS resource reference](resource-reference-aws.md).
 
-From there, your Astronomer representative will provide you with a unique `External ID` for each new cluster. Make note of this value for the next step.
+Once your cluster is created, Astronomer provides you with a unique `External ID` for every new cluster. You'll need these values to complete the next step.
 
 #### Step 2: Edit your AWS trust policy
 

--- a/astro/create-cluster.md
+++ b/astro/create-cluster.md
@@ -36,13 +36,13 @@ To create an Astro cluster, you need to have:
 
 To create a new Astro cluster on AWS for your Organization, you must first reach out to your Astronomer representative. For each new cluster that you want to provision, provide our team with the following information:
 
-- Your AWS Account ID.
-- Your preferred Astro cluster name.
-- The AWS region that you want to host your cluster in.
-- Your preferred node instance type.
-- Your preferred max node count.
+- Your AWS Account ID
+- Your preferred Astro cluster name
+- The AWS region that you want to host your cluster in
+- Your preferred node instance type
+- Your preferred max node count
 
-If not specified, Astronomer will create a cluster with two `m5.xlarge` nodes and a maximum node count of 20 in `us-east-1` by default. For information on all supported regions, configurations, and defaults, see [AWS resource reference](resource-reference-aws.md).
+If not specified, Astronomer will create a cluster with two `m5.xlarge` nodes and a maximum node count of 20 in `us-east-1`. For information on all supported regions, configurations, and defaults, see [AWS resource reference](resource-reference-aws.md).
 
 From there, your Astronomer representative will provide you with a unique `External ID` for each new cluster. Make note of this value for the next step.
 


### PR DESCRIPTION
I couldn't help myself! I was reading through this doc, which I know we've touched a bunch recently, and noticed a few things I wanted to clean up:

- Added context for AWS Transit Gateways (what are they, what are its benefits) in line with other sections
- Add steps for Workload Identity, also to be consistent with steps in other sections
- Add the two new connection methods to the top of the doc (AWS Transit Gateway
- AWS IAM roles), they were missing
- Moved the workload identity section to the bottom such that the AWS only sections were next to each other
- Language cleanup elsewhere

Let me know what you all think. Sorry for putting you through another round of this, @dnarain-astro ! 