### PR TITLE
Standardize integrations tutorials titles

### DIFF
--- a/tutorials/airflow-azure-container-instances.md
+++ b/tutorials/airflow-azure-container-instances.md
@@ -1,7 +1,7 @@
 ---
-title: "Orchestrating Azure Container Instances with Airflow"
-sidebar_label: "Orchestrate Azure Container Instances"
-description: "Orchestrating containers with Azure Container Instances from your Apache Airflow DAGs."
+title: "Orchestrate Azure Container Instances with Airflow"
+sidebar_label: "Azure Container Instances"
+description: "How to orchestrate containers with Azure Container Instances with your Airflow DAGs."
 id: airflow-azure-container-instances
 tags: ["Integrations", "Azure", "DAGs"]
 ---

--- a/tutorials/airflow-azure-data-explorer.md
+++ b/tutorials/airflow-azure-data-explorer.md
@@ -1,7 +1,7 @@
 ---
-title: "Executing Azure Data Explorer Queries with Airflow"
+title: "Orchestrate Azure Data Explorer Queries with Airflow"
 sidebar_label: "Azure Data Explorer"
-description: "Executing Azure Data Explorer queries from your Apache Airflow DAGs."
+description: "How to orchestrate Azure Data Explorer queries with your Apache Airflow DAGs."
 id: airflow-azure-data-explorer
 tags: ["Integrations", "Azure", "DAGs"]
 ---

--- a/tutorials/airflow-azure-data-factory-integration.md
+++ b/tutorials/airflow-azure-data-factory-integration.md
@@ -1,7 +1,7 @@
 ---
-title: "Executing Azure Data Factory pipelines with Airflow"
+title: "Orchestrate Azure Data Factory pipelines with Airflow"
 sidebar_label: "Azure Data Factory"
-description: "Trigger remote jobs in Azure Data Factory from your Apache Airflow DAGs."
+description: "Orchestrate remote jobs in Azure Data Factory with your Apache Airflow DAGs."
 id: airflow-azure-data-factory-integration
 tags: ["Integrations", "Azure"]
 ---

--- a/tutorials/airflow-databricks.md
+++ b/tutorials/airflow-databricks.md
@@ -1,7 +1,7 @@
 ---
-title: "Orchestrating Databricks jobs with Airflow"
-sidebar_label: "Orchestrating Databricks jobs with Airflow"
-description: "Orchestrating Databricks jobs from your Apache Airflow DAGs."
+title: "Orchestrate Databricks jobs with Airflow"
+sidebar_label: "Databricks"
+description: "Orchestrate Databricks jobs with your Airflow DAGs."
 id: airflow-databricks
 tags: [Integrations, DAGs]
 ---

--- a/tutorials/airflow-dbt.md
+++ b/tutorials/airflow-dbt.md
@@ -1,7 +1,7 @@
 ---
-title: "Integrating Airflow and dbt"
-sidebar_label: "Integrating Airflow and dbt"
-description: "Run dbt models in your Airflow DAGs."
+title: "Orchestrate dbt with Airflow"
+sidebar_label: "dbt"
+description: "Orchestrate dbt models with your Airflow DAGs."
 id: airflow-dbt
 keywords: [DAGs, Integrations]
 ---

--- a/tutorials/airflow-great-expectations.md
+++ b/tutorials/airflow-great-expectations.md
@@ -1,7 +1,7 @@
 ---
-title: "Integrating Airflow and Great Expectations"
+title: "Orchestrate Great Expectations wtih Airflow"
 sidebar_label: "Great Expectations"
-description: "Use the Great Expectations provider in your Airflow DAGs."
+description: "Orchestrate Great Expectations data quality checks with your Airflow DAGs."
 id: airflow-great-expectations
 ---
 

--- a/tutorials/airflow-great-expectations.md
+++ b/tutorials/airflow-great-expectations.md
@@ -1,5 +1,5 @@
 ---
-title: "Orchestrate Great Expectations wtih Airflow"
+title: "Orchestrate Great Expectations with Airflow"
 sidebar_label: "Great Expectations"
 description: "Orchestrate Great Expectations data quality checks with your Airflow DAGs."
 id: airflow-great-expectations

--- a/tutorials/airflow-openlineage.md
+++ b/tutorials/airflow-openlineage.md
@@ -1,7 +1,7 @@
 ---
-title: "OpenLineage and Airflow"
+title: "Integrate OpenLineage and Airflow"
 sidebar_label: "OpenLineage"
-description: "Using OpenLineage and Marquez to get lineage data from your Airflow DAGs."
+description: "Use OpenLineage and Marquez to get lineage data from your Airflow DAGs."
 id: airflow-openlineage
 tags: [Lineage]
 ---

--- a/tutorials/airflow-redshift.md
+++ b/tutorials/airflow-redshift.md
@@ -1,7 +1,7 @@
 ---
-title: "Orchestrate Redshift operations in Airflow"
+title: "Orchestrate Redshift operations with Airflow"
 sidebar_label: "Amazon Redshift"
-description: "Use Redshift modules to set up a Redshift connection."
+description: "Orchestrate Redshift queries from your Airflow DAGs."
 id: airflow-redshift
 tags: [Database, SQL, DAGs, Integrations, AWS]
 ---

--- a/tutorials/airflow-sagemaker.md
+++ b/tutorials/airflow-sagemaker.md
@@ -1,7 +1,7 @@
 ---
-title: "Use Airflow with SageMaker"
-sidebar_label: "SageMaker"
-description: "Orchestrate SageMaker machine learning pipelines with Airflow."
+title: "Orchestrate SageMaker with Airflow"
+sidebar_label: "Amazon SageMaker"
+description: "Orchestrate SageMaker machine learning pipelines with your Airflow DAGs."
 id: airflow-sagemaker
 ---
 

--- a/tutorials/airflow-snowflake.md
+++ b/tutorials/airflow-snowflake.md
@@ -1,6 +1,6 @@
 ---
 title: "Orchestrate Snowflake Queries with Airflow"
-description: "How to use Airflow to get enhanced observability and compute savings while orchestrating your Snowflake jobs."
+description: "Get enhanced observability and compute savings while orchestrating Snowflake jobs from your Airflow DAGs."
 id: airflow-snowflake
 sidebar_label: Snowflake
 ---

--- a/tutorials/airflow-talend-integration.md
+++ b/tutorials/airflow-talend-integration.md
@@ -1,6 +1,6 @@
 ---
-title: "Executing Talend Jobs with Airflow"
-description: "Triggering remote jobs in Talend from your Apache Airflow DAGs."
+title: "Orchestrate Talend Jobs with Airflow"
+description: "Orchestrate remote jobs in Talend with your Apache Airflow DAGs."
 id: airflow-talend-integration
 sidebar_label: "Talend"
 ---

--- a/tutorials/soda-data-quality.md
+++ b/tutorials/soda-data-quality.md
@@ -1,6 +1,6 @@
 ---
-title: "Soda Core and Airflow"
-description: "Using Soda Core to implement data quality checks in Airflow DAGs."
+title: "Orchestrate Soda Core with Airflow"
+description: "Orchestrate Soda Core data quality checks with your Airflow DAGs."
 id: soda-data-quality
 sidebar_label: "Soda Core"
 ---


### PR DESCRIPTION
Made a few minor changes to standardize the language we use for titles and descriptions for integrations tutorials:

- Use verbs in titles since these will be action-oriented
- Use "Orchestrate" for any integrations that involve running remote jobs from DAGs since this is more descriptive of what is actually happening and differentiates from "integrate", which is broader.
- Shorten side-bar labels to just the name of the tool being integrated
- Minor language standardization in the descriptions