### PR TITLE
Update install-gcp-standard.md

### DIFF
--- a/software/install-aws-standard.md
+++ b/software/install-aws-standard.md
@@ -176,7 +176,7 @@ If you received a certificate from a private CA, follow these steps instead:
 An SMTP service is required for sending and accepting email invites from Astronomer. If you're running Astronomer Software with `publicSignups` disabled (which is the default), you'll need to configure SMTP as a way for your users to receive and accept invites to the platform via email. To integrate your SMTP service with Astronomer, fetch your SMTP service's URI and store it in a Kubernetes secret:
 
 ```sh
-kubectl create secret generic astronomer-smtp --from-literal=connection=smtp://USERNAME:PASSWORD@HOST/?requireTLS=true -n astronomer
+kubectl create secret generic astronomer-smtp --from-literal=connection="smtp://USERNAME:PASSWORD@HOST/?requireTLS=true" -n astronomer
 ```
 
 In general, an SMTP URI will take the following form:

--- a/software/install-azure-standard.md
+++ b/software/install-azure-standard.md
@@ -205,7 +205,7 @@ If you received a certificate from a private CA, follow these steps instead:
 An SMTP service is required for sending and accepting email invites from Astronomer. If you're running Astronomer Software with `publicSignups` disabled (which is the default), you'll need to configure SMTP as a way for your users to receive and accept invites to the platform through an email invitation. To integrate your SMTP service with Astronomer, fetch your SMTP service's URI and store it in a Kubernetes secret:
 
 ```sh
-kubectl create secret generic astronomer-smtp --from-literal=connection=smtp://USERNAME:PASSWORD@HOST/?requireTLS=true -n astronomer
+kubectl create secret generic astronomer-smtp --from-literal=connection="smtp://USERNAME:PASSWORD@HOST/?requireTLS=true" -n astronomer
 ```
 
 In general, an SMTP URI will take the following form:

--- a/software/install-gcp-standard.md
+++ b/software/install-gcp-standard.md
@@ -202,7 +202,7 @@ If you received a certificate from a private CA, follow these steps instead:
 An SMTP service is required for sending and accepting email invites from Astronomer. If you're running Astronomer Software with `publicSignups` disabled (which is the default), you'll need to configure SMTP as a way for your users to receive and accept invites to the platform via email. To integrate your SMTP service with Astronomer, fetch your SMTP service's URI and store it in a Kubernetes secret:
 
 ```sh
-kubectl create secret generic astronomer-smtp --from-literal=connection=smtp://USERNAME:PASSWORD@HOST/?requireTLS=true -n astronomer
+kubectl create secret generic astronomer-smtp --from-literal=connection="smtp://USERNAME:PASSWORD@HOST/?requireTLS=true" -n astronomer
 ```
 
 In general, an SMTP URI will take the following form:


### PR DESCRIPTION
Can't create a secret like shown in the docs - without the `" "`, getting an error:

```
zsh: no matches found: --from-literal=connection=smtp://UUU:PPP@email-smtp.us-east-1.amazonaws.com/?requireTLS=true
```