### PR TITLE
IGNORE THIS: Create mock for documentation around GCP reduced access

### DIFF
--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -108,15 +108,15 @@ The data plane is a collection of infrastructure components for Astro that run i
     ```sh
     export MY_PROJECT_ID=$(gcloud projects describe $GOOGLE_CLOUD_PROJECT --format="value(projectId)")
     curl https://raw.githubusercontent.com/astronomer/astro-roles/gcp-custom-role.yaml >! /tmp/gcp.yaml
-    gcloud iam roles create astro-custom-role  project=$MY_PROJECT_ID --file=/tmp/gcp.yaml
+    gcloud iam roles create astrocustomrole  --project=$MY_PROJECT_ID --file=/tmp/gcp.yaml
     ```
 
 3. Run the following commands in your Google Cloud Shell to apply this custom role to your project: 
 
     ```sh
     export MY_PROJECT_NUMBER=$(gcloud projects describe $GOOGLE_CLOUD_PROJECT --format="value(projectNumber)")
-    gcloud projects add-iam-policy-binding $GOOGLE_CLOUD_PROJECT --member=serviceAccount:$MY_PROJECT_NUMBER@cloudservices.gserviceaccount.com --role=roles/astro-custom-role
-    gcloud projects add-iam-policy-binding $GOOGLE_CLOUD_PROJECT --member=serviceAccount:astronomer@astro-remote-mgmt.iam.gserviceaccount.com --role=roles/astro-custom-role
+    gcloud projects add-iam-policy-binding $GOOGLE_CLOUD_PROJECT --member=serviceAccount:$MY_PROJECT_NUMBER@cloudservices.gserviceaccount.com --role=roles/astrocustomrole
+    gcloud projects add-iam-policy-binding $GOOGLE_CLOUD_PROJECT --member=serviceAccount:astronomer@astro-remote-mgmt.iam.gserviceaccount.com --role=roles/astrocustomrole
     ```
 
 #### Notification of changes to the custom role

--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -131,7 +131,7 @@ You can use Logs Explorer to monitor changes to the custom role.  Access to Clou
 
     resource.type="iam_role"
     log_id("cloudaudit.googleapis.com/activity")
-    resource.type=iam_role AND protoPayload.methodName=google.iam.admin.v1.UpdateRole AND protoPayload.resourceNameresourceName=~"projects/<your-project-id>/roles/astro-custom-role"
+    resource.type=iam_role AND protoPayload.methodName=google.iam.admin.v1.UpdateRole AND protoPayload.resourceNameresourceName=~"/roles/astro-custom-role"
 
 To monitor updates to the custom role, create a log-based alert. For instructions on how to create an alert, see [Configure log-based Alerts](https://cloud.google.com/logging/docs/alerting/log-based-alerts)
 

--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -114,9 +114,10 @@ The data plane is a collection of infrastructure components for Astro that run i
 3. Run the following commands in your Google Cloud Shell to apply this custom role to your project: 
 
     ```sh
+    export MY_PROJECT_ID=$(gcloud projects describe $GOOGLE_CLOUD_PROJECT --format="value(projectId)")
     export MY_PROJECT_NUMBER=$(gcloud projects describe $GOOGLE_CLOUD_PROJECT --format="value(projectNumber)")
-    gcloud projects add-iam-policy-binding $GOOGLE_CLOUD_PROJECT --member=serviceAccount:$MY_PROJECT_NUMBER@cloudservices.gserviceaccount.com --role=roles/astrocustomrole
-    gcloud projects add-iam-policy-binding $GOOGLE_CLOUD_PROJECT --member=serviceAccount:astronomer@astro-remote-mgmt.iam.gserviceaccount.com --role=roles/astrocustomrole
+    gcloud projects add-iam-policy-binding $GOOGLE_CLOUD_PROJECT --member=serviceAccount:$MY_PROJECT_NUMBER@cloudservices.gserviceaccount.com --role=projects/$MY_PROJECT_ID/roles/astrocustomrole
+    gcloud projects add-iam-policy-binding $GOOGLE_CLOUD_PROJECT --member=serviceAccount:astronomer@astro-remote-mgmt.iam.gserviceaccount.com --role=projects/$MY_PROJECT_ID/roles/astrocustomrole
     ```
 
 #### Notification of changes to the custom role

--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -133,7 +133,7 @@ You can use Logs Explorer to monitor changes to the custom role.  Access to Clou
     log_id("cloudaudit.googleapis.com/activity")
     resource.type=iam_role AND protoPayload.methodName=google.iam.admin.v1.UpdateRole AND protoPayload.resourceNameresourceName=~"/roles/astro-custom-role"
 
-To monitor updates to the custom role, create a log-based alert. For instructions on how to create an alert, see [Configure log-based Alerts](https://cloud.google.com/logging/docs/alerting/log-based-alerts)
+For instructions on how to create a log-based alert to be notified of changes to this role, see [Configure log-based Alerts](https://cloud.google.com/logging/docs/alerting/log-based-alerts)
 
 ### Provide setup information to Astronomer
 

--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -129,11 +129,10 @@ Astronomer can reduce the access available to the custom without notification.
 #### Monitoring custom role for changes (Optional)
 You can use Logs Explorer to monitor changes to the custom role.  Access to Cloud Logging has been limited to prevent the accidental modification or deletion of Logs by Astronomer support. Use the following query in Logs Explorer to query for updates to the custom role:
 
-    ```sh
     resource.type="iam_role"
     log_id("cloudaudit.googleapis.com/activity")
     resource.type=iam_role AND protoPayload.methodName=google.iam.admin.v1.UpdateRole AND protoPayload.resourceNameresourceName=~"projects/<your-project-id>/roles/astro-custom-role"
-    ```
+
 To monitor updates to the custom role, create a log-based alert. For instructions on how to create an alert, see [Configure log-based Alerts](https://cloud.google.com/logging/docs/alerting/log-based-alerts)
 
 ### Provide setup information to Astronomer

--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -125,7 +125,7 @@ Occasionally, Astronomer makes changes to its policies to ensure the continued o
 
 Users with an Organization Owner role will receive an email notification from Astronomer 14 days before any changes are made to the policies governing the custom role that expands user access. Notifications will include an explanation of the changes being made and why the change was necessary.
 
-Astronomer can reduce the access available to the custom without notification.
+Astronomer can reduce the access available to the custom role without notification.
 
 #### Monitoring custom role for changes (Optional)
 You can use Logs Explorer to monitor changes to the custom role.  Access to Cloud Logging has been limited to prevent the accidental modification or deletion of Logs by Astronomer support. Use the following query in Logs Explorer to query for updates to the custom role:


### PR DESCRIPTION
I'm just creating a PR so I can have a deployment up to let engineering know what the end user view of this feature will look like.  Comments welcome, but approval/merging are not happening for quite some time. 