### PR TITLE
Update user-permissions.md

### DIFF
--- a/astro/user-permissions.md
+++ b/astro/user-permissions.md
@@ -59,7 +59,7 @@ Workspace Admins can set user roles on the **Access** tab in the Cloud UI. See [
 
 :::info
 
-1. If a user changes Workspace roles, it can take a maximum of 10 minutes for corresponding Airflow permission changes to take effect.
+When a user changes Workspace roles, it can take up to 10 minutes for the corresponding Airflow permissions to be updated.
 2. There are three roles with respect to deployments - Deployment Admin, Deployment Editor and Deployment Viewer. This gives flexibilty to manage deployment level permissions along with Workspace level permissions. For example: One can have a view access at workspace level, yet have admin level access at airflow deployment level.
 
 :::

--- a/astro/user-permissions.md
+++ b/astro/user-permissions.md
@@ -59,13 +59,8 @@ Workspace Admins can set user roles on the **Access** tab in the Cloud UI. See [
 
 :::info
 
-When a user changes Workspace roles, it can take up to 10 minutes for the corresponding Airflow permissions to be updated.
-There are three Deployment roles: Deployment Admin, Deployment Editor, and Deployment Viewer. These different roles let you manage Deployment and Workspace permissions individually. For example, a user can have Workspace view access and Deployment Admin permissions on a Deployment.
+If a user changes Workspace roles, it can take a maximum of 10 minutes for corresponding Airflow permission changes to take effect.
 
 :::
 
-:::caution
 
-When a user is a Workspace admin, they assume Deployment Admin permissions on the Airflow deployment.
-
-:::

--- a/astro/user-permissions.md
+++ b/astro/user-permissions.md
@@ -62,5 +62,3 @@ Workspace Admins can set user roles on the **Access** tab in the Cloud UI. See [
 If a user changes Workspace roles, it can take a maximum of 10 minutes for corresponding Airflow permission changes to take effect.
 
 :::
-
-

--- a/astro/user-permissions.md
+++ b/astro/user-permissions.md
@@ -66,6 +66,6 @@ There are three Deployment roles: Deployment Admin, Deployment Editor, and Deplo
 
 :::caution
 
-If a user has Workspace admin role, irrespective of the Deployment role, they can perofrm admin level actions on the Airflow deployment.
+When a user is a Workspace admin, they assume Deployment Admin permissions on the Airflow deployment.
 
 :::

--- a/astro/user-permissions.md
+++ b/astro/user-permissions.md
@@ -60,7 +60,7 @@ Workspace Admins can set user roles on the **Access** tab in the Cloud UI. See [
 :::info
 
 When a user changes Workspace roles, it can take up to 10 minutes for the corresponding Airflow permissions to be updated.
-2. There are three roles with respect to deployments - Deployment Admin, Deployment Editor and Deployment Viewer. This gives flexibilty to manage deployment level permissions along with Workspace level permissions. For example: One can have a view access at workspace level, yet have admin level access at airflow deployment level.
+There are three Deployment roles: Deployment Admin, Deployment Editor, and Deployment Viewer. These different roles let you manage Deployment and Workspace permissions individually. For example, a user can have Workspace view access and Deployment Admin permissions on a Deployment.
 
 :::
 

--- a/astro/user-permissions.md
+++ b/astro/user-permissions.md
@@ -59,6 +59,13 @@ Workspace Admins can set user roles on the **Access** tab in the Cloud UI. See [
 
 :::info
 
-If a user changes Workspace roles, it can take a maximum of 10 minutes for corresponding Airflow permission changes to take effect.
+1. If a user changes Workspace roles, it can take a maximum of 10 minutes for corresponding Airflow permission changes to take effect.
+2. There are three roles with respect to deployments - Deployment Admin, Deployment Editor and Deployment Viewer. This gives flexibilty to manage deployment level permissions along with Workspace level permissions. For example: One can have a view access at workspace level, yet have admin level access at airflow deployment level.
+
+:::
+
+:::caution
+
+If a user has Workspace admin role, irrespective of the Deployment role, they can perofrm admin level actions on the Airflow deployment.
 
 :::

--- a/software/role-permission-reference.md
+++ b/software/role-permission-reference.md
@@ -92,7 +92,7 @@ For a given Workspace, the Workspace Editor has the same default permissions as 
 
 ### Workspace Admin
 
-For a given Workspace, the Workspace Editor has the same default permissions as the Workspace Viewer and Workspace Editor, plus:
+For a given Workspace, the Workspace Admin has the same default permissions as the Workspace Viewer and Workspace Editor, plus:
 
 - `workspace.invites.get`: View pending user invites for the Workspace
 - `workspace.config.delete`: Delete the Workspace
@@ -100,7 +100,7 @@ For a given Workspace, the Workspace Editor has the same default permissions as 
 - `workspace.teams.getAll`: View all users in Teams belonging to the Workspace
 - `workspace.users.getAll`: View all users in the Workspace
 
-In addition, Workspace Admins have Deployment Editor permissions for all Deployments within the Workspace.
+In addition, Workspace Admins have Deployment Admin permissions for all Deployments within the Workspace.
 
 ## Workspace roles
 


### PR DESCRIPTION
- Adding caution message on the workspace and deployment role. This makes it clear that a workspace admin role has super user privilege and can override deployment level roles.
