### PR TITLE
Fix link to software version compatibility reference

### DIFF
--- a/software/release-lifecycle-policy.md
+++ b/software/release-lifecycle-policy.md
@@ -13,7 +13,7 @@ This document offers guidelines on the version lifecycle of Astronomer Software.
 - Which versions of Astronomer Software are currently available.
 - Release channels and the maintenance schedule for all versions.
 
-For information on the latest Astronomer Software releases, see [Release notes](release-notes.md). For information on compatibility between all versioned software, see [Software Version compatibility reference](release-lifecycle-policy.md).
+For information on the latest Astronomer Software releases, see [Release notes](release-notes.md). For information on compatibility between all versioned software, see [Software Version compatibility reference](version-compatibility-reference.md).
 
 :::info
 

--- a/software_versioned_docs/version-0.16/release-lifecycle-policy.md
+++ b/software_versioned_docs/version-0.16/release-lifecycle-policy.md
@@ -17,7 +17,7 @@ This document offers guidelines on the version lifecycle of Astronomer Software.
 
 For information on the latest Astronomer Software releases, see [release notes](release-notes.md). For the release and maintenance policy for Astronomer Certified, see the Certified [Versioning and Maintenance Policy](ac-support-policy.md).
 
-For information on compatibility between all versioned software, see [Software Version Compatibility Reference](release-lifecycle-policy.md).
+For information on compatibility between all versioned software, see [Software Version Compatibility Reference](version-compatibility-reference.md).
 
 ## Release Channels
 

--- a/software_versioned_docs/version-0.23/release-lifecycle-policy.md
+++ b/software_versioned_docs/version-0.23/release-lifecycle-policy.md
@@ -15,7 +15,7 @@ This document offers guidelines on the version lifecycle of Astronomer Software.
 - Which versions of Astronomer Software are currently available.
 - Release channels and the maintenance schedule for all versions.
 
-For information on the latest Astronomer Software releases, see [release notes](release-notes.md). For information on compatibility between all versioned software, see [Software Version Compatibility Reference](release-lifecycle-policy.md).
+For information on the latest Astronomer Software releases, see [release notes](release-notes.md). For information on compatibility between all versioned software, see [Software Version Compatibility Reference](version-compatibility-reference.md).
 
 :::info
 

--- a/software_versioned_docs/version-0.25/release-lifecycle-policy.md
+++ b/software_versioned_docs/version-0.25/release-lifecycle-policy.md
@@ -15,7 +15,7 @@ This document offers guidelines on the version lifecycle of Astronomer Software.
 - Which versions of Astronomer Software are currently available.
 - Release channels and the maintenance schedule for all versions.
 
-For information on the latest Astronomer Software releases, see [release notes](release-notes.md). For information on compatibility between all versioned software, see [Software Version Compatibility Reference](release-lifecycle-policy.md).
+For information on the latest Astronomer Software releases, see [release notes](release-notes.md). For information on compatibility between all versioned software, see [Software Version Compatibility Reference](version-compatibility-reference.md).
 
 :::info
 

--- a/software_versioned_docs/version-0.26/release-lifecycle-policy.md
+++ b/software_versioned_docs/version-0.26/release-lifecycle-policy.md
@@ -15,7 +15,7 @@ This document offers guidelines on the version lifecycle of Astronomer Software.
 - Which versions of Astronomer Software are currently available.
 - Release channels and the maintenance schedule for all versions.
 
-For information on the latest Astronomer Software releases, see [release notes](release-notes.md). For information on compatibility between all versioned software, see [Software Version Compatibility Reference](release-lifecycle-policy.md).
+For information on the latest Astronomer Software releases, see [release notes](release-notes.md). For information on compatibility between all versioned software, see [Software Version Compatibility Reference](version-compatibility-reference.md).
 
 :::info
 

--- a/software_versioned_docs/version-0.27/release-lifecycle-policy.md
+++ b/software_versioned_docs/version-0.27/release-lifecycle-policy.md
@@ -15,7 +15,7 @@ This document offers guidelines on the version lifecycle of Astronomer Software.
 - Which versions of Astronomer Software are currently available.
 - Release channels and the maintenance schedule for all versions.
 
-For information on the latest Astronomer Software releases, see [release notes](release-notes.md). For information on compatibility between all versioned software, see [Software Version Compatibility Reference](release-lifecycle-policy.md).
+For information on the latest Astronomer Software releases, see [release notes](release-notes.md). For information on compatibility between all versioned software, see [Software Version Compatibility Reference](version-compatibility-reference.md).
 
 :::info
 

--- a/software_versioned_docs/version-0.28/release-lifecycle-policy.md
+++ b/software_versioned_docs/version-0.28/release-lifecycle-policy.md
@@ -15,7 +15,7 @@ This document offers guidelines on the version lifecycle of Astronomer Software.
 - Which versions of Astronomer Software are currently available.
 - Release channels and the maintenance schedule for all versions.
 
-For information on the latest Astronomer Software releases, see [release notes](release-notes.md). For information on compatibility between all versioned software, see [Software Version Compatibility Reference](release-lifecycle-policy.md).
+For information on the latest Astronomer Software releases, see [release notes](release-notes.md). For information on compatibility between all versioned software, see [Software Version Compatibility Reference](version-compatibility-reference.md).
 
 :::info
 


### PR DESCRIPTION
This PR points the link "Software Version compatibility reference" in https://docs.astronomer.io/software/release-lifecycle-policy to the correct page.