### PR TITLE
Add link to intro tutorial to the intro concept page

### DIFF
--- a/learn/intro-to-airflow.md
+++ b/learn/intro-to-airflow.md
@@ -14,11 +14,7 @@ This guide offers an introduction to Apache Airflow and its core concepts. You'l
 - When you should use Airflow.
 - Core Airflow concepts.
 
-:::info
-
-For a hands-on introduction to Airflow using the Astro CLI check out the [Get started with Apache Airflow tutorial](get-started-with-airflow.md).
-
-:::
+For a hands-on introduction to Airflow using the Astro CLI, see [Get started with Apache Airflow](get-started-with-airflow.md).
 
 ## Assumed knowledge
 

--- a/learn/intro-to-airflow.md
+++ b/learn/intro-to-airflow.md
@@ -14,6 +14,12 @@ This guide offers an introduction to Apache Airflow and its core concepts. You'l
 - When you should use Airflow.
 - Core Airflow concepts.
 
+:::info
+
+For a hands-on introduction to Airflow using the Astro CLI check out the [Get started with Apache Airflow tutorial](get-started-with-airflow.md).
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
@@ -115,6 +121,6 @@ To learn more about the Airflow infrastructure, see [Airflow Components](airflow
 - [Astro CLI](https://docs.astronomer.io/astro/cli/get-started)
 - [Astronomer Webinars](https://www.astronomer.io/events/webinars/)
 - [LIVE with Astronomer](https://www.astronomer.io/events/live/)
-- [Astronomer Guides](https:/docs.astronomer.io/learn/)
+- [Astronomer Learn](https:/docs.astronomer.io/learn/)
 - [Astronomer Academy](https://academy.astronomer.io/)
 - [Official Airflow Documentation](https://airflow.apache.org/docs/)


### PR DESCRIPTION
Added a note at the start of the Intro to Airflow concept page about the Get started tutorial. I also changed the name of a link from Astronomer Guides to Astronomer Learn, assuming we are not using the umbrella term "Guides" anymore?