### PR TITLE
Fix AC 2.3 Policy to EOL in March 2023

### DIFF
--- a/software/ac-support-policy.md
+++ b/software/ac-support-policy.md
@@ -141,10 +141,10 @@ The following tables list the lifecycles for each published version of Astronome
 | AC Version                                                                           | Release Date   | End of Maintenance Date |
 | ------------------------------------------------------------------------------------ | -------------- | ----------------------- |
 | [2.1](https://github.com/astronomer/ap-airflow/blob/master/2.1.4/CHANGELOG.md)       | May 21, 2021   | November 2022           |
-| [2.3](https://github.com/astronomer/ap-airflow/blob/master/2.3.0/CHANGELOG.md)¹       | April 30, 2022 | October 2022            |
+| [2.3](https://github.com/astronomer/ap-airflow/blob/master/2.3.0/CHANGELOG.md)¹       | April 30, 2022 | March 2023            |
 | [2.4](https://github.com/astronomer/ap-airflow/blob/master/2.4.1/CHANGELOG.md)       | September 29, 2022 | March 2023            |
 
-> ¹ In November 2022, Astronomer Certified 2.3 was reclassified as a stable release only. Astronomer recommends upgrading or migrating to Astro Runtime 5.0.x to receive long term support for Apache Airflow 2.3. See [Migrate to Astro Runtime](migrate-to-runtime.md).
+> ¹ In November 2022, Astronomer Certified 2.3 was reclassified as a stable release with six months of additional support for a total of 13 months. Previously, AC 2.3 was listed as an LTS release. Astronomer recommends upgrading or migrating to Astro Runtime 5.0.x to receive long term support for Apache Airflow 2.3 through October 2023. See [Migrate to Astro Runtime](migrate-to-runtime.md).
 
 ### LTS releases
 


### PR DESCRIPTION
I spoke to @astro-rft earlier this week and we realized that we had a miscommunication and did not document the fact that while AC 2.3 was reclassified as a stable release (as we modified in our docs), we ALSO decided to give that version an extra 6 months of support to give folks some wiggle room.

I've updated our AC policy doc such that:

- March 2023 is now the EOL date for AC 2.3
- We specify that this release is stable but has an extra 6 months, and clarify what it was before

@jwitz If this looks good to you, want to apply it to other Software docs + Nebula?