### PR TITLE
Add Pypi Binaries to Path in Private Repo Doc

### DIFF
--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -447,6 +447,9 @@ This example assumes that the name of each of your Python packages is identical 
     FROM stage1 AS stage3
     # Copy requirements directory
     COPY --from=stage2 /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
+    COPY --from=stage2 /usr/local/bin /home/astro/.local/bin 
+    ENV PATH="/home/astro/.local/bin:$PATH"
+
     COPY . .
     ```
 
@@ -565,6 +568,9 @@ Ensure that the name of the package on the private repository does not clash wit
     FROM stage1 AS stage3
     # Copy requirements directory
     COPY --from=stage2 /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
+    COPY --from=stage2 /usr/local/bin /home/astro/.local/bin 
+    ENV PATH="/home/astro/.local/bin:$PATH"
+
     COPY . .
     ```
 

--- a/software/customize-image.md
+++ b/software/customize-image.md
@@ -343,6 +343,9 @@ This example assumes that the name of each of your Python packages is identical 
     FROM stage1 AS stage3
     # Copy requirements directory
     COPY --from=stage2 /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
+    COPY --from=stage2 /usr/local/bin /home/astro/.local/bin 
+    ENV PATH="/home/astro/.local/bin:$PATH"
+
     COPY . .
     ```
 
@@ -471,6 +474,9 @@ Ensure that the name of the package on the private repository does not clash wit
     FROM stage1 AS stage3
     # Copy requirements directory
     COPY --from=stage2 /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
+    COPY --from=stage2 /usr/local/bin /home/astro/.local/bin 
+    ENV PATH="/home/astro/.local/bin:$PATH"
+
     COPY . .
     ```
 


### PR DESCRIPTION
A customer had an issue - they had modified their Dockerfile like this, and couldn't access a CLI installed via `pip`. This fix copied the binaries into the final stage to make them accessible