### PR TITLE
Small changes to the SQL check operator concept guide

### DIFF
--- a/learn/airflow-sql-data-quality.md
+++ b/learn/airflow-sql-data-quality.md
@@ -28,7 +28,7 @@ The following SQL Check operators are recommended for implementing data quality 
 
 - **[`SQLColumnCheckOperator`](https://registry.astronomer.io/providers/common-sql/modules/sqlcolumncheckoperator)**: Runs multiple predefined data quality checks on multiple columns within the same task.
 - **[`SQLTableCheckOperator`](https://registry.astronomer.io/providers/common-sql/modules/sqltablecheckoperator)**: Runs multiple user-defined checks on one or more columns of a table.
-- **[`SQLCheckOperator`](https://registry.astronomer.io/providers/apache-airflow/modules/sqlcheckoperator)**: Takes any SQL query and returns a single row that is evaluated to booleans. This operator is useful for more complicated checks (e.g. spanning several tables of your database).
+- **[`SQLCheckOperator`](https://registry.astronomer.io/providers/apache-airflow/modules/sqlcheckoperator)**: Takes any SQL query and returns a single row that is evaluated to booleans. This operator is useful for more complicated checks that could span several tables of your database.
 - **[`SQLIntervalCheckOperator`](https://registry.astronomer.io/providers/apache-airflow/modules/sqlintervalcheckoperator)**: Checks current data against historical data.
 
 Additionally, two older SQL Check operators exist that can run one check at a time against a defined value or threshold:
@@ -152,7 +152,7 @@ The `SQLTableCheckOperator` is useful for:
 
 - Checks that include aggregate values using the whole table (e.g. comparing the average of one column to the average of another using the SQL `AVG()` function).
 - Row count checks.
-- Checking if a date is between certain bounds (e.g. using `MY_DATE_COL BETWEEN '2019-01-01' AND '2019-12-31'` to make sure only dates in the year 2019 occur).
+- Checking if a date is between certain bounds (for example, using `MY_DATE_COL BETWEEN '2019-01-01' AND '2019-12-31'` to make sure only dates in the year 2019 exist).
 - Comparisons between multiple columns, both aggregated and not aggregated.
 
 In the example below, three checks are defined: `my_row_count_check`, `my_column_sum_comparison_check` and  `my_column_addition_check`. The first check runs a SQL statement asserting that the table contains at least 1000 rows, the second check compares the sum of two columns, and the third check confirms that for each row `MY_COL_1 + MY_COL_2 = MY_COL_3` is true.

--- a/learn/airflow-sql-data-quality.md
+++ b/learn/airflow-sql-data-quality.md
@@ -69,7 +69,7 @@ This check is useful for:
 
 In the example below, 5 checks are performed on 3 different columns using the `SQLColumnCheckOperator`:
 
-- "MY_DATE_COL" is checked to ensure that it contains only _unique_ dates.
+- "MY_DATE_COL" is checked to ensure that it contains only unique dates.
 - "MY_TEXT_COL" is checked to ensure it has at least 10 distinct values and no `NULL` values.
 - "MY_NUM_COL" is checked to ensure it contains a minimum value of less than 10 and a maximum value of 100 with a 10% tolerance (maximum values between 90 and 110 are accepted).
 


### PR DESCRIPTION
Since this guide came out one bug has been fixed: it used to be necessary to separate aggregated from not-aggregated checks in the SQLTableCheckOperator, this is not necessary anymore.

Also both the SQLColumnCheckOperator and SQLTableCheckOperator will get a major update soon. This PR does not include the new functionality yet but moves datetime checks from the SQLColumn to the SQLTableCheckOperator because as of the next operator release datetime checks wont be possible anymore in the SQLColumnCheckOperator (min/max are only for numeric values).  

I am PRing this now because with the blog post coming out later this week I expect some traffic on the guide and think it should be up to date :) 