### PR TITLE
Simplify CI/CD templates by removing CLI versioning

### DIFF
--- a/astro/ci-cd.md
+++ b/astro/ci-cd.md
@@ -9,10 +9,6 @@ id: ci-cd
   <meta name="og:description" content="Learn how to create a continuous integration and continuous delivery (CI/CD) pipeline that triggers a deployment to Astro when your Airflow DAGs are modified." />
 </head>
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import {siteVariables} from '@site/src/versions';
-
 Continuous Integration and Continuous Delivery (CI/CD) is an industry term that refers to programmatic workflows that automate key parts of the software development lifecycle, including code changes, builds, and testing. CI/CD enables teams to develop faster, more securely, and more reliably.
 
 On Astro, you can use Deployment API keys to automate deploying code changes to a Deployment. Astronomer recommends hosting your Astro project source code in a version control tool and setting up a CI/CD workflow for all production environments.
@@ -664,7 +660,8 @@ To automate code deploys to a single Deployment using [Jenkins](https://www.jenk
 
 2. At the root of your Git repository, add a [Jenkinsfile](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/) that includes the following script:
 
-    <pre><code parentName="pre">{`pipeline {
+    ```
+    pipeline {
        agent any
          stages {
            stage('Deploy to Astronomer') {
@@ -675,9 +672,9 @@ To automate code deploys to a single Deployment using [Jenkins](https://www.jenk
              }
              steps {
                script {
-                 sh 'curl -LJO https://github.com/astronomer/astro-cli/releases/download/v${siteVariables.cliVersion}/astro_${siteVariables.cliVersion}_linux_amd64.tar.gz'
-                 sh 'tar xzf astro_${siteVariables.cliVersion}_linux_amd64.tar.gz'
-                 sh "./astro deploy ${siteVariables.deploymentid} -f"
+                 sh 'curl -LJO install.astronomer.io'
+                 sh 'sudo bash -s'
+                 sh "astro deploy ${ASTRONOMER_DEPLOYMENT_ID} -f"
                }
              }
            }
@@ -687,7 +684,8 @@ To automate code deploys to a single Deployment using [Jenkins](https://www.jenk
            cleanWs()
          }
        }
-   }`}</code></pre>
+   }
+   ```
 
     This Jenkinsfile triggers a code push to Astro every time a commit or pull request is merged to the `main` branch of your repository.
 
@@ -712,24 +710,25 @@ To automate code deploys across multiple Deployments using [Jenkins](https://www
 
 2. At the root of your Git repository, add a [Jenkinsfile](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/) that includes the following script:
 
-    <pre><code parentName="pre">{`pipeline {
+    ```
+    pipeline {
        agent any
          stages {
            stage('Set Environment Variables') {
               steps {
                   script {
                       if (env.GIT_BRANCH == 'main') {
-                          echo "The git branch is ${siteVariables.jenkinsenv}";
+                          echo "The git branch is ${env.GIT_BRANCH}";
                           env.ASTRONOMER_KEY_ID = env.PROD_ASTRONOMER_KEY_ID;
                           env.ASTRONOMER_KEY_SECRET = env.PROD_ASTRONOMER_KEY_SECRET;
                           env.ASTRONOMER_DEPLOYMENT_ID = env.PROD_DEPLOYMENT_ID;
                       } else if (env.GIT_BRANCH == 'dev') {
-                          echo "The git branch is ${siteVariables.jenkinsenv}";
+                          echo "The git branch is ${env.GIT_BRANCH}";
                           env.ASTRONOMER_KEY_ID = env.DEV_ASTRONOMER_KEY_ID;
                           env.ASTRONOMER_KEY_SECRET = env.DEV_ASTRONOMER_KEY_SECRET;
                           env.ASTRONOMER_DEPLOYMENT_ID = env.DEV_DEPLOYMENT_ID;
                       } else {
-                          echo "This git branch ${siteVariables.jenkinsenv} is not configured in this pipeline."
+                          echo "This git branch ${env.GIT_BRANCH} is not configured in this pipeline."
                       }
                   }
               }
@@ -737,9 +736,9 @@ To automate code deploys across multiple Deployments using [Jenkins](https://www
            stage('Deploy to Astronomer') {
              steps {
                script {
-                 sh 'curl -LJO https://github.com/astronomer/astro-cli/releases/download/v${siteVariables.cliVersion}/astro_${siteVariables.cliVersion}_linux_amd64.tar.gz'
-                 sh 'tar xzf astro_${siteVariables.cliVersion}_linux_amd64.tar.gz'
-                 sh "./astro deploy ${siteVariables.deploymentid} -f"
+                 sh 'curl -LJO install.astronomer.io'
+                 sh 'sudo bash -s'
+                 sh "astro deploy ${ASTRONOMER_DEPLOYMENT_ID} -f"
                }
              }
            }
@@ -750,7 +749,8 @@ To automate code deploys across multiple Deployments using [Jenkins](https://www
          }
        }
       }
-   }`}</code></pre>
+    }
+    ```
 
     This Jenkinsfile triggers a code push to an Astro Deployment every time a commit or pull request is merged to the `dev` or `main` branch of your repository.
 
@@ -865,7 +865,8 @@ To automate code deploys to a Deployment using [CircleCI](https://circleci.com/)
 
 2. Create a new YAML file in `.circleci/config.yml` that includes the following configuration:
 
-    <pre><code parentName="pre">{`# Use the latest 2.1 version of CircleCI pipeline process engine.
+    ```
+    # Use the latest 2.1 version of CircleCI pipeline process engine.
     # See: https://circleci.com/docs/2.0/configuration-reference
     version: 2.1
 
@@ -889,8 +890,8 @@ To automate code deploys to a Deployment using [CircleCI](https://circleci.com/)
           - run:
               name: "Setup custom environment variables"
               command: |
-                echo export ASTRONOMER_KEY_ID=${siteVariables.keyid} >> $BASH_ENV
-                echo export ASTRONOMER_KEY_SECRET=${siteVariables.keysecret} >> $BASH_ENV
+                echo export ASTRONOMER_KEY_ID=${ASTRONOMER_KEY_ID} >> $BASH_ENV
+                echo export ASTRONOMER_KEY_SECRET=${ASTRONOMER_KEY_SECRET} >> $BASH_ENV
           - run:
               name: "Deploy to Astro"
               command: |
@@ -910,7 +911,7 @@ To automate code deploys to a Deployment using [CircleCI](https://circleci.com/)
                 branches:
                   only:
                     - main
-    `}</code></pre>
+    ```
 
 ### Drone
 
@@ -932,7 +933,8 @@ This pipeline configuration requires:
 
 3. In the top level of your Git repository, create a file called `.drone.yml` that includes the following configuration:
 
-    <pre><code parentName="pre">{`---
+    ```
+    ---
     kind: pipeline
     type: docker
     name: deploy
@@ -984,7 +986,7 @@ This pipeline configuration requires:
       - main
       event:
       - push
-    `}</code></pre>
+    ```
 
 ### GitLab
 
@@ -1013,15 +1015,16 @@ To automate code deploys to a Deployment using [GitLab](https://gitlab.com/), co
 
 2. Go to the Editor option in your project's CI/CD section and commit the following:
 
-   <pre><code parentName="pre">{`---
+   ```
+   ---
     astro_deploy:
       stage: deploy
       image: docker:latest
       services:
        - docker:dind
       variables:
-         ASTRONOMER_KEY_ID: ${siteVariables.keyid}
-         ASTRONOMER_KEY_SECRET: ${siteVariables.keyid}
+         ASTRONOMER_KEY_ID: ${ASTRONOMER_KEY_ID}
+         ASTRONOMER_KEY_SECRET: ${ASTRONOMER_KEY_SECRET}
       before_script:
        - apk add --update curl && rm -rf /var/cache/apk/*
        - apk add bash
@@ -1030,7 +1033,7 @@ To automate code deploys to a Deployment using [GitLab](https://gitlab.com/), co
        - astro deploy -f
       only:
        - main
-   `}</code></pre>
+   ```
 
 </TabItem>
 
@@ -1053,15 +1056,16 @@ When you create environment variables that will be used in multiple branches, yo
 
 2. Go to the Editor option in your project's CI/CD section and commit the following:
 
-   <pre><code parentName="pre">{`---
+   ```
+   ---
       astro_deploy_dev:
         stage: deploy
         image: docker:latest
         services:
           - docker:dind
         variables:
-            ASTRONOMER_KEY_ID: ${siteVariables.devkeyid}
-            ASTRONOMER_KEY_SECRET: ${siteVariables.devkeysecret}
+            ASTRONOMER_KEY_ID: ${DEV_ASTRONOMER_KEY_ID}
+            ASTRONOMER_KEY_SECRET: ${DEV_ASTRONOMER_KEY_SECRET}
         before_script:
           - apk add --update curl && rm -rf /var/cache/apk/*
           - apk add bash
@@ -1077,8 +1081,8 @@ When you create environment variables that will be used in multiple branches, yo
         services:
           - docker:dind
         variables:
-            ASTRONOMER_KEY_ID: ${siteVariables.prodkeyid}
-            ASTRONOMER_KEY_SECRET: ${siteVariables.prodkeysecret}
+            ASTRONOMER_KEY_ID: ${PROD_ASTRONOMER_KEY_ID}
+            ASTRONOMER_KEY_SECRET: ${PROD_ASTRONOMER_KEY_SECRET}
         before_script:
           - apk add --update curl && rm -rf /var/cache/apk/*
           - apk add bash
@@ -1087,7 +1091,7 @@ When you create environment variables that will be used in multiple branches, yo
           - astro deploy -f
         only:
           - main
-   `}</code></pre>
+   ```
 
 
 
@@ -1105,7 +1109,7 @@ To automate code deploys to a Deployment using [Bitbucket](https://bitbucket.org
 
 2. Create a new YAML file in `bitbucket-pipelines.yml` at the root of the repository that includes the following configuration:
 
-    <pre><code parentName="pre">{`
+    ```
     pipelines:
       pull-requests: # The branch pattern under pull requests defines the *source* branch.
         dev:
@@ -1117,7 +1121,7 @@ To automate code deploys to a Deployment using [Bitbucket](https://bitbucket.org
                 - astro deploy
               services:
                 - docker
-    `}</code></pre>
+    ```
 
 
 ### Azure DevOps
@@ -1131,7 +1135,7 @@ To automate code deploys to a Deployment using [Azure DevOps](https://dev.azure.
 
 2. Create a new YAML file in `astro-devops-cicd.yaml` at the root of the repository that includes the following configuration:
 
-    <pre><code parentName="pre">{`
+    ```
     trigger:
     - main
 
@@ -1150,4 +1154,4 @@ To automate code deploys to a Deployment using [Azure DevOps](https://dev.azure.
           env:
             ASTRONOMER_KEY_ID: $(ASTRONOMER_KEY_ID)
             ASTRONOMER_KEY_SECRET: $(ASTRONOMER_KEY_SECRET)
-    `}</code></pre>
+    ```

--- a/src/versions.js
+++ b/src/versions.js
@@ -2,14 +2,4 @@ export const siteVariables = {
   // version-specific
   cliVersion: '1.8.1',
   runtimeVersion: '6.0.4',
-  // Hacky variable so that we can use env var formatting in CI/CD templates
-  deploymentid: '${ASTRONOMER_DEPLOYMENT_ID}',
-  keyid: '${ASTRONOMER_KEY_ID}',
-  keysecret: '${ASTRONOMER_KEY_SECRET}',
-  devkeyid: '${DEV_ASTRONOMER_KEY_ID}',
-  devkeysecret: '${DEV_ASTRONOMER_KEY_SECRET}',
-  prodkeyid: '${PROD_ASTRONOMER_KEY_ID}',
-  prodkeysecret: '${PROD_ASTRONOMER_KEY_SECRET}',
-  // Hacky variable for droneci
-  deploymentiddrone: '$ASTRONOMER_DEPLOYMENT_ID',
 };


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/1531

Now that we have a stable URL for curl installing the latest CLI release, we should update our templates to use it. This also means we no longer have to use our site variable functionality to pull in the latest CLI version to docs, which is high-maintenance and presents a barrier to contributing.