### PR TITLE
Add data source setup to SQL CLI docs

### DIFF
--- a/astro/cli/sql-cli.md
+++ b/astro/cli/sql-cli.md
@@ -126,7 +126,7 @@ astro flow validate --connection=snowflake_conn --env=dev
 
 To run SQL as a workflow, add your `.sql` files to a workflow subfolder in `workflows`. All SQL files in a given workflow run together when you run `astro flow run`. See [Run a SQL workflow](#run-a-sql-workflow).
 
-Each `.sql` file must have a database connection defined as `conn_id` in the front matter of the file. This front matter tells the Astro CLI where to load the query results. In the following example, a SQL query runs against the `imdb.db` database in the `data` folder. The Astro CLI sends the results of the query to a Snowflake database defined in `snowflake_conn`.
+Each `.sql` file must have a database connection defined as `conn_id` in the front matter header of the file. This front matter tells the Astro CLI where to load the query results. In the following example, a SQL query runs against the `imdb.db` database in the `data` folder. The Astro CLI sends the results of the query to a Snowflake database defined in `snowflake_conn`.
 
 ```sql
 ---

--- a/astro/cli/sql-cli.md
+++ b/astro/cli/sql-cli.md
@@ -71,17 +71,17 @@ new_proj/
 
 Each SQL project is composed of three directories:
 
-- `config`: This directory contains configurations for different environments for running SQL. These configurations  store connections to external databases. Each SQL environment has one subdirectory containing one file named `configuration.yml`. The default SQL project includes `default` and `dev` environments.
-- `workflows`: Each subdirectory is used to define an independent SQL workflow. A workflow is a subdirectory that contains one or more related SQL files that should be run together. The default SQL project includes a few example workflows you can run immediately.
-- `data`: This directory can contain datasets to run your SQL workflows. The default SQL project includes sample SQLite databases (`.db` files) for a film ranking and a simple retail platform.
+- `config`: This folder contains configurations for different environments for running SQL. These configurations store connections to external databases. Each SQL environment has one subfolder containing its own `configuration.yml`. The default SQL project includes `default` and `dev` environments.
+- `workflows`: This folder contains independent SQL workflows. A workflow is a subfolder that contains one or more related SQL files that should be run together. The default SQL project includes a few example workflows you can run out of the box.
+- `data`: This folder can contain datasets to run your SQL workflows. The default SQL project includes sample SQLite databases (`.db` files) for a film ranking and a simple retail platform.
 
 ## Develop your SQL project 
 
-If you have existing `.sql` files and datasets, you can develop a running SQL workflow by adding files to a few directories.
+If you have existing `.sql` files and datasets, you can develop a running SQL workflow by adding files to a few folders.
 
 ### Configure environments and connections
 
-An environment requires a connection to the external databases in which you will run your SQL workflows. You can configure one or multiple connections withing a single `configuration.yml` file.
+An environment requires a connection to the databases in which you will run your SQL workflows. You can configure multiple connections to both data sources and data destinations within a single `configuration.yml` file. 
 
 [`dev/configuration.yml`](https://github.com/astronomer/astro-sdk/blob/main/sql-cli/include/base/config/dev/configuration.yml) contains templates for for each supported connection type. Use these templates to configure all required key-value pairs for your connection. 
 
@@ -104,7 +104,7 @@ connections:
       database: Database
 ```
 
-Your Astro project currently can't access the connections configured in this directory. Similarly, your SQL project can't access connections configured in your Astro project. Features for unifying these two sets of connections will be available in upcoming releases.
+A standard Astro project currently can't access the connections configured in this directory. Similarly, a SQL project can't access connections configured in an Astro project. Features for unifying these two project structures will be available in upcoming releases.
 
 #### Test database connections
 
@@ -114,23 +114,23 @@ To test all configured databases within an environment, run the following comman
 astro flow validate --env=<env-directory-name>
 ```
 
-This command runs a connection test for all databases configured in the `configuration.yml` file of your environment subdirectory. 
+This command runs a connection test for all databases configured in the `configuration.yml` file of your environment subfolder. 
 
-You can also test individual databases within an environment. For example, to test a `snowflake_default` connection in the `dev/configuration.yml`, you run the following command to test the connection:
+You can also test individual databases within an environment. For example, to test a `snowflake_conn` connection in the `dev/configuration.yml`, you run the following command to test the connection:
 
 ```sh
-astro flow validate --connection=snowflake_default --env=dev
+astro flow validate --connection=snowflake_conn --env=dev
 ```
 
 ### Create SQL workflows 
 
-To run SQL as a workflow, add your `.sql` files to one of your workflow subdirectories in `workflows`. All SQL files in a given workflow run together when you run `astro flow run`. See [Run a SQL workflow](#run-a-sql-workflow).
+To run SQL as a workflow, add your `.sql` files to a workflow subfolder in `workflows`. All SQL files in a given workflow run together when you run `astro flow run`. See [Run a SQL workflow](#run-a-sql-workflow).
 
-Each `.sql` file must have a database connection defined as `conn_id` in the front matter of the file. This front matter tells the Astro CLI where to extract and load data. In the following example, a SQL query runs against a Snowflake database: 
+Each `.sql` file must have a database connection defined as `conn_id` in the front matter of the file. This front matter tells the Astro CLI where to load the results of the query. In the following example, a SQL query runs against the `imdb.db` database in the `data` folder. The Astro CLI sends the results of the query to a Snowflake database defined in `snowflake_conn`.
 
 ```sql
 ---
-conn_id: snowflake_default
+conn_id: snowflake_conn
 ---
 SELECT Title, Rating
 FROM movies
@@ -147,7 +147,77 @@ SQL files within a workflow can be dependent on each other using Jinja templatin
 
 If you define a database connection in a `.sql` file with a downstream dependency, the downstream `.sql` file will automatically inherit the database connection information. 
 
-::: 
+:::
+
+### Configure a local data source 
+
+Configure a local data source to test your SQL queries using only a standard SQLite connection. 
+
+1. Add the data source to your `data` directory. 
+2. Decide the environment in which you want to use the data. In your `config` directory, open the `configuration.yaml` for the environment. 
+3. Configure a SQLite connection to your data source. For example:
+
+    ```yaml
+    ## Example of SQLite connection
+      - conn_id: sqlite_conn
+        conn_type: sqlite
+        host: data/<your-data-file>.db
+        schema:
+        login:
+        password:
+    ```
+
+    When you reference a table from your local data source in a workflow query, the SQL CLI automatically uses a local SQLite connection to load the table from your `data` directory. 
+
+### Configure an external data source
+
+To run a query against data hosted outside of your project, you create a `YAML` file describing how to load the data, then add the file to the workflow where you want to use the data.
+
+1. Create connections for your data source and data destination. See [Configure environments and connections](#configure-environments-and-connections). Copy the `conn_id` of both connections for the next step.
+2. In the workflow where you want to use the data, create a new `yaml` file that tells the CLI about your data source and your data destination. You can use the following example file to load data from Amazon S3 to Amazon Redshift.
+
+    ```yaml
+    load_file:
+      input_file:
+        path: "s3://tmp9/homes_main.csv"
+        conn_id: "aws_conn"
+      output_table:
+        conn_id: "redshift_conn"
+        metadata:
+          schema: "astro"
+          database: "dev"
+      native_support_kwargs:
+        IGNOREHEADER: 1
+        REGION: "us-west-2"
+        IAM_ROLE: "arn:aws:iam::<account_id>:role/redshift-s3-readonly"
+    ```
+
+3. Specify your data source in your queries using one of the following options: 
+
+    - Reference the name of your `yaml` file in your queries using Jinja templating. For example, if the example YAML file in the previous step was named `load_s3.yaml`, your SQL query might look like the following: 
+
+    ```sql
+    ---
+    conn_id: redshift_conn
+    ---
+    SELECT *
+    FROM {{load_s3}}
+    LIMIT 5;
+    ```
+
+    - Reference `input_file` in your queries. For example: 
+
+
+    ```sql
+    ---
+    conn_id: redshift_conn
+    ---
+    SELECT *
+    FROM input_file
+    LIMIT 5;
+    ```
+    
+    When you run your workflow, the CLI automatically uses the configured data source in your `YAML` file for all queries. This option does not work if you have multiple configured data sources in your workflow.
 
 ## Run a SQL workflow
 
@@ -163,7 +233,7 @@ This command automatically builds and runs your project as an Airflow DAG based 
 astro flow run example_templating --env=dev
 ```
 
-After running this command, the CLI:
+The `example_templating` workflow contains two separate SQL queries: `filtered_orders.sql` and `joint_orders_customers.sql`. After running this command, the CLI:
 
 - Connects to the `data` directory using the `sqlite_conn` connection that's defined in `dev/configuration.yml` and configured in `filtered_orders.sql`.
 - Creates a table named `filtered_orders` and runs `filtered_orders.sql` to populate the table with data from `data/retail.db`.

--- a/astro/cli/sql-cli.md
+++ b/astro/cli/sql-cli.md
@@ -72,7 +72,7 @@ new_proj/
 Each SQL project is composed of three directories:
 
 - `config`: This folder contains configurations for different environments for running SQL. These configurations store connections to external databases. Each SQL environment has one subfolder containing its own `configuration.yml`. The default SQL project includes `default` and `dev` environments.
-- `workflows`: This folder contains independent SQL workflows. A workflow is a subfolder containing one or more related SQL files that should be run together. The default SQL project includes a few example workflows that you can run to test functionality.
+- `workflows`: This folder contains independent SQL workflows. A workflow is a subfolder containing related SQL queries and data management tasks that run together. The default SQL project includes a few example workflows that you can run to test functionality.
 - `data`: This folder can contain datasets to run your SQL workflows. The default SQL project includes sample film ranking and retail SQLite databases (`.db` files).
 
 ## Develop your SQL project 
@@ -83,7 +83,7 @@ If you have existing `.sql` files and datasets, you can develop a running SQL wo
 
 An environment requires a connection to the databases in which you run your SQL workflows. You can configure multiple connections to data sources and data destinations within a single `configuration.yml` file. 
 
-[`dev/configuration.yml`](https://github.com/astronomer/astro-sdk/blob/main/sql-cli/include/base/config/dev/configuration.yml) contains templates for for each supported connection type. Use these templates to configure all required key-value pairs for your connection. 
+[`default/configuration.yml`](https://github.com/astronomer/astro-sdk/blob/main/sql-cli/include/base/config/default/configuration.yml) contains templates for for each supported connection type. Use these templates to configure all required key-value pairs for your connection. 
 
 For example, a Snowflake connection in `dev/configuration.yml` might look like the following: 
 
@@ -174,29 +174,28 @@ Configure a local data source to test your SQL queries using only a standard SQL
 To run a query against data hosted outside of your project, you create a `YAML` file describing how to load the data, then add the file to the workflow where you want to use the data.
 
 1. Create connections for your data source and data destination. See [Configure environments and connections](#configure-environments-and-connections). 
-
 2. Copy the `conn_id` for both connections.
 3. In the workflow where you want to use the data, create a new `yaml` file that tells the CLI about your data source and your data destination. You can use the following example file to load data from Amazon S3 to Amazon Redshift.
 
     ```yaml
     load_file:
       input_file:
-        path: "s3://tmp9/homes_main.csv"
+        path: "s3://<your-data-filepath>.csv"
         conn_id: "aws_conn"
       output_table:
         conn_id: "redshift_conn"
         metadata:
-          schema: "astro"
-          database: "dev"
+          schema: "<your-schema>"
+          database: "<your-database>"
       native_support_kwargs:
         IGNOREHEADER: 1
-        REGION: "us-west-2"
+        REGION: "<your-region>"
         IAM_ROLE: "arn:aws:iam::<account_id>:role/redshift-s3-readonly"
     ```
 
-4. Specify the data source for your queries using one of the following options: 
+4. In your SQL files, specify the table to query using one of the following options: 
 
-    - Reference the name of your `yaml` file in your queries using Jinja templating. For example, if the example YAML file in the previous step was named `load_s3.yaml`, your SQL query might look like the following: 
+    - Reference the name of your `yaml` file in your SQL files using Jinja templating. The SQL CLI assumes which table to use based on the information provided in your YAML file. For example, if the example YAML file in the previous step was named `load_s3.yaml`, your SQL query might look like the following: 
 
     ```sql
     ---
@@ -207,7 +206,7 @@ To run a query against data hosted outside of your project, you create a `YAML` 
     LIMIT 5;
     ```
 
-    - Reference `input_file` in your queries. For example: 
+    - Reference the table name directly in your queries. For example: 
 
 
     ```sql
@@ -215,7 +214,7 @@ To run a query against data hosted outside of your project, you create a `YAML` 
     conn_id: redshift_conn
     ---
     SELECT *
-    FROM input_file
+    FROM <your-input-table>
     LIMIT 5;
     ```
     

--- a/astro/cli/sql-cli.md
+++ b/astro/cli/sql-cli.md
@@ -72,6 +72,7 @@ new_proj/
 Each SQL project is composed of three directories:
 
 - `config`: This folder contains configurations for different environments for running SQL. These configurations store connections to external databases. Each SQL environment has one subfolder containing its own `configuration.yml`. The default SQL project includes `default` and `dev` environments.
+    - `config/global.yml`: This file contains configurations that apply to all of your SQL environments.
 - `workflows`: This folder contains independent SQL workflows. A workflow is a subfolder containing related SQL queries and data management tasks that run together. The default SQL project includes a few example workflows that you can run to test functionality.
 - `data`: This folder can contain datasets to run your SQL workflows. The default SQL project includes sample film ranking and retail SQLite databases (`.db` files).
 

--- a/astro/cli/sql-cli.md
+++ b/astro/cli/sql-cli.md
@@ -72,8 +72,8 @@ new_proj/
 Each SQL project is composed of three directories:
 
 - `config`: This folder contains configurations for different environments for running SQL. These configurations store connections to external databases. Each SQL environment has one subfolder containing its own `configuration.yml`. The default SQL project includes `default` and `dev` environments.
-- `workflows`: This folder contains independent SQL workflows. A workflow is a subfolder that contains one or more related SQL files that should be run together. The default SQL project includes a few example workflows you can run out of the box.
-- `data`: This folder can contain datasets to run your SQL workflows. The default SQL project includes sample SQLite databases (`.db` files) for a film ranking and a simple retail platform.
+- `workflows`: This folder contains independent SQL workflows. A workflow is a subfolder containing one or more related SQL files that should be run together. The default SQL project includes a few example workflows that you can run to test functionality.
+- `data`: This folder can contain datasets to run your SQL workflows. The default SQL project includes sample film ranking and retail SQLite databases (`.db` files).
 
 ## Develop your SQL project 
 
@@ -81,7 +81,7 @@ If you have existing `.sql` files and datasets, you can develop a running SQL wo
 
 ### Configure environments and connections
 
-An environment requires a connection to the databases in which you will run your SQL workflows. You can configure multiple connections to both data sources and data destinations within a single `configuration.yml` file. 
+An environment requires a connection to the databases in which you run your SQL workflows. You can configure multiple connections to data sources and data destinations within a single `configuration.yml` file. 
 
 [`dev/configuration.yml`](https://github.com/astronomer/astro-sdk/blob/main/sql-cli/include/base/config/dev/configuration.yml) contains templates for for each supported connection type. Use these templates to configure all required key-value pairs for your connection. 
 
@@ -104,7 +104,7 @@ connections:
       database: Database
 ```
 
-A standard Astro project currently can't access the connections configured in this directory. Similarly, a SQL project can't access connections configured in an Astro project. Features for unifying these two project structures will be available in upcoming releases.
+An Astro project can't access the connections configured in this directory. Similarly, a SQL project can't access connections configured in an Astro project. Features for unifying these two project structures will be available in upcoming releases.
 
 #### Test database connections
 
@@ -126,7 +126,7 @@ astro flow validate --connection=snowflake_conn --env=dev
 
 To run SQL as a workflow, add your `.sql` files to a workflow subfolder in `workflows`. All SQL files in a given workflow run together when you run `astro flow run`. See [Run a SQL workflow](#run-a-sql-workflow).
 
-Each `.sql` file must have a database connection defined as `conn_id` in the front matter of the file. This front matter tells the Astro CLI where to load the results of the query. In the following example, a SQL query runs against the `imdb.db` database in the `data` folder. The Astro CLI sends the results of the query to a Snowflake database defined in `snowflake_conn`.
+Each `.sql` file must have a database connection defined as `conn_id` in the front matter of the file. This front matter tells the Astro CLI where to load the query results. In the following example, a SQL query runs against the `imdb.db` database in the `data` folder. The Astro CLI sends the results of the query to a Snowflake database defined in `snowflake_conn`.
 
 ```sql
 ---
@@ -173,8 +173,10 @@ Configure a local data source to test your SQL queries using only a standard SQL
 
 To run a query against data hosted outside of your project, you create a `YAML` file describing how to load the data, then add the file to the workflow where you want to use the data.
 
-1. Create connections for your data source and data destination. See [Configure environments and connections](#configure-environments-and-connections). Copy the `conn_id` of both connections for the next step.
-2. In the workflow where you want to use the data, create a new `yaml` file that tells the CLI about your data source and your data destination. You can use the following example file to load data from Amazon S3 to Amazon Redshift.
+1. Create connections for your data source and data destination. See [Configure environments and connections](#configure-environments-and-connections). 
+
+2. Copy the `conn_id` for both connections.
+3. In the workflow where you want to use the data, create a new `yaml` file that tells the CLI about your data source and your data destination. You can use the following example file to load data from Amazon S3 to Amazon Redshift.
 
     ```yaml
     load_file:
@@ -192,7 +194,7 @@ To run a query against data hosted outside of your project, you create a `YAML` 
         IAM_ROLE: "arn:aws:iam::<account_id>:role/redshift-s3-readonly"
     ```
 
-3. Specify your data source in your queries using one of the following options: 
+4. Specify the data source for your queries using one of the following options: 
 
     - Reference the name of your `yaml` file in your queries using Jinja templating. For example, if the example YAML file in the previous step was named `load_s3.yaml`, your SQL query might look like the following: 
 

--- a/astro/cli/sql-cli.md
+++ b/astro/cli/sql-cli.md
@@ -175,7 +175,7 @@ To run a query against data hosted outside of your project, you create a `YAML` 
 
 1. Create connections for your data source and data destination. See [Configure environments and connections](#configure-environments-and-connections). 
 2. Copy the `conn_id` for both connections.
-3. In the workflow where you want to use the data, create a new `yaml` file that tells the CLI about your data source and your data destination. You can use the following example file to load data from Amazon S3 to Amazon Redshift.
+3. In the workflow where you want to use the data, create a new `yaml` file that tells the CLI to load the contents of a specific database. For example, the following file gives the CLI instructions to load data from Amazon S3 and store the results of your SQL query in Amazon Redshift.
 
     ```yaml
     load_file:

--- a/astro/cli/sql-cli.md
+++ b/astro/cli/sql-cli.md
@@ -154,7 +154,7 @@ If you define a database connection in a `.sql` file with a downstream dependenc
 Configure a local data source to test your SQL queries using only a standard SQLite connection. 
 
 1. Add the data source to your `data` directory. 
-2. Decide the environment in which you want to use the data. In your `config` directory, open the `configuration.yaml` for the environment. 
+2. In your `config` directory, open the `configuration.yaml` for the environment where you want to use the data.
 3. Configure a SQLite connection to your data source. For example:
 
     ```yaml


### PR DESCRIPTION
Adding steps for how to configure data sources in SQL CLI projects. I also tidied up some other sections of the doc while I was at it!

I left questions throughout the doc for SMEs. @kwcanuck I would hold off on reviewing this until SME review is complete - the doc could change quite a bit