### PR TITLE
Update integrate-iam.md

### DIFF
--- a/software/integrate-iam.md
+++ b/software/integrate-iam.md
@@ -303,7 +303,7 @@ astronomer:
     ```bash
     gcloud iam service-accounts add-iam-policy-binding \
     --role roles/iam.workloadIdentityUser \
-    --member "serviceAccount:<project-id>.svc.id.goog[<your-airflow-namespace>/<gke-service-account-name>]" \
+    --member "serviceAccount:<project-id>.svc.id.goog[<your-airflow-namespace>/<airflow-worker-service-account-name>]" \
     <gsa-name>@<project-id>.iam.gserviceaccount.com
     ```
 


### PR DESCRIPTION
`--member "serviceAccount:<project-id>.svc.id.goog[<your-airflow-namespace>/<gke-service-account-name>]" \`

This line is misleading. We need to provide the airflow worker service account name, not the GKE SA name.