### PR TITLE
Fix testing airflow code snippets

### DIFF
--- a/learn/testing-airflow.md
+++ b/learn/testing-airflow.md
@@ -73,54 +73,50 @@ If you are using custom hooks or operators, Astronomer recommends using unit tes
 
 ```python
 from airflow.models import BaseOperator
-from airflow.utils.decorators import apply_defaults
 
 class EvenNumberCheckOperator(BaseOperator):
-    @apply_defaults
     def __init__(self, my_operator_param, *args, **kwargs):
         self.operator_param = my_operator_param
-        super(EvenNumberCheckOperator, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def execute(self, context):
-		if self.operator_param % 2:
-		    return True
+        if self.operator_param % 2:
+            return True
         else:
-			return False
+            return False
 ```
 
 You then write a `test_evencheckoperator.py` file with unit tests similar to the following example:
 
 ```python
 import unittest
-import pytest
 from datetime import datetime
 from airflow import DAG
 from airflow.models import TaskInstance
-from airflow.operators import EvenNumberCheckOperator
 
 DEFAULT_DATE = datetime(2021, 1, 1)
 
 class EvenNumberCheckOperator(unittest.TestCase):
 
-	def setUp(self):
-      super().setUp()
-      self.dag = DAG('test_dag', default_args={'owner': 'airflow', 'start_date': DEFAULT_DATE})
-			self.even = 10
-			self.odd = 11
+    def setUp(self):
+        super().setUp()
+        self.dag = DAG('test_dag', default_args={'owner': 'airflow', 'start_date': DEFAULT_DATE})
+        self.even = 10
+        self.odd = 11
 
-	def test_even(self):
-      """Tests that the EvenNumberCheckOperator returns True for 10."""
-      task = EvenNumberCheckOperator(my_operator_param=self.even, task_id='even', dag=self.dag)
-      ti = TaskInstance(task=task, execution_date=datetime.now())
-      result = task.execute(ti.get_template_context())
-      assert result is True
+    def test_even(self):
+        """Tests that the EvenNumberCheckOperator returns True for 10."""
+        task = EvenNumberCheckOperator(my_operator_param=self.even, task_id='even', dag=self.dag)
+        ti = TaskInstance(task=task, execution_date=datetime.now())
+        result = task.execute(ti.get_template_context())
+        assert result is True
 
-	def test_odd(self):
-      """Tests that the EvenNumberCheckOperator returns False for 11."""
-      task = EvenNumberCheckOperator(my_operator_param=self.odd, task_id='odd', dag=self.dag)
-      ti = TaskInstance(task=task, execution_date=datetime.now())
-      result = task.execute(ti.get_template_context())
-      assert result is False
+    def test_odd(self):
+        """Tests that the EvenNumberCheckOperator returns False for 11."""
+        task = EvenNumberCheckOperator(my_operator_param=self.odd, task_id='odd', dag=self.dag)
+        ti = TaskInstance(task=task, execution_date=datetime.now())
+        result = task.execute(ti.get_template_context())
+        assert result is False
 ```
 
 If your DAGs contain `PythonOperators` that execute your own Python functions, it is recommended that you write unit tests for those functions as well. 
@@ -142,88 +138,91 @@ One straightforward way to implement data integrity tests is to build them direc
 There are many ways you can integrate data checks into your DAG. One method is using [Great Expectations](https://greatexpectations.io/) which is an open source Python framework for data validations. The [Great Expectations provider package](https://registry.astronomer.io/providers/great-expectations) lets you quickly integrate Great Expectations tasks into your DAGs. In the following example DAG, an Azure Data Factory pipeline generates data and then Great Expectations validates the data before sending an email.
 
 ```python
-from airflow import DAG
 from datetime import datetime, timedelta
+
 from airflow.operators.email_operator import EmailOperator
 from airflow.operators.python_operator import PythonOperator
-from airflow.providers.microsoft.azure.hooks.azure_data_factory import AzureDataFactoryHook
-from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 from great_expectations_provider.operators.great_expectations import GreatExpectationsOperator
 
-#Get yesterday's date, in the correct format
-yesterday_date = '{{ yesterday_ds_nodash }}'
+from airflow import DAG
+from airflow.providers.microsoft.azure.hooks.azure_data_factory import AzureDataFactoryHook
+from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 
-#Define Great Expectations file paths
-data_dir = '/usr/local/airflow/include/data/'
-data_file_path = '/usr/local/airflow/include/data/'
-ge_root_dir = '/usr/local/airflow/include/great_expectations'
+# Get yesterday's date, in the correct format
+yesterday_date = "{{ yesterday_ds_nodash }}"
+
+# Define Great Expectations file paths
+data_dir = "/usr/local/airflow/include/data/"
+data_file_path = "/usr/local/airflow/include/data/"
+ge_root_dir = "/usr/local/airflow/include/great_expectations"
+
 
 def run_adf_pipeline(pipeline_name, date):
-    '''Runs an Azure Data Factory pipeline using the AzureDataFactoryHook and passes in a date parameter
-    '''
-    
-    #Create a dictionary with date parameter 
+    """Runs an Azure Data Factory pipeline using the AzureDataFactoryHook and passes in a date parameter"""
+
+    # Create a dictionary with date parameter
     params = {}
     params["date"] = date
 
-    #Make connection to ADF, and run pipeline with parameter
-    hook = AzureDataFactoryHook('azure_data_factory_conn')
+    # Make connection to ADF, and run pipeline with parameter
+    hook = AzureDataFactoryHook("azure_data_factory_conn")
     hook.run_pipeline(pipeline_name, parameters=params)
 
+
 def get_azure_blob_files(blobname, output_filename):
-    '''Downloads file from Azure blob storage
-    '''
-    azure = WasbHook(wasb_conn_id='azure_blob')
-    azure.get_file(output_filename, container_name='covid-data', blob_name=blobname)
-    
+    """Downloads file from Azure blob storage"""
+    azure = WasbHook(wasb_conn_id="azure_blob")
+    azure.get_file(output_filename, container_name="covid-data", blob_name=blobname)
+
 
 default_args = {
-    'owner': 'airflow',
-    'depends_on_past': False,
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'retries': 0,
-    'retry_delay': timedelta(minutes=5)
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": timedelta(minutes=5),
 }
 
-with DAG('adf_great_expectations',
-         start_date=datetime(2021, 1, 1),
-         max_active_runs=1,
-         schedule_interval='@daily', 
-         default_args=default_args,
-         catchup=False
-         ) as dag:
+with DAG(
+    "adf_great_expectations",
+    start_date=datetime(2021, 1, 1),
+    max_active_runs=1,
+    schedule_interval="@daily",
+    default_args=default_args,
+    catchup=False,
+) as dag:
 
-         run_pipeline = PythonOperator(
-            task_id='run_pipeline',
-            python_callable=run_adf_pipeline,
-            op_kwargs={'pipeline_name': 'pipeline1', 'date': yesterday_date}
-         )
+    run_pipeline = PythonOperator(
+        task_id="run_pipeline",
+        python_callable=run_adf_pipeline,
+        op_kwargs={"pipeline_name": "pipeline1", "date": yesterday_date},
+    )
 
-         download_data = PythonOperator(
-            task_id='download_data',
-            python_callable=get_azure_blob_files,
-            op_kwargs={'blobname': 'or/'+ yesterday_date +'.csv', 'output_filename': data_file_path+'or_'+yesterday_date+'.csv'}
-         )
+    download_data = PythonOperator(
+        task_id="download_data",
+        python_callable=get_azure_blob_files,
+        op_kwargs={
+            "blobname": "or/" + yesterday_date + ".csv",
+            "output_filename": data_file_path + "or_" + yesterday_date + ".csv",
+        },
+    )
 
-         ge_check = GreatExpectationsOperator(
-            task_id='ge_checkpoint',
-            expectation_suite_name='azure.demo',
-            batch_kwargs={
-                'path': data_file_path+'or_'+yesterday_date+'.csv',
-                'datasource': 'data__dir'
-            },
-            data_context_root_dir=ge_root_dir
-        )
+    ge_check = GreatExpectationsOperator(
+        task_id="ge_checkpoint",
+        expectation_suite_name="azure.demo",
+        batch_kwargs={"path": data_file_path + "or_" + yesterday_date + ".csv", "datasource": "data__dir"},
+        data_context_root_dir=ge_root_dir,
+    )
 
-         send_email = EmailOperator(
-            task_id='send_email',
-            to='noreply@astronomer.io',
-            subject='Covid to S3 DAG',
-            html_content='<p>The great expectations checks passed successfully. <p>'
-        )
+    send_email = EmailOperator(
+        task_id="send_email",
+        to="noreply@astronomer.io",
+        subject="Covid to S3 DAG",
+        html_content="<p>The great expectations checks passed successfully. <p>",
+    )
 
-         run_pipeline >> download_data >> ge_check >> send_email
+    run_pipeline >> download_data >> ge_check >> send_email
 ```
 
 If the Great Expectations validation fails, all downstream tasks are skipped. Implementing checkpoints like this allows you to conditionally branch your pipeline to deal with data that doesn't meet your criteria, or skip all downstream tasks so problematic data won't be loaded into your data warehouse or fed to a model. For more information on conditional DAG design, see [Trigger Rules](https://airflow.apache.org/docs/apache-airflow/2.0.0/concepts.html#trigger-rules) and [Branching in Airflow](airflow-branch-operator.md).

--- a/learn/testing-airflow.md
+++ b/learn/testing-airflow.md
@@ -38,23 +38,22 @@ python your-dag-file.py
 To test for import errors, run a command similar to the following example:
 
 ```python
-import pytest
 from airflow.models import DagBag
 
 def test_no_import_errors():
-  dag_bag = DagBag()
-  assert len(dag_bag.import_errors) == 0, "No Import Failures"
+    dag_bag = DagBag()
+    assert len(dag_bag.import_errors) == 0, "No Import Failures"
 ```
 
 You can also use DAG validation tests to test for properties that you want to be consistent across all DAGs. For example, if all of your DAGs must include two retries for each task, run a command similar to the following example to enforce this requirement:
 
 ```python
 def test_retries_present():
-  dag_bag = DagBag()
-  for dag in dag_bag.dags:
-      retries = dag_bag.dags[dag].default_args.get('retries', [])
-      error_msg = 'Retries not set to 2 for DAG {id}'.format(id=dag)
-      assert retries == 2, error_msg
+    dag_bag = DagBag()
+    for dag in dag_bag.dags:
+        retries = dag_bag.dags[dag].default_args.get('retries', [])
+        error_msg = 'Retries not set to 2 for DAG {id}'.format(id=dag)
+        assert retries == 2, error_msg
 ```
 
 To see an example of running these tests as part of a CI/CD workflow, see the [airflow-testing-guide](https://github.com/astronomer/airflow-testing-guide)repository.
@@ -65,7 +64,7 @@ To see an example of running these tests as part of a CI/CD workflow, see the [a
 
 ```python
 def test_function_returns_5():
-	assert my_function(input) == 5
+    assert my_function(input) == 5
 ```
 
 In the context of Airflow, you can write unit tests for any part of your DAG, but they are most frequently applied to hooks and operators. All Airflow hooks, operators, and provider packages must pass unit testing before code can be merged into the project. For an example of unit testing, see [AWS `S3Hook`](https://registry.astronomer.io/providers/amazon/modules/s3hook) and the associated [unit tests](https://github.com/apache/airflow/blob/main/tests/providers/amazon/aws/hooks/test_s3.py). 
@@ -83,10 +82,10 @@ class EvenNumberCheckOperator(BaseOperator):
         super(EvenNumberCheckOperator, self).__init__(*args, **kwargs)
 
     def execute(self, context):
-				if self.operator_param % 2:
-						return True
+		if self.operator_param % 2:
+		    return True
         else:
-						return False
+			return False
 ```
 
 You then write a `test_evencheckoperator.py` file with unit tests similar to the following example:


### PR DESCRIPTION
The indentation in code snippets in https://docs.astronomer.io/learn/testing-airflow is off (mix of tabs & spaces, NBSP chars, too many whitespaces, etc). This PR fixes the code samples in that doc.