### PR TITLE
Removed Instances of Prisma

### DIFF
--- a/software/install-aws-standard.md
+++ b/software/install-aws-standard.md
@@ -392,7 +392,6 @@ astronomer-nginx-746589b744-h6r5n                          1/1     Running      
 astronomer-nginx-746589b744-hscb9                          1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-4vjmz            1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-7m86w            1/1     Running             0          24m
-astronomer-prisma-57d5bf6c64-zcmsh                         1/1     Running             0          24m
 astronomer-prometheus-0                                    1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-865h2   1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-szr4s   1/1     Running             0          24m
@@ -425,7 +424,6 @@ astronomer-kubed                     ClusterIP      172.20.4.200     <none>     
 astronomer-nginx                     LoadBalancer   172.20.54.142    ELB_ADDRESS.us-east-1.elb.amazonaws.com                                   80:31925/TCP,443:32461/TCP,10254:32424/TCP   24d
 astronomer-nginx-default-backend     ClusterIP      172.20.186.254   <none>                                                                    8080/TCP                                     24d
 astronomer-astro-ui                  ClusterIP      172.20.186.166   <none>                                                                    8080/TCP                                     24d
-astronomer-prisma                    ClusterIP      172.20.144.188   <none>                                                                    4466/TCP                                     24d
 astronomer-prometheus                ClusterIP      172.20.72.196    <none>                                                                    9090/TCP                                     24d
 astronomer-registry                  ClusterIP      172.20.100.102   <none>                                                                    5000/TCP                                     24d
 ```

--- a/software/install-azure-standard.md
+++ b/software/install-azure-standard.md
@@ -431,7 +431,6 @@ astronomer-nginx-746589b744-h6r5n                          1/1     Running      
 astronomer-nginx-746589b744-hscb9                          1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-4vjmz            1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-7m86w            1/1     Running             0          24m
-astronomer-prisma-57d5bf6c64-zcmsh                         1/1     Running             0          24m
 astronomer-prometheus-0                                    1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-865h2   1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-szr4s   1/1     Running             0          24m
@@ -466,7 +465,6 @@ astronomer-nginx                              LoadBalancer   10.0.146.24    20.1
 astronomer-nginx-default-backend              ClusterIP      10.0.132.182   <none>          8080/TCP                                     6m48s
 astronomer-postgresql                         ClusterIP      10.0.0.252     <none>          5432/TCP                                     6m48s
 astronomer-postgresql-headless                ClusterIP      None           <none>          5432/TCP                                     6m48s
-astronomer-prisma                             ClusterIP      10.0.30.160    <none>          4466/TCP                                     6m48s
 astronomer-prometheus                         ClusterIP      10.0.128.170   <none>          9090/TCP                                     6m48s
 astronomer-prometheus-blackbox-exporter       ClusterIP      10.0.125.142   <none>          9115/TCP                                     6m48s
 astronomer-prometheus-node-exporter           ClusterIP      10.0.2.116     <none>          9100/TCP                                     6m48s

--- a/software/install-gcp-standard.md
+++ b/software/install-gcp-standard.md
@@ -412,7 +412,6 @@ newbie-norse-kube-state-549f45544f-mcv7m               1/1     Running     0    
 newbie-norse-nginx-7f6b5dfc9c-dm6tj                    1/1     Running     0          30m
 newbie-norse-nginx-default-backend-5ccdb9554d-5cm5q    1/1     Running     0          30m
 newbie-norse-astro-ui-d5585ccd8-h8zkr                  1/1     Running     0          30m
-newbie-norse-prisma-699bd664bb-vbvlf                   1/1     Running     0          30m
 newbie-norse-prometheus-0                              1/1     Running     0          30m
 newbie-norse-registry-0                                1/1     Running     0          30m
 ```
@@ -445,7 +444,6 @@ astronomer-nginx                              LoadBalancer   10.0.146.24    20.1
 astronomer-nginx-default-backend              ClusterIP      10.0.132.182   <none>          8080/TCP                                     6m48s
 astronomer-postgresql                         ClusterIP      10.0.0.252     <none>          5432/TCP                                     6m48s
 astronomer-postgresql-headless                ClusterIP      None           <none>          5432/TCP                                     6m48s
-astronomer-prisma                             ClusterIP      10.0.30.160    <none>          4466/TCP                                     6m48s
 astronomer-prometheus                         ClusterIP      10.0.128.170   <none>          9090/TCP                                     6m48s
 astronomer-prometheus-blackbox-exporter       ClusterIP      10.0.125.142   <none>          9115/TCP                                     6m48s
 astronomer-prometheus-node-exporter           ClusterIP      10.0.2.116     <none>          9100/TCP                                     6m48s

--- a/software_versioned_docs/version-0.23/debug-install.md
+++ b/software_versioned_docs/version-0.23/debug-install.md
@@ -5,11 +5,11 @@ id: debug-install
 ---
 
 
-If the Astronomer platform is not functioning after following the instructions in the installation guide for any specific environment, here are a few things to try:
+Use the information provided here when the Astronomer platform is not functioning as expected after you install it.
 
-## Houston, Grafana, and Prisma stuck in CrashLoopBackOff
+## Houston and Grafana stuck in CrashLoopBackOff
 
-When deploying the base Astronomer platform, the only three pods that will connect directly to the database are Houston (API), Grafana, and Prisma. All other database connections will be created from Airflow deployments created on Astronomer.
+When deploying the base Astronomer platform, the Houston (API) and Grafana pods connect directly to the database. All other database connections are created from Airflow deployments created on Astronomer.
 
 ```
 $ kubectl get pods -n astro-demo
@@ -43,12 +43,11 @@ manageable-snail-kubed-5b5d65dd9d-l7nds                    1/1     Running      
 manageable-snail-nginx-799d79ccf9-kfnzn                    1/1     Running            0          1h
 manageable-snail-nginx-default-backend-5cc4755696-vh5zq    1/1     Running            0          1h
 manageable-snail-astro-ui-7b9b9df4f9-pb99f                 1/1     Running            0          1h
-manageable-snail-prisma-6b5d944bdc-szn8f                   0/1     CrashLoopBackOff   20         1h
 manageable-snail-prometheus-0                              1/1     Running            0          1h
 manageable-snail-registry-0                                1/1     Running            0          1h
 ```
 
-If these are the only three pods that are not coming up as healthy, it is usually indicative of an issue with connecting to the database. Try checking:
+If these pods do not come up in a healthy state, it is usually an issue with the database connection. See the following topics to confirm your connection.
 
 #### Networking
 Make sure that the Kubernetes cluster Astronomer is running on can connect to the database. One way to check this is to jump into an Astronomer pod and try connecting directly to the database:
@@ -110,8 +109,6 @@ manageable-snail-kubed-apiserver-cert                  Opaque                   
 manageable-snail-kubed-notifier                        Opaque                                0      33h
 manageable-snail-kubed-token-dhd94                     kubernetes.io/service-account-token   3      33h
 manageable-snail-nginx-token-xk5pn                     kubernetes.io/service-account-token   3      33h
-manageable-snail-prisma-api-secret                     Opaque                                2      33h
-manageable-snail-prisma-bootstrapper-token-8zhjm       kubernetes.io/service-account-token   3      33h
 manageable-snail-prometheus-token-2v59c                kubernetes.io/service-account-token   3      33h
 manageable-snail-registry-auth                         kubernetes.io/dockerconfigjson        1      33h
 ```

--- a/software_versioned_docs/version-0.23/install-aws-standard.md
+++ b/software_versioned_docs/version-0.23/install-aws-standard.md
@@ -352,7 +352,6 @@ astronomer-nginx-746589b744-h6r5n                          1/1     Running      
 astronomer-nginx-746589b744-hscb9                          1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-4vjmz            1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-7m86w            1/1     Running             0          24m
-astronomer-prisma-57d5bf6c64-zcmsh                         1/1     Running             0          24m
 astronomer-prometheus-0                                    1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-865h2   1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-szr4s   1/1     Running             0          24m
@@ -385,7 +384,6 @@ astronomer-kubed                     ClusterIP      172.20.4.200     <none>     
 astronomer-nginx                     LoadBalancer   172.20.54.142    ELB_ADDRESS.us-east-1.elb.amazonaws.com                                   80:31925/TCP,443:32461/TCP,10254:32424/TCP   24d
 astronomer-nginx-default-backend     ClusterIP      172.20.186.254   <none>                                                                    8080/TCP                                     24d
 astronomer-astro-ui                  ClusterIP      172.20.186.166   <none>                                                                    8080/TCP                                     24d
-astronomer-prisma                    ClusterIP      172.20.144.188   <none>                                                                    4466/TCP                                     24d
 astronomer-prometheus                ClusterIP      172.20.72.196    <none>                                                                    9090/TCP                                     24d
 astronomer-registry                  ClusterIP      172.20.100.102   <none>                                                                    5000/TCP                                     24d
 ```

--- a/software_versioned_docs/version-0.23/install-azure-standard.md
+++ b/software_versioned_docs/version-0.23/install-azure-standard.md
@@ -382,7 +382,6 @@ astronomer-nginx-746589b744-h6r5n                          1/1     Running      
 astronomer-nginx-746589b744-hscb9                          1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-4vjmz            1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-7m86w            1/1     Running             0          24m
-astronomer-prisma-57d5bf6c64-zcmsh                         1/1     Running             0          24m
 astronomer-prometheus-0                                    1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-865h2   1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-szr4s   1/1     Running             0          24m
@@ -417,7 +416,6 @@ astronomer-nginx                              LoadBalancer   10.0.146.24    20.1
 astronomer-nginx-default-backend              ClusterIP      10.0.132.182   <none>          8080/TCP                                     6m48s
 astronomer-postgresql                         ClusterIP      10.0.0.252     <none>          5432/TCP                                     6m48s
 astronomer-postgresql-headless                ClusterIP      None           <none>          5432/TCP                                     6m48s
-astronomer-prisma                             ClusterIP      10.0.30.160    <none>          4466/TCP                                     6m48s
 astronomer-prometheus                         ClusterIP      10.0.128.170   <none>          9090/TCP                                     6m48s
 astronomer-prometheus-blackbox-exporter       ClusterIP      10.0.125.142   <none>          9115/TCP                                     6m48s
 astronomer-prometheus-node-exporter           ClusterIP      10.0.2.116     <none>          9100/TCP                                     6m48s

--- a/software_versioned_docs/version-0.23/install-gcp-standard.md
+++ b/software_versioned_docs/version-0.23/install-gcp-standard.md
@@ -372,7 +372,6 @@ newbie-norse-kube-state-549f45544f-mcv7m               1/1     Running     0    
 newbie-norse-nginx-7f6b5dfc9c-dm6tj                    1/1     Running     0          30m
 newbie-norse-nginx-default-backend-5ccdb9554d-5cm5q    1/1     Running     0          30m
 newbie-norse-astro-ui-d5585ccd8-h8zkr                  1/1     Running     0          30m
-newbie-norse-prisma-699bd664bb-vbvlf                   1/1     Running     0          30m
 newbie-norse-prometheus-0                              1/1     Running     0          30m
 newbie-norse-registry-0                                1/1     Running     0          30m
 ```
@@ -405,7 +404,6 @@ astronomer-nginx                              LoadBalancer   10.0.146.24    20.1
 astronomer-nginx-default-backend              ClusterIP      10.0.132.182   <none>          8080/TCP                                     6m48s
 astronomer-postgresql                         ClusterIP      10.0.0.252     <none>          5432/TCP                                     6m48s
 astronomer-postgresql-headless                ClusterIP      None           <none>          5432/TCP                                     6m48s
-astronomer-prisma                             ClusterIP      10.0.30.160    <none>          4466/TCP                                     6m48s
 astronomer-prometheus                         ClusterIP      10.0.128.170   <none>          9090/TCP                                     6m48s
 astronomer-prometheus-blackbox-exporter       ClusterIP      10.0.125.142   <none>          9115/TCP                                     6m48s
 astronomer-prometheus-node-exporter           ClusterIP      10.0.2.116     <none>          9100/TCP                                     6m48s

--- a/software_versioned_docs/version-0.25/debug-install.md
+++ b/software_versioned_docs/version-0.25/debug-install.md
@@ -5,11 +5,11 @@ id: debug-install
 ---
 
 
-If the Astronomer platform is not functioning after following the instructions in the installation guide for any specific environment, here are a few things to try:
+Use the information provided here when the Astronomer platform is not functioning as expected after you install it.
 
-## Houston, Grafana, and Prisma stuck in CrashLoopBackOff
+## Houston and Grafana stuck in CrashLoopBackOff
 
-When deploying the base Astronomer platform, the only three pods that will connect directly to the database are Houston (API), Grafana, and Prisma. All other database connections will be created from Airflow deployments created on Astronomer.
+When deploying the base Astronomer platform, the Houston (API) and Grafana pods connect directly to the database. All other database connections are created from Airflow deployments created on Astronomer.
 
 ```
 $ kubectl get pods -n astro-demo
@@ -43,12 +43,11 @@ manageable-snail-kubed-5b5d65dd9d-l7nds                    1/1     Running      
 manageable-snail-nginx-799d79ccf9-kfnzn                    1/1     Running            0          1h
 manageable-snail-nginx-default-backend-5cc4755696-vh5zq    1/1     Running            0          1h
 manageable-snail-astro-ui-7b9b9df4f9-pb99f                 1/1     Running            0          1h
-manageable-snail-prisma-6b5d944bdc-szn8f                   0/1     CrashLoopBackOff   20         1h
 manageable-snail-prometheus-0                              1/1     Running            0          1h
 manageable-snail-registry-0                                1/1     Running            0          1h
 ```
 
-If these are the only three pods that are not coming up as healthy, it is usually indicative of an issue with connecting to the database. Try checking:
+If these pods do not come up in a healthy state, it is usually an issue with the database connection. See the following topics to confirm your connection.
 
 #### Networking
 Make sure that the Kubernetes cluster Astronomer is running on can connect to the database. One way to check this is to jump into an Astronomer pod and try connecting directly to the database:
@@ -110,8 +109,6 @@ manageable-snail-kubed-apiserver-cert                  Opaque                   
 manageable-snail-kubed-notifier                        Opaque                                0      33h
 manageable-snail-kubed-token-dhd94                     kubernetes.io/service-account-token   3      33h
 manageable-snail-nginx-token-xk5pn                     kubernetes.io/service-account-token   3      33h
-manageable-snail-prisma-api-secret                     Opaque                                2      33h
-manageable-snail-prisma-bootstrapper-token-8zhjm       kubernetes.io/service-account-token   3      33h
 manageable-snail-prometheus-token-2v59c                kubernetes.io/service-account-token   3      33h
 manageable-snail-registry-auth                         kubernetes.io/dockerconfigjson        1      33h
 ```

--- a/software_versioned_docs/version-0.25/install-aws-standard.md
+++ b/software_versioned_docs/version-0.25/install-aws-standard.md
@@ -352,7 +352,6 @@ astronomer-nginx-746589b744-h6r5n                          1/1     Running      
 astronomer-nginx-746589b744-hscb9                          1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-4vjmz            1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-7m86w            1/1     Running             0          24m
-astronomer-prisma-57d5bf6c64-zcmsh                         1/1     Running             0          24m
 astronomer-prometheus-0                                    1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-865h2   1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-szr4s   1/1     Running             0          24m
@@ -385,7 +384,6 @@ astronomer-kubed                     ClusterIP      172.20.4.200     <none>     
 astronomer-nginx                     LoadBalancer   172.20.54.142    ELB_ADDRESS.us-east-1.elb.amazonaws.com                                   80:31925/TCP,443:32461/TCP,10254:32424/TCP   24d
 astronomer-nginx-default-backend     ClusterIP      172.20.186.254   <none>                                                                    8080/TCP                                     24d
 astronomer-astro-ui                  ClusterIP      172.20.186.166   <none>                                                                    8080/TCP                                     24d
-astronomer-prisma                    ClusterIP      172.20.144.188   <none>                                                                    4466/TCP                                     24d
 astronomer-prometheus                ClusterIP      172.20.72.196    <none>                                                                    9090/TCP                                     24d
 astronomer-registry                  ClusterIP      172.20.100.102   <none>                                                                    5000/TCP                                     24d
 ```

--- a/software_versioned_docs/version-0.25/install-azure-standard.md
+++ b/software_versioned_docs/version-0.25/install-azure-standard.md
@@ -407,7 +407,6 @@ astronomer-nginx-746589b744-h6r5n                          1/1     Running      
 astronomer-nginx-746589b744-hscb9                          1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-4vjmz            1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-7m86w            1/1     Running             0          24m
-astronomer-prisma-57d5bf6c64-zcmsh                         1/1     Running             0          24m
 astronomer-prometheus-0                                    1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-865h2   1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-szr4s   1/1     Running             0          24m
@@ -442,7 +441,6 @@ astronomer-nginx                              LoadBalancer   10.0.146.24    20.1
 astronomer-nginx-default-backend              ClusterIP      10.0.132.182   <none>          8080/TCP                                     6m48s
 astronomer-postgresql                         ClusterIP      10.0.0.252     <none>          5432/TCP                                     6m48s
 astronomer-postgresql-headless                ClusterIP      None           <none>          5432/TCP                                     6m48s
-astronomer-prisma                             ClusterIP      10.0.30.160    <none>          4466/TCP                                     6m48s
 astronomer-prometheus                         ClusterIP      10.0.128.170   <none>          9090/TCP                                     6m48s
 astronomer-prometheus-blackbox-exporter       ClusterIP      10.0.125.142   <none>          9115/TCP                                     6m48s
 astronomer-prometheus-node-exporter           ClusterIP      10.0.2.116     <none>          9100/TCP                                     6m48s

--- a/software_versioned_docs/version-0.25/install-gcp-standard.md
+++ b/software_versioned_docs/version-0.25/install-gcp-standard.md
@@ -395,7 +395,6 @@ newbie-norse-kube-state-549f45544f-mcv7m               1/1     Running     0    
 newbie-norse-nginx-7f6b5dfc9c-dm6tj                    1/1     Running     0          30m
 newbie-norse-nginx-default-backend-5ccdb9554d-5cm5q    1/1     Running     0          30m
 newbie-norse-astro-ui-d5585ccd8-h8zkr                  1/1     Running     0          30m
-newbie-norse-prisma-699bd664bb-vbvlf                   1/1     Running     0          30m
 newbie-norse-prometheus-0                              1/1     Running     0          30m
 newbie-norse-registry-0                                1/1     Running     0          30m
 ```
@@ -428,7 +427,6 @@ astronomer-nginx                              LoadBalancer   10.0.146.24    20.1
 astronomer-nginx-default-backend              ClusterIP      10.0.132.182   <none>          8080/TCP                                     6m48s
 astronomer-postgresql                         ClusterIP      10.0.0.252     <none>          5432/TCP                                     6m48s
 astronomer-postgresql-headless                ClusterIP      None           <none>          5432/TCP                                     6m48s
-astronomer-prisma                             ClusterIP      10.0.30.160    <none>          4466/TCP                                     6m48s
 astronomer-prometheus                         ClusterIP      10.0.128.170   <none>          9090/TCP                                     6m48s
 astronomer-prometheus-blackbox-exporter       ClusterIP      10.0.125.142   <none>          9115/TCP                                     6m48s
 astronomer-prometheus-node-exporter           ClusterIP      10.0.2.116     <none>          9100/TCP                                     6m48s

--- a/software_versioned_docs/version-0.26/debug-install.md
+++ b/software_versioned_docs/version-0.26/debug-install.md
@@ -6,11 +6,11 @@ description: Common snags users run into while deploying and running Astronomer 
 ---
 
 
-If the Astronomer platform is not functioning after following the instructions in the installation guide for any specific environment, here are a few things to try:
+Use the information provided here when the Astronomer platform is not functioning as expected after you install it.
 
-## Houston, Grafana, and Prisma stuck in CrashLoopBackOff
+## Houston and Grafana stuck in CrashLoopBackOff
 
-When deploying the base Astronomer platform, the only three pods that will connect directly to the database are Houston (API), Grafana, and Prisma. All other database connections will be created from Airflow deployments created on Astronomer.
+When deploying the base Astronomer platform, the Houston (API) and Grafana pods connect directly to the database. All other database connections are created from Airflow deployments created on Astronomer.
 
 ```
 $ kubectl get pods -n astro-demo
@@ -44,12 +44,11 @@ manageable-snail-kubed-5b5d65dd9d-l7nds                    1/1     Running      
 manageable-snail-nginx-799d79ccf9-kfnzn                    1/1     Running            0          1h
 manageable-snail-nginx-default-backend-5cc4755696-vh5zq    1/1     Running            0          1h
 manageable-snail-astro-ui-7b9b9df4f9-pb99f                 1/1     Running            0          1h
-manageable-snail-prisma-6b5d944bdc-szn8f                   0/1     CrashLoopBackOff   20         1h
 manageable-snail-prometheus-0                              1/1     Running            0          1h
 manageable-snail-registry-0                                1/1     Running            0          1h
 ```
 
-If these are the only three pods that are not coming up as healthy, it is usually indicative of an issue with connecting to the database. Try checking:
+If these pods do not come up in a healthy state, it is usually an issue with the database connection. See the following topics to confirm your connection.
 
 #### Networking
 Make sure that the Kubernetes cluster Astronomer is running on can connect to the database. One way to check this is to jump into an Astronomer pod and try connecting directly to the database:
@@ -111,8 +110,6 @@ manageable-snail-kubed-apiserver-cert                  Opaque                   
 manageable-snail-kubed-notifier                        Opaque                                0      33h
 manageable-snail-kubed-token-dhd94                     kubernetes.io/service-account-token   3      33h
 manageable-snail-nginx-token-xk5pn                     kubernetes.io/service-account-token   3      33h
-manageable-snail-prisma-api-secret                     Opaque                                2      33h
-manageable-snail-prisma-bootstrapper-token-8zhjm       kubernetes.io/service-account-token   3      33h
 manageable-snail-prometheus-token-2v59c                kubernetes.io/service-account-token   3      33h
 manageable-snail-registry-auth                         kubernetes.io/dockerconfigjson        1      33h
 ```

--- a/software_versioned_docs/version-0.26/install-aws-standard.md
+++ b/software_versioned_docs/version-0.26/install-aws-standard.md
@@ -353,7 +353,6 @@ astronomer-nginx-746589b744-h6r5n                          1/1     Running      
 astronomer-nginx-746589b744-hscb9                          1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-4vjmz            1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-7m86w            1/1     Running             0          24m
-astronomer-prisma-57d5bf6c64-zcmsh                         1/1     Running             0          24m
 astronomer-prometheus-0                                    1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-865h2   1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-szr4s   1/1     Running             0          24m
@@ -386,7 +385,6 @@ astronomer-kubed                     ClusterIP      172.20.4.200     <none>     
 astronomer-nginx                     LoadBalancer   172.20.54.142    ELB_ADDRESS.us-east-1.elb.amazonaws.com                                   80:31925/TCP,443:32461/TCP,10254:32424/TCP   24d
 astronomer-nginx-default-backend     ClusterIP      172.20.186.254   <none>                                                                    8080/TCP                                     24d
 astronomer-astro-ui                  ClusterIP      172.20.186.166   <none>                                                                    8080/TCP                                     24d
-astronomer-prisma                    ClusterIP      172.20.144.188   <none>                                                                    4466/TCP                                     24d
 astronomer-prometheus                ClusterIP      172.20.72.196    <none>                                                                    9090/TCP                                     24d
 astronomer-registry                  ClusterIP      172.20.100.102   <none>                                                                    5000/TCP                                     24d
 ```

--- a/software_versioned_docs/version-0.26/install-azure-standard.md
+++ b/software_versioned_docs/version-0.26/install-azure-standard.md
@@ -407,7 +407,6 @@ astronomer-nginx-746589b744-h6r5n                          1/1     Running      
 astronomer-nginx-746589b744-hscb9                          1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-4vjmz            1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-7m86w            1/1     Running             0          24m
-astronomer-prisma-57d5bf6c64-zcmsh                         1/1     Running             0          24m
 astronomer-prometheus-0                                    1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-865h2   1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-szr4s   1/1     Running             0          24m
@@ -442,7 +441,6 @@ astronomer-nginx                              LoadBalancer   10.0.146.24    20.1
 astronomer-nginx-default-backend              ClusterIP      10.0.132.182   <none>          8080/TCP                                     6m48s
 astronomer-postgresql                         ClusterIP      10.0.0.252     <none>          5432/TCP                                     6m48s
 astronomer-postgresql-headless                ClusterIP      None           <none>          5432/TCP                                     6m48s
-astronomer-prisma                             ClusterIP      10.0.30.160    <none>          4466/TCP                                     6m48s
 astronomer-prometheus                         ClusterIP      10.0.128.170   <none>          9090/TCP                                     6m48s
 astronomer-prometheus-blackbox-exporter       ClusterIP      10.0.125.142   <none>          9115/TCP                                     6m48s
 astronomer-prometheus-node-exporter           ClusterIP      10.0.2.116     <none>          9100/TCP                                     6m48s

--- a/software_versioned_docs/version-0.26/install-gcp-standard.md
+++ b/software_versioned_docs/version-0.26/install-gcp-standard.md
@@ -395,7 +395,6 @@ newbie-norse-kube-state-549f45544f-mcv7m               1/1     Running     0    
 newbie-norse-nginx-7f6b5dfc9c-dm6tj                    1/1     Running     0          30m
 newbie-norse-nginx-default-backend-5ccdb9554d-5cm5q    1/1     Running     0          30m
 newbie-norse-astro-ui-d5585ccd8-h8zkr                  1/1     Running     0          30m
-newbie-norse-prisma-699bd664bb-vbvlf                   1/1     Running     0          30m
 newbie-norse-prometheus-0                              1/1     Running     0          30m
 newbie-norse-registry-0                                1/1     Running     0          30m
 ```
@@ -428,7 +427,6 @@ astronomer-nginx                              LoadBalancer   10.0.146.24    20.1
 astronomer-nginx-default-backend              ClusterIP      10.0.132.182   <none>          8080/TCP                                     6m48s
 astronomer-postgresql                         ClusterIP      10.0.0.252     <none>          5432/TCP                                     6m48s
 astronomer-postgresql-headless                ClusterIP      None           <none>          5432/TCP                                     6m48s
-astronomer-prisma                             ClusterIP      10.0.30.160    <none>          4466/TCP                                     6m48s
 astronomer-prometheus                         ClusterIP      10.0.128.170   <none>          9090/TCP                                     6m48s
 astronomer-prometheus-blackbox-exporter       ClusterIP      10.0.125.142   <none>          9115/TCP                                     6m48s
 astronomer-prometheus-node-exporter           ClusterIP      10.0.2.116     <none>          9100/TCP                                     6m48s

--- a/software_versioned_docs/version-0.27/debug-install.md
+++ b/software_versioned_docs/version-0.27/debug-install.md
@@ -6,11 +6,11 @@ description: Common snags users run into while deploying and running Astronomer 
 ---
 
 
-If the Astronomer platform is not functioning after following the instructions in the installation guide for any specific environment, here are a few things to try:
+Use the information provided here when the Astronomer platform is not functioning as expected after you install it.
 
-## Houston, Grafana, and Prisma stuck in CrashLoopBackOff
+## Houston and Grafana stuck in CrashLoopBackOff
 
-When deploying the base Astronomer platform, the only three pods that will connect directly to the database are Houston (API), Grafana, and Prisma. All other database connections will be created from Airflow deployments created on Astronomer.
+When deploying the base Astronomer platform, the Houston (API) and Grafana pods connect directly to the database. All other database connections are created from Airflow deployments created on Astronomer.
 
 ```
 $ kubectl get pods -n astro-demo
@@ -44,12 +44,11 @@ manageable-snail-kubed-5b5d65dd9d-l7nds                    1/1     Running      
 manageable-snail-nginx-799d79ccf9-kfnzn                    1/1     Running            0          1h
 manageable-snail-nginx-default-backend-5cc4755696-vh5zq    1/1     Running            0          1h
 manageable-snail-astro-ui-7b9b9df4f9-pb99f                 1/1     Running            0          1h
-manageable-snail-prisma-6b5d944bdc-szn8f                   0/1     CrashLoopBackOff   20         1h
 manageable-snail-prometheus-0                              1/1     Running            0          1h
 manageable-snail-registry-0                                1/1     Running            0          1h
 ```
 
-If these are the only three pods that are not coming up as healthy, it is usually indicative of an issue with connecting to the database. Try checking:
+If these pods do not come up in a healthy state, it is usually an issue with the database connection. See the following topics to confirm your connection.
 
 #### Networking
 Make sure that the Kubernetes cluster Astronomer is running on can connect to the database. One way to check this is to jump into an Astronomer pod and try connecting directly to the database:
@@ -111,8 +110,6 @@ manageable-snail-kubed-apiserver-cert                  Opaque                   
 manageable-snail-kubed-notifier                        Opaque                                0      33h
 manageable-snail-kubed-token-dhd94                     kubernetes.io/service-account-token   3      33h
 manageable-snail-nginx-token-xk5pn                     kubernetes.io/service-account-token   3      33h
-manageable-snail-prisma-api-secret                     Opaque                                2      33h
-manageable-snail-prisma-bootstrapper-token-8zhjm       kubernetes.io/service-account-token   3      33h
 manageable-snail-prometheus-token-2v59c                kubernetes.io/service-account-token   3      33h
 manageable-snail-registry-auth                         kubernetes.io/dockerconfigjson        1      33h
 ```

--- a/software_versioned_docs/version-0.27/install-aws-standard.md
+++ b/software_versioned_docs/version-0.27/install-aws-standard.md
@@ -370,7 +370,6 @@ astronomer-nginx-746589b744-h6r5n                          1/1     Running      
 astronomer-nginx-746589b744-hscb9                          1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-4vjmz            1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-7m86w            1/1     Running             0          24m
-astronomer-prisma-57d5bf6c64-zcmsh                         1/1     Running             0          24m
 astronomer-prometheus-0                                    1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-865h2   1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-szr4s   1/1     Running             0          24m
@@ -403,7 +402,6 @@ astronomer-kubed                     ClusterIP      172.20.4.200     <none>     
 astronomer-nginx                     LoadBalancer   172.20.54.142    ELB_ADDRESS.us-east-1.elb.amazonaws.com                                   80:31925/TCP,443:32461/TCP,10254:32424/TCP   24d
 astronomer-nginx-default-backend     ClusterIP      172.20.186.254   <none>                                                                    8080/TCP                                     24d
 astronomer-astro-ui                  ClusterIP      172.20.186.166   <none>                                                                    8080/TCP                                     24d
-astronomer-prisma                    ClusterIP      172.20.144.188   <none>                                                                    4466/TCP                                     24d
 astronomer-prometheus                ClusterIP      172.20.72.196    <none>                                                                    9090/TCP                                     24d
 astronomer-registry                  ClusterIP      172.20.100.102   <none>                                                                    5000/TCP                                     24d
 ```

--- a/software_versioned_docs/version-0.27/install-azure-standard.md
+++ b/software_versioned_docs/version-0.27/install-azure-standard.md
@@ -424,7 +424,6 @@ astronomer-nginx-746589b744-h6r5n                          1/1     Running      
 astronomer-nginx-746589b744-hscb9                          1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-4vjmz            1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-7m86w            1/1     Running             0          24m
-astronomer-prisma-57d5bf6c64-zcmsh                         1/1     Running             0          24m
 astronomer-prometheus-0                                    1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-865h2   1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-szr4s   1/1     Running             0          24m
@@ -459,7 +458,6 @@ astronomer-nginx                              LoadBalancer   10.0.146.24    20.1
 astronomer-nginx-default-backend              ClusterIP      10.0.132.182   <none>          8080/TCP                                     6m48s
 astronomer-postgresql                         ClusterIP      10.0.0.252     <none>          5432/TCP                                     6m48s
 astronomer-postgresql-headless                ClusterIP      None           <none>          5432/TCP                                     6m48s
-astronomer-prisma                             ClusterIP      10.0.30.160    <none>          4466/TCP                                     6m48s
 astronomer-prometheus                         ClusterIP      10.0.128.170   <none>          9090/TCP                                     6m48s
 astronomer-prometheus-blackbox-exporter       ClusterIP      10.0.125.142   <none>          9115/TCP                                     6m48s
 astronomer-prometheus-node-exporter           ClusterIP      10.0.2.116     <none>          9100/TCP                                     6m48s

--- a/software_versioned_docs/version-0.27/install-gcp-standard.md
+++ b/software_versioned_docs/version-0.27/install-gcp-standard.md
@@ -412,7 +412,6 @@ newbie-norse-kube-state-549f45544f-mcv7m               1/1     Running     0    
 newbie-norse-nginx-7f6b5dfc9c-dm6tj                    1/1     Running     0          30m
 newbie-norse-nginx-default-backend-5ccdb9554d-5cm5q    1/1     Running     0          30m
 newbie-norse-astro-ui-d5585ccd8-h8zkr                  1/1     Running     0          30m
-newbie-norse-prisma-699bd664bb-vbvlf                   1/1     Running     0          30m
 newbie-norse-prometheus-0                              1/1     Running     0          30m
 newbie-norse-registry-0                                1/1     Running     0          30m
 ```
@@ -445,7 +444,6 @@ astronomer-nginx                              LoadBalancer   10.0.146.24    20.1
 astronomer-nginx-default-backend              ClusterIP      10.0.132.182   <none>          8080/TCP                                     6m48s
 astronomer-postgresql                         ClusterIP      10.0.0.252     <none>          5432/TCP                                     6m48s
 astronomer-postgresql-headless                ClusterIP      None           <none>          5432/TCP                                     6m48s
-astronomer-prisma                             ClusterIP      10.0.30.160    <none>          4466/TCP                                     6m48s
 astronomer-prometheus                         ClusterIP      10.0.128.170   <none>          9090/TCP                                     6m48s
 astronomer-prometheus-blackbox-exporter       ClusterIP      10.0.125.142   <none>          9115/TCP                                     6m48s
 astronomer-prometheus-node-exporter           ClusterIP      10.0.2.116     <none>          9100/TCP                                     6m48s

--- a/software_versioned_docs/version-0.28/debug-install.md
+++ b/software_versioned_docs/version-0.28/debug-install.md
@@ -6,11 +6,11 @@ description: Common snags users run into while deploying and running Astronomer 
 ---
 
 
-If the Astronomer platform is not functioning after following the instructions in the installation guide for any specific environment, here are a few things to try:
+Use the information provided here when the Astronomer platform is not functioning as expected after you install it.
 
-## Houston, Grafana, and Prisma stuck in CrashLoopBackOff
+## Houston and Grafana stuck in CrashLoopBackOff
 
-When deploying the base Astronomer platform, the only three pods that will connect directly to the database are Houston (API), Grafana, and Prisma. All other database connections will be created from Airflow deployments created on Astronomer.
+When deploying the base Astronomer platform, the Houston (API) and Grafana pods connect directly to the database. All other database connections are created from Airflow deployments created on Astronomer.
 
 ```
 $ kubectl get pods -n astro-demo
@@ -44,12 +44,11 @@ manageable-snail-kubed-5b5d65dd9d-l7nds                    1/1     Running      
 manageable-snail-nginx-799d79ccf9-kfnzn                    1/1     Running            0          1h
 manageable-snail-nginx-default-backend-5cc4755696-vh5zq    1/1     Running            0          1h
 manageable-snail-astro-ui-7b9b9df4f9-pb99f                 1/1     Running            0          1h
-manageable-snail-prisma-6b5d944bdc-szn8f                   0/1     CrashLoopBackOff   20         1h
 manageable-snail-prometheus-0                              1/1     Running            0          1h
 manageable-snail-registry-0                                1/1     Running            0          1h
 ```
 
-If these are the only three pods that are not coming up as healthy, it is usually indicative of an issue with connecting to the database. Try checking:
+If these pods do not come up in a healthy state, it is usually an issue with the database connection. See the following topics to confirm your connection.
 
 #### Networking
 Make sure that the Kubernetes cluster Astronomer is running on can connect to the database. One way to check this is to jump into an Astronomer pod and try connecting directly to the database:
@@ -111,8 +110,6 @@ manageable-snail-kubed-apiserver-cert                  Opaque                   
 manageable-snail-kubed-notifier                        Opaque                                0      33h
 manageable-snail-kubed-token-dhd94                     kubernetes.io/service-account-token   3      33h
 manageable-snail-nginx-token-xk5pn                     kubernetes.io/service-account-token   3      33h
-manageable-snail-prisma-api-secret                     Opaque                                2      33h
-manageable-snail-prisma-bootstrapper-token-8zhjm       kubernetes.io/service-account-token   3      33h
 manageable-snail-prometheus-token-2v59c                kubernetes.io/service-account-token   3      33h
 manageable-snail-registry-auth                         kubernetes.io/dockerconfigjson        1      33h
 ```

--- a/software_versioned_docs/version-0.28/install-aws-standard.md
+++ b/software_versioned_docs/version-0.28/install-aws-standard.md
@@ -370,7 +370,6 @@ astronomer-nginx-746589b744-h6r5n                          1/1     Running      
 astronomer-nginx-746589b744-hscb9                          1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-4vjmz            1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-7m86w            1/1     Running             0          24m
-astronomer-prisma-57d5bf6c64-zcmsh                         1/1     Running             0          24m
 astronomer-prometheus-0                                    1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-865h2   1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-szr4s   1/1     Running             0          24m
@@ -403,7 +402,6 @@ astronomer-kubed                     ClusterIP      172.20.4.200     <none>     
 astronomer-nginx                     LoadBalancer   172.20.54.142    ELB_ADDRESS.us-east-1.elb.amazonaws.com                                   80:31925/TCP,443:32461/TCP,10254:32424/TCP   24d
 astronomer-nginx-default-backend     ClusterIP      172.20.186.254   <none>                                                                    8080/TCP                                     24d
 astronomer-astro-ui                  ClusterIP      172.20.186.166   <none>                                                                    8080/TCP                                     24d
-astronomer-prisma                    ClusterIP      172.20.144.188   <none>                                                                    4466/TCP                                     24d
 astronomer-prometheus                ClusterIP      172.20.72.196    <none>                                                                    9090/TCP                                     24d
 astronomer-registry                  ClusterIP      172.20.100.102   <none>                                                                    5000/TCP                                     24d
 ```

--- a/software_versioned_docs/version-0.28/install-azure-standard.md
+++ b/software_versioned_docs/version-0.28/install-azure-standard.md
@@ -431,7 +431,6 @@ astronomer-nginx-746589b744-h6r5n                          1/1     Running      
 astronomer-nginx-746589b744-hscb9                          1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-4vjmz            1/1     Running             0          24m
 astronomer-nginx-default-backend-8cb66c54-7m86w            1/1     Running             0          24m
-astronomer-prisma-57d5bf6c64-zcmsh                         1/1     Running             0          24m
 astronomer-prometheus-0                                    1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-865h2   1/1     Running             0          24m
 astronomer-prometheus-blackbox-exporter-65f6c5f456-szr4s   1/1     Running             0          24m
@@ -466,7 +465,6 @@ astronomer-nginx                              LoadBalancer   10.0.146.24    20.1
 astronomer-nginx-default-backend              ClusterIP      10.0.132.182   <none>          8080/TCP                                     6m48s
 astronomer-postgresql                         ClusterIP      10.0.0.252     <none>          5432/TCP                                     6m48s
 astronomer-postgresql-headless                ClusterIP      None           <none>          5432/TCP                                     6m48s
-astronomer-prisma                             ClusterIP      10.0.30.160    <none>          4466/TCP                                     6m48s
 astronomer-prometheus                         ClusterIP      10.0.128.170   <none>          9090/TCP                                     6m48s
 astronomer-prometheus-blackbox-exporter       ClusterIP      10.0.125.142   <none>          9115/TCP                                     6m48s
 astronomer-prometheus-node-exporter           ClusterIP      10.0.2.116     <none>          9100/TCP                                     6m48s

--- a/software_versioned_docs/version-0.28/install-gcp-standard.md
+++ b/software_versioned_docs/version-0.28/install-gcp-standard.md
@@ -412,7 +412,6 @@ newbie-norse-kube-state-549f45544f-mcv7m               1/1     Running     0    
 newbie-norse-nginx-7f6b5dfc9c-dm6tj                    1/1     Running     0          30m
 newbie-norse-nginx-default-backend-5ccdb9554d-5cm5q    1/1     Running     0          30m
 newbie-norse-astro-ui-d5585ccd8-h8zkr                  1/1     Running     0          30m
-newbie-norse-prisma-699bd664bb-vbvlf                   1/1     Running     0          30m
 newbie-norse-prometheus-0                              1/1     Running     0          30m
 newbie-norse-registry-0                                1/1     Running     0          30m
 ```
@@ -445,7 +444,6 @@ astronomer-nginx                              LoadBalancer   10.0.146.24    20.1
 astronomer-nginx-default-backend              ClusterIP      10.0.132.182   <none>          8080/TCP                                     6m48s
 astronomer-postgresql                         ClusterIP      10.0.0.252     <none>          5432/TCP                                     6m48s
 astronomer-postgresql-headless                ClusterIP      None           <none>          5432/TCP                                     6m48s
-astronomer-prisma                             ClusterIP      10.0.30.160    <none>          4466/TCP                                     6m48s
 astronomer-prometheus                         ClusterIP      10.0.128.170   <none>          9090/TCP                                     6m48s
 astronomer-prometheus-blackbox-exporter       ClusterIP      10.0.125.142   <none>          9115/TCP                                     6m48s
 astronomer-prometheus-node-exporter           ClusterIP      10.0.2.116     <none>          9100/TCP                                     6m48s


### PR DESCRIPTION
Resolves #424 

From the SME:

_Prisma was part of Enterprise Software until [0.16.0](https://github.com/astronomer/astronomer/tree/v0.16.19/charts/astronomer/templates) and then from [0.23](https://github.com/astronomer/astronomer/tree/v0.23.9/charts/astronomer/templates) it was removed._

Additional detail in the original issue.