### PR TITLE
Fix alignment issue on docs cards

### DIFF
--- a/src/theme/DocCard/index.js
+++ b/src/theme/DocCard/index.js
@@ -23,7 +23,7 @@ function CardLayout({item, href, icon, title, description}) {
   return (
     <CardContainer href={href}>
       <h2 className={clsx('text--truncate', styles.cardTitle)} title={title}>
-        {icon} &nbsp; {title}
+        {icon}&nbsp;{title}
       </h2>
       {description && (
         <p

--- a/src/theme/DocCard/index.js
+++ b/src/theme/DocCard/index.js
@@ -23,7 +23,7 @@ function CardLayout({item, href, icon, title, description}) {
   return (
     <CardContainer href={href}>
       <h2 className={clsx('text--truncate', styles.cardTitle)} title={title}>
-        {icon} {title}
+        {icon} &nbsp; {title}
       </h2>
       {description && (
         <p

--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -20,7 +20,12 @@
 
 .cardTitle {
   font-size: 1.2rem;
+  display: flex;
 }
+
+/* .cardTitle img {
+  vertical-align: middle;
+} */
 
 .cardDescription {
   font-size: 0.8rem;


### PR DESCRIPTION
The icons and titles on docs pages were out of alignment and it was bugging me :). Before and after screenshots below:

Before:
<img width="582" alt="image" src="https://user-images.githubusercontent.com/32076749/198169980-4b412007-503d-44de-bc75-764b60841c20.png">

After:
<img width="578" alt="image" src="https://user-images.githubusercontent.com/32076749/198170057-795a9333-e60a-46df-aba9-f0b416c760f5.png">
