### PR TITLE
Add error notifications concept guide to the sidebar

### DIFF
--- a/sidebarsLearn.js
+++ b/sidebarsLearn.js
@@ -54,6 +54,7 @@ module.exports = {
             'managing-airflow-code',
             'templating',
             'cross-dag-dependencies',
+            'error-notifications-in-airflow',
           ],
         },
         {


### PR DESCRIPTION
Noticed that the [Manage Airflow DAG notifications concept guide](https://docs.astronomer.io/learn/error-notifications-in-airflow) does not show up in the sidebar. 