### PR TITLE
GCP project ID requirement

### DIFF
--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -103,6 +103,7 @@ The data plane is a collection of infrastructure components for Astro that run i
 
 Once you've activated your data plane, provide Astronomer with:
 
+- Your GCP project ID.
 - Your preferred Astro cluster name.
 - The GCP region that you want to host your cluster in.
 - Your preferred node instance type.


### PR DESCRIPTION
Maybe during the normal onboarding this gets shared with the field engineers, but when we (CRE) are trying to launch a cluster for a customer, we need them to provide this