### PR TITLE
Update AWS Secret Manager env

### DIFF
--- a/astro/secrets-backend.md
+++ b/astro/secrets-backend.md
@@ -119,8 +119,8 @@ For more information on adding secrets to Secrets Manager, see [AWS documentatio
 1. Add the following lines to your `Dockerfile`:
 
     ```dockerfile
-    ENV AIRFLOW__SECRETS__BACKEND=airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend
-    ENV AIRFLOW__SECRETS__BACKEND_KWARGS={"connections_prefix": "/airflow/connections", "variables_prefix": "/airflow/variables",  "role_arn": $SECRETS_BACKEND_ARN, "region_name": $SECRETS_BACKEND_REGION}
+    ENV AIRFLOW__SECRETS__BACKEND=airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend
+    ENV AIRFLOW__SECRETS__BACKEND_KWARGS={"connections_prefix": "airflow/connections", "variables_prefix": "airflow/variables",  "role_arn": $SECRETS_BACKEND_ARN, "region_name": $SECRETS_BACKEND_REGION}
     ```
 
 2. Add the following lines to your `.env` file:


### PR DESCRIPTION
The env was configured to use the AWS Parameter Store instead of the Secret Manager and there was one extra / in the variable and connection address.