### PR TITLE
Update get-started-with-airflow-part-2.md

### DIFF
--- a/tutorials/get-started-with-airflow-part-2.md
+++ b/tutorials/get-started-with-airflow-part-2.md
@@ -187,7 +187,7 @@ with DAG(
 ):
 ```
 
-The DAG itself has two tasks. The first task uses the `GithubTagSensor` to check whether a tag named `v1.0` has been to your GitHub repository. It utilizes the Airflow variable (`my_github_repo`) and connection (`my_github_connection`) to access the correct repository with the appropriate credentials. The sensor checks for the tag every 30 seconds and will time out after one day. It is best practice to always set a `timeout` because the default value is quite long at 7 days, which can impact performance if left unchanged in DAGs that run on a higher frequency.
+The DAG itself has two tasks. The first task uses the `GithubTagSensor` to check whether a tag named `v1.0` has been added to your GitHub repository. It utilizes the Airflow variable (`my_github_repo`) and connection (`my_github_connection`) to access the correct repository with the appropriate credentials. The sensor checks for the tag every 30 seconds and will time out after one day. It is best practice to always set a `timeout` because the default value is quite long at 7 days, which can impact performance if left unchanged in DAGs that run on a higher frequency.
 
 ```python
     tag_sensor = GithubTagSensor(


### PR DESCRIPTION
Added missing word. 

PS. In the step 8 there's a sentence "Notice how both the SimpleHttpOperator as well as the GithubTagSensor are part of the provider packages you installed." - to be fair, we only install Github provider as HTTP is pre-installed :)