### PR TITLE
Fix GitHub link to Airflow SQL DAGs tutorial code

### DIFF
--- a/learn/airflow-sql.md
+++ b/learn/airflow-sql.md
@@ -16,7 +16,7 @@ In this guide you'll learn about the best practices for executing SQL from your 
 
 :::info
 
-All code used in this guide is located in the [Astronomer GitHub](https://github.com/astronomer/airflow-sql).
+All code used in this guide is located in the [Astronomer GitHub](https://github.com/astronomer/airflow-sql-tutorial).
 
 :::
 


### PR DESCRIPTION
The current link to the GitHub repo for the Airflow DAGs code is outdated. This PR fixes this link in the documentation for SQL use cases. 