### PR TITLE
Install Astro on Azure Updates

### DIFF
--- a/astro/install-azure.md
+++ b/astro/install-azure.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 To complete the installation process, you'll:
 
 - Add the Astronomer Service Principal to your Azure Active Directory (Azure AD) instance.
-- Assign an Owner role to the Astronomer Service Principal who manages subscriptions for your organization.
+- Assign the Astronomer Service Principal an Owner role to your subscription.
 - Register Microsoft Azure features.
 
 When you've completed the installation process, Astronomer support creates a cluster within your Azure subscription to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks.

--- a/astro/install-azure.md
+++ b/astro/install-azure.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 To complete the installation process, you'll:
 
 - Add the Astronomer Service Principal to your Azure Active Directory (Azure AD) instance.
-- Assign an Owner role to your subscription.
+- Assign an Owner role to the Astronomer Service Principal who manages subscriptions for your organization.
 - Register Microsoft Azure features.
 
 When you've completed the installation process, Astronomer support creates a cluster within your Azure subscription to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks.
@@ -24,6 +24,8 @@ For more information about managing Azure subscriptions with the Azure CLI, see 
 - An Azure AD user with the following role assignments:
     - `Application Administrator`. See [Understand roles in Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/roles/concept-understand-roles).
     - `Owner` with permission to create and manage subscription resources of all types. See [Azure built-in roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles).
+    
+    These role assignments are required for cluster creation, and can be removed after the cluster is created.
 - Microsoft Azure CLI or Azure Az PowerShell module.  See [How to install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) and [Install the Azure Az PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps).
 - A minimum quota of 48 Standard Ddv5-series vCPUs in the deployment region. You can use Dv5-series vCPUs, but you'll need 96 total vCPUs composed of 48 Ddv5-series vCPUs and 48 Dv5-series vCPUs. To adjust your quota limits up or down, see [Increase VM-family vCPU quotas](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/per-vm-quota-requests).
 - A subscription to the [Astro Status Page](https://status.astronomer.io). This ensures that you're alerted when an incident occurs or when scheduled maintenance is planned.


### PR DESCRIPTION
Resolves #986 

Hi, @dnarain-astro. I have addressed all but one of the issue you identified in issue 986. In the issue, you requested clarification that "that the word _minimum_ in the prerequisites section applies to quotas not resources". I'm not sure how this can be clarified, as the existing text reads "A _minimum quota_ of 48 Standard Ddv5-series vCPUs...". No mention is made of _resources_. I am concerned that adding _resources_ could make this information very confusing. Let me know if you have any suggestions to address this concern. When time permits, please review the changes and provide your feedback. Thanks!