### PR TITLE
Fix astro dev init:  add '--' for CLI parameter runtime-version

### DIFF
--- a/astro/cli/astro-dev-init.md
+++ b/astro/cli/astro-dev-init.md
@@ -17,7 +17,7 @@ astro dev init
 
 | Option              | Description                                                                                                        | Possible Values             |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------- |
-| `-v`, `runtime-version` | Initialize a project with a specific Runtime version | Any supported Runtime version |
+| `-v`, `--runtime-version` | Initialize a project with a specific Runtime version | Any supported Runtime version |
 | `-n`,`--name`            | Name of your Astro project                                                                                    | Any string                  |
 | `--use-astronomer-certified`            | Only for use on Astronomer Software. Initializes your project with an Astronomer Certified image.                                                 | ``                 |
 


### PR DESCRIPTION
In this PR, I'm fixing a typo for the documentation for the command `astro dev init --runtime-version`. As the examples show, this parameter needs `--` to work, but the documentation didn't show it in the table.