### PR TITLE
Add links to other versioned release notes

### DIFF
--- a/software_versioned_docs/version-0.25/release-notes.md
+++ b/software_versioned_docs/version-0.25/release-notes.md
@@ -6,9 +6,17 @@ id: release-notes
 
 This document contains all release notes for Astronomer Software 0.25.
 
-0.30 is the latest long-term support (LTS) version of Astronomer Software. To upgrade to 0.30, read [Upgrade Astronomer](upgrade-astronomer.md). For more information about Software release channels, see [Release and lifecycle policies](release-lifecycle-policy.md). To review release notes specifically for the Astro CLI, see [Astro CLI release notes](cli-release-notes.md).
+0.30 is the latest long-term support (LTS) version of Astronomer Software. To upgrade to 0.30, read [Upgrade Astronomer](upgrade-astronomer.md). For more information about Software release channels, see [Release and lifecycle policies](release-lifecycle-policy.md). 
 
 If you're upgrading to Astronomer v0.30, see [Upgrade to Astronomer v0.25](upgrade-astronomer.md). For instructions on how to upgrade to a patch version within the Astronomer v0.25 series, see [Upgrade to a Patch Version of Astronomer Software](upgrade-astronomer.md).
+
+For more Software release notes, see:
+
+- [Astro CLI release notes](cli-release-notes.md)
+- [Astro Runtime release notes](runtime-release-notes.md)
+- [Astronomer Software 0.29 release notes](https://docs.astronomer.io/software/0.29/release-notes)
+- [Astronomer Software 0.28 release notes](https://docs.astronomer.io/software/0.28/release-notes)
+- [Astronomer Software 0.25 release notes](https://docs.astronomer.io/software/0.25/release-notes)
 
 All Astronomer Software versions are tested for scale, reliability and security on Amazon EKS, Google GKE, and Azure AKS. If you have questions or an issue to report, contact [Astronomer support](https://support.astronomer.io).
 

--- a/software_versioned_docs/version-0.25/release-notes.md
+++ b/software_versioned_docs/version-0.25/release-notes.md
@@ -8,9 +8,9 @@ This document contains all release notes for Astronomer Software 0.25.
 
 0.30 is the latest long-term support (LTS) version of Astronomer Software. To upgrade to 0.30, read [Upgrade Astronomer](upgrade-astronomer.md). For more information about Software release channels, see [Release and lifecycle policies](release-lifecycle-policy.md). 
 
-If you're upgrading to Astronomer v0.30, see [Upgrade to Astronomer v0.25](upgrade-astronomer.md). For instructions on how to upgrade to a patch version within the Astronomer v0.25 series, see [Upgrade to a Patch Version of Astronomer Software](upgrade-astronomer.md).
+If you're upgrading to Astronomer v0.30, see [Upgrade to Astronomer v0.25](upgrade-astronomer.md). To upgrade to a patch version within the Astronomer v0.25 series, see [Upgrade to a Patch Version of Astronomer Software](upgrade-astronomer.md).
 
-For more Software release notes, see:
+For more Astronomer Software release notes, see:
 
 - [Astro CLI release notes](cli-release-notes.md)
 - [Astro Runtime release notes](runtime-release-notes.md)

--- a/software_versioned_docs/version-0.28/release-notes.md
+++ b/software_versioned_docs/version-0.28/release-notes.md
@@ -11,7 +11,7 @@ description: Astronomer Software release notes.
 
 This document includes all release notes for Astronomer Software v0.28.
 
-0.30 is the latest long-term support (LTS) version of Astronomer Software. To upgrade to 0.30, see [Upgrade Astronomer](upgrade-astronomer.md). For more information about Software release channels, see [Release and lifecycle policies](release-lifecycle-policy.md). For more Software release notes, see:
+0.30 is the latest long-term support (LTS) version of Astronomer Software. To upgrade to 0.30, see [Upgrade Astronomer](upgrade-astronomer.md). For more information about Astronomer Software release channels, see [Release and lifecycle policies](release-lifecycle-policy.md). For more Astronomer Software release notes, see:
 
 - [Astro CLI release notes](cli-release-notes.md)
 - [Astro Runtime release notes](runtime-release-notes.md)

--- a/software_versioned_docs/version-0.28/release-notes.md
+++ b/software_versioned_docs/version-0.28/release-notes.md
@@ -11,7 +11,13 @@ description: Astronomer Software release notes.
 
 This document includes all release notes for Astronomer Software v0.28.
 
-0.30 is the latest long-term support (LTS) version of Astronomer Software. To upgrade to 0.30, see [Upgrade Astronomer](upgrade-astronomer.md). For more information about Software release channels, see [Release and lifecycle policies](release-lifecycle-policy.md). To review release notes specifically for the Astro CLI, see [Astro CLI release notes](cli-release-notes.md).
+0.30 is the latest long-term support (LTS) version of Astronomer Software. To upgrade to 0.30, see [Upgrade Astronomer](upgrade-astronomer.md). For more information about Software release channels, see [Release and lifecycle policies](release-lifecycle-policy.md). For more Software release notes, see:
+
+- [Astro CLI release notes](cli-release-notes.md)
+- [Astro Runtime release notes](runtime-release-notes.md)
+- [Astronomer Software 0.29 release notes](https://docs.astronomer.io/software/0.29/release-notes)
+- [Astronomer Software 0.28 release notes](https://docs.astronomer.io/software/0.28/release-notes)
+- [Astronomer Software 0.25 release notes](https://docs.astronomer.io/software/0.25/release-notes)
 
 All Astronomer Software versions are tested for scale, reliability and security on Amazon EKS, Google GKE, and Azure AKS. If you have questions or an issue to report, contact [Astronomer support](https://support.astronomer.io).
 

--- a/software_versioned_docs/version-0.29/release-notes.md
+++ b/software_versioned_docs/version-0.29/release-notes.md
@@ -10,7 +10,7 @@ description: Astronomer Software release notes.
 
 This document includes all release notes for Astronomer Software version 0.29.
 
-0.30 is the latest long-term support (LTS) version of Astronomer Software. To upgrade to 0.30, see [Upgrade Astronomer](upgrade-astronomer.md). For more information about Software release channels, see [Release and lifecycle policies](release-lifecycle-policy.md). For more Software release notes, see:
+0.30 is the latest long-term support (LTS) version of Astronomer Software. To upgrade to 0.30, see [Upgrade Astronomer](upgrade-astronomer.md). For more information about Astronomer Software release channels, see [Release and lifecycle policies](release-lifecycle-policy.md). For more Astronomer Software release notes, see:
 
 - [Astro CLI release notes](cli-release-notes.md)
 - [Astro Runtime release notes](runtime-release-notes.md)

--- a/software_versioned_docs/version-0.29/release-notes.md
+++ b/software_versioned_docs/version-0.29/release-notes.md
@@ -10,7 +10,13 @@ description: Astronomer Software release notes.
 
 This document includes all release notes for Astronomer Software version 0.29.
 
-0.30 is the latest long-term support (LTS) version of Astronomer Software. To upgrade to 0.30, see [Upgrade Astronomer](upgrade-astronomer.md). For more information about Software release channels, see [Release and lifecycle policies](release-lifecycle-policy.md). To review release notes specifically for the Astro CLI, see [Astro CLI release notes](cli-release-notes.md).
+0.30 is the latest long-term support (LTS) version of Astronomer Software. To upgrade to 0.30, see [Upgrade Astronomer](upgrade-astronomer.md). For more information about Software release channels, see [Release and lifecycle policies](release-lifecycle-policy.md). For more Software release notes, see:
+
+- [Astro CLI release notes](cli-release-notes.md)
+- [Astro Runtime release notes](runtime-release-notes.md)
+- [Astronomer Software 0.29 release notes](https://docs.astronomer.io/software/0.29/release-notes)
+- [Astronomer Software 0.28 release notes](https://docs.astronomer.io/software/0.28/release-notes)
+- [Astronomer Software 0.25 release notes](https://docs.astronomer.io/software/0.25/release-notes)
 
 Astronomer tests all Astronomer Software versions for scale, reliability, and security on Amazon EKS, Google GKE, and Azure AKS. If you have questions or an issue to report, contact [Astronomer support](https://support.astronomer.io).
 


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/1229

This hub of links should be useful both for the Astronomer team and for customers who quickly want to cross reference releases to make sure a specific change was made in at least one of several versions. 