### PR TITLE
Fix tabs not updating from user's current URL

### DIFF
--- a/static/scripts/set-tab.js
+++ b/static/scripts/set-tab.js
@@ -3,6 +3,9 @@
   if (!querystring) {
     return;
   }
+  // pull groupId from anchor text, which should be equivalent
+  const getAnchor = querystring.split("#");
+  const groupId = getAnchor[1];
 
   const entries = querystring
     .slice(1)
@@ -12,8 +15,6 @@
       entries[key] = value;
       return entries;
     }, {});
-
-  // for app dev guide
   if (typeof entries.tab === "string") {
     const tab = entries.tab.toLowerCase();
     window.localStorage.setItem(`docusaurus.tab.${groupId}`, tab);

--- a/static/scripts/set-tab.js
+++ b/static/scripts/set-tab.js
@@ -1,0 +1,22 @@
+(function () {
+  const querystring = window.location.search;
+  if (!querystring) {
+    return;
+  }
+
+  const entries = querystring
+    .slice(1)
+    .split("&")
+    .reduce((entries, str) => {
+      const [key, value] = str.split("=").map((v) => decodeURIComponent(v));
+      entries[key] = value;
+      return entries;
+    }, {});
+
+  // for app dev guide
+  if (typeof entries.tab === "string") {
+    const tab = entries.tab.toLowerCase();
+    window.localStorage.setItem(`docusaurus.tab.${groupId}`, tab);
+    }
+  }
+})();

--- a/static/scripts/set-tab.js
+++ b/static/scripts/set-tab.js
@@ -4,8 +4,7 @@
     return;
   }
   // pull groupId from anchor text, which should be equivalent
-  const getAnchor = querystring.split("#");
-  const groupId = getAnchor[1];
+  const groupId = window.location.hash.replace("#", '');
 
   const entries = querystring
     .slice(1)
@@ -16,8 +15,14 @@
       return entries;
     }, {});
   if (typeof entries.tab === "string") {
-    const tab = entries.tab.toLowerCase();
+    const tab = entries.tab;
     window.localStorage.setItem(`docusaurus.tab.${groupId}`, tab);
-    }
   }
 })();
+
+function scrollToHeading() {
+  const heading = document.querySelector(`${window.location.hash}`);
+  heading.scrollIntoView();
+}
+
+window.onload = () => window.location.hash && scrollToHeading();


### PR DESCRIPTION
@katiebrady-astro I think I might be out of my depth with this one 😵 

A few days ago, [I pushed a change](https://github.com/astronomer/docs/pull/1106) where clicking a tab item on the docs site would generate a specific link for that tab which you could share. I thought the links were working because the tab would automatically open when you used the link, but it turns out this was just based on the cookies present on my browser. I think in order to dynamically update a tab value, we need to run a script based on the current URL.

I'm trying a hack where I'm setting a tab menu's [groupId](https://docusaurus.io/docs/markdown-features/tabs#syncing-tab-choices) to the anchor text of the section it's in. From there, this script should read the user's current URL, parse out the anchor text, and load in the tab choice based on the groupId with the same name as the anchor text. Let me know if you need any more info for this review!


Current behavior:

1. Click on a tab, URL becomes `docs.astronomer.io/<doc>?tab=<tabname>#<anchor-link>
2. Switch to a second tab
3. Reload the URL as `docs.astronomer.io/<doc>?tab=<tabname>#<anchor-link>
4. The tab automatically goes to the second tab, because that was the tab that the user last visited.


Expected behavior:

1. Click on a first tab, URL becomes `docs.astronomer.io/<doc>?tab=<tabname>#<anchor-link>
2. Switch to a second tab
3. Reload the URL as `docs.astronomer.io/<doc>?tab=<tabname>#<anchor-link>
4. The tab automatically goes to the first tab, because that was the tab that's associated with the URL