### PR TITLE
Hosted customers won't know their project name

### DIFF
--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -87,7 +87,6 @@ To grant a Deployment on Astro access to external data services on GCP, such as 
     
     To locate your Google Cloud account ID, in the Cloud UI click **Clusters**. The Google Cloud account ID is located in the **Account ID** column.
 
-
     For example, for a Google Cloud project named `astronomer-prod` and a Deployment namespace defined as `nuclear-science-2730`, the service account for the Deployment would be:
 
     ```text

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -82,9 +82,9 @@ To grant a Deployment on Astro access to external data services on GCP, such as 
     Google service accounts for Astro Deployments are formatted as follows:
 
     ```text
-    astro-<deployment-namespace>@<gcp-project-id>.iam.gserviceaccount.com
+    astro-<deployment-namespace>@<gcp-account-id>.iam.gserviceaccount.com
     ```
-    To locate your Google Cloud project ID, in the Cloud UI click **Clusters**. The Google Cloud project ID is located in the **Account ID** column.
+    To locate your Google Cloud account ID, in the Cloud UI click **Clusters**. The Google Cloud account ID is located in the **Account ID** column.
 
 
     For example, for a Google Cloud project named `astronomer-prod` and a Deployment namespace defined as `nuclear-science-2730`, the service account for the Deployment would be:

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -84,6 +84,7 @@ To grant a Deployment on Astro access to external data services on GCP, such as 
     ```text
     astro-<deployment-namespace>@<gcp-account-id>.iam.gserviceaccount.com
     ```
+    
     To locate your Google Cloud account ID, in the Cloud UI click **Clusters**. The Google Cloud account ID is located in the **Account ID** column.
 
 

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -84,7 +84,7 @@ To grant a Deployment on Astro access to external data services on GCP, such as 
     ```text
     astro-<deployment-namespace>@<gcp-project-name>.iam.gserviceaccount.com
     ```
-To locate your <gcp-project-name>, in the Cloud UI click Clusters. The <gcp-project-name> is located in the Account ID column.
+    To locate your Google Cloud project name, in the Cloud UI click **Clusters**. The Google Cloud project name is located in the **Account ID** column.
 
 
     For example, for a Google Cloud project named `astronomer-prod` and a Deployment namespace defined as `nuclear-science-2730`, the service account for the Deployment would be:

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -82,9 +82,9 @@ To grant a Deployment on Astro access to external data services on GCP, such as 
     Google service accounts for Astro Deployments are formatted as follows:
 
     ```text
-    astro-<deployment-namespace>@<gcp-project-name>.iam.gserviceaccount.com
+    astro-<deployment-namespace>@<gcp-project-id>.iam.gserviceaccount.com
     ```
-    To locate your Google Cloud project name, in the Cloud UI click **Clusters**. The Google Cloud project name is located in the **Account ID** column.
+    To locate your Google Cloud project ID, in the Cloud UI click **Clusters**. The Google Cloud project ID is located in the **Account ID** column.
 
 
     For example, for a Google Cloud project named `astronomer-prod` and a Deployment namespace defined as `nuclear-science-2730`, the service account for the Deployment would be:

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -84,6 +84,8 @@ To grant a Deployment on Astro access to external data services on GCP, such as 
     ```text
     astro-<deployment-namespace>@<gcp-project-name>.iam.gserviceaccount.com
     ```
+To locate your <gcp-project-name>, in the Cloud UI click Clusters. The <gcp-project-name> is located in the Account ID column.
+
 
     For example, for a Google Cloud project named `astronomer-prod` and a Deployment namespace defined as `nuclear-science-2730`, the service account for the Deployment would be:
 


### PR DESCRIPTION
Show customers how to get their project name from CloudUI, because customers running on Hosted won't know where their cluster is running.