### PR TITLE
Bug fix for home activeBaseRegex

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,7 +50,7 @@ module.exports = {
           label: 'Home',
           position: 'left',
           activeClassName: 'navbar__link--active',
-          activeBaseRegex: '(?!)',
+          activeBaseRegex: '^[\/]+$',
         },
         {
           to: '/astro/',


### PR DESCRIPTION
This PR fixes a bug so the "Home" tab is properly underlined when on the Docs Overview home page.

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/96535736/195873478-ccc8b5fd-18af-4277-9d0b-ee689c3f3f8e.png">
