### PR TITLE
Fix three links in the Get started tutorial

### DIFF
--- a/tutorials/get-started-with-airflow.md
+++ b/tutorials/get-started-with-airflow.md
@@ -33,7 +33,7 @@ To complete this tutorial, you'll need to know:
 - A terminal that accepts bash commands. This is pre-installed on most operating systems.
 - [Python 3](https://www.python.org/downloads/).
 - [Docker Desktop](https://docs.docker.com/get-docker/) (v18.09 or higher).
-- The [Astro CLI](cli/configure-cli.md).
+- The [Astro CLI](astro/cli/install-cli.md).
 - An integrated development environment (IDE) for Python development, such as [VSCode](https://code.visualstudio.com/).
 
 ## Step 1: Create an Astro project

--- a/tutorials/get-started-with-airflow.md
+++ b/tutorials/get-started-with-airflow.md
@@ -315,5 +315,5 @@ Astronomer offers a variety of resources like this tutorial to learn more about 
 Don't know where to start? For beginners, the next resources we recommend are:
 
 - [Managing connections in Airflow](https://www.astronomer.io/guides/connections/): Learn how to connect Airflow to third party products and services.
-- [Develop a project](develop-project.md): Learn about all of the ways you can configure your Astro project and local Airflow environment.
+- [Develop a project](astro/develop-project.md): Learn about all of the ways you can configure your Astro project and local Airflow environment.
 - [DAG Writing Best Practices](https://www.astronomer.io/guides/dag-best-practices?search=best): Learn how to write efficient, secure, and scalable DAGs.

--- a/tutorials/get-started-with-airflow.md
+++ b/tutorials/get-started-with-airflow.md
@@ -33,7 +33,7 @@ To complete this tutorial, you'll need to know:
 - A terminal that accepts bash commands. This is pre-installed on most operating systems.
 - [Python 3](https://www.python.org/downloads/).
 - [Docker Desktop](https://docs.docker.com/get-docker/) (v18.09 or higher).
-- The [Astro CLI](astro/cli/install-cli.md).
+- The [Astro CLI](https://docs.astronomer.io/astro/cli/install-cli).
 - An integrated development environment (IDE) for Python development, such as [VSCode](https://code.visualstudio.com/).
 
 ## Step 1: Create an Astro project
@@ -315,5 +315,5 @@ Astronomer offers a variety of resources like this tutorial to learn more about 
 Don't know where to start? For beginners, the next resources we recommend are:
 
 - [Managing connections in Airflow](https://www.astronomer.io/guides/connections/): Learn how to connect Airflow to third party products and services.
-- [Develop a project](astro/develop-project.md): Learn about all of the ways you can configure your Astro project and local Airflow environment.
+- [Develop a project](https://docs.astronomer.io/astro/develop-project): Learn about all of the ways you can configure your Astro project and local Airflow environment.
 - [DAG Writing Best Practices](https://www.astronomer.io/guides/dag-best-practices?search=best): Learn how to write efficient, secure, and scalable DAGs.

--- a/tutorials/overview.md
+++ b/tutorials/overview.md
@@ -24,5 +24,5 @@ Learn how to write data pipelines and become an expert on data orchestration. Th
 Don't know where to start? For beginners, the next resources we recommend are:
 
 - [Managing connections in Airflow](https://www.astronomer.io/guides/connections/): Learn how to connect Airflow to third party products and services.
-- [Develop a project](develop-project.md): Learn about all of the ways you can configure your Astro project and local Airflow environment.
+- [Develop a project](https://docs.astronomer.io/astro/develop-project): Learn about all of the ways you can configure your Astro project and local Airflow environment.
 - [DAG Writing Best Practices](https://www.astronomer.io/guides/dag-best-practices?search=best): Learn how to write efficient, secure, and scalable DAGs.


### PR DESCRIPTION
Two links in the Get started tutorial (to the Astro CLI Install page and to develop a project) and one in the overview 404ed, this should fix that :)