### PR TITLE
Modify Upgrade Astro Runtime

### DIFF
--- a/astro/upgrade-runtime.md
+++ b/astro/upgrade-runtime.md
@@ -24,6 +24,29 @@ Consider the following when you upgrade Astro Runtime:
 
 To stay up to date on the latest versions of Astro Runtime, see [Astro Runtime release notes](runtime-release-notes.md). For more information on Astro Runtime versioning and support, see [Astro Runtime versioning and lifecycle policy](runtime-version-lifecycle-policy.md). For a full collection of Astro Runtime Docker images, go to the [Astro Runtime repository on Quay.io](https://quay.io/repository/astronomer/astro-runtime?tab=tags).
 
+### Version upgrade considerations
+
+This is where you'll find the upgrade considerations for specific Astro Runtime versions. This includes breaking changes, database migrations, and other considerations.
+
+#### Runtime 6 (Airflow 2.4)
+
+Smart Sensors were deprecated in Airflow 2.2.4, and were removed in Airflow 2.4.0. If your organization is still using Smart Sensors, you'll need to move to deferrable operators. See [Deferrable operators](https://docs.astronomer.io/learn/deferrable-operators).
+
+#### Runtime 5 (Airflow 2.3)
+
+Astro Runtime 5.0.0, based on Airflow 2.3, includes changes to the schema of the Airflow metadata database. When you first upgrade to Runtime 5.0.0, consider the following:
+
+- Upgrading to Runtime 5.0.0 can take 10 to 30 minutes or more depending on the number of task instances that have been recorded in the metadata database throughout the lifetime of your Deployment on Astro.
+- Once you upgrade successfully to Runtime 5, you might see errors in the Airflow UI that warn you of incompatible data in certain tables of the database. For example:
+
+    ```txt
+    Airflow found incompatible data in the `dangling_rendered_task_instance_fields` table in your metadata database, and moved...
+    ```
+
+    These warnings have no impact on your tasks or DAGs and can be ignored. If you want to remove these warning messages from the Airflow UI, reach out to [Astronomer support](https://cloud.astronomer.io/support). If requested, Astronomer can drop incompatible tables from your metadata database.
+
+For more information on Airflow 2.3, see ["Apache Airflow 2.3.0 is here"](https://airflow.apache.org/blog/airflow-2.3.0/) or the [Airflow 2.3.0 changelog](https://airflow.apache.org/docs/apache-airflow/2.3.0/release_notes.html#airflow-2-3-0-2022-04-30).
+
 ## Prerequisites
 
 - An [Astro project](create-project.md).
@@ -36,7 +59,7 @@ If you're upgrading a local Airflow environment, you don't need an Astro Deploym
 
 :::
 
-## Step 1: Update Your Dockerfile
+## Update Your Dockerfile
 
 1. In your Astro project, open your `Dockerfile`.
 2. Change the Docker image in the `FROM` statement of your `Dockerfile` to a new version of Astro Runtime.
@@ -47,7 +70,7 @@ If you're upgrading a local Airflow environment, you don't need an Astro Deploym
 
     You must always specify the major, minor, and patch version of any given Astro Runtime version.
 
-## Step 2: Test Astro Runtime locally
+## Test Astro Runtime locally
 
 Astronomer recommends testing new versions of Astro Runtime locally before upgrading a Deployment on Astro.
 
@@ -58,7 +81,7 @@ Astronomer recommends testing new versions of Astro Runtime locally before upgra
 
     ![Runtime Version banner - Local](/img/docs/image-tag-airflow-ui-local.png)
 
-## Step 3: Deploy to Astronomer
+## Deploy to Astronomer
 
 To push your upgraded project to an Astro Deployment, run:
 
@@ -74,7 +97,7 @@ Once you upgrade to a Deployment on Astro to a new version of Astro Runtime, you
 
 :::
 
-## Step 4: Confirm your upgrade on Astro
+## Confirm your upgrade on Astro
 
 1. In the Cloud UI, select a Workspace and then select a Deployment.
 2. Click **Open Airflow**.
@@ -84,23 +107,3 @@ Once you upgrade to a Deployment on Astro to a new version of Astro Runtime, you
 
     You will also see an **Image tag** for your deploy. This tag is shown only for Deployments on Astro and is not generated for changes in a local environment.
 
-## Version upgrade considerations
-
-This topic contains information about upgrading to specific versions of Astro Runtime. This includes breaking changes, database migrations, and other considerations.
-
-### Runtime 5 (Airflow 2.3)
-
-#### Changes to the Airflow metadata database 
-
-Astro Runtime 5.0.0, based on Airflow 2.3, includes changes to the schema of the Airflow metadata database. When you first upgrade to Runtime 5.0.0, consider the following:
-
-- Upgrading to Runtime 5.0.0 can take 10 to 30 minutes or more depending on the number of task instances that have been recorded in the metadata database throughout the lifetime of your Deployment on Astro.
-- Once you upgrade successfully to Runtime 5, you might see errors in the Airflow UI that warn you of incompatible data in certain tables of the database. For example:
-
-    ```txt
-    Airflow found incompatible data in the `dangling_rendered_task_instance_fields` table in your metadata database, and moved...
-    ```
-
-    These warnings have no impact on your tasks or DAGs and can be ignored. If you want to remove these warning messages from the Airflow UI, reach out to [Astronomer support](https://cloud.astronomer.io/support). If requested, Astronomer can drop incompatible tables from your metadata database.
-
-For more information on Airflow 2.3, see ["Apache Airflow 2.3.0 is here"](https://airflow.apache.org/blog/airflow-2.3.0/) or the [Airflow 2.3.0 changelog](https://airflow.apache.org/docs/apache-airflow/2.3.0/release_notes.html#airflow-2-3-0-2022-04-30).

--- a/astro/upgrade-runtime.md
+++ b/astro/upgrade-runtime.md
@@ -30,7 +30,7 @@ This is where you'll find the upgrade considerations for specific Astro Runtime 
 
 #### Runtime 6 (Airflow 2.4)
 
-Smart Sensors were deprecated in Airflow 2.2.4, and were removed in Airflow 2.4.0. If your organization is still using Smart Sensors, you'll need to move to deferrable operators. See [Deferrable operators](https://docs.astronomer.io/learn/deferrable-operators).
+Smart Sensors were deprecated in Airflow 2.2.4 and removed in Airflow 2.4.0. If your organization is still using Smart Sensors, you'll need to start using deferrable operators. See [Deferrable operators](https://docs.astronomer.io/learn/deferrable-operators).
 
 #### Runtime 5 (Airflow 2.3)
 

--- a/learn/deferrable-operators.md
+++ b/learn/deferrable-operators.md
@@ -35,7 +35,7 @@ With deferrable operators, worker slots are released when a task is polling for 
 
 ## Use deferrable operators
 
-Deferrable operators should be used whenever you have tasks that occupy a worker slot while polling for a condition in an external system. For example, using deferrable operators for sensor tasks can provide efficiency gains and reduce operational costs. If your organization uses [smart sensors](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html#smart-sensors), you should consider using deferrable operators instead. Compared to smart sensors, which were deprecated in Airflow 2.2.4, deferrable operators offer greater functionality and are better supported by Airflow.
+Deferrable operators should be used whenever you have tasks that occupy a worker slot while polling for a condition in an external system. For example, using deferrable operators for sensor tasks can provide efficiency gains and reduce operational costs. Smart Sensors were deprecated in Airflow 2.2.4, and were removed in Airflow 2.4.0. Use deferrable operators instead of Smart Sensors because they provide greater functionality and they are supported by Airflow.
 
 To use a deferrable version of an existing operator in your DAG, you only need to replace the import statement for the existing operator. For example, Airflow's `TimeSensorAsync` is a replacement of the non-deferrable `TimeSensor` ([source](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/sensors/time_sensor/index.html?highlight=timesensor#module-contents)). To use `TimeSensorAsync`, remove your existing `import` and replace it with the following:
 


### PR DESCRIPTION
In [a Slack conversation](https://astronomer.slack.com/archives/C015V2JFKT5/p1669300007427149), Olivier Daneau asked the following question:

_Would it be possible to add a section to document upgrade considerations for Runtime 6 (to [Upgrade Astro Runtime](https://docs.astronomer.io/astro/upgrade-runtime#version-upgrade-considerations))_

Specifically, Daniel indicated that it was important "...to mention breaking changes like the removal of Smart Sensors". I did find mention of the deprecation of Smart Sensors [here](https://docs.astronomer.io/learn/deferrable-operators#use-deferrable-operators), but not in the Astro Runtime docs. 

After reviewing Upgrade Astro Runtime, I noticed that the existing section titled _Version upgrade considerations_ seemed to be in an odd location at the bottom of the topic. I relocated this information to make it easier to review _prior_ to completing the task. I also removed the step numbering for individual tasks. As discussed previously, most users understand that a collection of tasks are completed sequentially from the top of a topic to the bottom. Also, our preferred style guide makes this recommendation:

![image](https://user-images.githubusercontent.com/104205257/203824719-0ab88dc8-791e-43fe-a405-a13a4a01c82f.png)

Hand numbering a task sequence often results in errors, is difficult to maintain, and makes cross referencing awkward. Currently, sequential task numbering is applied inconsistently. I recommend a broader discussion and the removal of sequential task numbering entirely.
 