### PR TITLE
Document podman limitations + style updates

### DIFF
--- a/software/cli-podman.md
+++ b/software/cli-podman.md
@@ -18,7 +18,7 @@ Alternatively, you can use [Podman](https://podman.io/) to execute these same co
 To complete this setup, you need:
 
 - Podman 3.1.0+ installed on your local machine.
-- The Astro CLI.
+- A pre-1.0 version of the [Astro CLI](install-cli.md), such as version 0.29.1.
 
 ## Linux setup
 

--- a/software/upgrade-astro-cli.md
+++ b/software/upgrade-astro-cli.md
@@ -1,52 +1,56 @@
 ---
-title: "Upgrade to Astro CLI v1.0+"
-sidebar_label: "Upgrade to Astro CLI v1.0+"
+title: "Upgrade to Astro CLI version 1.0+"
+sidebar_label: "Upgrade to Astro CLI version 1.0+"
 id: upgrade-astro-cli
-description: A list of all breaking changes and upgrade steps related to the major release of Astro CLI v1.0+
+description: A list of all breaking changes and upgrade steps related to the major release of Astro CLI version 1.0+
 ---
 
-Astro CLI v1.0+ delivers several new features to Astronomer Software and establishes a shared CLI framework across all Astronomer products.
+Astro CLI version 1.0+ delivers several new features to Astronomer Software and establishes a shared CLI framework across all Astronomer products.
 
-Several commands and their flags have been updated as part of this release, resulting in breaking changes for users of Astronomer Software. Use this document to learn about these breaking changes and prepare for your upgrade to Astro CLI v1.0+.
+Several commands and their flags have been updated as part of this release, resulting in breaking changes for users of Astronomer Software. Use this document to learn about these breaking changes and prepare for your upgrade to Astro CLI version 1.0+.
 
 This information applies only to users who are upgrading the Astro CLI from a pre-1.0 to a post-1.0 version. To install the latest version of the CLI for the first time, see [Install the CLI](install-cli.md).
 
-## Upgrade Checklist
+## Upgrade checklist
 
-Before installing Astro CLI v1.0+, complete all of the following steps:
+Before installing Astro CLI version 1.0+, complete all of the following steps:
 
-- Make sure you are running Astronomer Software v0.28+. If you're not sure, ask your system administrator.
+- Make sure you are running Astronomer Software version 0.28+. If you're not sure, ask your system administrator.
 - Review the [Breaking Changes](upgrade-astro-cli.md#breaking-changes) section in this document.
 - Update any CI/CD pipelines or automated processes that use Astro CLI commands to ensure that these commands do not break after you upgrade.
 - Review any custom shortcuts in your local CLI terminal to ensure that your shortcuts do not run any CLI commands that are no longer supported.
 
-After you complete these steps, upgrade to Astro CLI v1.0+ by following the instructions in [Install the CLI](install-cli.md).
+After you complete these steps, upgrade to Astro CLI version 1.0+ by following the instructions in [Install the CLI](install-cli.md).
 
 ## Features
 
-### New `astro dev restart` command to test local changes.
+### New `astro dev restart` command to test local changes
 
 For users making continuous changes to an Astro project locally, the Astro CLI now supports a new `astro dev restart` command. With this new command, you no longer need to run `astro dev stop` followed by `astro dev start` when you're testing locally.
 
 For more information, see [CLI Command Reference](cli-reference.md#astro-dev-restart).
 
-### New Command to Run DAG Unit Tests with pytest
+### New command to run DAG unit tests with pytest
 
 You can now run custom unit tests for all DAGs in your Astro project with `astro dev pytest`, a new Astro CLI command that uses [pytest](https://docs.pytest.org/en/7.1.x/contents.html#), a common testing framework for Python. As part of this change, new Astro projects created with `astro dev init` now include a `tests` directory, which includes one example unit test built by Astronomer.
 
 In addition to running tests locally, you can also run `astro dev pytest` as part of the deploy process to Astronomer Software. For more information, see [CLI Command Reference](cli-reference.md#astro-dev-pytest).
 
-### New Command to Parse DAGs for Errors
+### New command to parse DAGs for errors
 
 The new `astro dev parse` command allows you to run a basic test against your Astro project to ensure that your DAGs are able to to render in the Airflow UI. This includes the DAG integrity test that is run with `astro dev pytest`, which checks that your DAGs are able to to render in the Airflow UI. Now, you can quickly run `astro dev parse` and see import and syntax errors directly in your terminal without having to restart all Airflow services locally.
 
 For more complex testing, Astronomer recommends using `astro dev pytest` to run custom tests in your project. For more information on `astro dev parse`, see the [CLI Command Reference](cli-reference.md#astro-dev-parse).
 
-## Breaking Changes
+## Breaking changes
 
-This topic contains all information related to breaking changes included in Astro CLI v1.0+ relative to Astro CLI v0.28 and below.
+This topic contains all information related to breaking changes included in Astro CLI version 1.0+ relative to version 0.28 and below.
 
 This topic does not include information about new features and changes that are not breaking. For a summary of all changes, see the [CLI Release Notes](cli-release-notes.md).
+
+### Podman is no longer supported
+
+[Running the Astro CLI with Podman containers](cli-podman.md) is currently unsupported in version 1.0+. Podman functionality is still actively maintained in patches for versions 0.29 and 0.28. If you want to continue using Podman to run the Astro CLI, do not upgrade to version 1.0+ until further support is announced.
 
 ### `astro dev init`: New `--use-astronomer-certified` Flag Required for All New Projects Deployed to Software
 
@@ -62,7 +66,7 @@ astro dev init
 astro dev init --use-astronomer-certified
 ```
 
-### `astro auth login` Is Now `astro login`
+### `astro auth login` is now `astro login`
 
 The previous `astro auth login` and `astro auth logout` commands have been simplified:
 
@@ -76,7 +80,7 @@ astro login <domain>
 astro logout
 ```
 
-### `astro workspace create/update`: Now Takes All Configurations as Flags
+### `astro workspace create/update` now takes all configurations as flags
 
 When you specify configurations for a Workspace using `astro workspace create` or `astro workspace update`, you must now specify those properties with new flags.
 
@@ -88,7 +92,7 @@ astro workspace create label=my-workspace
 astro workspace create --label=my-workspace
 ```
 
-### `astro workspace create/update`: `--desc` Flag Has Been Renamed to `--description`
+### `astro workspace create/update`: `--desc` flag has been renamed to `--description`
 
 The flag for specifying a description for a Workspace has been renamed from `--desc` to `--description`.
 
@@ -100,7 +104,7 @@ astro workspace create label=my-workspace --desc="my description"
 astro workspace create --label=my-workspace --description="my description"
 ```
 
-### `astro workspace user add`: User Email Is Now Specified as a Flag
+### `astro workspace user add`: User email is now specified as a flag
 
 You must now specify a new user's email using the `--email` flag when running `astro workspace `
 
@@ -111,7 +115,7 @@ astro workspace user add email-to-add@astronomer.io --role WORKSPACE_VIEWER
 astro workspace user add --email email-to-add@astronomer.io --role WORKSPACE_VIEWER
 ```
 
-### `astro deploy` Now Accepts a Deployment ID Instead of a Release Name
+### `astro deploy` Now accepts a Deployment ID instead of a release name
 
 To deploy code to a specific Deployment without manually selecting a Deployment from a list, you must now specify that Deployment's ID instead of its release name when running `astro deploy`.
 
@@ -123,7 +127,7 @@ astro deploy <release-name>
 astro deploy <deployment-id>
 ```
 
-### `astro workspace sa get` Is Now `astro workspace sa list`
+### `astro workspace sa get` is now `astro workspace sa list`
 
 ```sh
 # Before upgrade
@@ -132,7 +136,7 @@ astro workspace sa get
 astro workspace sa list
 ```
 
-### `astro deployment/workspace sa create`: `--role` Only Accepts Full Role Names
+### `astro deployment/workspace sa create`: `--role` only accepts full role names
 
 The `--role` flag now accepts either `WORKSPACE_EDITOR`, `WORKSPACE_ADMIN`, or `WORKSPACE_VIEWER`.
 
@@ -144,7 +148,7 @@ astro workspace sa create --role viewer
 astro workspace sa create --role WORKSPACE_VIEWER
 ```
 
-### `astro deployment create/update` Now Takes All Properties as Flags
+### `astro deployment create/update` now takes all properties as flags
 
 You must now specify a Deployment's properties using flags when you run `astro deployment create` or `astro deployment update`.
 
@@ -168,7 +172,7 @@ astro deployment user list <deployment-id>
 astro deployment user list --deployment-id=<deployment-id>
 ```
 
-### `astro deployment user add`: `--email` Flag Is Now Required
+### `astro deployment user add`: `--email` flag is now required
 
 You must now specify a user's email using the `--email` flag when running `astro deployment user add`.
 
@@ -180,7 +184,7 @@ astro deployment user add <email> --deployment-id=<deployment-id>
 astro deployment user add --email=<email> --deployment-id=<deployment-id>
 ```
 
-### `astro deployment user delete` Is Now `astro deployment user remove`
+### `astro deployment user delete` is now `astro deployment user remove`
 
 ```sh
 # Before upgrade
@@ -190,11 +194,11 @@ astro deployment user delete <email> --deployment-id=<deployment-id>
 astro deployment user remove <email> --deployment-id=<deployment-id>
 ```
 
-### `astro logs <component>` Is Now Deprecated
+### `astro logs <component>` is now deprecated
 
 The `astro logs` command has been removed. This command has been unavailable for the last several CLI releases. Use `astro dev logs` to view logs locally or `astro deployment logs <component>` to view logs for a Deployment hosted on Astronomer Software.
 
-### `astro cluster list/switch` Is Now `astro context list/switch`
+### `astro cluster list/switch` is now `astro context list/switch`
 
 ```sh
 # Before upgrade
@@ -204,11 +208,11 @@ astro cluster list
 astro context list
 ```
 
-### `astro deployment sa create`: `--system-sa` and `--user-id` are Deprecated
+### `astro deployment sa create`: `--system-sa` and `--user-id` are deprecated
 
 The `--system-sa` and `--user-id` flags have been deprecated for `astro deployment sa create`. These flags have not been functional for the last several CLI versions.
 
-### `astro dev init`: Shortcut for `--airflow-version` Is Now `-a`
+### `astro dev init`: shortcut for `--airflow-version` is now `-a`
 
 The shortcut for specifying an Astronomer Certified version for `astro dev init` has been changed from `-v` to `-a`.
 

--- a/software/upgrade-astro-cli.md
+++ b/software/upgrade-astro-cli.md
@@ -48,9 +48,9 @@ This topic contains all information related to breaking changes included in Astr
 
 This topic does not include information about new features and changes that are not breaking. For a summary of all changes, see the [CLI release notes](cli-release-notes.md).
 
-### Podman is no longer supported
+### Podman is not supported in version 1.0+
 
-[Running the Astro CLI with Podman containers](cli-podman.md) is currently unsupported in version 1.0+. Podman functionality is still actively maintained in patches for versions 0.29 and 0.28. If you want to continue using Podman to run the Astro CLI, do not upgrade to version 1.0+ until further support is announced.
+[Running the Astro CLI with Podman containers](cli-podman.md) is currently unsupported in version 1.0+. Podman functionality is still actively maintained in patches for versions 0.29 and 0.28. To continue using Podman to run the Astro CLI, do not upgrade to version 1.0+ until further support is announced.
 
 ### `astro dev init`: New `--use-astronomer-certified` Flag Required for All New Projects Deployed to Software
 

--- a/software/upgrade-astro-cli.md
+++ b/software/upgrade-astro-cli.md
@@ -16,7 +16,7 @@ This information applies only to users who are upgrading the Astro CLI from a pr
 Before installing Astro CLI version 1.0+, complete all of the following steps:
 
 - Make sure you are running Astronomer Software version 0.28+. If you're not sure, ask your system administrator.
-- Review the [Breaking Changes](upgrade-astro-cli.md#breaking-changes) section in this document.
+- Review the [Breaking changes](upgrade-astro-cli.md#breaking-changes) section in this document.
 - Update any CI/CD pipelines or automated processes that use Astro CLI commands to ensure that these commands do not break after you upgrade.
 - Review any custom shortcuts in your local CLI terminal to ensure that your shortcuts do not run any CLI commands that are no longer supported.
 
@@ -28,25 +28,25 @@ After you complete these steps, upgrade to Astro CLI version 1.0+ by following t
 
 For users making continuous changes to an Astro project locally, the Astro CLI now supports a new `astro dev restart` command. With this new command, you no longer need to run `astro dev stop` followed by `astro dev start` when you're testing locally.
 
-For more information, see [CLI Command Reference](cli-reference.md#astro-dev-restart).
+For more information, see [CLI command reference](cli-reference.md#astro-dev-restart).
 
 ### New command to run DAG unit tests with pytest
 
 You can now run custom unit tests for all DAGs in your Astro project with `astro dev pytest`, a new Astro CLI command that uses [pytest](https://docs.pytest.org/en/7.1.x/contents.html#), a common testing framework for Python. As part of this change, new Astro projects created with `astro dev init` now include a `tests` directory, which includes one example unit test built by Astronomer.
 
-In addition to running tests locally, you can also run `astro dev pytest` as part of the deploy process to Astronomer Software. For more information, see [CLI Command Reference](cli-reference.md#astro-dev-pytest).
+In addition to running tests locally, you can also run `astro dev pytest` as part of the deploy process to Astronomer Software. For more information, see [CLI command reference](cli-reference.md#astro-dev-pytest).
 
 ### New command to parse DAGs for errors
 
 The new `astro dev parse` command allows you to run a basic test against your Astro project to ensure that your DAGs are able to to render in the Airflow UI. This includes the DAG integrity test that is run with `astro dev pytest`, which checks that your DAGs are able to to render in the Airflow UI. Now, you can quickly run `astro dev parse` and see import and syntax errors directly in your terminal without having to restart all Airflow services locally.
 
-For more complex testing, Astronomer recommends using `astro dev pytest` to run custom tests in your project. For more information on `astro dev parse`, see the [CLI Command Reference](cli-reference.md#astro-dev-parse).
+For more complex testing, Astronomer recommends using `astro dev pytest` to run custom tests in your project. For more information on `astro dev parse`, see the [CLI command reference](cli-reference.md#astro-dev-parse).
 
 ## Breaking changes
 
 This topic contains all information related to breaking changes included in Astro CLI version 1.0+ relative to version 0.28 and below.
 
-This topic does not include information about new features and changes that are not breaking. For a summary of all changes, see the [CLI Release Notes](cli-release-notes.md).
+This topic does not include information about new features and changes that are not breaking. For a summary of all changes, see the [CLI release notes](cli-release-notes.md).
 
 ### Podman is no longer supported
 

--- a/software_versioned_docs/version-0.28/cli-podman.md
+++ b/software_versioned_docs/version-0.28/cli-podman.md
@@ -20,7 +20,7 @@ Alternatively, you can use [Podman](https://podman.io/) to execute these same co
 To complete this setup, you need:
 
 - Podman 3.1.0+ installed on your local machine.
-- The Astro CLI.
+- A pre-1.0 version of the [Astro CLI](install-cli.md), such as version 0.28.2.
 
 ## Linux Setup
 

--- a/software_versioned_docs/version-0.28/upgrade-astro-cli.md
+++ b/software_versioned_docs/version-0.28/upgrade-astro-cli.md
@@ -50,7 +50,7 @@ This topic does not include information about new features and changes that are 
 
 ### Podman is not supported in version 1.0+
 
-[Running the Astro CLI with Podman containers](cli-podman.md) is currently unsupported in version 1.0+. Podman functionality is still actively maintained in patches for versions 0.29 and 0.28. If you want to continue using Podman to run the Astro CLI, do not upgrade to version 1.0+ until further support is announced.
+[Running the Astro CLI with Podman containers](cli-podman.md) is currently unsupported in version 1.0+. Podman functionality is still actively maintained in patches for versions 0.29 and 0.28. To continue using Podman to run the Astro CLI, do not upgrade to version 1.0+ until further support is announced.
 
 ### `astro dev init`: New `--use-astronomer-certified` Flag Required for All New Projects Deployed to Software
 

--- a/software_versioned_docs/version-0.28/upgrade-astro-cli.md
+++ b/software_versioned_docs/version-0.28/upgrade-astro-cli.md
@@ -48,7 +48,7 @@ This topic contains all information related to breaking changes included in Astr
 
 This topic does not include information about new features and changes that are not breaking. For a summary of all changes, see the [CLI release notes](cli-release-notes.md).
 
-### Podman is no longer supported
+### Podman is not supported in version 1.0+
 
 [Running the Astro CLI with Podman containers](cli-podman.md) is currently unsupported in version 1.0+. Podman functionality is still actively maintained in patches for versions 0.29 and 0.28. If you want to continue using Podman to run the Astro CLI, do not upgrade to version 1.0+ until further support is announced.
 

--- a/software_versioned_docs/version-0.28/upgrade-astro-cli.md
+++ b/software_versioned_docs/version-0.28/upgrade-astro-cli.md
@@ -16,7 +16,7 @@ This information applies only to users who are upgrading the Astro CLI from a pr
 Before installing Astro CLI version 1.0+, complete all of the following steps:
 
 - Make sure you are running Astronomer Software version 0.28+. If you're not sure, ask your system administrator.
-- Review the [Breaking Changes](upgrade-astro-cli.md#breaking-changes) section in this document.
+- Review the [Breaking changes](upgrade-astro-cli.md#breaking-changes) section in this document.
 - Update any CI/CD pipelines or automated processes that use Astro CLI commands to ensure that these commands do not break after you upgrade.
 - Review any custom shortcuts in your local CLI terminal to ensure that your shortcuts do not run any CLI commands that are no longer supported.
 
@@ -28,25 +28,25 @@ After you complete these steps, upgrade to Astro CLI version 1.0+ by following t
 
 For users making continuous changes to an Astro project locally, the Astro CLI now supports a new `astro dev restart` command. With this new command, you no longer need to run `astro dev stop` followed by `astro dev start` when you're testing locally.
 
-For more information, see [CLI Command Reference](cli-reference.md#astro-dev-restart).
+For more information, see [CLI command reference](cli-reference.md#astro-dev-restart).
 
 ### New command to run DAG unit tests with pytest
 
 You can now run custom unit tests for all DAGs in your Astro project with `astro dev pytest`, a new Astro CLI command that uses [pytest](https://docs.pytest.org/en/7.1.x/contents.html#), a common testing framework for Python. As part of this change, new Astro projects created with `astro dev init` now include a `tests` directory, which includes one example unit test built by Astronomer.
 
-In addition to running tests locally, you can also run `astro dev pytest` as part of the deploy process to Astronomer Software. For more information, see [CLI Command Reference](cli-reference.md#astro-dev-pytest).
+In addition to running tests locally, you can also run `astro dev pytest` as part of the deploy process to Astronomer Software. For more information, see [CLI command reference](cli-reference.md#astro-dev-pytest).
 
 ### New command to parse DAGs for errors
 
 The new `astro dev parse` command allows you to run a basic test against your Astro project to ensure that your DAGs are able to to render in the Airflow UI. This includes the DAG integrity test that is run with `astro dev pytest`, which checks that your DAGs are able to to render in the Airflow UI. Now, you can quickly run `astro dev parse` and see import and syntax errors directly in your terminal without having to restart all Airflow services locally.
 
-For more complex testing, Astronomer recommends using `astro dev pytest` to run custom tests in your project. For more information on `astro dev parse`, see the [CLI Command Reference](cli-reference.md#astro-dev-parse).
+For more complex testing, Astronomer recommends using `astro dev pytest` to run custom tests in your project. For more information on `astro dev parse`, see the [CLI command reference](cli-reference.md#astro-dev-parse).
 
 ## Breaking changes
 
 This topic contains all information related to breaking changes included in Astro CLI version 1.0+ relative to version 0.28 and below.
 
-This topic does not include information about new features and changes that are not breaking. For a summary of all changes, see the [CLI Release Notes](cli-release-notes.md).
+This topic does not include information about new features and changes that are not breaking. For a summary of all changes, see the [CLI release notes](cli-release-notes.md).
 
 ### Podman is no longer supported
 

--- a/software_versioned_docs/version-0.28/upgrade-astro-cli.md
+++ b/software_versioned_docs/version-0.28/upgrade-astro-cli.md
@@ -1,60 +1,62 @@
 ---
-title: "Upgrade to Astro CLI v1.0+"
-sidebar_label: "Upgrade to Astro CLI v1.0+"
+title: "Upgrade to Astro CLI version 1.0+"
+sidebar_label: "Upgrade to Astro CLI version 1.0+"
 id: upgrade-astro-cli
-description: A list of all breaking changes and upgrade steps related to the major release of Astro CLI v1.0+
+description: A list of all breaking changes and upgrade steps related to the major release of Astro CLI version 1.0+
 ---
 
-## Overview
+Astro CLI version 1.0+ delivers several new features to Astronomer Software and establishes a shared CLI framework across all Astronomer products.
 
-Astro CLI v1.0 delivers several new features to Astronomer Software and establishes a shared CLI framework across all Astronomer products.
-
-Several commands and their flags have been updated as part of this release, resulting in breaking changes for users of Astronomer Software. Use this document to learn about these breaking changes and prepare for your upgrade to Astro CLI v1.0.
+Several commands and their flags have been updated as part of this release, resulting in breaking changes for users of Astronomer Software. Use this document to learn about these breaking changes and prepare for your upgrade to Astro CLI version 1.0+.
 
 This information applies only to users who are upgrading the Astro CLI from a pre-1.0 to a post-1.0 version. To install the latest version of the CLI for the first time, see [Install the CLI](install-cli.md).
 
-## Upgrade Checklist
+## Upgrade checklist
 
-Before installing Astro CLI v1.0+, complete all of the following steps:
+Before installing Astro CLI version 1.0+, complete all of the following steps:
 
-- Make sure you are running Astronomer Software v0.28+. If you're not sure, ask your system administrator.
+- Make sure you are running Astronomer Software version 0.28+. If you're not sure, ask your system administrator.
 - Review the [Breaking Changes](upgrade-astro-cli.md#breaking-changes) section in this document.
 - Update any CI/CD pipelines or automated processes that use Astro CLI commands to ensure that these commands do not break after you upgrade.
 - Review any custom shortcuts in your local CLI terminal to ensure that your shortcuts do not run any CLI commands that are no longer supported.
 
-After you complete these steps, upgrade to Astro CLI v1.0+ by following the instructions in [Install the CLI](install-cli.md).
+After you complete these steps, upgrade to Astro CLI version 1.0+ by following the instructions in [Install the CLI](install-cli.md).
 
 ## Features
 
-### New `astro dev restart` command to test local changes.
+### New `astro dev restart` command to test local changes
 
-For users making quick and continuous changes to an Astro project locally, the Astro CLI now supports a new `astro dev restart` command. This command makes local testing significantly easier and is equivalent to running `astro dev stop` followed by `astro dev start`.
+For users making continuous changes to an Astro project locally, the Astro CLI now supports a new `astro dev restart` command. With this new command, you no longer need to run `astro dev stop` followed by `astro dev start` when you're testing locally.
 
-For more information, see [CLI command reference](cli-reference.md#astro-dev-restart).
+For more information, see [CLI Command Reference](cli-reference.md#astro-dev-restart).
 
-### New Command to Run DAG Unit Tests with pytest
+### New command to run DAG unit tests with pytest
 
-You can now run custom unit tests for all DAGs in your Astro project with `astro dev pytest`, a new Astro CLI command that uses [pytest](https://docs.pytest.org/en/7.1.x/contents.html#), a common testing framework for Python. As part of this change, new Astro projects created via `astro dev init` now include a `tests` directory, which includes one example unit test built by Astronomer.
+You can now run custom unit tests for all DAGs in your Astro project with `astro dev pytest`, a new Astro CLI command that uses [pytest](https://docs.pytest.org/en/7.1.x/contents.html#), a common testing framework for Python. As part of this change, new Astro projects created with `astro dev init` now include a `tests` directory, which includes one example unit test built by Astronomer.
 
-In addition to running tests locally, you can also run `astro dev pytest` as part of the deploy process to Astronomer Software. For more information, see [CLI command reference](cli-reference.md#astro-dev-pytest).
+In addition to running tests locally, you can also run `astro dev pytest` as part of the deploy process to Astronomer Software. For more information, see [CLI Command Reference](cli-reference.md#astro-dev-pytest).
 
-### New Command to Parse DAGs for Errors
+### New command to parse DAGs for errors
 
-New `astro dev parse` command that allows you to run a basic test against your Astro project to ensure that your DAGs are able to to render in the Airflow UI. This includes the DAG integrity test that is run with `astro dev pytest`, which checks that your DAGs are able to to render in the Airflow UI. Now, you can quickly run `astro dev parse` and see import and syntax errors directly in your terminal without having to restart all Airflow services locally.
+The new `astro dev parse` command allows you to run a basic test against your Astro project to ensure that your DAGs are able to to render in the Airflow UI. This includes the DAG integrity test that is run with `astro dev pytest`, which checks that your DAGs are able to to render in the Airflow UI. Now, you can quickly run `astro dev parse` and see import and syntax errors directly in your terminal without having to restart all Airflow services locally.
 
-For more complex testing, we still recommend using `astro dev pytest`, which allows you to run other custom tests in your project. For more information on `astro dev parse`, see the [CLI command reference](cli-reference.md#astro-dev-parse).
+For more complex testing, Astronomer recommends using `astro dev pytest` to run custom tests in your project. For more information on `astro dev parse`, see the [CLI Command Reference](cli-reference.md#astro-dev-parse).
 
-## Breaking Changes
+## Breaking changes
 
-This topic contains all information related to breaking changes included in Astro CLI v1.0+ relative to Astro CLI v0.28 and below.
+This topic contains all information related to breaking changes included in Astro CLI version 1.0+ relative to version 0.28 and below.
 
 This topic does not include information about new features and changes that are not breaking. For a summary of all changes, see the [CLI Release Notes](cli-release-notes.md).
 
+### Podman is no longer supported
+
+[Running the Astro CLI with Podman containers](cli-podman.md) is currently unsupported in version 1.0+. Podman functionality is still actively maintained in patches for versions 0.29 and 0.28. If you want to continue using Podman to run the Astro CLI, do not upgrade to version 1.0+ until further support is announced.
+
 ### `astro dev init`: New `--use-astronomer-certified` Flag Required for All New Projects Deployed to Software
 
-When you create a new Astro project via `astro dev init`, you must now specify the `--use-astronomer-certified` flag if you want to [deploy the project](deploy-cli.md) to a Deployment on Astronomer Software. This flag initializes your project with the latest version of Astronomer Certified.
+When you create a new Astro project with the `astro dev init` command, you must now specify the `--use-astronomer-certified` flag if you want to [deploy the project](deploy-cli.md) to a Deployment on Astronomer Software. This flag initializes your project with the latest Astronomer Certified version.
 
-If you don't specify this flag, the project will be generated with an Astro Runtime image. Support for Astro Runtime on Astronomer Software is coming soon.
+If you don't specify this flag, the project is initialized with an Astro Runtime image. Support for Astro Runtime on Astronomer Software is coming soon.
 
 ```sh
 # Before upgrade
@@ -64,7 +66,7 @@ astro dev init
 astro dev init --use-astronomer-certified
 ```
 
-### `astro auth login` Is Now `astro login`
+### `astro auth login` is now `astro login`
 
 The previous `astro auth login` and `astro auth logout` commands have been simplified:
 
@@ -78,7 +80,7 @@ astro login <domain>
 astro logout
 ```
 
-### `astro workspace create/update`: Now Takes All Configurations as Flags
+### `astro workspace create/update` now takes all configurations as flags
 
 When you specify configurations for a Workspace using `astro workspace create` or `astro workspace update`, you must now specify those properties with new flags.
 
@@ -90,7 +92,7 @@ astro workspace create label=my-workspace
 astro workspace create --label=my-workspace
 ```
 
-### `astro workspace create/update`: `--desc` Flag Has Been Renamed to `--description`
+### `astro workspace create/update`: `--desc` flag has been renamed to `--description`
 
 The flag for specifying a description for a Workspace has been renamed from `--desc` to `--description`.
 
@@ -102,7 +104,7 @@ astro workspace create label=my-workspace --desc="my description"
 astro workspace create --label=my-workspace --description="my description"
 ```
 
-### `astro workspace user add`: User Email Is Now Specified as a Flag
+### `astro workspace user add`: User email is now specified as a flag
 
 You must now specify a new user's email using the `--email` flag when running `astro workspace `
 
@@ -113,9 +115,9 @@ astro workspace user add email-to-add@astronomer.io --role WORKSPACE_VIEWER
 astro workspace user add --email email-to-add@astronomer.io --role WORKSPACE_VIEWER
 ```
 
-### `astro deploy` Now Accepts a Deployment ID Instead of a Release Name
+### `astro deploy` Now accepts a Deployment ID instead of a release name
 
-To deploy code to a specific Deployment without manually slecting a Deployment from a list, you must now specify that Deployment's ID instead of its release name when running `astro deploy`.
+To deploy code to a specific Deployment without manually selecting a Deployment from a list, you must now specify that Deployment's ID instead of its release name when running `astro deploy`.
 
 ```sh
 # Before upgrade
@@ -125,7 +127,7 @@ astro deploy <release-name>
 astro deploy <deployment-id>
 ```
 
-### `astro workspace sa get` Is Now `astro workspace sa list`
+### `astro workspace sa get` is now `astro workspace sa list`
 
 ```sh
 # Before upgrade
@@ -134,7 +136,7 @@ astro workspace sa get
 astro workspace sa list
 ```
 
-### `astro deployment/workspace sa create`: `--role` Only Accepts Full Role Names
+### `astro deployment/workspace sa create`: `--role` only accepts full role names
 
 The `--role` flag now accepts either `WORKSPACE_EDITOR`, `WORKSPACE_ADMIN`, or `WORKSPACE_VIEWER`.
 
@@ -146,7 +148,7 @@ astro workspace sa create --role viewer
 astro workspace sa create --role WORKSPACE_VIEWER
 ```
 
-### `astro deployment create/update` Now Takes All Properties as Flags
+### `astro deployment create/update` now takes all properties as flags
 
 You must now specify a Deployment's properties using flags when you run `astro deployment create` or `astro deployment update`.
 
@@ -170,7 +172,7 @@ astro deployment user list <deployment-id>
 astro deployment user list --deployment-id=<deployment-id>
 ```
 
-### `astro deployment user add`: `--email` Flag Is Now Required
+### `astro deployment user add`: `--email` flag is now required
 
 You must now specify a user's email using the `--email` flag when running `astro deployment user add`.
 
@@ -182,7 +184,7 @@ astro deployment user add <email> --deployment-id=<deployment-id>
 astro deployment user add --email=<email> --deployment-id=<deployment-id>
 ```
 
-### `astro deployment user delete` Is Now `astro deployment user remove`
+### `astro deployment user delete` is now `astro deployment user remove`
 
 ```sh
 # Before upgrade
@@ -192,11 +194,11 @@ astro deployment user delete <email> --deployment-id=<deployment-id>
 astro deployment user remove <email> --deployment-id=<deployment-id>
 ```
 
-### `astro logs <component>` Is Now Deprecated
+### `astro logs <component>` is now deprecated
 
-The `astro logs` commands has been removed. This command has been non-functional for the last several CLI releases. Instead, use `astro dev logs` to see logs locally or `astro deployment logs <component>` to see logs for a Deployment hosted on Astronomer Software.
+The `astro logs` command has been removed. This command has been unavailable for the last several CLI releases. Use `astro dev logs` to view logs locally or `astro deployment logs <component>` to view logs for a Deployment hosted on Astronomer Software.
 
-### `astro cluster list/switch` Is Now `astro context list/switch`
+### `astro cluster list/switch` is now `astro context list/switch`
 
 ```sh
 # Before upgrade
@@ -206,11 +208,11 @@ astro cluster list
 astro context list
 ```
 
-### `astro deployment sa create`: `--system-sa` and `--user-id` are Deprecated
+### `astro deployment sa create`: `--system-sa` and `--user-id` are deprecated
 
 The `--system-sa` and `--user-id` flags have been deprecated for `astro deployment sa create`. These flags have not been functional for the last several CLI versions.
 
-### `astro dev init`: Shortcut for `--airflow-version` Is Now `-a`
+### `astro dev init`: shortcut for `--airflow-version` is now `-a`
 
 The shortcut for specifying an Astronomer Certified version for `astro dev init` has been changed from `-v` to `-a`.
 


### PR DESCRIPTION
We didn't have the Podman breaking change documented in our CLI docs, this PR fixes that. I also updated our CLI migration guide to meet our capitalization standards, as it seems to have gotten missed in the major overhaul PR 