### PR TITLE
Allowlist clarification

### DIFF
--- a/astro/install-aws.md
+++ b/astro/install-aws.md
@@ -35,7 +35,7 @@ For a complete list of the AWS resources that Astronomer support provisions in y
 
    See [Creating an administrator IAM user and user group (console)](https://docs.aws.amazon.com/IAM/latest/UserGuide/getting-started_create-admin-group.html#getting-started_create-admin-group-console).
 - A subscription to the [Astro Status Page](https://status.astronomer.io/). This will ensure that you're alerted in the case of an incident or scheduled maintenance.
-- The following domains added to your organization's allowlist:
+- The following domains added to your organization's allowlist for any user amd CI/CD environments:
     - `https://cloud.astronomer.io/`
     - `https://astro-<your-org>.datakin.com/`
     - `https://<your-org>.astronomer.run/`

--- a/astro/install-aws.md
+++ b/astro/install-aws.md
@@ -35,7 +35,7 @@ For a complete list of the AWS resources that Astronomer support provisions in y
 
    See [Creating an administrator IAM user and user group (console)](https://docs.aws.amazon.com/IAM/latest/UserGuide/getting-started_create-admin-group.html#getting-started_create-admin-group-console).
 - A subscription to the [Astro Status Page](https://status.astronomer.io/). This will ensure that you're alerted in the case of an incident or scheduled maintenance.
-- The following domains added to your organization's allowlist for any user amd CI/CD environments:
+- The following domains added to your organization's allowlist for any user and CI/CD environments:
     - `https://cloud.astronomer.io/`
     - `https://astro-<your-org>.datakin.com/`
     - `https://<your-org>.astronomer.run/`

--- a/astro/install-azure.md
+++ b/astro/install-azure.md
@@ -30,7 +30,7 @@ For more information about managing Azure subscriptions with the Azure CLI, see 
 - Microsoft Azure CLI or Azure Az PowerShell module.  See [How to install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) and [Install the Azure Az PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps).
 - A minimum quota of 48 Standard Ddv5-series vCPUs in the deployment region. You can use Dv5-series vCPUs, but you'll need 96 total vCPUs composed of 48 Ddv5-series vCPUs and 48 Dv5-series vCPUs. To adjust your quota limits up or down, see [Increase VM-family vCPU quotas](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/per-vm-quota-requests).
 - A subscription to the [Astro Status Page](https://status.astronomer.io). This ensures that you're alerted when an incident occurs or when scheduled maintenance is planned.
-- The following domains added to your organization's allowlist:
+- The following domains added to your organization's allowlist for any user amd CI/CD environments:
     - `https://cloud.astronomer.io/`
     - `https://astro-<your-org>.datakin.com/`
     - `https://<your-org>.astronomer.run/`

--- a/astro/install-azure.md
+++ b/astro/install-azure.md
@@ -30,7 +30,7 @@ For more information about managing Azure subscriptions with the Azure CLI, see 
 - Microsoft Azure CLI or Azure Az PowerShell module.  See [How to install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) and [Install the Azure Az PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps).
 - A minimum quota of 48 Standard Ddv5-series vCPUs in the deployment region. You can use Dv5-series vCPUs, but you'll need 96 total vCPUs composed of 48 Ddv5-series vCPUs and 48 Dv5-series vCPUs. To adjust your quota limits up or down, see [Increase VM-family vCPU quotas](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/per-vm-quota-requests).
 - A subscription to the [Astro Status Page](https://status.astronomer.io). This ensures that you're alerted when an incident occurs or when scheduled maintenance is planned.
-- The following domains added to your organization's allowlist for any user amd CI/CD environments:
+- The following domains added to your organization's allowlist for any user and CI/CD environments:
     - `https://cloud.astronomer.io/`
     - `https://astro-<your-org>.datakin.com/`
     - `https://<your-org>.astronomer.run/`

--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -26,7 +26,7 @@ For more information about managing Google Cloud projects, see [GCP documentatio
 - A minimum [CPU](https://cloud.google.com/compute/quotas#cpu_quota) quota of 36. To adjust your project's quota limits up or down, see [Managing your quota using the Cloud console](https://cloud.google.com/docs/quota#managing_your_quota_console).
 - A minimum [N2_CPU](https://cloud.google.com/compute/quotas#cpu_quota) quota of 24. To adjust your project's quota limits up or down, see [Managing your quota using the Cloud console](https://cloud.google.com/docs/quota#managing_your_quota_console).
 - A subscription to the [Astro Status Page](https://status.astronomer.io). This ensures that you're alerted when an incident occurs or scheduled maintenance is required.
-- The following domains added to your organization's allowlist:
+- The following domains added to your organization's allowlist for any user amd CI/CD environments:
     - `https://cloud.astronomer.io/`
     - `https://astro-<your-org>.datakin.com/`
     - `https://<your-org>.astronomer.run/`

--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -26,7 +26,7 @@ For more information about managing Google Cloud projects, see [GCP documentatio
 - A minimum [CPU](https://cloud.google.com/compute/quotas#cpu_quota) quota of 36. To adjust your project's quota limits up or down, see [Managing your quota using the Cloud console](https://cloud.google.com/docs/quota#managing_your_quota_console).
 - A minimum [N2_CPU](https://cloud.google.com/compute/quotas#cpu_quota) quota of 24. To adjust your project's quota limits up or down, see [Managing your quota using the Cloud console](https://cloud.google.com/docs/quota#managing_your_quota_console).
 - A subscription to the [Astro Status Page](https://status.astronomer.io). This ensures that you're alerted when an incident occurs or scheduled maintenance is required.
-- The following domains added to your organization's allowlist for any user amd CI/CD environments:
+- The following domains added to your organization's allowlist for any user and CI/CD environments:
     - `https://cloud.astronomer.io/`
     - `https://astro-<your-org>.datakin.com/`
     - `https://<your-org>.astronomer.run/`


### PR DESCRIPTION
This caused confusion for a customer today. Clarifying that the allowlist is only relevant for their user and CI/CD environments and not in the path between the Data Plane and Control Plane.