### PR TITLE
Change description on DAG docs tutorial.

### DIFF
--- a/learn/custom-airflow-ui-docs-tutorial.md
+++ b/learn/custom-airflow-ui-docs-tutorial.md
@@ -2,7 +2,7 @@
 title: 'Create DAG documentation in Apache Airflow'
 sidebar_label: 'Write DAG documentation'
 id: custom-airflow-ui-docs-tutorial
-description: 'Use Airflow's built-in documentation features to generate documentation for your DAGs UI.'
+description: "Use Apache Airflow's built-in documentation features to generate documentation for your DAGs in the Airflow UI."
 ---
 
 import Tabs from '@theme/Tabs';

--- a/learn/custom-airflow-ui-docs-tutorial.md
+++ b/learn/custom-airflow-ui-docs-tutorial.md
@@ -2,7 +2,7 @@
 title: 'Create DAG documentation in Apache Airflow'
 sidebar_label: 'Write DAG documentation'
 id: custom-airflow-ui-docs-tutorial
-description: 'Use tutorials and guides to make the most out of Airflow and Astronomer.'
+description: 'Use Airflow's built-in documentation features to generate documentation for your DAGs UI.'
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
I had reverted the changed description because it broke build (I think there might be a character limit on it). Then I forgot to customize the description afterwards before publishing. Sorry 😅 

EDIT: oh nvm it was a quotes issue @jwitz I used your suggested description. :) 