### PR TITLE
Adjust 5.0 EOL and Stable maintenance windows

### DIFF
--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -30,10 +30,10 @@ For customers looking for less frequent upgrades and functional changes, we reco
 
 The maintenance period for an Astro Runtime version depends on its release channel:
 
-| Release Channel | Maintenance Duration |
-| --------------- | -------------------- |
-| Stable          | 6 Months             |
-| LTS             | 18 Months            |
+| Release Channel | Maintenance Duration                                                        |
+| --------------- | --------------------------------------------------------------------------- |
+| Stable          | 6 months or 3 months after next major Runtime release (whichever is longer) |
+| LTS             | 18 months                                                                   |
 
 For each `major.minor` pair, only the latest patch is supported at any given time. If you report an issue with an Astro Runtime patch version that is not latest, the Astronomer Support team will always ask that you upgrade as a first step to resolution. For example, we encourage any user who reports an issue with Astro Runtime 4.0.2 to first upgrade to the latest 4.0.x version as soon as it's generally available.
 
@@ -83,9 +83,8 @@ The following table contains the exact lifecycle for each published version of A
 
 | Runtime Version                                     | Apache Airflow version | Release Date       | End of Maintenance Date |
 | --------------------------------------------------- | ---------------------- | ------------------ | ----------------------- |
-| [4.1.x](runtime-release-notes.md#astro-runtime-410) | 2.2.4                  | February 22, 2022  | August 2022             |
 | [4.2.x](runtime-release-notes.md#astro-runtime-420) | 2.2.4-2.2.5            | March 10, 2022     | September 2023          |
-| [5.0.x](runtime-release-notes.md#astro-runtime-500) | 2.3.0-2.3.4            | April 30, 2022     | October 2022            |
+| [5.0.x](runtime-release-notes.md#astro-runtime-500) | 2.3.0-2.3.4            | April 30, 2022     | December 2022           |
 | [6.0.x](runtime-release-notes.md#astro-runtime-600) | 2.4.0-2.4.1            | September 19, 2022 | March 2024              |
 
 ### Long-term support (LTS) releases 

--- a/software/runtime-version-lifecycle-policy.md
+++ b/software/runtime-version-lifecycle-policy.md
@@ -26,10 +26,10 @@ For customers looking for less frequent upgrades and functional changes, we reco
 
 The maintenance period for an Astro Runtime version depends on its release channel:
 
-| Release Channel | Maintenance Duration |
-| --------------- | -------------------- |
-| Stable          | 6 Months             |
-| LTS             | 18 Months            |
+| Release Channel | Maintenance Duration                                                        |
+| --------------- | --------------------------------------------------------------------------- |
+| Stable          | 6 months or 3 months after next major Runtime release (whichever is longer) |
+| LTS             | 18 months                                                                   |
 
 For each `major.minor` pair, only the latest patch is supported at any given time. If you report an issue with an Astro Runtime patch version that is not latest, the Astronomer Support team will always ask that you upgrade as a first step to resolution. For example, we encourage any user who reports an issue with Astro Runtime 4.0.2 to first upgrade to the latest 4.0.x version as soon as it's generally available.
 
@@ -77,9 +77,8 @@ The following table contains the exact lifecycle for each published version of A
 
 | Runtime Version                                     | Apache Airflow version | Release Date       | End of Maintenance Date |
 | --------------------------------------------------- | ---------------------- | ------------------ | ----------------------- |
-| [4.1.x](runtime-release-notes.md#astro-runtime-410) | 2.2.4                  | February 22, 2022  | August 2022             |
 | [4.2.x](runtime-release-notes.md#astro-runtime-420) | 2.2.4-2.2.5            | March 10, 2022     | September 2023          |
-| [5.0.x](runtime-release-notes.md#astro-runtime-500) | 2.3.0-2.3.4            | April 30, 2022     | October 2022            |
+| [5.0.x](runtime-release-notes.md#astro-runtime-500) | 2.3.0-2.3.4            | April 30, 2022     | December 2022           |
 | [6.0.x](runtime-release-notes.md#astro-runtime-600) | 2.4.0-2.4.1            | September 19, 2022 | March 2024              |
 
 ### Long-term support (LTS) releases 


### PR DESCRIPTION
We've decided to start supporting a runtime minor for 6 months OR 3 months after the next runtime major (e.g. Airflow minor), whichever is longer.