### PR TITLE
HOTFIX: Update Link Syntax

### DIFF
--- a/astro/cli/get-started.md
+++ b/astro/cli/get-started.md
@@ -246,7 +246,7 @@ To view your new DAG in the Airflow UI, enter `http://localhost:8080/` in your b
 
 When your new DAG appears in the Airflow UI, you can run it to test it.
 
-1. Start the new DAG and trigger a run like you did in [Step 4](getting-started.md#step-4-trigger-a-dag-run).
+1. Start the new DAG and trigger a run like you did in [Step 4](#step-4-trigger-a-dag-run).
 2. Click the name of your new DAG and open the **Graph** view. After your DAG runs, there should be a dark green border around the tasks in the graph showing that your run was successful.
 
 ## Step 8: View task logs

--- a/astro/release-notes.md
+++ b/astro/release-notes.md
@@ -100,7 +100,7 @@ To learn more, see [Worker queue settings](configure-deployment-resources.md#wor
 
 A single user account can now belong to multiple Organizations. A user with multiple Organizations can switch to another Organization by clicking on their current Organization's name in the Cloud UI and then clicking **Switch Organization**.
 
-Note that switching Organizations with the Astro CLI is not yet supported. For more information, see [Switch Organizations](log-in-to-astro.md#switch-organizations.md).
+Note that switching Organizations with the Astro CLI is not yet supported. For more information, see [Switch Organizations](log-in-to-astro.md#switch-organizations).
 
 ### New Azure region (Australia East)
 

--- a/astro/resource-reference-aws.md
+++ b/astro/resource-reference-aws.md
@@ -95,7 +95,7 @@ Astro supports a variety of AWS RDS instance types. Instance types comprise of v
 
 A node pool is a group of nodes within a cluster that all have the same configuration. On Astro, worker nodes are responsible for running the Pods that execute Airflow tasks. Each worker node pool can be configured with a node instance type and a maximum node count. All Astro clusters have one worker node pool by default, but you can configure additional node pools for advanced configurability.
 
-If your cluster has multiple worker node pools with different worker node instance types, users in your organization can configure tasks to run on those worker types using [worker queues](configure-deployment-resources.md#worker-queues.md). To enable a new worker type for your cluster, contact [Astronomer support](https://support.astronomer.io) with a request to create a new node pool or modify an existing node pool.
+If your cluster has multiple worker node pools with different worker node instance types, users in your organization can configure tasks to run on those worker types using [worker queues](configure-deployment-resources.md#worker-queues). To enable a new worker type for your cluster, contact [Astronomer support](https://support.astronomer.io) with a request to create a new node pool or modify an existing node pool.
 
 Astronomer monitors your usage and the number of nodes deployed in your cluster. As your usage of Airflow increases, Astronomer support might contact you and provide recommendations for updating your node pools to optimize your infrastructure spend or increase the efficiency of your tasks.
 

--- a/astro/resource-reference-azure.md
+++ b/astro/resource-reference-azure.md
@@ -46,7 +46,7 @@ Modifying the region of an existing Astro cluster isn't supported. If you're int
 
 ### Worker node pools
 
-Node pools are a scalable collection of worker nodes with the same instance type. These nodes are responsible for running the Pods that execute Airflow tasks. If your cluster has a node pool for a specific instance type, you can configure tasks to run on those instance types using [worker queues](configure-deployment-resources.md#worker-queues.md). To make an instance type available in a cluster, contact [Astronomer support](https://support.astronomer.io) with a request to create a new node pool for the specific instance type. Not all instance types are supported in all AWS regions.
+Node pools are a scalable collection of worker nodes with the same instance type. These nodes are responsible for running the Pods that execute Airflow tasks. If your cluster has a node pool for a specific instance type, you can configure tasks to run on those instance types using [worker queues](configure-deployment-resources.md#worker-queues). To make an instance type available in a cluster, contact [Astronomer support](https://support.astronomer.io) with a request to create a new node pool for the specific instance type. Not all instance types are supported in all AWS regions.
 
 Astronomer monitors your usage and the number of nodes deployed in your cluster. As your usage of Airflow increases, Astronomer support might contact you and provide recommendations for updating your node pools to optimize your infrastructure spend or increase the efficiency of your tasks.
 

--- a/astro/resource-reference-azure.md
+++ b/astro/resource-reference-azure.md
@@ -65,7 +65,7 @@ The following table lists all available instance types for worker node pools, as
 | Standard_D4d_v5 - 4/16 (Default) | 2.5 CPUs | 9.3 GiB MEM |
 | Standard_D8d_v5 - 8/32           | 6.4 CPUs | 24 GiB MEM  |
 
-If your Organization needs an instance type that supports a larger worker size, contact [Astronomer support](https://support.astronomer.io). For more information about configuring worker size on Astro, see [Configure a Deployment](configure-deployment-resources.md#worker-resources).
+If your Organization needs an instance type that supports a larger worker size, contact [Astronomer support](https://support.astronomer.io). For more information about configuring worker size on Astro, see [Configure a Deployment](configure-deployment-resources.md).
 
 :::info
 

--- a/astro/resource-reference-gcp.md
+++ b/astro/resource-reference-gcp.md
@@ -76,7 +76,7 @@ Modifying the region of an existing Astro cluster isn't supported. If you're int
 
 ### Worker node pools
 
-Node pools are a scalable collection of worker nodes with the same instance type. These nodes are responsible for running the Pods that execute Airflow tasks. If your cluster has a node pool for a specific instance type, you can configure tasks to run on those instance types using [worker queues](configure-deployment-resources.md#worker-queues.md). To make an instance type available in a cluster, reach out to [Astronomer support](https://support.astronomer.io) with a request to create a new node pool for the specific instance type. Note that not all machine types are supported in all GCP regions.
+Node pools are a scalable collection of worker nodes with the same instance type. These nodes are responsible for running the Pods that execute Airflow tasks. If your cluster has a node pool for a specific instance type, you can configure tasks to run on those instance types using [worker queues](configure-deployment-resources.md#worker-queues). To make an instance type available in a cluster, reach out to [Astronomer support](https://support.astronomer.io) with a request to create a new node pool for the specific instance type. Note that not all machine types are supported in all GCP regions.
 
 Astronomer monitors your usage and number of nodes deployed in your cluster. As your usage of Airflow increases, Astronomer might reach out with recommendations for updating your node pools to optimize your infrastructure spend or increase the efficiency of your tasks.
 

--- a/astro/resource-reference-gcp.md
+++ b/astro/resource-reference-gcp.md
@@ -91,7 +91,7 @@ The following table lists all available instance types for worker node pools, as
 | e2-standard-4      | 2 CPUs    | 7.5  GiB MEM |
 | e2-standard-8      | 6 CPUs    | 22.5 GiB MEM |
 
-If your Organization is interested in using an instance type that supports a larger worker size, contact [Astronomer support](https://support.astronomer.io). For more information about configuring worker size on Astro, see [Configure a Deployment](configure-deployment-resources.md#worker-resources).
+If your Organization is interested in using an instance type that supports a larger worker size, contact [Astronomer support](https://support.astronomer.io). For more information about configuring worker size on Astro, see [Configure a Deployment](configure-deployment-resources.md).
 
 :::info
 

--- a/software/kubepodoperator.md
+++ b/software/kubepodoperator.md
@@ -65,7 +65,7 @@ KubernetesPodOperator(
 For each instantiation of the KubernetesPodOperator, you must specify the following values:
 
 - `namespace = conf.get("kubernetes", "NAMESPACE")`: Every Deployment runs on its own Kubernetes namespace. Information about this namespace can be programmatically imported as long as you set this variable.
-- `image`: This is the Docker image that the operator will use to run its defined task, commands, and arguments. The value you specify is assumed to be an image tag that's publicly available on [Docker Hub](https://hub.docker.com/). To pull an image from a private registry, read [Pull images from a Private Registry](kubernetespodoperator.md#pulling-images-from-a-private-registry).
+- `image`: This is the Docker image that the operator will use to run its defined task, commands, and arguments. The value you specify is assumed to be an image tag that's publicly available on [Docker Hub](https://hub.docker.com/). To pull an image from a private registry, read [Pull images from a Private Registry](#pulling-images-from-a-private-registry).
 - `in_cluster=True`: When this value is set, your task will run within the cluster from which it's instantiated. This ensures that the Kubernetes Pod running your task has the correct permissions within the cluster.
 - `is_delete_operator_pod=True`: This setting ensures that once a KubernetesPodOperator task is complete, the Kubernetes Pod that ran that task is terminated. This ensures that there are no unused pods in your cluster taking up resources.
 


### PR DESCRIPTION
Builds are failing for guide-migration-base. I examined the logs and discovered that there were numerous link errors. This PR attempts to resolve these errors. Log results:

![image](https://user-images.githubusercontent.com/104205257/187916227-dfc83d49-d59e-4732-821e-de1801d9cd42.png)
