### PR TITLE
Add GCP Integration to the Learn/Integrations section

### DIFF
--- a/learn/airflow-google-cloud-platform.md
+++ b/learn/airflow-google-cloud-platform.md
@@ -1,6 +1,6 @@
 # Authenticate with User Credentials for local development (Google Cloud)
 
-It is possible to use local User credentials instead of Service Account Keys to autenticate to Google Cloud.
+It is possible to use local User credentials instead of Service Account Keys to authenticate to Google Cloud.
 
 Using these credentials, it is also possible to configure a custom Secret Backend like Google Secret Manager for local development.
 
@@ -16,7 +16,7 @@ Steps:
     gcloud auth application-default login
     ```
 
-    Running the command in your terminal will provide a like and open a webpage to authenticate to your Google Cloud Account.
+    Running the command in your terminal will provide a link and open a webpage to authenticate to your Google Cloud Account.
     Once login is complete, it will store user credentials in your local Google Cloud SDK folder. 
     This credentials file is named Application Default Credentials (ADC).
     The file is used in place of the Service Account Key file.
@@ -32,7 +32,7 @@ Steps:
 2. Mount your Google Cloud application_default_credentials file as a volume and attach it to Airflow:
 
     This step is done by overriding the CLI Docker Compose file.
-    Make sure that the source path matches the file location mentionned in step 1 above.
+    Make sure that the source path matches the file location mentioned in step 1 above.
 
     For Linux, MacOS:
     ```yaml

--- a/learn/airflow-google-cloud-platform.md
+++ b/learn/airflow-google-cloud-platform.md
@@ -38,24 +38,30 @@ Steps:
     ```yaml
     version: "3.1"
     services:
-    scheduler:
-        volumes:
-        - /home/<username>/.config/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
-    webserver:
-        volumes:
-        - /home/<username>/.config/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
+        scheduler:
+            volumes:
+            - /home/<username>/.config/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
+        webserver:
+            volumes:
+            - /home/<username>/.config/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
+        triggerer:
+            volumes:
+            - /home/<username>/.config/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
     ```
 
     For Windows:
     ```yaml
     version: "3.1"
     services:
-    scheduler:
-        volumes:
-        - /c/Users/OlivierDaneau/AppData/Roaming/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
-    webserver:
-        volumes:
-        - /c/Users/OlivierDaneau/AppData/Roaming/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
+        scheduler:
+            volumes:
+            - /c/Users/OlivierDaneau/AppData/Roaming/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
+        webserver:
+            volumes:
+            - /c/Users/OlivierDaneau/AppData/Roaming/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
+        triggerer:
+            volumes:
+            - /c/Users/OlivierDaneau/AppData/Roaming/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
     ```
 
     For more information:

--- a/learn/airflow-google-cloud-platform.md
+++ b/learn/airflow-google-cloud-platform.md
@@ -1,91 +1,176 @@
-# Authenticate with User Credentials for local development (Google Cloud)
+---
+title: "Add GCP user credentials to a local Apache Airflow environment"
+sidebar_label: "Authenticate to GCP locally"
+description: "Learn how to connect to a hosted environment on Google Cloud Platform (GCP) from Apache Airflow. Use GCP credentials to access secrets backends and more from a locally running Airflow environment."
+id: airflow-google-cloud-platform
+---
 
-It is possible to use local User credentials instead of Service Account Keys to authenticate to Google Cloud.
+For initial testing and DAG development, running Airflow with local test data and publicly accessible APIs is often enough. Once you start expanding your Airflow use within your organization, you might need to develop and test DAGs locally with data from your organization's cloud. For example, you might need to test your DAGs using environment variables stored in a secrets backend like Google Cloud Secret Manager.
 
-Using these credentials, it is also possible to configure a custom Secret Backend like Google Secret Manager for local development.
+You could create access keys for each user developing locally, but service account keys are difficult to track and manage especially on larger teams. Instead, Astronomer recommends exporting credentials for your own GCP account and securely adding these credentials to Airflow. This way, you know which permissions Airflow has without needing to configure a separate access key. 
 
-Pre-requisites:
-- Install the Google Cloud SDK: https://cloud.google.com/sdk/docs/install-sdk
+## Prerequisites 
 
-Steps:
-1. Acquire user credentials with Google Cloud SDK
+- A user account on GCP with access to GCP cloud resources
+- The [Google Cloud SDK](https://cloud.google.com/sdk/docs/install-sdk)
+- The [Astro CLI](https://docs.astronomer.io/astro/cli/overview)
+- Optional. Access to a secrets backend hosted on GCP, such as GCP Secret Manager
+  
+## Step 1:  Retrieve GCP user credentials locally
+
+Run the following command to obtain your user credentials locally:
+
+```sh
+gcloud auth application-default login
+```
+
+The SDK provides a link to a webpage where you can log in to your Google Cloud account. After you complete your login, the SDK stores your user credentials in a file name named `application_default_credentials.json`.
+
+The location of this file depends on your operating system:
+
+- Linux: `$HOME/.config/gcloud/application_default_credentials.json`
+- Mac: `/Users/<username>/.config/gcloud/application_default_credentials.json`
+- Windows: `%APPDATA%/gcloud/application_default_credentials.json`
+
+## Step 2: Configure your Astro project
+
+The Astro CLI runs Airflow in a Docker-based environment. To give Airflow access to your credential files, you'll mount them as a volume in Docker.
+
+1. Run the following commands to create an Astro project:
+
+    ```sh
+    $ mkdir gcp-airflow && cd gcp-airflow
+    $ astro dev init
+    ```
+
+2. Add a file named `docker-compose.override.yml` to your project with the following configuration: 
+   
+3. Mount your Google Cloud application_default_credentials file as a volume and attach it to Airflow:
+
+<Tabs
+    defaultValue="mac"
+    groupId= "step-2-configure-your-astro-project"
+    values={[
+        {label: 'Mac', value: 'mac'},
+        {label: 'Linux', value: 'linux'},
+        {label: 'Windows', value: 'windows'},
+    ]}>
+<TabItem value="mac">
+
+```yaml
+version: "3.1"
+services:
+    scheduler:
+        volumes:
+        - /Users/<username>/.config/gcloud/application_default_credentials.json:/usr/local/airflow/gcloud/application_default_credentials.json:ro
+    webserver:
+        volumes:
+        - /Users/<username>/.config/gcloud/application_default_credentials.json:/usr/local/airflow/gcloud/application_default_credentials.json:ro
+    triggerer:
+        volumes:
+        - /Users/<username>/.config/gcloud/application_default_credentials.json:/usr/local/airflow/gcloud/application_default_credentials.json:ro
+```
+
+</TabItem>
+<TabItem value="linux">
+
+```yaml
+version: "3.1"
+services:
+    scheduler:
+        volumes:
+        - /home/<username>/.config/gcloud/application_default_credentials.json:/usr/local/airflow/gcloud/application_default_credentials.json:ro
+    webserver:
+        volumes:
+        - /home/<username>/.config/gcloud/application_default_credentials.json:/usr/local/airflow/gcloud/application_default_credentials.json:ro
+    triggerer:
+        volumes:
+        - /home/<username>/.config/gcloud/application_default_credentials.json:/usr/local/airflow/gcloud/application_default_credentials.json:ro
+```
+
+</TabItem>
+<TabItem value="windows">
+
+```yaml
+version: "3.1"
+services:
+    scheduler:
+        volumes:
+        - /c/Users/<username>/AppData/Roaming/gcloud/application_default_credentials.json:/usr/local/airflow/gcloud/application_default_credentials.json:ro
+    webserver:
+        volumes:
+        - /c/Users/<username>/AppData/Roaming/gcloud/application_default_credentials.json:/usr/local/airflow/gcloud/application_default_credentials.json:ro
+    triggerer:
+        volumes:
+        - /c/Users/<username>/AppData/Roaming/gcloud/application_default_credentials.json:/usr/local/airflow/gcloud/application_default_credentials.json:ro
+```
+
+</TabItem>
+</Tabs>
+
+3. In your Astro project's `.env` file, add the following environment variable. Ensure that this volume path is the same as the one your configured in `docker-compose.override.yml`.
     
-    The following command is used to obtain user access credentials via a web flow. 
-    
-    ```
-    gcloud auth application-default login
+    ```text
+    GOOGLE_APPLICATION_CREDENTIALS=/usr/local/airflow/gcloud/application_default_credentials.json
     ```
 
-    Running the command in your terminal will provide a link and open a webpage to authenticate to your Google Cloud Account.
-    Once login is complete, it will store user credentials in your local Google Cloud SDK folder. 
-    This credentials file is named Application Default Credentials (ADC).
-    The file is used in place of the Service Account Key file.
-    
-    The location of the Application Default Credentials file depends on your operating system:
-    - Linux, macOS: `$HOME/.config/gcloud/application_default_credentials.json`
-    - Windows: `%APPDATA%/gcloud/application_default_credentials.json`
+When you run Airflow locally, all GCP connections without defined credentials now automatically fall back to your user credentials when connecting to GCP.
 
-    For more information:
-    [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials#personal)
-    [Google Cloud Auth Login](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login)
+## Step 3: Test your credentials with a secrets backend (Optional)
 
-2. Mount your Google Cloud application_default_credentials file as a volume and attach it to Airflow:
+Now that Airflow has access to your user credentials, you can use them to connect to GCP services. Use the following example setup to test your credentials by pulling a variable from GCP Secret Manager. 
 
-    This step is done by overriding the CLI Docker Compose file.
-    Make sure that the source path matches the file location mentioned in step 1 above.
+1. Create a secret for an Airflow variable or connection in GCP Secret Manager. You can do this using the Google Cloud Console or the gcloud CLI. All Airflow variables and connection keys must be prefixed with the following strings respectively:
 
-    For Linux, MacOS:
-    ```yaml
-    version: "3.1"
-    services:
-        scheduler:
-            volumes:
-            - /home/<username>/.config/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
-        webserver:
-            volumes:
-            - /home/<username>/.config/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
-        triggerer:
-            volumes:
-            - /home/<username>/.config/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
-    ```
+    - `airflow-variables-`
+    - `airflow-connections-`
 
-    For Windows:
-    ```yaml
-    version: "3.1"
-    services:
-        scheduler:
-            volumes:
-            - /c/Users/OlivierDaneau/AppData/Roaming/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
-        webserver:
-            volumes:
-            - /c/Users/OlivierDaneau/AppData/Roaming/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
-        triggerer:
-            volumes:
-            - /c/Users/OlivierDaneau/AppData/Roaming/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
-    ```
+    When setting the secret type, choose `Other type of secret` and select the `Plaintext` option. If you're creating a connection URI or a non-dict variable as a secret, remove the brackets and quotations that are pre-populated in the plaintext field.
 
-    For more information:
-    [Override the CLI Docker Compose file](https://docs.astronomer.io/astro/test-and-troubleshoot-locally#override-the-cli-docker-compose-file)
+2. Add the following environment variables to your Astro project `.env` file:
 
-3. Configure the GOOGLE_APPLICATION_CREDENTIALS environment variable:
-
-    Make sure that the path matches the file location mentioned in the Yaml override file above.
-    ```
-    GOOGLE_APPLICATION_CREDENTIALS=/home/astro/.config/gcloud/application_default_credentials.json
-    ```
-
-4. Optional - Configure your Custom Secret Backend
-    For custom Airflow Secret Backend Only
-
-    Follow the steps to configure an external secrets backend described here: https://docs.astronomer.io/astro/secrets-backend?tab=gcp#setup
-
-    Make sure to configure the AIRFLOW__SECRETS__BACKEND_KWARGS environment variables as follows:
-    - Remove any mention of `gcp_keyfile_dict` or `gcp_key_path`.
-    - Add the Project ID key
-
-    Example:
-    
-    ```
+    ```text
     AIRFLOW__SECRETS__BACKEND=airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend
-    AIRFLOW__SECRETS__BACKEND_KWARGS={"connections_prefix": "airflow-connections", "variables_prefix": "airflow-variables", "project_id": "<GCP PROJECT ID>"}
+    AIRFLOW__SECRETS__BACKEND_KWARGS={"connections_prefix": "airflow-connections", "variables_prefix": "airflow-variables"}
     ```
+
+3. Run the following command to start Airflow locally:
+
+    ```sh
+    astro dev start
+    ```
+
+4. Access the Airflow UI at `localhost:8080` and create an Airflow GCP connection named `gcp_standard` with no credentials. See [Connections](connections.md).
+
+   When you use this connection in your DAG, it will fall back to using your configured user credentials. 
+
+5. Add a DAG  which uses the secrets backend to your Astro project `dags` directory. You can use the following example DAG to retrieve a value from `airflow/variables` and print it to the terminal:
+
+    ```python
+    from airflow import DAG
+    from airflow.hooks.base import BaseHook
+    from airflow.models import Variable
+    from airflow.operators.python import PythonOperator
+    from datetime import datetime
+    
+    def print_var():
+        my_var = Variable.get("<your-variable-key>")
+        print(f'My variable is: {my_var}')
+    
+        conn = BaseHook.get_connection(conn_id="gcp_standard")
+        print(conn.get_uri())
+    
+    with DAG(
+        dag_id='example_secrets_dag',
+        start_date=datetime(2022, 1, 1),
+        schedule=None
+    ):
+    
+        test_task = PythonOperator(
+            task_id='test-task',
+            python_callable=print_var
+        )
+    ```
+
+6. In the Airflow UI, unpause your DAG and click **Play** to trigger a DAG run. 
+7. View logs for your DAG run. If the connection was successful, the value of your secret appears in your logs. See [Airflow logging](https://docs.astronomer.io/learn/logging).

--- a/learn/airflow-google-cloud-platform.md
+++ b/learn/airflow-google-cloud-platform.md
@@ -1,0 +1,85 @@
+# Authenticate with User Credentials for local development (Google Cloud)
+
+It is possible to use local User credentials instead of Service Account Keys to autenticate to Google Cloud.
+
+Using these credentials, it is also possible to configure a custom Secret Backend like Google Secret Manager for local development.
+
+Pre-requisites:
+- Install the Google Cloud SDK: https://cloud.google.com/sdk/docs/install-sdk
+
+Steps:
+1. Acquire user credentials with Google Cloud SDK
+    
+    The following command is used to obtain user access credentials via a web flow. 
+    
+    ```
+    gcloud auth application-default login
+    ```
+
+    Running the command in your terminal will provide a like and open a webpage to authenticate to your Google Cloud Account.
+    Once login is complete, it will store user credentials in your local Google Cloud SDK folder. 
+    This credentials file is named Application Default Credentials (ADC).
+    The file is used in place of the Service Account Key file.
+    
+    The location of the Application Default Credentials file depends on your operating system:
+    - Linux, macOS: `$HOME/.config/gcloud/application_default_credentials.json`
+    - Windows: `%APPDATA%/gcloud/application_default_credentials.json`
+
+    For more information:
+    [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials#personal)
+    [Google Cloud Auth Login](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login)
+
+2. Mount your Google Cloud application_default_credentials file as a volume and attach it to Airflow:
+
+    This step is done by overriding the CLI Docker Compose file.
+    Make sure that the source path matches the file location mentionned in step 1 above.
+
+    For Linux, MacOS:
+    ```yaml
+    version: "3.1"
+    services:
+    scheduler:
+        volumes:
+        - /home/<username>/.config/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
+    webserver:
+        volumes:
+        - /home/<username>/.config/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
+    ```
+
+    For Windows:
+    ```yaml
+    version: "3.1"
+    services:
+    scheduler:
+        volumes:
+        - /c/Users/OlivierDaneau/AppData/Roaming/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
+    webserver:
+        volumes:
+        - /c/Users/OlivierDaneau/AppData/Roaming/gcloud/application_default_credentials.json:/home/astro/.config/gcloud/application_default_credentials.json:ro
+    ```
+
+    For more information:
+    [Override the CLI Docker Compose file](https://docs.astronomer.io/astro/test-and-troubleshoot-locally#override-the-cli-docker-compose-file)
+
+3. Configure the GOOGLE_APPLICATION_CREDENTIALS environment variable:
+
+    Make sure that the path matches the file location mentioned in the Yaml override file above.
+    ```
+    GOOGLE_APPLICATION_CREDENTIALS=/home/astro/.config/gcloud/application_default_credentials.json
+    ```
+
+4. Optional - Configure your Custom Secret Backend
+    For custom Airflow Secret Backend Only
+
+    Follow the steps to configure an external secrets backend described here: https://docs.astronomer.io/astro/secrets-backend?tab=gcp#setup
+
+    Make sure to configure the AIRFLOW__SECRETS__BACKEND_KWARGS environment variables as follows:
+    - Remove any mention of `gcp_keyfile_dict` or `gcp_key_path`.
+    - Add the Project ID key
+
+    Example:
+    
+    ```
+    AIRFLOW__SECRETS__BACKEND=airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend
+    AIRFLOW__SECRETS__BACKEND_KWARGS={"connections_prefix": "airflow-connections", "variables_prefix": "airflow-variables", "project_id": "<GCP PROJECT ID>"}
+    ```


### PR DESCRIPTION
Adds an integration page to document local development with Google Cloud Platform.

Related to : https://github.com/astronomer/docs/pull/1593 & https://github.com/astronomer/docs/pull/1599