### PR TITLE
Rework Software "Administration" tab information architecture

### DIFF
--- a/sidebarsSoftware.js
+++ b/sidebarsSoftware.js
@@ -42,18 +42,10 @@ module.exports = {
       'kubernetes-executor',
         ],
       },
+      'deploy-cli',
       'cli-podman',
       'upgrade-astro-cli',
     ],
-    },
-    {
-      type: 'category',
-      label: 'Deploy',
-      items: [
-      'deploy-cli',
-      'configure-deployment',
-      'environment-variables',
-      ],
     },
     {
       type: 'category',
@@ -82,8 +74,17 @@ module.exports = {
         },
         {
         type: 'category',
+        label: 'Manage Deployments',
+        items: [
+          'configure-deployment',
+          'environment-variables',
+          ],
+        },
+        {
+        type: 'category',
         label: 'CI/CD and automation',
         items: [
+        'ci-cd.md',
         'houston-api',
         'deploy-git-sync',
         'deploy-nfs',

--- a/sidebarsSoftware.js
+++ b/sidebarsSoftware.js
@@ -69,43 +69,41 @@ module.exports = {
           ],
         },
         'upgrade-astronomer',
-        {
-        type: 'category',
-        label: 'Platform setup',
-        items: [
-        'integrate-auth-system',
-        'logs-to-s3',
-        'registry-backend',
-        'renew-tls-cert',
-        'namespace-pools',
-        'export-task-logs',
-        'third-party-ingress-controllers',
-        'custom-image-registry',
-          ],
-        },
-        {
-        type: 'category',
-        label: 'Platform management',
-        items: [
         'apply-platform-config',
-        'houston-api',
-        'configure-platform-resources',
-          ],
-        },
         {
-          type: 'category',
-          label: 'Deployment management',
-          items: [
+        type: 'category',
+        label: 'Manage resources',
+        items: [
           'configure-deployment',
-          'secrets-backend',
           'environment-variables',
-          'deploy-git-sync',
-          'deploy-nfs',
+          'registry-backend',
+          'namespace-pools',
+          'configure-platform-resources',
           ],
         },
         {
         type: 'category',
-        label: 'User access',
+        label: 'CI/CD and automation',
+        items: [
+        'houston-api',
+        'deploy-git-sync',
+        'deploy-nfs',
+          ],
+        },
+        {
+        type: 'category',
+        label: 'Security and compliance',
+        items: [
+          'secrets-backend',
+          'integrate-auth-system',
+          'custom-image-registry',
+          'third-party-ingress-controllers',
+          'renew-tls-cert',
+          ],
+        },
+        {
+        type: 'category',
+        label: 'User access and management',
         items: [
         'manage-workspaces',
         'import-idp-groups',
@@ -125,6 +123,8 @@ module.exports = {
       'kibana-logging',
       'airflow-alerts',
       'platform-alerts',
+      'logs-to-s3',
+      'export-task-logs',
       ],
     },
     {

--- a/sidebarsSoftware.js
+++ b/sidebarsSoftware.js
@@ -84,7 +84,7 @@ module.exports = {
         type: 'category',
         label: 'CI/CD and automation',
         items: [
-        'ci-cd.md',
+        'ci-cd',
         'houston-api',
         'deploy-git-sync',
         'deploy-nfs',

--- a/sidebarsSoftware.js
+++ b/sidebarsSoftware.js
@@ -51,7 +51,8 @@ module.exports = {
       label: 'Deploy',
       items: [
       'deploy-cli',
-      'ci-cd',
+      'configure-deployment',
+      'environment-variables',
       ],
     },
     {
@@ -72,10 +73,8 @@ module.exports = {
         'apply-platform-config',
         {
         type: 'category',
-        label: 'Manage resources',
+        label: 'Manage platform resources',
         items: [
-          'configure-deployment',
-          'environment-variables',
           'registry-backend',
           'namespace-pools',
           'configure-platform-resources',
@@ -88,6 +87,15 @@ module.exports = {
         'houston-api',
         'deploy-git-sync',
         'deploy-nfs',
+          ],
+        },
+        {
+        type: 'category',
+        label: 'Platform observability',
+        items: [
+          'platform-alerts',
+          'logs-to-s3',
+          'export-task-logs',
           ],
         },
         {
@@ -118,13 +126,10 @@ module.exports = {
       type: 'category',
       label: 'Observability',
       items: [
-      'deployment-logs',
       'grafana-metrics',
       'kibana-logging',
+      'deployment-logs',
       'airflow-alerts',
-      'platform-alerts',
-      'logs-to-s3',
-      'export-task-logs',
       ],
     },
     {

--- a/software/export-task-logs.md
+++ b/software/export-task-logs.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: 'Export task logs'
-title: 'Export task logs to ElasticSearch'
+sidebar_label: 'Configure task log collection'
+title: 'Configure task log collection and exporting to ElasticSearch'
 id: export-task-logs
 description: Configure how Astronomer exports task logs to your ElasticSearch instance.
 ---
@@ -15,7 +15,7 @@ You can configure how Astronomer collects Deployment task logs and exports them 
 - Using a Fluentd Daemonset pod on each Kubernetes node in your cluster.
 - Using container sidecars for Deployment components.
 
-## Export task logs Using a Fluentd DaemonSet
+## Export task logs using a Fluentd DaemonSet
 
 By default, Astronomer Software uses a Fluentd DaemonSet to aggregate task logs. The is the workflow for the default implementation:
 

--- a/software/logs-to-s3.md
+++ b/software/logs-to-s3.md
@@ -1,6 +1,6 @@
 ---
 title: 'Forward Astronomer Software logs to Amazon S3'
-sidebar_label: 'Forward logs to S3'
+sidebar_label: 'Forward task logs to S3'
 id: logs-to-s3
 description: Configure Astronomer Software to forward logs to Amazon S3.
 ---


### PR DESCRIPTION
After some extended time with the "Administration" tab in production, it's clear that there's some improvements we can make to how it's organized. The docs in each of the setup/ management/ deployment management tabs are too diverse to be grouped like they are, so you really have to do some digging if you're navigating docs purely from the sidebar. 

I'm proposing that have a more topic-based approach that makes it easier to find docs if you already know what you're looking for.

@cmarteepants Is this a step in the right direction? And more specifically:
- Do you think "Manage Resources" is scoped correctly?
- Should `export-task-logs` and `logs-to-s3` be in Observability or an Administrative topic? They are definitely administrative tasks, but I could also see keeping them in Observability because that's where the average person might expect to find that information. 