### PR TITLE
Make K8s support patch-specific

### DIFF
--- a/software/version-compatibility-reference.md
+++ b/software/version-compatibility-reference.md
@@ -15,10 +15,20 @@ While the tables below reference the minimum compatible versions, we typically r
 
 | Astronomer Platform | Kubernetes             | Astro CLI     | Postgres | Python                                    | Astronomer Certified / Astro Runtime         | Helm |
 | ------------------- | ---------------------- | ------------- | -------- | ----------------------------------------- | -------------------------------------------- | ---- |
-| v0.25               | 1.19, 1.20, 1.21       | 0.25.x        | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions*            | 3.6  |
-| v0.28               | 1.21, 1.22, 1.23, 1.24 | 1.0.x - 1.1.x | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions             | 3.6  |
-| v0.29               | 1.21, 1.22, 1.23, 1.24 | 1.3.x         | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
-| v0.30               | 1.21, 1.22, 1.23, 1.24 | 1.4.x - 1.7.x | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
+| v0.25               | 1.17¹, 1.18¹, 1.19¹, 1.20¹, 1.21       | 0.25.x        | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions*            | 3.6  |
+| v0.28               | 1.19¹, 1.20¹, 1.21, 1.22, 1.23, 1.24 | 1.0.x - 1.1.x | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions             | 3.6  |
+| v0.29               | 1.19¹, 1.20¹, 1.21, 1.22, 1.23, 1.24 | 1.3.x         | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
+| v0.30               | 1.19¹, 1.20¹, 1.21, 1.22, 1.23, 1.24 | 1.4.x - 1.7.x | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
+
+:::info
+
+¹ Some Kubernetes versions are compatible only up until a specific patch version of Astronomer Software.
+
+- Support for Kubernetes 1.17 ends with 0.25.12.
+- Support for Kubernetes 1.18 ends with 0.25.13.
+- Support for Kubernetes 1.19 and 1.20 ends with 0.25.15, 0.28.7, 0.29.5, and 0.30.4.
+
+:::
 
 For more detail about the changes in each Astronomer Software release, see the [Astronomer Software Release Notes](release-notes.md).
 
@@ -27,9 +37,17 @@ All currently supported Astronomer-distributed images are compatible with all ve
 - [Astro Runtime maintenance and lifecycle policy](runtime-version-lifecycle-policy.md)
 - [Astronomer Certified versioning and support](ac-support-policy.md)
 
-> **Note:** Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private CAs starting with Kubernetes 1.19. If you use a private CA, contact [Astronomer support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on AKS.
+:::info
 
-> **Note:** While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow triggerer is available only in Astronomer v0.26+. To use [deferrable operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), which require the Airflow triggerer, you must upgrade.
+Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private CAs starting with Kubernetes 1.19. If you use a private CA, contact [Astronomer support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on AKS.
+
+:::
+
+:::info
+
+While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow triggerer is available only in Astronomer v0.26+. To use [deferrable operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), which require the Airflow triggerer, you must upgrade.
+
+:::
 
 ### Kubernetes version support policy
 

--- a/software_versioned_docs/version-0.25/release-notes.md
+++ b/software_versioned_docs/version-0.25/release-notes.md
@@ -52,7 +52,7 @@ Release date: September 21, 2022
 
 ## 0.25.13
 
-Release date: February 23, 2021
+Release date: February 23, 2022
 
 ### Additional improvements
 

--- a/software_versioned_docs/version-0.25/version-compatibility-reference.md
+++ b/software_versioned_docs/version-0.25/version-compatibility-reference.md
@@ -24,11 +24,11 @@ While the tables below reference the minimum compatible versions, we typically r
 
 :::info
 
-¹ Some Kubernetes versions are compatible only up until a specific patch version of Astronomer Software.
+¹ Support for some Kubernetes versions is limited to specific Astronomer Software patch versions.
 
-- Support for Kubernetes 1.17 ends with 0.25.12.
-- Support for Kubernetes 1.18 ends with 0.25.13.
-- Support for Kubernetes 1.19 and 1.20 ends with 0.25.15, 0.28.7, 0.29.5, and 0.30.4.
+- Support for Kubernetes 1.17 ends with Astronomer Software 0.25.12.
+- Support for Kubernetes 1.18 ends with Astronomer Software 0.25.13.
+- Support for Kubernetes 1.19 and 1.20 ends with Astronomer Software versions 0.25.15, 0.28.7, 0.29.5, and 0.30.4.
 
 :::
 
@@ -41,13 +41,13 @@ All currently supported Astronomer-distributed images are compatible with all ve
 
 :::info
 
-Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private CAs starting with Kubernetes 1.19. If you use a private CA, contact [Astronomer support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on AKS.
+Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private Certificate Authorities (CAs) starting with Kubernetes 1.19. If your organization is using a private CA, contact [Astronomer support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on Azure Kubernetes Service (AKS).
 
 :::
 
 :::info
 
-While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow triggerer is available only in Astronomer v0.26+. To use [deferrable operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), which require the Airflow triggerer, you must upgrade.
+While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow triggerer is available only in Astronomer v0.26 and later. To use [deferrable operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), that require the Airflow triggerer, you must upgrade.
 
 :::
 

--- a/software_versioned_docs/version-0.25/version-compatibility-reference.md
+++ b/software_versioned_docs/version-0.25/version-compatibility-reference.md
@@ -15,12 +15,22 @@ While the tables below reference the minimum compatible versions, we typically r
 
 <!--- Version-specific -->
 
-| Astronomer Platform | Kubernetes             | Postgres | Python                                    | Astronomer Certified / Astro Runtime         | Helm |
-| ------------------- | ---------------------- | -------- | ----------------------------------------- | -------------------------------------------- | ---- |
-| v0.25               | 1.19, 1.20, 1.21       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions*            | 3.6  |
-| v0.28               | 1.21, 1.22, 1.23, 1.24 | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions             | 3.6  |
-| v0.29               | 1.21, 1.22, 1.23, 1.24 | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
-| v0.30               | 1.21, 1.22, 1.23, 1.24 | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
+| Astronomer Platform | Kubernetes             | Astro CLI     | Postgres | Python                                    | Astronomer Certified / Astro Runtime         | Helm |
+| ------------------- | ---------------------- | ------------- | -------- | ----------------------------------------- | -------------------------------------------- | ---- |
+| v0.25               | 1.17¹, 1.18¹, 1.19¹, 1.20¹, 1.21       | 0.25.x        | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions*            | 3.6  |
+| v0.28               | 1.19¹, 1.20¹, 1.21, 1.22, 1.23, 1.24 | 1.0.x - 1.1.x | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions             | 3.6  |
+| v0.29               | 1.19¹, 1.20¹, 1.21, 1.22, 1.23, 1.24 | 1.3.x         | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
+| v0.30               | 1.19¹, 1.20¹, 1.21, 1.22, 1.23, 1.24 | 1.4.x - 1.7.x | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
+
+:::info
+
+¹ Some Kubernetes versions are compatible only up until a specific patch version of Astronomer Software.
+
+- Support for Kubernetes 1.17 ends with 0.25.12.
+- Support for Kubernetes 1.18 ends with 0.25.13.
+- Support for Kubernetes 1.19 and 1.20 ends with 0.25.15, 0.28.7, 0.29.5, and 0.30.4.
+
+:::
 
 For more detail about the changes in each Astronomer Software release, see the [Astronomer Software Release Notes](release-notes.md).
 
@@ -29,11 +39,17 @@ All currently supported Astronomer-distributed images are compatible with all ve
 - [Astro Runtime maintenance and lifecycle policy](runtime-version-lifecycle-policy.md)
 - [Astronomer Certified versioning and support](ac-support-policy.md)
 
-> **Note:** On Astronomer v0.23+, new versions of Apache Airflow on Astronomer Certified are automatically made available in the Software UI and CLI within 24 hours of their publication. For more information, refer to [Available Astronomer Certified Versions](ac-support-policy.md#astronomer-certified-lifecycle-schedule).
+:::info
 
-> **Note:** Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private CAs starting with Kubernetes 1.19. If you use a private CA, contact [Astronomer Support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on AKS.
+Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private CAs starting with Kubernetes 1.19. If you use a private CA, contact [Astronomer support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on AKS.
 
-> **Note:** While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow Triggerer is available only in Astronomer v0.26+. To use [Deferrable Operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), which require the Airflow Triggerer, you must upgrade.
+:::
+
+:::info
+
+While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow triggerer is available only in Astronomer v0.26+. To use [deferrable operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), which require the Airflow triggerer, you must upgrade.
+
+:::
 
 ### Kubernetes Version Support Policy
 

--- a/software_versioned_docs/version-0.28/version-compatibility-reference.md
+++ b/software_versioned_docs/version-0.28/version-compatibility-reference.md
@@ -13,7 +13,6 @@ While the tables below reference the minimum compatible versions, we typically r
 
 ## Astronomer Software
 
-
 <!--- Version-specific -->
 
 | Astronomer Platform | Kubernetes             | Astro CLI     | Postgres | Python                                    | Astronomer Certified / Astro Runtime         | Helm |
@@ -25,11 +24,11 @@ While the tables below reference the minimum compatible versions, we typically r
 
 :::info
 
-¹ Some Kubernetes versions are compatible only up until a specific patch version of Astronomer Software.
+¹ Support for some Kubernetes versions is limited to specific Astronomer Software patch versions.
 
-- Support for Kubernetes 1.17 ends with 0.25.12.
-- Support for Kubernetes 1.18 ends with 0.25.13.
-- Support for Kubernetes 1.19 and 1.20 ends with 0.25.15, 0.28.7, 0.29.5, and 0.30.4.
+- Support for Kubernetes 1.17 ends with Astronomer Software 0.25.12.
+- Support for Kubernetes 1.18 ends with Astronomer Software 0.25.13.
+- Support for Kubernetes 1.19 and 1.20 ends with Astronomer Software versions 0.25.15, 0.28.7, 0.29.5, and 0.30.4.
 
 :::
 
@@ -42,13 +41,13 @@ All currently supported Astronomer-distributed images are compatible with all ve
 
 :::info
 
-Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private CAs starting with Kubernetes 1.19. If you use a private CA, contact [Astronomer support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on AKS.
+Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private Certificate Authorities (CAs) starting with Kubernetes 1.19. If your organization is using a private CA, contact [Astronomer support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on Azure Kubernetes Service (AKS).
 
 :::
 
 :::info
 
-While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow triggerer is available only in Astronomer v0.26+. To use [deferrable operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), which require the Airflow triggerer, you must upgrade.
+While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow triggerer is available only in Astronomer v0.26 and later. To use [deferrable operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), that require the Airflow triggerer, you must upgrade.
 
 :::
 

--- a/software_versioned_docs/version-0.28/version-compatibility-reference.md
+++ b/software_versioned_docs/version-0.28/version-compatibility-reference.md
@@ -13,14 +13,25 @@ While the tables below reference the minimum compatible versions, we typically r
 
 ## Astronomer Software
 
+
 <!--- Version-specific -->
 
-| Astronomer Platform | Kubernetes             | Postgres | Python                                    | Astronomer Certified / Astro Runtime         | Helm |
-| ------------------- | ---------------------- | -------- | ----------------------------------------- | -------------------------------------------- | ---- |
-| v0.25               | 1.19, 1.20, 1.21       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions*            | 3.6  |
-| v0.28               | 1.21, 1.22, 1.23, 1.24 | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions             | 3.6  |
-| v0.29               | 1.21, 1.22, 1.23, 1.24 | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
-| v0.30               | 1.21, 1.22, 1.23, 1.24 | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
+| Astronomer Platform | Kubernetes             | Astro CLI     | Postgres | Python                                    | Astronomer Certified / Astro Runtime         | Helm |
+| ------------------- | ---------------------- | ------------- | -------- | ----------------------------------------- | -------------------------------------------- | ---- |
+| v0.25               | 1.17¹, 1.18¹, 1.19¹, 1.20¹, 1.21       | 0.25.x        | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions*            | 3.6  |
+| v0.28               | 1.19¹, 1.20¹, 1.21, 1.22, 1.23, 1.24 | 1.0.x - 1.1.x | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions             | 3.6  |
+| v0.29               | 1.19¹, 1.20¹, 1.21, 1.22, 1.23, 1.24 | 1.3.x         | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
+| v0.30               | 1.19¹, 1.20¹, 1.21, 1.22, 1.23, 1.24 | 1.4.x - 1.7.x | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
+
+:::info
+
+¹ Some Kubernetes versions are compatible only up until a specific patch version of Astronomer Software.
+
+- Support for Kubernetes 1.17 ends with 0.25.12.
+- Support for Kubernetes 1.18 ends with 0.25.13.
+- Support for Kubernetes 1.19 and 1.20 ends with 0.25.15, 0.28.7, 0.29.5, and 0.30.4.
+
+:::
 
 For more detail about the changes in each Astronomer Software release, see the [Astronomer Software Release Notes](release-notes.md).
 
@@ -29,11 +40,17 @@ All currently supported Astronomer-distributed images are compatible with all ve
 - [Astro Runtime maintenance and lifecycle policy](runtime-version-lifecycle-policy.md)
 - [Astronomer Certified versioning and support](ac-support-policy.md)
 
-> **Note:** On Astronomer v0.23+, new versions of Apache Airflow on Astronomer Certified and Runtime are automatically made available in the Software UI and CLI within 24 hours of their publication. For more information, refer to [Available Astronomer Certified Versions](ac-support-policy.md#astronomer-certified-lifecycle-schedule).
+:::info
 
-> **Note:** Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private CAs starting with Kubernetes 1.19. If you use a private CA, contact [Astronomer Support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on AKS.
+Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private CAs starting with Kubernetes 1.19. If you use a private CA, contact [Astronomer support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on AKS.
 
-> **Note:** While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow Triggerer is available only in Astronomer v0.26+. To use [Deferrable Operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), which require the Airflow Triggerer, you must upgrade.
+:::
+
+:::info
+
+While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow triggerer is available only in Astronomer v0.26+. To use [deferrable operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), which require the Airflow triggerer, you must upgrade.
+
+:::
 
 ### Kubernetes Version Support Policy
 

--- a/software_versioned_docs/version-0.29/version-compatibility-reference.md
+++ b/software_versioned_docs/version-0.29/version-compatibility-reference.md
@@ -13,13 +13,22 @@ While the tables below reference the minimum compatible versions, we typically r
 
 <!--- Version-specific -->
 
-| Astronomer Platform | Kubernetes             | Postgres | Python                                    | Astronomer Certified / Astro Runtime         | Helm |
-| ------------------- | ---------------------- | -------- | ----------------------------------------- | -------------------------------------------- | ---- |
-| v0.25               | 1.19, 1.20, 1.21       | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions*            | 3.6  |
-| v0.28               | 1.21, 1.22, 1.23, 1.24 | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions             | 3.6  |
-| v0.29               | 1.21, 1.22, 1.23, 1.24 | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
-| v0.30               | 1.21, 1.22, 1.23, 1.24 | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
+| Astronomer Platform | Kubernetes             | Astro CLI     | Postgres | Python                                    | Astronomer Certified / Astro Runtime         | Helm |
+| ------------------- | ---------------------- | ------------- | -------- | ----------------------------------------- | -------------------------------------------- | ---- |
+| v0.25               | 1.17¹, 1.18¹, 1.19¹, 1.20¹, 1.21       | 0.25.x        | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions*            | 3.6  |
+| v0.28               | 1.19¹, 1.20¹, 1.21, 1.22, 1.23, 1.24 | 1.0.x - 1.1.x | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified versions             | 3.6  |
+| v0.29               | 1.19¹, 1.20¹, 1.21, 1.22, 1.23, 1.24 | 1.3.x         | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
+| v0.30               | 1.19¹, 1.20¹, 1.21, 1.22, 1.23, 1.24 | 1.4.x - 1.7.x | 9.6+     | 3.6, 3.7, 3.8, 3.9 (_requires AC 2.2.0+_) | All supported Certified and Runtime versions | 3.6  |
 
+:::info
+
+¹ Some Kubernetes versions are compatible only up until a specific patch version of Astronomer Software.
+
+- Support for Kubernetes 1.17 ends with 0.25.12.
+- Support for Kubernetes 1.18 ends with 0.25.13.
+- Support for Kubernetes 1.19 and 1.20 ends with 0.25.15, 0.28.7, 0.29.5, and 0.30.4.
+
+:::
 
 For more detail about the changes in each Astronomer Software release, see the [Astronomer Software Release Notes](release-notes.md).
 
@@ -28,11 +37,17 @@ All currently supported Astronomer-distributed images are compatible with all ve
 - [Astro Runtime maintenance and lifecycle policy](runtime-version-lifecycle-policy.md)
 - [Astronomer Certified versioning and support](ac-support-policy.md)
 
-> **Note:** On Astronomer v0.23+, new versions of Apache Airflow on Astronomer Certified and Runtime are automatically made available in the Software UI and CLI within 24 hours of their publication. For more information, refer to [Available Astronomer Certified Versions](ac-support-policy.md#astronomer-certified-lifecycle-schedule).
+:::info
 
-> **Note:** Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private CAs starting with Kubernetes 1.19. If you use a private CA, contact [Astronomer support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on AKS.
+Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private CAs starting with Kubernetes 1.19. If you use a private CA, contact [Astronomer support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on AKS.
 
-> **Note:** While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow triggerer is available only in Astronomer v0.26+. To use [deferrable operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), which require the Airflow triggerer, you must upgrade.
+:::
+
+:::info
+
+While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow triggerer is available only in Astronomer v0.26+. To use [deferrable operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), which require the Airflow triggerer, you must upgrade.
+
+:::
 
 ### Kubernetes version support policy
 

--- a/software_versioned_docs/version-0.29/version-compatibility-reference.md
+++ b/software_versioned_docs/version-0.29/version-compatibility-reference.md
@@ -22,11 +22,11 @@ While the tables below reference the minimum compatible versions, we typically r
 
 :::info
 
-¹ Some Kubernetes versions are compatible only up until a specific patch version of Astronomer Software.
+¹ Support for some Kubernetes versions is limited to specific Astronomer Software patch versions.
 
-- Support for Kubernetes 1.17 ends with 0.25.12.
-- Support for Kubernetes 1.18 ends with 0.25.13.
-- Support for Kubernetes 1.19 and 1.20 ends with 0.25.15, 0.28.7, 0.29.5, and 0.30.4.
+- Support for Kubernetes 1.17 ends with Astronomer Software 0.25.12.
+- Support for Kubernetes 1.18 ends with Astronomer Software 0.25.13.
+- Support for Kubernetes 1.19 and 1.20 ends with Astronomer Software versions 0.25.15, 0.28.7, 0.29.5, and 0.30.4.
 
 :::
 
@@ -39,13 +39,13 @@ All currently supported Astronomer-distributed images are compatible with all ve
 
 :::info
 
-Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private CAs starting with Kubernetes 1.19. If you use a private CA, contact [Astronomer support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on AKS.
+Due to the [deprecation of Dockershim](https://kubernetes.io/blog/2020/12/02/dockershim-faq/), Azure does not support private Certificate Authorities (CAs) starting with Kubernetes 1.19. If your organization is using a private CA, contact [Astronomer support](https://support.astronomer.io) before upgrading to Kubernetes 1.19 on Azure Kubernetes Service (AKS).
 
 :::
 
 :::info
 
-While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow triggerer is available only in Astronomer v0.26+. To use [deferrable operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), which require the Airflow triggerer, you must upgrade.
+While Astronomer v0.25 is compatible with Astronomer Certified 2.2.0, support for the Airflow triggerer is available only in Astronomer v0.26 and later. To use [deferrable operators](https://airflow.apache.org/docs/apache-airflow/stable/concepts/deferring.html), that require the Airflow triggerer, you must upgrade.
 
 :::
 


### PR DESCRIPTION
Original discussion: https://astronomer.slack.com/archives/C015V2JFKT5/p1669072065160589

I tried piecing together our K8s support for various patches based on when we dropped support in the following PRs:

https://github.com/astronomer/certgenerator/pull/85
https://github.com/astronomer/astronomer/pull/1298
https://github.com/astronomer/airflow-chart/pull/289

Once the change is approved, I'll push it to other versions of Software docs.