### PR TITLE
Bug fix for SearchBar Hit

### DIFF
--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -20,7 +20,7 @@ import Translate, { translate } from '@docusaurus/Translate';
 import styles from './styles.module.css';
 let DocSearchModal = null;
 function Hit({ hit, children }) {
-  return <Link to={hit.url}>{children}</Link>;
+  return <Link to={hit.url.replace('#docusaurus_skipToContent_fallback', '')}>{children}</Link>;
 }
 function ResultsFooter({ state, onClose }) {
   const { generateSearchPageLink } = useSearchPage();


### PR DESCRIPTION
Fixes #1472 

This PR adds a simple `replace()` method to the `DocSearch-Hit` URL string to remove the `#docusaurus_skipToContent_fallback` parameter that is accidentally being added by (I think) [skipToContentUtils.jsx](https://github.com/facebook/docusaurus/blob/308b5390b526d3038c7c3026af7d63d9f1cdf448/packages/docusaurus-theme-common/src/utils/skipToContentUtils.tsx) in the `docusaurus-theme-common` package.

Technically doesn't fix whatever's placing the param on Algolia result items in the first place but it _does_ solve the issue for users so it'll no longer be polluting results!