### PR TITLE
we should mention smtp server URL too

### DIFF
--- a/software/install-gcp-standard.md
+++ b/software/install-gcp-standard.md
@@ -319,6 +319,7 @@ astronomer:
       email:
         enabled: true
         reply: "noreply@astronomer.io" # Emails will be sent from this address
+        smtpUrl: ~           # The SMTP server URL.         
       auth:
         github:
           enabled: true # Lets users authenticate with Github


### PR DESCRIPTION
some of the users might miss SMTP URL configuration by referring to our website
an example ticket:
https://astronomer.zendesk.com/agent/tickets/14150