### PR TITLE
we should mention smtp server URL too

### DIFF
--- a/software/install-aws-standard.md
+++ b/software/install-aws-standard.md
@@ -293,6 +293,8 @@ astronomer:
       email:
         enabled: true
         reply: "noreply@astronomer.io" # Emails will be sent from this address
+        # The SMTP server URL.
+        smtpUrl: ~        
       auth:
         github:
           enabled: true # Lets users authenticate with Github

--- a/software/install-aws-standard.md
+++ b/software/install-aws-standard.md
@@ -293,8 +293,7 @@ astronomer:
       email:
         enabled: true
         reply: "noreply@astronomer.io" # Emails will be sent from this address
-        # The SMTP server URL.
-        smtpUrl: ~        
+        smtpUrl: ~           # The SMTP server URL
       auth:
         github:
           enabled: true # Lets users authenticate with Github


### PR DESCRIPTION
some of the users might miss SMTP URL configuration by referring to our website
an example ticket:
https://astronomer.zendesk.com/agent/tickets/14150