### PR TITLE
Add "release-header" class to each h2 on release notes pages

### DIFF
--- a/src/theme/MDXContent/index.js
+++ b/src/theme/MDXContent/index.js
@@ -1,0 +1,20 @@
+import React, { useEffect } from 'react';
+import MDXContent from '@theme-original/MDXContent';
+
+export default function MDXContentWrapper(props) {
+  useEffect(() => {
+    // Check if this is a release-notes page
+    let isReleaseNotesPage = document.querySelector('html[class*="release-notes"]') !== null;
+
+    // if it is, then add the "release-header" class to each h2 element
+    if (isReleaseNotesPage) {
+      let h2s = document.querySelectorAll('h2');
+      h2s.forEach((h2) => h2.classList.add('release-header'));
+    }
+  }, []);
+  return (
+    <>
+      <MDXContent {...props} />
+    </>
+  );
+}


### PR DESCRIPTION
This PR creates a [Swizzle](https://docusaurus.io/docs/swizzling) of the MDXContent component. If the current page is one with release notes then add the `release-header` class to each h2 element.