### PR TITLE
Fix bottomButtons z-index on mobile

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -653,6 +653,7 @@ a.navbar-sidebar__logolink::before {
 .navbar-sidebar__items {
   display: grid;
   height: auto;
+  background: var(--ifm-navbar-background-color);
 }
 
 .navbar-sidebar__item.menu.primaryMenu {
@@ -696,6 +697,7 @@ a.navbar-sidebar__logolink::before {
   justify-content: center;
   position: absolute;
   bottom: 0;
+  z-index: -1;
 }
 
 html[data-theme="dark"] .navbar-sidebar__item.menu.bottomButtons {


### PR DESCRIPTION
This PR fixes a bug where the bottom buttons CTA in the mobile menu were rendering on top of secondary menu items when the menu was longer than the screen.