### PR TITLE
Update Known Limitations Section in Run the KubernetesPodOperator on Astro

### DIFF
--- a/astro/kubernetespodoperator.md
+++ b/astro/kubernetespodoperator.md
@@ -21,9 +21,9 @@ On Astro, the Kubernetes infrastructure required to run the KubernetesPodOperato
 
 ## Known limitations
 
-- Cross-account service accounts are not supported on Pods launched in an Astro cluster.
+- Cross-account service accounts are not supported on Pods launched in an Astro cluster. To allow access to external data sources, you can provide credentials and secrets to tasks.
 - PersistentVolumes (PVs) are not supported on Pods launched in an Astro cluster.
-- You cannot run a KubernetesPodOperator task in a worker queue or node pool that is different than the worker queue of its parent worker. For example, a KubernetesPodOperator task that is triggered by an `m5.4xlarge` worker on AWS will also be run on an `m5.4xlarge` node. To run a task on a different node instance type, you must launch it in a Kubernetes cluster outside of the Astro data plane.
+- You cannot run a KubernetesPodOperator task in a worker queue or node pool that is different than the worker queue of its parent worker. For example, a KubernetesPodOperator task that is triggered by an `m5.4xlarge` worker on AWS will also be run on an `m5.4xlarge` node. To run a task on a different node instance type, you must launch it in a Kubernetes cluster outside of the Astro data plane. If you need assistance launching KubernetesPodOperator tasks in external Kubernetes clusters, contact [Astronomer support](https://support.astronomer.io).
 
 ## Prerequisites
 


### PR DESCRIPTION
Resolves #1099 

@paolaperaza and @fritz-astronomer in the originating issue, @ben-astro made the following statement:

In the _Known limitations_ section, the third bullet's last line is _To run a task on a different node instance type, you must launch it in a Kubernetes cluster outside of the Astro data plane_. We don't provide any guidance on how to do that. I'm not sure if consensus is that we should or shouldn't provide that, would like to get thoughts from @paolaperaza and @fritz-astronomer on that. Maybe we could add a line like If you'd like more information on how to launch a KubernetesPodOperator task to an external kubernetes cluster, please reach out to Astronomer support. And then we'd need to have an internal doc/article available for our teams when this situation arose. (Or we just provide the example in the public doc, in my mind that works too.)

I added a statement indicating that users should contact Astronomer support if they need assistance launching KubernetesPodOperator tasks in external Kubernetes clusters. Let me know if you would prefer to provide a detailed procedure instead.