### PR TITLE
Fix ambiguous verbiage in migrate-to-runtime.md

### DIFF
--- a/software/migrate-to-runtime.md
+++ b/software/migrate-to-runtime.md
@@ -9,7 +9,7 @@ import {siteVariables} from '@site/src/versions';
 
 Astro Runtime builds on the reliability of Astronomer Certified (AC) with new features that center on usability and performance.
 
-Apache Airflow 2.3 will be the last Airflow version supported by AC. To avoid disruption in the future, Astronomer recommends migrating Deployments from AC to Astro Runtime as soon as your team is ready.
+Apache Airflow 2.3 will be the last Airflow version supported by AC. To avoid future disruptions, Astronomer recommends migrating Deployments from AC to Astro Runtime as soon as your organization is ready.
 
 Migrating a Deployment to Astro Runtime is similar to the standard upgrade process. There are no known disruptions when migrating a Deployment from AC to the equivalent version of Astro Runtime.
 

--- a/software/migrate-to-runtime.md
+++ b/software/migrate-to-runtime.md
@@ -9,7 +9,7 @@ import {siteVariables} from '@site/src/versions';
 
 Astro Runtime builds on the reliability of Astronomer Certified (AC) with new features that center on usability and performance.
 
-Astronomer will no longer release new versions of AC starting with the release of Apache Airflow 2.4. To avoid disruption in the future, Astronomer recommends migrating Deployments from AC to Astro Runtime as soon as your team is ready.
+Apache Airflow 2.3 will be the last Airflow version supported by AC. To avoid disruption in the future, Astronomer recommends migrating Deployments from AC to Astro Runtime as soon as your team is ready.
 
 Migrating a Deployment to Astro Runtime is similar to the standard upgrade process. There are no known disruptions when migrating a Deployment from AC to the equivalent version of Astro Runtime.
 


### PR DESCRIPTION
As it currently reads, I think users can confuse this as meaning 2.4 will be the last Airflow version supported by Airflow.