### PR TITLE
Update astro-deployment-inspect.md

### DIFF
--- a/astro/cli/astro-deployment-inspect.md
+++ b/astro/cli/astro-deployment-inspect.md
@@ -17,7 +17,7 @@ astro deployment inspect
 When using the `--key` flag, specify the complete path of the key you want to return the value for, excluding `deployment`. For example, to return the `cluster_id` for a specific Deployment, you would run:
 
 ```sh
-astro deployment inspect <deployment-name> --key information.status
+astro deployment inspect <deployment-name> --key configuration.cluster_id
 ```
 
 See [Example output](#example-output) for all possible values to return. 


### PR DESCRIPTION
`--key information.status` doesn't return a cluster id, `--key configutation.cluster_id` does. 

Additionally, this doc seems outdated in general because in the version 1.8.2 I don't see a section `information` - it's all under `metadata` (i.e., to get the status, I need to run `astro deployment inspect <deployment-id> --key metadata.status`).