### PR TITLE
Update URL for Python SDK docsite

### DIFF
--- a/tutorials/astro-python-sdk.md
+++ b/tutorials/astro-python-sdk.md
@@ -378,4 +378,4 @@ You now know how to use the Astro SDK to write a common ETL pipeline! More speci
 - Merge tables from different schemas and platforms without using XComs.
 - Run SQL in an entirely Pythonic context.
 
-As a next step, read the [Astro Python SDK documentation](https://astro-sdk-python.readthedocs.io/en/latest/) to learn more about its functionality and task decorators.
+As a next step, read the [Astro Python SDK documentation](https://astro-sdk-python.readthedocs.io/) to learn more about its functionality and task decorators.


### PR DESCRIPTION
The current docs were pointing at the docs from [`main`](https://astro-sdk-python.readthedocs.io/en/latest/) whereas I would like to point it to a stable release. Just pointing to the main URL allows me to control what to show from ReadTheDocs

https://astro-sdk-python.readthedocs.io/ redirects to https://astro-sdk-python.readthedocs.io/en/stable/