### PR TITLE
Update Add DAG Utility Files

### DIFF
--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -109,7 +109,7 @@ If you are deploying only DAGs, Astronomer recommends moving the `include` folde
             └── helper_functions
                 └── helper.py
             └── templated_SQL_scripts
-    │       └── custom operators
+    │       └── custom_operators
     ├── Dockerfile
     ├── tests
     │   └── test_dag_integrity.py

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -95,7 +95,7 @@ To rebuild your project after making a change to any of these files, you must [r
 
 ## Add DAG utility files
 
-Use the `include` folder to store additional utilities required by your DAGs. For example, helper functions, templated SQL scripts, and custom operators. Storing additional utilities in the `include` folder lets you deploy code without an image restart and  
+Use the `include` folder to store additional utilities required by your DAGs. For example, helper functions, templated SQL scripts, and custom operators. Storing additional utilities in the `include` folder lets you deploy code without an image restart. 
 
 When you use the `astro deploy -—dags` command, the `include` folder in the Astro project directory is not deployed with your DAGs and is instead built into the Docker image with your other project files.
 

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -99,7 +99,7 @@ Use the `include` folder to store additional utilities required by your DAGs. Fo
 
 When you use the `astro deploy -—dags` command, the `include` folder in the Astro project directory is not deployed with your DAGs and is instead built into the Docker image with your other project files.
 
-If you are deploying only DAGs, Astronomer recommends moving the `include` folder into the `dags` directory so that your DAGs can access your utility files.  Here is how the recommended folder structure might appear:
+If you are deploying only DAGs, Astronomer recommends moving the `include` folder into the `dags` directory so that your DAGs can access your utility files.  Here is how the recommended directory structure might appear:
 
 ```bash
     .

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -119,7 +119,7 @@ Here is how the recommended directory structure might appear:
     │   └── example-plugin.py
     └── requirements.txt
 ```
-If you do not use DAG-only deploys or you decide to keep the `include` directory separate from the `dags` directory, the `include` folder in your Astro project directory is not deployed with your DAGs and is built into the Docker image with your other project files. See [Deploy DAGs only](deploy-code.md#deploy-dags-only).
+If you do not use DAG-only deploys or you decide to keep the `include` directory separate from the `dags` directory, the `include` folder in your Astro project directory is not deployed with your DAGs and is built into the Docker image with your other project files. 
 
 ## Explore Airflow providers and modules
 

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -106,9 +106,11 @@ If you are deploying only DAGs, Astronomer recommends moving the `include` folde
     ├── airflow_settings.yaml
     ├── dags
     │   └── include
+            └── helper_functions
+                └── helper.py
+            └── templated_SQL_scripts
+    │       └── custom operators
     ├── Dockerfile
-    ├── helper_functions
-    │   └── helper.py
     ├── tests
     │   └── test_dag_integrity.py
     ├── packages.txt

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -95,16 +95,28 @@ To rebuild your project after making a change to any of these files, you must [r
 
 ## Add DAG utility files
 
-Use the `include` folder to store additional utilities required by your DAGs. For example, helper functions, templated SQL scripts, and custom operators.
-
-
-:::tip
+Use the `include` folder to store additional utilities required by your DAGs. For example, helper functions, templated SQL scripts, and custom operators. Storing additional utilities in the `include` folder lets you deploy code without an image restart and  
 
 When you use the `astro deploy -—dags` command, the `include` folder in the Astro project directory is not deployed with your DAGs and is instead built into the Docker image with your other project files.
 
-If you are deploying only DAGs, Astronomer recommends moving the `include` folder into the `dags` directory so that your DAGs can access your utility files. See [Deploy DAGs only](deploy-code.md#deploy-dags-only).
+If you are deploying only DAGs, Astronomer recommends moving the `include` folder into the `dags` directory so that your DAGs can access your utility files.  Here is how the recommended folder structure might appear:
 
-:::
+```bash
+    .
+    ├── airflow_settings.yaml
+    ├── dags
+    │   └── include
+    ├── Dockerfile
+    ├── helper_functions
+    │   └── helper.py
+    ├── tests
+    │   └── test_dag_integrity.py
+    ├── packages.txt
+    ├── plugins
+    │   └── example-plugin.py
+    └── requirements.txt
+```
+The Triggerer does not restart when you deploy only DAGs. See [Deploy DAGs only](deploy-code.md#deploy-dags-only).
 
 ## Explore Airflow providers and modules
 

--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -95,11 +95,12 @@ To rebuild your project after making a change to any of these files, you must [r
 
 ## Add DAG utility files
 
-Use the `include` folder to store additional utilities required by your DAGs. For example, helper functions, templated SQL scripts, and custom operators. Storing additional utilities in the `include` folder lets you deploy code without an image restart. 
+Use the `include` folder to store additional utilities required by your DAGs. For example, helper functions, templated SQL scripts, and custom operators.
 
-When you use the `astro deploy -—dags` command, the `include` folder in the Astro project directory is not deployed with your DAGs and is instead built into the Docker image with your other project files.
+Astronomer recommends storing the `include` folder inside the `dags` directory of your Astro project. If you're using [DAG-only deploys](deploy-code.md#deploy-dags-only), this allows you to deploy DAG code without an image restart by running `astro deploy --dags` and it makes sure that your DAGs can access your utility files when you deploy them.
 
-If you are deploying only DAGs, Astronomer recommends moving the `include` folder into the `dags` directory so that your DAGs can access your utility files.  Here is how the recommended directory structure might appear:
+Here is how the recommended directory structure might appear:
+
 
 ```bash
     .
@@ -118,7 +119,7 @@ If you are deploying only DAGs, Astronomer recommends moving the `include` folde
     │   └── example-plugin.py
     └── requirements.txt
 ```
-The Triggerer does not restart when you deploy only DAGs. See [Deploy DAGs only](deploy-code.md#deploy-dags-only).
+If you do not use DAG-only deploys or you decide to keep the `include` directory separate from the `dags` directory, the `include` folder in your Astro project directory is not deployed with your DAGs and is built into the Docker image with your other project files. See [Deploy DAGs only](deploy-code.md#deploy-dags-only).
 
 ## Explore Airflow providers and modules
 


### PR DESCRIPTION
Resolves #1566 

Responses to requests from @paolaperaza:

_This is what is suggested in the OSS docs: https://airflow.apache.org/docs/apache-airflow/2.4.3/modules_management.html_

It wasn't clear what Paola was requesting. She'll need to clarify during her review if she wants content in the OSS doc duplicated in Astronomer documentation.

_Having this structure allows DAG/user code to be deployed without an image restart._

The sentence _Storing additional utilities in the `include` folder lets you deploy code without an image restart_ was added to address this request. Edit as required.

_Confirm in docs that the Triggerer does not restart on a dags only deploy_

The sentence _the Triggerer does not restart when you deploy only DAGs_ was added to address this request. Edit as required.

Address this comment made by @ReadytoRocc:

![image](https://user-images.githubusercontent.com/104205257/204892924-7548bd07-7388-47aa-8a73-9b890ff4d19e.png)

This text was added previously: 

_If you are deploying only DAGs, Astronomer recommends moving the `include` folder into the `dags` directory so that your DAGs can access your utility files._

_Add an example dags directory and move this information out of tip as it applies to everyone_

An example DAGs directory has been added, although I'm not sure how useful or helpful it is. The content has been moved out of a tip.

All requests have been addressed.