### PR TITLE
Update GH link for Astro Python SDK

### DIFF
--- a/learn/astro-python-sdk-etl.md
+++ b/learn/astro-python-sdk-etl.md
@@ -5,7 +5,7 @@ description: "Use the Astro Python SDK to implement ELT use cases in Airflow."
 id: "astro-python-sdk-etl"
 ---
 
-The [Astro Python SDK](https://github.com/astro-projects/astro) is an open source tool and Python package for DAG development that is built and maintained by Astronomer. The purpose of the SDK is to remove the complexity of writing DAGs in Apache Airflow, particularly in the context of Extract, Load, Transform (ELT) use cases. This enables pipeline authors to focus more on writing business logic in Python, and less on setting Airflow configurations.
+The [Astro Python SDK]([https://github.com/astro-projects/astro](https://github.com/astronomer/astro-sdk/)) is an open source tool and Python package for DAG development that is built and maintained by Astronomer. The purpose of the SDK is to remove the complexity of writing DAGs in Apache Airflow, particularly in the context of Extract, Load, Transform (ELT) use cases. This enables pipeline authors to focus more on writing business logic in Python, and less on setting Airflow configurations.
 
 The Astro SDK uses Python [decorators](https://realpython.com/primer-on-python-decorators/) and the TaskFlow API to simplify Python functions for common data orchestration use cases. Specifically, the Astro SDK decorators include eight python functions that make it easier to:
 


### PR DESCRIPTION
The project was moved from https://github.com/astro-projects/astro to https://github.com/astronomer/astro-sdk/ long back