### PR TITLE
Runtime 6.0.4 release notes

### DIFF
--- a/astro/release-notes.md
+++ b/astro/release-notes.md
@@ -13,7 +13,7 @@ Astronomer is committed to continuous delivery of both features and bug fixes to
 
 If you have any questions or a bug to report, reach out to [Astronomer support](https://cloud.astronomer.io/support).
 
-**Latest Astro Runtime Version**: 6.0.3 ([Release notes](runtime-release-notes.md))
+**Latest Astro Runtime Version**: 6.0.4 ([Release notes](runtime-release-notes.md))
 
 **Latest CLI Version**: 1.7.0 ([Release notes](cli/release-notes.md))
 

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -16,6 +16,38 @@ Astro Runtime is a Docker image built and published by Astronomer that extends t
 
 To upgrade Astro Runtime, see [Upgrade Astro Runtime](upgrade-runtime.md). For general product release notes, see [Astro Release Notes](release-notes.md). If you have any questions or a bug to report, contact [Astronomer support](https://cloud.astronomer.io/support).
 
+## Astro Runtime 6.0.4
+
+- Release date: November 14, 2022
+- Airflow version: 2.4.3
+
+### Support for ARM64 and Apple M1 processors in local development 
+
+:::warning Astro CLI version dependency 
+
+To deploy a project using Astro Runtime 6.0.4 to Astro, you must use Astro CLI version 1.5.0 or later or else the deploy will fail. See [Install the CLI](install-cli.md).
+
+:::
+
+Astro Runtime images now support both AMD64 and ARM64 processor architectures for local development. Because the Astro Runtime image tag is multi-arch, it automatically uses the correct distribution for the architecture on which you're running the image. 
+
+Users testing Airflow locally on ARM64-based processors, such as the Apple M1, should see a significant performance improvement when starting Airflow using `astro dev start`. 
+
+### Airflow 2.4.3 
+
+Astro Runtime 6.0.4 includes same-day support for Airflow 2.4.3, which includes a collection of bug fixes. Fixes include:
+
+- Make `RotatingFilehandler` used in `DagProcessor` non-caching ([27223](https://github.com/apache/airflow/pull/27223))
+- Fix double logging with some task logging handler ([27591](https://github.com/apache/airflow/pull/27591))
+
+For a complete list of commits, see the [Apache Airflow 2.4.3 release notes](https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-4-3-2022-11-14).
+
+### Additional improvements 
+
+- Upgraded `openlineage-airflow` to 0.16.1. This release includes the `DefaultExtractor`, which allows you to extract the default available OpenLineage data for external operators without needing to write a custom extractor. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/releases/tag/0.16.1) for more information. 
+- Upgraded `astronomer-providers` to 1.11.1, which includes bug fixes. For a complete list of changes, see the [Astronomer Providers changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#1111-2022-10-28).
+
+
 ## Astro Runtime 6.0.3
 
 - Release date: October 24, 2022

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -29,9 +29,11 @@ To deploy a project using Astro Runtime 6.0.4 from an Apple M1 computer to Astro
 
 :::
 
-Astro Runtime images now support both AMD64 and ARM64 processor architectures for local development. Because the Astro Runtime image tag is multi-arch, it automatically uses the correct distribution for the architecture on which you're running the image. 
+Astro Runtime images now support both AMD64 and ARM64 processor architectures for local development. When you install Astro Runtime 6.0.4 or later, Docker automatically runs the correct architecture based on the computer you're using.
 
-Users testing Airflow locally on ARM64-based processors, such as the Apple M1, should see a significant performance improvement when starting Airflow using `astro dev start`. 
+If you run the Astro CLI on a Mac computer that uses an ARM-based [Apple M1 Silicon chip](https://www.apple.com/newsroom/2020/11/apple-unleashes-m1/), you will see a significant performance improvement when running Airflow locally. For example, the time it takes to run `astro dev start` on average has decreased from over 5 minutes to less than 2 minutes.
+
+For more information on developing locally with the Astro CLI, see [Develop a Project](develop-project.md)
 
 ### Airflow 2.4.3 
 

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -40,12 +40,12 @@ Astro Runtime 6.0.4 includes same-day support for Airflow 2.4.3, which includes 
 - Make `RotatingFilehandler` used in `DagProcessor` non-caching ([27223](https://github.com/apache/airflow/pull/27223))
 - Fix double logging with some task logging handler ([27591](https://github.com/apache/airflow/pull/27591))
 
-For a complete list of commits, see the [Apache Airflow 2.4.3 release notes](https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-4-3-2022-11-14).
+For a complete list of the changes, see the [Apache Airflow 2.4.3 release notes](https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-4-3-2022-11-14).
 
 ### Additional improvements 
 
 - Upgraded `openlineage-airflow` to 0.16.1. This release includes the `DefaultExtractor`, which allows you to extract the default available OpenLineage data for external operators without needing to write a custom extractor. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/releases/tag/0.16.1) for more information. 
-- Upgraded `astronomer-providers` to 1.11.1, which includes bug fixes. For a complete list of changes, see the [Astronomer Providers changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#1111-2022-10-28).
+- Upgraded `astronomer-providers` to 1.11.1, which includes bug fixes. For a complete list of the changes, see the [Astronomer Providers changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#1111-2022-10-28).
 
 
 ## Astro Runtime 6.0.3

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -21,11 +21,11 @@ To upgrade Astro Runtime, see [Upgrade Astro Runtime](upgrade-runtime.md). For g
 - Release date: November 14, 2022
 - Airflow version: 2.4.3
 
-### Support for ARM64 and Apple M1 processors in local development 
+### ARM64-based images for faster local development with Apple M1
 
-:::warning Astro CLI version dependency 
+:::caution
 
-To deploy a project using Astro Runtime 6.0.4 to Astro, you must use Astro CLI version 1.5.0 or later or else the deploy will fail. See [Install the CLI](install-cli.md).
+To deploy a project using Astro Runtime 6.0.4 from an Apple M1 computer to Astro, you must use Astro CLI version 1.4.0 or later or else the deploy will fail. See [Install the CLI](install-cli.md).
 
 :::
 

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,7 +1,7 @@
 export const siteVariables = {
   // version-specific
   cliVersion: '1.7.0',
-  runtimeVersion: '6.0.3',
+  runtimeVersion: '6.0.4',
   // Hacky variable so that we can use env var formatting in CI/CD templates
   deploymentid: '${ASTRONOMER_DEPLOYMENT_ID}',
   keyid: '${ASTRONOMER_KEY_ID}',


### PR DESCRIPTION
This PR only covers release notes. Updates based on the new ARM support are in https://github.com/astronomer/docs/pull/1481

When this change is approved, I'll add it to the Runtime release notes in Software as well. 