### PR TITLE
Standardize language in concept guides

### DIFF
--- a/learn/airflow-passing-data-between-tasks.md
+++ b/learn/airflow-passing-data-between-tasks.md
@@ -11,7 +11,7 @@ id: airflow-passing-data-between-tasks
 
 Sharing data between tasks is a very common use case in Airflow. If you've been writing DAGs, you probably know that breaking them up into smaller tasks is a best practice for debugging and recovering quickly from failures. What do you do when one of your downstream tasks requires metadata about an upstream task, or processes the results of the task immediately before it?
 
-There are a few methods you can use to implement data sharing between your Airflow tasks. In this tutorial, you'll walk through the two most commonly used methods, learn when to use them, and use some example DAGs to understand how they can be implemented.
+There are a few methods you can use to implement data sharing between your Airflow tasks. In this concept guide, you'll walk through the two most commonly used methods, learn when to use them, and use some example DAGs to understand how they can be implemented.
 
 :::info
 

--- a/learn/airflow-passing-data-between-tasks.md
+++ b/learn/airflow-passing-data-between-tasks.md
@@ -11,7 +11,7 @@ id: airflow-passing-data-between-tasks
 
 Sharing data between tasks is a very common use case in Airflow. If you've been writing DAGs, you probably know that breaking them up into smaller tasks is a best practice for debugging and recovering quickly from failures. What do you do when one of your downstream tasks requires metadata about an upstream task, or processes the results of the task immediately before it?
 
-There are a few methods you can use to implement data sharing between your Airflow tasks. In this concept guide, you'll walk through the two most commonly used methods, learn when to use them, and use some example DAGs to understand how they can be implemented.
+There are a few methods you can use to implement data sharing between your Airflow tasks. In this guide, you'll walk through the two most commonly used methods, learn when to use them, and use some example DAGs to understand how they can be implemented.
 
 :::info
 

--- a/learn/airflow-pools.md
+++ b/learn/airflow-pools.md
@@ -9,7 +9,7 @@ One of the benefits of Apache Airflow is that it is built to scale. With the rig
 
 Pools allow you to limit parallelism for an arbitrary set of tasks, allowing you to control when your tasks are run. They are often used in cases where you want to limit the number of parallel tasks that do a certain thing. For example, tasks that make requests to the same API or database, or tasks that run on a GPU node of a Kubernetes cluster.
 
-In this tutorial, you'll learn basic Airflow pool concepts, how to create and assign pools, and what you can and can't do with pools. You'll also implement some sample DAGs that use pools to fulfill simple requirements. 
+In this concept guide, you'll learn basic Airflow pool concepts, how to create and assign pools, and what you can and can't do with pools. You'll also implement some sample DAGs that use pools to fulfill simple requirements. 
 
 ## Assumed knowledge
 

--- a/learn/airflow-pools.md
+++ b/learn/airflow-pools.md
@@ -9,7 +9,7 @@ One of the benefits of Apache Airflow is that it is built to scale. With the rig
 
 Pools allow you to limit parallelism for an arbitrary set of tasks, allowing you to control when your tasks are run. They are often used in cases where you want to limit the number of parallel tasks that do a certain thing. For example, tasks that make requests to the same API or database, or tasks that run on a GPU node of a Kubernetes cluster.
 
-In this concept guide, you'll learn basic Airflow pool concepts, how to create and assign pools, and what you can and can't do with pools. You'll also implement some sample DAGs that use pools to fulfill simple requirements. 
+In this guide, you'll learn basic Airflow pool concepts, how to create and assign pools, and what you can and can't do with pools. You'll also implement some sample DAGs that use pools to fulfill simple requirements. 
 
 ## Assumed knowledge
 

--- a/learn/airflow-scaling-workers.md
+++ b/learn/airflow-scaling-workers.md
@@ -17,7 +17,7 @@ Airflow exposes a number of parameters that are closely related to DAG and task-
 - DAG-level settings.
 - Task-level settings.
 
-In this tutorial, you'll learn about the key parameters that you can use to modify Airflow performance. you'll also learn how your choice of executor can impact scaling and how best to respond to common scaling issues.
+In this concept guide, you'll learn about the key parameters that you can use to modify Airflow performance. you'll also learn how your choice of executor can impact scaling and how best to respond to common scaling issues.
 
 This guide references the parameters available in Airflow version 2.0 and later. If you're using an earlier version of Airflow, some of the parameter names might be different.
 

--- a/learn/airflow-scaling-workers.md
+++ b/learn/airflow-scaling-workers.md
@@ -17,7 +17,7 @@ Airflow exposes a number of parameters that are closely related to DAG and task-
 - DAG-level settings.
 - Task-level settings.
 
-In this concept guide, you'll learn about the key parameters that you can use to modify Airflow performance. you'll also learn how your choice of executor can impact scaling and how best to respond to common scaling issues.
+In this guide, you'll learn about the key parameters that you can use to modify Airflow performance. you'll also learn how your choice of executor can impact scaling and how best to respond to common scaling issues.
 
 This guide references the parameters available in Airflow version 2.0 and later. If you're using an earlier version of Airflow, some of the parameter names might be different.
 

--- a/learn/airflow-sql-data-quality.md
+++ b/learn/airflow-sql-data-quality.md
@@ -9,7 +9,7 @@ Data quality is key to the success of an organization's data systems. With in-DA
 
 Executing SQL queries is one of the most common use cases for data pipelines, and it's a simple and effective way to implement data quality checks. Using Airflow, you can quickly put together a pipeline specifically for checking data quality, or you can add quality checks to existing ETL/ELT pipelines with just a few lines of boilerplate code.
 
-In this concept guide, you'll learn about three SQL Check operators and how to use them to build a robust data quality suite for your DAGs.
+In this guide, you'll learn about three SQL Check operators and how to use them to build a robust data quality suite for your DAGs.
 
 All code used in this guide is located in the [Astronomer Registry](https://github.com/astronomer/airflow-data-quality-demo/).
 

--- a/learn/airflow-sql-data-quality.md
+++ b/learn/airflow-sql-data-quality.md
@@ -9,13 +9,13 @@ Data quality is key to the success of an organization's data systems. With in-DA
 
 Executing SQL queries is one of the most common use cases for data pipelines, and it's a simple and effective way to implement data quality checks. Using Airflow, you can quickly put together a pipeline specifically for checking data quality, or you can add quality checks to existing ETL/ELT pipelines with just a few lines of boilerplate code.
 
-In this tutorial, you'll learn about three SQL Check operators and how to use them to build a robust data quality suite for your DAGs.
+In this concept guide, you'll learn about three SQL Check operators and how to use them to build a robust data quality suite for your DAGs.
 
-All code used in this tutorial is located in the [Astronomer Registry](https://github.com/astronomer/airflow-data-quality-demo/).
+All code used in this guide is located in the [Astronomer Registry](https://github.com/astronomer/airflow-data-quality-demo/).
 
 ## Assumed knowledge
 
-To get the most out of this tutorial, you should have an understanding of:
+To get the most out of this guide, you should have an understanding of:
 
 - How to design a data quality process. See [Data quality and Airflow](data-quality.md).
 - Running SQL from Airflow. See [Using Airflow to execute SQL](airflow-sql.md).

--- a/learn/airflow-sql.md
+++ b/learn/airflow-sql.md
@@ -12,11 +12,11 @@ sidebar_label: "Run SQL"
 
 Executing SQL queries is one of the most common use cases for data pipelines. Whether you're extracting and loading data, calling a stored procedure, or executing a complex query for a report, Airflow has you covered. Using Airflow, you can orchestrate all of your SQL tasks elegantly with just a few lines of boilerplate code.
 
-In this tutorial you'll learn about the best practices for executing SQL from your DAG, review the  most commonly used Airflow SQL-related operators, and then use sample code to implement a few common SQL use cases.
+In this concept guide you'll learn about the best practices for executing SQL from your DAG, review the  most commonly used Airflow SQL-related operators, and then use sample code to implement a few common SQL use cases.
 
 :::info
 
-All code used in this tutorial is located in the [Astronomer GitHub](https://github.com/astronomer/airflow-sql).
+All code used in this guide is located in the [Astronomer GitHub](https://github.com/astronomer/airflow-sql).
 
 :::
 
@@ -61,7 +61,7 @@ Remember that Airflow is primarily an orchestrator, not a transformation framewo
 
 ## SQL operators
 
-To make working with SQL easier, Airflow includes many built in operators. This tutorial discusses some of the most commonly used operators and shouldn't be considered a definitive resource. For more information about the available Airflow operators, see [airflow.operators](https://airflow.apache.org/docs/stable/_api/airflow/operators/index.html#).
+To make working with SQL easier, Airflow includes many built in operators. This guide discusses some of the most commonly used operators and shouldn't be considered a definitive resource. For more information about the available Airflow operators, see [airflow.operators](https://airflow.apache.org/docs/stable/_api/airflow/operators/index.html#).
 
 :::info
 
@@ -92,7 +92,7 @@ Transfer operators move data from a source to a destination. For SQL-related tas
 
 ## Examples
 
-Now that you've learned about the most commonly used Airflow SQL operators, you'll use the operators in some SQL use cases. For this tutorial you'll use [Snowflake](https://www.snowflake.com/), but the concepts shown can be adapted for other databases. Some of the environment setup for each example makes use of the [Astro CLI](https://docs.astronomer.io/astro/cli/overview) and Astro project structure, but you can also adapt this setup for use with Apache Airflow.
+Now that you've learned about the most commonly used Airflow SQL operators, you'll use the operators in some SQL use cases. For this guide you'll use [Snowflake](https://www.snowflake.com/), but the concepts shown can be adapted for other databases. Some of the environment setup for each example makes use of the [Astro CLI](https://docs.astronomer.io/astro/cli/overview) and Astro project structure, but you can also adapt this setup for use with Apache Airflow.
 
 ### Example 1: Execute a query
 

--- a/learn/airflow-sql.md
+++ b/learn/airflow-sql.md
@@ -12,7 +12,7 @@ sidebar_label: "Run SQL"
 
 Executing SQL queries is one of the most common use cases for data pipelines. Whether you're extracting and loading data, calling a stored procedure, or executing a complex query for a report, Airflow has you covered. Using Airflow, you can orchestrate all of your SQL tasks elegantly with just a few lines of boilerplate code.
 
-In this concept guide you'll learn about the best practices for executing SQL from your DAG, review the  most commonly used Airflow SQL-related operators, and then use sample code to implement a few common SQL use cases.
+In this guide you'll learn about the best practices for executing SQL from your DAG, review the  most commonly used Airflow SQL-related operators, and then use sample code to implement a few common SQL use cases.
 
 :::info
 

--- a/learn/connections.md
+++ b/learn/connections.md
@@ -11,7 +11,7 @@ id: connections
 
 Connections in Airflow are sets of configurations used to connect with other tools in the data ecosystem. Because most hooks and operators rely on connections to send and retrieve data from external systems, understanding how to create and configure them is essential for running Airflow in a production environment.
 
-In this tutorial you'll:
+In this concept guide you'll:
 
 - Learn about Airflow connections.
 - Learn how to define connections using the Airflow UI.

--- a/learn/connections.md
+++ b/learn/connections.md
@@ -11,7 +11,7 @@ id: connections
 
 Connections in Airflow are sets of configurations used to connect with other tools in the data ecosystem. Because most hooks and operators rely on connections to send and retrieve data from external systems, understanding how to create and configure them is essential for running Airflow in a production environment.
 
-In this concept guide you'll:
+In this guide you'll:
 
 - Learn about Airflow connections.
 - Learn how to define connections using the Airflow UI.
@@ -20,7 +20,7 @@ In this concept guide you'll:
 
 ## Assumed knowledge
 
-To get the most out of this concept guide, you should have an understanding of:
+To get the most out of this guide, you should have an understanding of:
 
 - Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md/).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
@@ -39,7 +39,7 @@ Airflow connections can be created by using one of the following methods:
 - The [`airflow.cfg` file](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html)
 - The [Airflow CLI](https://airflow.apache.org/docs/apache-airflow/stable/usage-cli.html)
 
-This concept guide focuses on adding connections using the Airflow UI and environment variables. For more in-depth information on configuring connections using other methods, see the [REST API reference](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Connection), [Managing Connections](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) and [Secrets Backend](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html).
+This guide focuses on adding connections using the Airflow UI and environment variables. For more in-depth information on configuring connections using other methods, see the [REST API reference](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Connection), [Managing Connections](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) and [Secrets Backend](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html).
 
 Each connection has a unique `conn_id` which can be provided to operators and [hooks](what-is-a-hook.md) that require a connection.
 

--- a/learn/connections.md
+++ b/learn/connections.md
@@ -20,7 +20,7 @@ In this concept guide you'll:
 
 ## Assumed knowledge
 
-To get the most out of this tutorial, you should have an understanding of:
+To get the most out of this concept guide, you should have an understanding of:
 
 - Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md/).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
@@ -39,7 +39,7 @@ Airflow connections can be created by using one of the following methods:
 - The [`airflow.cfg` file](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html)
 - The [Airflow CLI](https://airflow.apache.org/docs/apache-airflow/stable/usage-cli.html)
 
-This tutorial focuses on adding connections using the Airflow UI and environment variables. For more in-depth information on configuring connections using other methods, see the [REST API reference](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Connection), [Managing Connections](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) and [Secrets Backend](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html).
+This concept guide focuses on adding connections using the Airflow UI and environment variables. For more in-depth information on configuring connections using other methods, see the [REST API reference](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Connection), [Managing Connections](https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html) and [Secrets Backend](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html).
 
 Each connection has a unique `conn_id` which can be provided to operators and [hooks](what-is-a-hook.md) that require a connection.
 

--- a/learn/custom-xcom-backends.md
+++ b/learn/custom-xcom-backends.md
@@ -11,7 +11,7 @@ As part of this update, support was introduced for configuring [custom XCom back
 
 This guide discusses the benefits of using an XCom backend, shows an example of implementing an XCom backend with Airflow S3, and describes how to set this up if you're running Airflow on Astro.
 
-All code used in this tutorial is located in the [Astronomer Registry](https://github.com/astronomer/custom-xcom-backend-tutorial).
+All code used in this concept guide is located in the [Astronomer Registry](https://github.com/astronomer/custom-xcom-backend-tutorial).
 
 ## Assumed knowledge
 

--- a/learn/custom-xcom-backends.md
+++ b/learn/custom-xcom-backends.md
@@ -11,7 +11,7 @@ As part of this update, support was introduced for configuring [custom XCom back
 
 This guide discusses the benefits of using an XCom backend, shows an example of implementing an XCom backend with Airflow S3, and describes how to set this up if you're running Airflow on Astro.
 
-All code used in this concept guide is located in the [Astronomer Registry](https://github.com/astronomer/custom-xcom-backend-tutorial).
+All code used in this guide is located in the [Astronomer Registry](https://github.com/astronomer/custom-xcom-backend-tutorial).
 
 ## Assumed knowledge
 

--- a/learn/dags.md
+++ b/learn/dags.md
@@ -12,7 +12,7 @@ id: dags
 
 In Airflow, data pipelines are defined in Python code as directed acyclic graphs, also known as DAGs. Within a graph, each node represents a task which completes a unit of work, and each edge represents a dependency between tasks.
 
-In this tutorial, you'll learn DAG basics and about DAG parameters and how to define a DAG in Python.
+In this concept guide, you'll learn DAG basics and about DAG parameters and how to define a DAG in Python.
 
 ## Assumed knowledge
 

--- a/learn/dags.md
+++ b/learn/dags.md
@@ -12,7 +12,7 @@ id: dags
 
 In Airflow, data pipelines are defined in Python code as directed acyclic graphs, also known as DAGs. Within a graph, each node represents a task which completes a unit of work, and each edge represents a dependency between tasks.
 
-In this concept guide, you'll learn DAG basics and about DAG parameters and how to define a DAG in Python.
+In this guide, you'll learn DAG basics and about DAG parameters and how to define a DAG in Python.
 
 ## Assumed knowledge
 

--- a/learn/dynamically-generating-dags.md
+++ b/learn/dynamically-generating-dags.md
@@ -15,7 +15,7 @@ Sometimes, manually writing DAGs isn't practical. Maybe you have hundreds or tho
 
 Because everything in Airflow is code, you can dynamically generate DAGs using Python alone. As long as a `DAG` object in `globals()` is created by Python code that is stored in the `dags_folder`, Airflow will load it. In this guide, you'll learn how to dynamically generate DAGs. You'll learn when DAG generation is the preferred option and what pitfalls to avoid.
 
-All code used in this tutorial is located in the [Astronomer Registry](https://github.com/astronomer/dynamic-dags-tutorial).
+All code used in this concept guide is located in the [Astronomer Registry](https://github.com/astronomer/dynamic-dags-tutorial).
 
 ## Assumed knowledge
 

--- a/learn/dynamically-generating-dags.md
+++ b/learn/dynamically-generating-dags.md
@@ -15,7 +15,7 @@ Sometimes, manually writing DAGs isn't practical. Maybe you have hundreds or tho
 
 Because everything in Airflow is code, you can dynamically generate DAGs using Python alone. As long as a `DAG` object in `globals()` is created by Python code that is stored in the `dags_folder`, Airflow will load it. In this guide, you'll learn how to dynamically generate DAGs. You'll learn when DAG generation is the preferred option and what pitfalls to avoid.
 
-All code used in this concept guide is located in the [Astronomer Registry](https://github.com/astronomer/dynamic-dags-tutorial).
+All code used in this guide is located in the [Astronomer Registry](https://github.com/astronomer/dynamic-dags-tutorial).
 
 ## Assumed knowledge
 

--- a/learn/soda-data-quality.md
+++ b/learn/soda-data-quality.md
@@ -13,11 +13,11 @@ Soda Core lets you:
 - Provide a SQL query within the YAML file and check against a returned value if no preset checks fit your use case.
 - Integrate data quality checks with commonly used data engineering tools such as Airflow, Apache Spark, PostgreSQL, Snowflake [and more](https://www.soda.io/integrations).
 
-In this guide, you'll learn about the key features of Soda Core and how to use it with Airflow. For an overview of data quality and the tools you can use to run data quality checks in Airflow, see [Data quality and Airflow](data-quality.md).
+In this concept guide, you'll learn about the key features of Soda Core and how to use it with Airflow. For an overview of data quality and the tools you can use to run data quality checks in Airflow, see [Data quality and Airflow](data-quality.md).
 
 ## Assumed knowledge
 
-To get the most out of this tutorial, make sure you have an understanding of:
+To get the most out of this guide, make sure you have an understanding of:
 
 - How to design a data quality process. See [Data quality and Airflow](data-quality.md).
 - The basics of Soda Core. See [How Soda Core works](https://docs.soda.io/soda-core/how-core-works.html).

--- a/learn/soda-data-quality.md
+++ b/learn/soda-data-quality.md
@@ -13,11 +13,11 @@ Soda Core lets you:
 - Provide a SQL query within the YAML file and check against a returned value if no preset checks fit your use case.
 - Integrate data quality checks with commonly used data engineering tools such as Airflow, Apache Spark, PostgreSQL, Snowflake [and more](https://www.soda.io/integrations).
 
-In this concept guide, you'll learn about the key features of Soda Core and how to use it with Airflow. For an overview of data quality and the tools you can use to run data quality checks in Airflow, see [Data quality and Airflow](data-quality.md).
+In this tutorial, you'll learn about the key features of Soda Core and how to use it with Airflow. For an overview of data quality and the tools you can use to run data quality checks in Airflow, see [Data quality and Airflow](data-quality.md).
 
 ## Assumed knowledge
 
-To get the most out of this guide, make sure you have an understanding of:
+To get the most out of this tutorial, make sure you have an understanding of:
 
 - How to design a data quality process. See [Data quality and Airflow](data-quality.md).
 - The basics of Soda Core. See [How Soda Core works](https://docs.soda.io/soda-core/how-core-works.html).


### PR DESCRIPTION
I noticed some of the concept guides referred to themselves as tutorials. Replaced those instances with "concept guide" or "guide". 