### PR TITLE
Adding instructions for using the Airflow REST API locally.

### DIFF
--- a/astro/airflow-api.md
+++ b/astro/airflow-api.md
@@ -9,6 +9,13 @@ This guide explains how to make requests to Airflow's REST API for your Deployme
 
 You can use Airflow's [REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html) to automate various Airflow workflows in your Deployments. For example, you can externally trigger a DAG run without accessing your Deployment directly by making an HTTP request in Python or cURL to the [corresponding endpoint](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#operation/post_dag_run) in the Airflow REST API.
 
+
+:::info
+
+To make an Airflow API request to the local instance of Airflow created with the Astro CLI, see this [section](https://docs.astronomer.io/astro/test-and-troubleshoot-locally#make-requests-to-the-airflow-rest-api) of our Test and troubleshoot locally docs.
+
+:::
+
 ## Prerequisites
 
 To make an Airflow API request, you need:

--- a/astro/airflow-api.md
+++ b/astro/airflow-api.md
@@ -12,7 +12,7 @@ You can use Airflow's [REST API](https://airflow.apache.org/docs/apache-airflow/
 
 :::info
 
-To make an Airflow API request to the local instance of Airflow created with the Astro CLI, see this [section](https://docs.astronomer.io/astro/test-and-troubleshoot-locally#make-requests-to-the-airflow-rest-api) of our Test and troubleshoot locally docs.
+To test Airflow API calls in a local Airflow environment running with the Astro CLI, see [Test and Troubleshoot Locally](test-and-troubleshoot-locally.md#make-requests-to-the-airflow-rest-api).
 
 ## Prerequisites
 

--- a/astro/airflow-api.md
+++ b/astro/airflow-api.md
@@ -14,8 +14,6 @@ You can use Airflow's [REST API](https://airflow.apache.org/docs/apache-airflow/
 
 To make an Airflow API request to the local instance of Airflow created with the Astro CLI, see this [section](https://docs.astronomer.io/astro/test-and-troubleshoot-locally#make-requests-to-the-airflow-rest-api) of our Test and troubleshoot locally docs.
 
-:::
-
 ## Prerequisites
 
 To make an Airflow API request, you need:

--- a/astro/airflow-api.md
+++ b/astro/airflow-api.md
@@ -10,8 +10,6 @@ This guide explains how to make requests to Airflow's REST API for your Deployme
 You can use Airflow's [REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html) to automate various Airflow workflows in your Deployments. For example, you can externally trigger a DAG run without accessing your Deployment directly by making an HTTP request in Python or cURL to the [corresponding endpoint](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#operation/post_dag_run) in the Airflow REST API.
 
 
-:::info
-
 To test Airflow API calls in a local Airflow environment running with the Astro CLI, see [Test and Troubleshoot Locally](test-and-troubleshoot-locally.md#make-requests-to-the-airflow-rest-api).
 
 ## Prerequisites

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -95,8 +95,6 @@ response = requests.get(
 )
 ```
 
-:::info
-
 To make requests to the Airflow REST API on an Astro Deployment, see [Airflow API](airflow-api.md).
 
 ## Troubleshoot KubernetesPodOperator issues

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -73,7 +73,7 @@ You can only use `astro dev run` in a local Airflow environment. To automate Air
 
 :::
 
-## Call Airflow REST API in a local environment
+## Call the Airflow REST API in a local environment
 
 Use HTTP basic access authentication to make requests to the [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html) in a local Airflow environment. This can be useful for testing API calls that you might have to execute in a production environment.
 

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -75,7 +75,7 @@ You can only use `astro dev run` in a local Airflow environment. To automate Air
 
 ## Make requests to the Airflow REST API locally
 
-Make requests to the [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html) in a local Airflow environment with HTTP basic access authentication. This can be useful for testing API calls that you might have to execute in a production Deployment on Astro.
+Make requests to the [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html) in a local Airflow environment with HTTP basic access authentication. This can be useful for testing API calls before executing them in a production Deployment on Astro.
 
 To make local requests with cURL or Python, you only need the username and password for your local user. Both of these values are `admin` by default. They are the same credentials that are listed when you run `astro dev start` with the Astro CLI and required by the Airflow UI in a local environment.
 

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -97,8 +97,6 @@ response = requests.get(
 
 For more information on making requests to Airflow REST API and common examples, please see our [guide](https://docs.astronomer.io/astro/airflow-api) on this topic.
 
-:::
-
 ## Troubleshoot KubernetesPodOperator issues
 
 View local Kubernetes logs to troubleshoot issues with Pods that are created by the operator. See [Test and Troubleshoot the KubernetesPodOperator Locally](kubepodoperator-local.md#step-4-view-kubernetes-logs).

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -95,7 +95,7 @@ response = requests.get(
 
 :::info
 
-For more information on making requests to Airflow REST API and common examples, please see our [guide](https://docs.astronomer.io/astro/airflow-api) on this topic.
+To make requests to the Airflow REST API on an Astro Deployment, see [Airflow API](airflow-api.md).
 
 ## Troubleshoot KubernetesPodOperator issues
 

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -73,6 +73,31 @@ You can only use `astro dev run` in a local Airflow environment. To automate Air
 
 :::
 
+## Make requests to the Airflow REST API
+
+To make requests to the [Apache Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html) locally, you can use HTTP Basic Authentication with the credentials output by the `astro dev start` command:
+
+#### cURL
+```cURL
+curl -X GET localhost:8080/api/v1/<endpoint> --user "admin:admin"
+```
+
+#### Python
+```python
+import requests
+
+response = requests.get(
+   url="localhost:8080/api/v1/<endpoint>",
+   auth=("admin", "admin")
+)
+```
+
+:::info
+
+For more information on making requests to Airflow REST API and common examples, please see our [guide](https://docs.astronomer.io/astro/airflow-api) on this topic.
+
+:::
+
 ## Troubleshoot KubernetesPodOperator issues
 
 View local Kubernetes logs to troubleshoot issues with Pods that are created by the operator. See [Test and Troubleshoot the KubernetesPodOperator Locally](kubepodoperator-local.md#step-4-view-kubernetes-logs).

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -82,7 +82,8 @@ To make requests to the [Apache Airflow REST API](https://airflow.apache.org/doc
 ```sh
 curl -X GET localhost:8080/api/v1/<endpoint> --user "admin:admin"
 
-#### Python
+### Python
+
 ```python
 import requests
 

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -73,16 +73,17 @@ You can only use `astro dev run` in a local Airflow environment. To automate Air
 
 :::
 
-## Call the Airflow REST API in a local environment
+## Make requests to the Airflow REST API locally
 
-Use HTTP basic access authentication to make requests to the [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html) in a local Airflow environment. This can be useful for testing API calls that you might have to execute in a production environment.
+Make requests to the [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html) in a local Airflow environment with HTTP basic access authentication. This can be useful for testing API calls that you might have to execute in a production Deployment on Astro.
 
-To authenticate to your environment through HTTP, you only need your Airflow UI username and password, which by default are both `admin`.
+To make local requests with cURL or Python, you only need the username and password for your local user. Both of these values are `admin` by default. They are the same credentials that are listed when you run `astro dev start` with the Astro CLI and required by the Airflow UI in a local environment.
 
 ### cURL
 
 ```sh
 curl -X GET localhost:8080/api/v1/<endpoint> --user "admin:admin"
+```
 
 ### Python
 

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -75,7 +75,9 @@ You can only use `astro dev run` in a local Airflow environment. To automate Air
 
 ## Call Airflow REST API in a local environment
 
-To make requests to the [Apache Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html) locally, you can use HTTP Basic Authentication with the credentials output by the `astro dev start` command:
+Use HTTP basic access authentication to make requests to the [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html) in a local Airflow environment. This can be useful for testing API calls that you might have to execute in a production environment.
+
+To authenticate to your environment through HTTP, you only need your Airflow UI username and password, which by default are both `admin`.
 
 ### cURL
 

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -77,10 +77,10 @@ You can only use `astro dev run` in a local Airflow environment. To automate Air
 
 To make requests to the [Apache Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html) locally, you can use HTTP Basic Authentication with the credentials output by the `astro dev start` command:
 
-#### cURL
-```cURL
+### cURL
+
+```sh
 curl -X GET localhost:8080/api/v1/<endpoint> --user "admin:admin"
-```
 
 #### Python
 ```python

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -73,7 +73,7 @@ You can only use `astro dev run` in a local Airflow environment. To automate Air
 
 :::
 
-## Make requests to the Airflow REST API
+## Call Airflow REST API in a local environment
 
 To make requests to the [Apache Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html) locally, you can use HTTP Basic Authentication with the credentials output by the `astro dev start` command:
 

--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -75,9 +75,11 @@ You can only use `astro dev run` in a local Airflow environment. To automate Air
 
 ## Make requests to the Airflow REST API locally
 
-Make requests to the [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html) in a local Airflow environment with HTTP basic access authentication. This can be useful for testing API calls before executing them in a production Deployment on Astro.
+Make requests to the [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html) in a local Airflow environment with HTTP basic access authentication. This can be useful for testing and troubleshooting API calls before executing them in a Deployment on Astro.
 
 To make local requests with cURL or Python, you only need the username and password for your local user. Both of these values are `admin` by default. They are the same credentials that are listed when you run `astro dev start` with the Astro CLI and required by the Airflow UI in a local environment.
+
+To make requests to the Airflow REST API in a Deployment on Astro, see [Airflow API](airflow-api.md).
 
 ### cURL
 
@@ -95,8 +97,6 @@ response = requests.get(
    auth=("admin", "admin")
 )
 ```
-
-To make requests to the Airflow REST API on an Astro Deployment, see [Airflow API](airflow-api.md).
 
 ## Troubleshoot KubernetesPodOperator issues
 


### PR DESCRIPTION
Adding instructions for using the Airflow REST API with the local Airflow instance produced by the Astro CLI.