### PR TITLE
Slightly rework install docs

### DIFF
--- a/astro/install-aws.md
+++ b/astro/install-aws.md
@@ -100,7 +100,7 @@ If you want to continue with the second option, you'll additionally need:
 - VPC Name / ID for peering with Astronomer (accessible through the [AWS VPC console](https://console.aws.amazon.com/vpc/)).
 - The IP addresses of your DNS servers.
 
-### Access Astro
+### Step 1: Access Astro
 
 1. Go to https://cloud.astronomer.io/ and create an account, or enter your email address, and then click **Continue**.
 
@@ -113,7 +113,7 @@ If you want to continue with the second option, you'll additionally need:
 
     If you're the first person in your Organization to authenticate, you'll be granted Organization owner permissions. You can create a Workspace and add other team members to the Workspace without the assistance of Astronomer support. See [Create a Workspace](manage-workspaces.md#create-a-workspace) and [Add a user](add-user.md). To integrate an identity provider (IdP) with Astro, see [Set up an identity provider](configure-idp.md).
 
-### Retrieve an external ID from the Cloud UI
+### Step 2: Retrieve an external ID from the Cloud UI
 
 You must be an Organization Owner to view the external ID. If you are not an Organization Owner, the field will not appear in the Cloud UI.
 
@@ -123,7 +123,7 @@ You must be an Organization Owner to view the external ID. If you are not an Org
 
 3. Save the external ID as a secret or in another secure format. See [How to use an external ID when granting access to your AWS resources to a third party](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
 
-### Create a cross-account IAM role for Astro
+### Step 3: Create a cross-account IAM role for Astro
 
 Use the external ID to create a cross-account IAM role for Astro. Astronomer recommends using the AWS Management Console to create the role.
 
@@ -206,6 +206,18 @@ Use the external ID to create a cross-account IAM role for Astro. Astronomer rec
 </TabItem>
 </Tabs>
 
+### Step 4: Provide setup information to Astronomer
+
+After creating the AWS account, provide Astronomer support with the following information:
+
+- Your AWS Account ID.
+- Your preferred Astro cluster name.
+- The AWS region that you want to host your cluster in.
+- Your preferred node instance type.
+- Your preferred maximum node count.
+
+If you do not specify configuration preferences, Astronomer creates a cluster with `m5.xlarge` nodes and a maximum node count of 20 in `us-east-1`. For information on all supported regions, configurations, and defaults, see [AWS cluster configurations](resource-reference-aws.md).
+
 To provision additional Clusters after completing your initial installation, see [Create a cluster](create-cluster.md).
 
 :::caution
@@ -218,18 +230,6 @@ If you're setting up your first cluster in any of these regions, you need to com
 
 :::
 
-### Provide setup information to Astronomer
-
-After creating the AWS account, provide Astronomer support with the following information:
-
-- Your AWS Account ID.
-- Your preferred Astro cluster name.
-- The AWS region that you want to host your cluster in.
-- Your preferred node instance type.
-- Your preferred maximum node count.
-
-If you do not specify configuration preferences, Astronomer creates a cluster with `m5.xlarge` nodes and a maximum node count of 20 in `us-east-1`. For information on all supported regions, configurations, and defaults, see [AWS cluster configurations](resource-reference-aws.md).
-
 #### VPC peering prerequisites (optional)
 
 If you need to VPC peer with Astronomer, provide the following information to your Astronomer representative:
@@ -238,7 +238,7 @@ If you need to VPC peer with Astronomer, provide the following information to yo
 - VPC Name/ID and region for peering with Astronomer. This is accessible through the [AWS VPC console](https://console.aws.amazon.com/vpc/).
 - The IPs of your DNS servers.
 
-### Astronomer support creates the cluster
+### Step 5: Astronomer support creates the cluster
 
 After you've created the cross-account IAM role for Astro, contact [Astronomer support](https://cloud.astronomer.io/support). Astronomer support will finish creating the cluster in your AWS account.
 
@@ -281,13 +281,13 @@ If you want to continue with the second option, you'll additionally need:
 - VPC Name / ID for peering with Astronomer (accessible through the [AWS VPC console](https://console.aws.amazon.com/vpc/)).
 - The IP addresses of your DNS servers.
 
-### Astronomer support creates the cluster
+### Step 1: Astronomer support creates the cluster
 
 Astronomer support creates your first Astro cluster in a dedicated AWS account after you've provided your setup information.
 
 Wait for confirmation that the installation is successful before you access Astro and create a Deployment.
 
-### Access Astro
+### Step 2: Access Astro
 
 1. Optional. If you haven't created an Astronomer account, go to https://cloud.astronomer.io/ and create an account.
 
@@ -306,14 +306,18 @@ Wait for confirmation that the installation is successful before you access Astr
 
 </Tabs>
 
-## Create a Deployment
+## Next steps
+Congratulations on installing Astro on AWS! Astronomer recommends completing some of the following actions to make the most of your new installation.
+
+### Create a Deployment
 
 When Astronomer support confirms that your Astro cluster has been created, you can create a Deployment and start deploying DAGs. See [Create a Deployment](create-deployment.md). When you create your Deployment, the Astro cluster created by Astronomer support appears as an option in the **Cluster** list as shown in the following image.
 
 ![Cloud UI New Deployment screen](/img/docs/create-new-deployment-select-cluster.png)
 
-## Next steps
+### Additional documentation
 
+The following documents include setup steps for key Astro features and tools: 
 - [Set up an identity provider](configure-idp.md)
 - [Install CLI](cli/overview.md)
 - [Configure Deployments](configure-deployment-resources.md)

--- a/astro/install-aws.md
+++ b/astro/install-aws.md
@@ -47,6 +47,7 @@ Astronomer support will create a cluster within your AWS account that hosts the 
 ### Prerequisites
 
 - An AWS IAM user with the following permissions:
+
     - `cloudformation:*`
     - `GetRole`
     - `GetRolePolicy`
@@ -57,9 +58,11 @@ Astronomer support will create a cluster within your AWS account that hosts the 
     - `UpdateAssumeRolePolicy`
 
    See [Creating an administrator IAM user and user group (console)](https://docs.aws.amazon.com/IAM/latest/UserGuide/getting-started_create-admin-group.html#getting-started_create-admin-group-console).
+
 - A dedicated AWS account with minimum EC2 service quotas.
 - A subscription to the [Astro Status Page](https://status.astronomer.io/). This will ensure that you're alerted in the case of an incident or scheduled maintenance.
 - The following domains added to your organization's allowlist for any user and CI/CD environments:
+  
     - `https://cloud.astronomer.io/`
     - `https://astro-<your-org>.datakin.com/`
     - `https://<your-org>.astronomer.run/`
@@ -230,9 +233,9 @@ If you're setting up your first cluster in any of these regions, you need to com
 
 :::
 
-#### VPC peering prerequisites (optional)
+#### Provide VPC peering information (Optional)
 
-If you need to VPC peer with Astronomer, provide the following information to your Astronomer representative:
+If you need to VPC peer with Astronomer, provide the following additional information to Astronomer support:
 
 - Subnet CIDRs (RFC 1918 IP Space).
 - VPC Name/ID and region for peering with Astronomer. This is accessible through the [AWS VPC console](https://console.aws.amazon.com/vpc/).
@@ -275,7 +278,7 @@ If any AWS resources are on a private network, you can choose between two option
 - Allow traffic through the public internet and use allow-lists for communication.
 - Create a VPC Peering connection between the Astronomer VPC and the VPCs for your broader network.
 
-If you want to continue with the second option, you'll additionally need:
+If you want to continue with the second option, you'll additionally need to provide Astronomer support with:
 
 - A CIDR block (RFC 1918 IP Space) no smaller than a `/19` range. You must ensure it does not overlap with the AWS VPC(s) that you will be peering with later. The default CIDR range is `172.20.0.0/19`.
 - VPC Name / ID for peering with Astronomer (accessible through the [AWS VPC console](https://console.aws.amazon.com/vpc/)).
@@ -307,6 +310,7 @@ Wait for confirmation that the installation is successful before you access Astr
 </Tabs>
 
 ## Next steps
+
 Congratulations on installing Astro on AWS! Astronomer recommends completing some of the following actions to make the most of your new installation.
 
 ### Create a Deployment
@@ -318,6 +322,7 @@ When Astronomer support confirms that your Astro cluster has been created, you c
 ### Additional documentation
 
 The following documents include setup steps for key Astro features and tools: 
+
 - [Set up an identity provider](configure-idp.md)
 - [Install CLI](cli/overview.md)
 - [Configure Deployments](configure-deployment-resources.md)

--- a/astro/install-azure.md
+++ b/astro/install-azure.md
@@ -260,7 +260,7 @@ Wait for confirmation that the installation is successful before you access Astr
 
 </Tabs>
 
-## Create a Deployment
+## Confirm the install
 
 When Astronomer support confirms that your Astro cluster has been created, you can create a Deployment and start deploying DAGs. See [Create a Deployment](create-deployment.md). When you create your Deployment, the Astro cluster created by Astronomer support appears as an option in the **Cluster** list as shown in the following image.
 

--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -126,7 +126,7 @@ Once you've activated your data plane, provide Astronomer with:
 
 If you don't specify your organization's preferred configurations, Astronomer creates a cluster in `us-central1` with a node pool of `e2-standard-4` nodes. For more information, see [GCP resource reference](resource-reference-gcp.md).
 
-#### VPC peering with Astronomer
+#### Provide VPC peering information (Optional)
 
 Astro supports [Private Services Connect](https://cloud.google.com/vpc/docs/private-service-connect), which allows private consumption of services across VPC networks that belong to different projects or organizations. If you have created custom services that are not published using Private Services Connect, then you might want to peer with Astronomer. To set up peering, provide the following information to Astronomer:
 
@@ -194,7 +194,7 @@ Wait for confirmation that the installation is successful before you access Astr
 
 </Tabs>
 
-## Create a Deployment
+## Confirm the install
 
 When Astronomer support confirms that your Astro cluster has been created, you can create a Deployment and start deploying DAGs. See [Create a Deployment](create-deployment.md). When you create your Deployment, the Astro cluster created by Astronomer support appears as an option in the **Cluster** list as shown in the following image.
 


### PR DESCRIPTION
Noticed a few inconsistencies/ opportunities in the AWS install guide, which I can port over to the other install guides once we get approval: 

- Create a Deployment isn't really an install step, it's more of a "Next step", so I added those instructions in that section. 
- When I was reading through the install I felt a bit lost without some numbered steps within each tab, so added those back. We also had some existing steps that referenced step numbers, but those numbers had since been removed. 
- Moved a section about creating new clusters in other regions to a more relevant step
- General tidying up with headers