### PR TITLE
Add back overview

### DIFF
--- a/astro/astro-architecture.md
+++ b/astro/astro-architecture.md
@@ -1,0 +1,12 @@
+---
+sidebar_label: 'Architecture'
+title: 'Astro architecture'
+id: astro-architecture
+description: Astro uses a multi-plane structure to help make Airflow more secure and reliable. Use this doc to learn how the control plane and data plane work together on the cloud.
+---
+
+
+Astro uses a multi-plane structure to help make Airflow more secure and reliable. The control plane is entirely managed and hosted by Astronomer, while the data plane can run in either your cloud or Astronomer's cloud. The following diagram outlines how the control plane, data plane, and users are connected to enable Astro.
+
+![Astro architecture overview](/img/docs/architecture-overview.png)
+

--- a/astro/astro-architecture.md
+++ b/astro/astro-architecture.md
@@ -2,11 +2,15 @@
 sidebar_label: 'Architecture'
 title: 'Astro architecture'
 id: astro-architecture
-description: Astro uses a multi-plane structure to help make Airflow more secure and reliable. Use this doc to learn how the control plane and data plane work together on the cloud.
+description: Astro uses a multi-plane structure to help make Airflow more secure and reliable. Learn how the control plane and data plane work together on the cloud.
 ---
 
 
-Astro uses a multi-plane structure to help make Airflow more secure and reliable. The control plane is entirely managed and hosted by Astronomer, while the data plane can run in either your cloud or Astronomer's cloud. The following diagram outlines how the control plane, data plane, and users are connected to enable Astro.
+Astro is a managed service for data orchestration that is built for the cloud and powered by Apache Airflow. Astro is built with a multi-plane architecture which consists of a control plane that is hosted by Astronomer, and a data plane that can run either in your cloud or in a single-tenant account hosted by Astronomer. In all cases, both the control plane and data plane are managed by Astronomer and require no operational oversight by your team.
+
+Astro's architecture ensures that tasks are executed securely within your network and corporate boundaries, while enabling Astronomer to deliver the full promises of a managed service. The following diagram outlines how the control plane, data plane, and users are connected to enable the Astro feature set. This architecture applies to Astro on Amazon Web Services (AWS), Google Cloud Platform (GCP), and Microsoft Azure.
+
+For more information on Astro's architecture, contact [Astronomer support](https://cloud.astronomer.io/support).
 
 ![Astro architecture overview](/img/docs/architecture-overview.png)
 

--- a/astro/features.md
+++ b/astro/features.md
@@ -1,0 +1,23 @@
+---
+sidebar_label: 'Features'
+title: 'Astro features'
+id: environment-variables
+description: Set environment variables on Astro to specify Airflow configurations and custom logic.
+---
+
+Astro is a managed software service that offers a next-generation experience for modern data teams running Apache Airflow, the open source industry standard for data orchestration.
+
+Astro boasts a hybrid deployment model founded on a control plane hosted by Astronomer and a data plane that is hosted in your cloud environment. Both are fully managed by Astronomer. This model offers the self-service convenience of a fully managed service while respecting the need to keep data private, secure, and within corporate boundaries. This solution optimizes security and reduces operational overhead.
+
+Beyond architecture, Astro offers a suite of first-class features that make it easy to author, run, and monitor data pipelines.
+
+## Feature list
+
+The key features of Astro include:
+
+- Worker auto-scaling, powered by the Airflow Celery executor + KEDA. See [Worker queues](configure-worker-queues.md).
+- The ability to run multiple clusters in your organization's network on AWS, GCP, or Azure.
+- Astro Runtime, a collection of Docker images that provides a differentiated data orchestration experience. See [Runtime image architecture](runtime-image-architecture.md).
+- Timely support for the latest major, minor, and patch versions of the Apache Airflow open source project.
+- Support for role-based access control (RBAC) and single sign-on (SSO) for secure user management and authentication. See [Configure an identity provider (IdP)](configure-idp.md) and [User permissions](user-permissions.md).
+- An observability experience that gives you insight into the health and resource consumption of your tasks and pipelines in real time. See [Deployment metrics](deployment-metrics.md) and [Data lineage](data-lineage.md).

--- a/astro/features.md
+++ b/astro/features.md
@@ -13,11 +13,10 @@ Beyond architecture, Astro offers a suite of first-class features that make it e
 
 ## Feature list
 
-The key features of Astro include:
 
-- Worker auto-scaling, powered by the Airflow Celery executor + KEDA. See [Worker queues](configure-worker-queues.md).
+- Worker auto-scaling, powered by the Airflow Celery executor and KEDA. See [Worker queues](configure-worker-queues.md).
 - The ability to run multiple clusters in your organization's network on AWS, GCP, or Azure.
 - Astro Runtime, a collection of Docker images that provides a differentiated data orchestration experience. See [Runtime image architecture](runtime-image-architecture.md).
 - Timely support for the latest major, minor, and patch versions of the Apache Airflow open source project.
 - Support for role-based access control (RBAC) and single sign-on (SSO) for secure user management and authentication. See [Configure an identity provider (IdP)](configure-idp.md) and [User permissions](user-permissions.md).
-- An observability experience that gives you insight into the health and resource consumption of your tasks and pipelines in real time. See [Deployment metrics](deployment-metrics.md) and [Data lineage](data-lineage.md).
+- An observability experience that gives you data lineage across your ecosystem as well as real-time insight into the health and resource consumption of your data pipelines on Astro. See  [Data lineage](data-lineage.md] and [Deployment metrics](deployment-metrics.md).

--- a/astro/features.md
+++ b/astro/features.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: 'Features'
 title: 'Astro features'
-id: environment-variables
+id: features
 description: Set environment variables on Astro to specify Airflow configurations and custom logic.
 ---
 

--- a/sidebarsAstro.js
+++ b/sidebarsAstro.js
@@ -10,13 +10,9 @@
 module.exports = {
   cloud: [
     {
-      type: 'doc',
-      label: 'Home',
-      id: 'overview'
-    },
-    {
       type: 'Category',
-      label: 'Astro overview',
+      label: 'Overview',
+      link: { type: 'doc', id: 'overview' },
       items: [
         'features',
         'astro-architecture',

--- a/sidebarsAstro.js
+++ b/sidebarsAstro.js
@@ -11,8 +11,16 @@ module.exports = {
   cloud: [
     {
       type: 'doc',
-      label: 'Overview',
+      label: 'Home',
       id: 'overview'
+    },
+    {
+      type: 'Category',
+      label: 'Astro overview',
+      items: [
+        'features',
+        'astro-architecture',
+      ],
     },
     {
       type: 'category',

--- a/sidebarsAstro.js
+++ b/sidebarsAstro.js
@@ -10,7 +10,7 @@
 module.exports = {
   cloud: [
     {
-      type: 'Category',
+      type: 'category',
       label: 'Overview',
       link: { type: 'doc', id: 'overview' },
       items: [


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/1359

Bare-bones docs to get overview info back into Astro docs. We can add on these over time, but let's get these merged sooner rather than later. 