### PR TITLE
Fix text null bug in SelectNav

### DIFF
--- a/src/components/SelectNav/index.js
+++ b/src/components/SelectNav/index.js
@@ -14,7 +14,7 @@ export default function SelectNav({ label, items }) {
   };
 
   useEffect(() => {
-    setCurrentVersion(document.querySelector(`option[value*='${path.pathname}']`).text);
+    document.querySelector(`option[value*='${path.pathname}']`) && setCurrentVersion(document.querySelector(`option[value*='${path.pathname}']`).text);
   }, [currentVersion]);
 
   return (


### PR DESCRIPTION
Fixes a bug in the SelectNav component that was causing crashing of some pages in Software docs.
Example: https://docs.astronomer.io/software/import-idp-groups#step-2-add-a-group-claim-to-your-idp-group