### PR TITLE
Runtime is now supported based on major version

### DIFF
--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -24,7 +24,7 @@ For more information about the features that are available in Astro Runtime rele
 Astro Runtime versions are released regularly and use [semantic versioning](https://semver.org/). Astronomer ships major, minor, and patch releases of Astro Runtime in the format of `major.minor.patch`.
 
 - **Major** versions are released for significant feature additions. This includes new major or minor versions of Apache Airflow as well as API or DAG specification changes that are not backwards-compatible.
-- **Minor** versions are released for functional changes. This includes API or DAG specification changes that are backwards-compatible.
+- **Minor** versions are released for functional changes. This includes API or DAG specification changes that are backwards-compatible. This includes new minor versions of `astronomer-providers`, and `openlineage-airflow`.
 - **Patch** versions are released for bug and security fixes that resolve unwanted behavior. This includes new patch versions of Apache Airflow, `astronomer-providers`, and `openlineage-airflow`.
 
 Every version of Astro Runtime correlates to an Apache Airflow version. All Deployments on Astro must run only one version of Astro Runtime, but you can run different versions of Astro Runtime on different Deployments within a given cluster or Workspace. See [Create a Deployment](create-deployment.md#create-a-deployment).
@@ -39,14 +39,13 @@ This table lists Astro Runtime releases and their associated Apache Airflow vers
 
 | Astro Runtime | Apache Airflow version |
 | ------------- | ---------------------- |
-| 4.1.x         | 2.2.4                  |
-| 4.2.x         | 2.2.4-2.2.5            |
-| 5.0.x         | 2.3.0-2.3.4            |
-| 6.0.x         | 2.4.0-2.4.1            |
-| 7.0.x         | 2.5.0            |
+| 4             | 2.2.4-2.2.5            |
+| 5             | 2.3.0-2.3.4            |
+| 6             | 2.4.0-2.4.1            |
+| 7             | 2.5.0            |
 
 :::info
-Each Runtime version in a given minor series supports only a single version of Apache Airflow. For specific version compatibility information, see [Runtime release notes](runtime-release-notes.md).
+For specific version compatibility information, see [Runtime release notes](runtime-release-notes.md).
 :::
 
 ## Default environment variables
@@ -120,13 +119,12 @@ For a list of all Astro Runtime Docker images, see [Quay.io](https://quay.io/rep
 The following table lists the operating systems and architectures supported by each Astro Runtime version. If you're using a Mac computer with an M1 chip, Astronomer recommends using Astro Runtime 6.0.4 or later.
 
 | Astro Runtime | Operating System (OS)                 | Architecture    |
-| ------------- | ---------------------- | -------------   |
-| 4.1.x         | Debian 11.3 (bullseye)        | AMD64           |
-| 4.2.x         | Debian 11.3 (bullseye)        | AMD64           |
-| 5.0.x         | Debian 11.3 (bullseye)        | AMD64           |
-| 6.0.0 - 6.0.3         | Debian 11.3 (bullseye)        | AMD64           |
-| 6.0.4 - 6.0.x         | Debian 11.3 (bullseye)        | AMD64 and ARM64 |
-| 7.0.x         | Debian 11.3 (bullseye)        | AMD64 and ARM64 |
+| ------------- | ------------------------------------- | -------------   |
+| 4             | Debian 11.3 (bullseye)                | AMD64           |
+| 5             | Debian 11.3 (bullseye)                | AMD64           |
+| 6.0.0 - 6.0.3 | Debian 11.3 (bullseye)                | AMD64           |
+| 6.0.4+        | Debian 11.3 (bullseye)                | AMD64 and ARM64 |
+| 7             | Debian 11.3 (bullseye)                | AMD64 and ARM64 |
 
 Astro Runtime 6.0.4 and later images are multi-arch and support AMD64 and ARM64 processor architectures for local development. Docker automatically uses the correct processor architecture based on the computer you are using.
 

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -24,7 +24,7 @@ For more information about the features that are available in Astro Runtime rele
 Astro Runtime versions are released regularly and use [semantic versioning](https://semver.org/). Astronomer ships major, minor, and patch releases of Astro Runtime in the format of `major.minor.patch`.
 
 - **Major** versions are released for significant feature additions. This includes new major or minor versions of Apache Airflow, as well as API or DAG specification changes that are not backwards-compatible.
-- **Minor** versions are released for functional changes. This includes API or DAG specification changes that are backwards-compatible, as well as new minor versions of `astronomer-providers` and `openlineage-airflow`.
+- **Minor** versions are released for functional changes. This includes API or DAG specification changes that are backwards-compatible, which may include new minor versions of `astronomer-providers` and `openlineage-airflow`.
 - **Patch** versions are released for bug and security fixes that resolve unwanted behavior. This includes new patch versions of Apache Airflow, `astronomer-providers`, and `openlineage-airflow`.
 
 Every version of Astro Runtime correlates to an Apache Airflow version. All Deployments on Astro must run only one version of Astro Runtime, but you can run different versions of Astro Runtime on different Deployments within a given cluster or Workspace. See [Create a Deployment](create-deployment.md#create-a-deployment).
@@ -122,8 +122,7 @@ The following table lists the operating systems and architectures supported by e
 | ------------- | ------------------------------------- | -------------   |
 | 4             | Debian 11.3 (bullseye)                | AMD64           |
 | 5             | Debian 11.3 (bullseye)                | AMD64           |
-| 6.0.0 - 6.0.3 | Debian 11.3 (bullseye)                | AMD64           |
-| 6.0.4+        | Debian 11.3 (bullseye)                | AMD64 and ARM64 |
+| 6        | Debian 11.3 (bullseye)                | AMD64 and ARM64 |
 | 7             | Debian 11.3 (bullseye)                | AMD64 and ARM64 |
 
 Astro Runtime 6.0.4 and later images are multi-arch and support AMD64 and ARM64 processor architectures for local development. Docker automatically uses the correct processor architecture based on the computer you are using.

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -44,9 +44,7 @@ This table lists Astro Runtime releases and their associated Apache Airflow vers
 | 6             | 2.4                    |
 | 7             | 2.5                    |
 
-:::info
 For specific version compatibility information, see [Runtime release notes](runtime-release-notes.md).
-:::
 
 ## Default environment variables
 

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -39,10 +39,10 @@ This table lists Astro Runtime releases and their associated Apache Airflow vers
 
 | Astro Runtime | Apache Airflow version |
 | ------------- | ---------------------- |
-| 4             | 2.2.4-2.2.5            |
-| 5             | 2.3.0-2.3.4            |
-| 6             | 2.4.0-2.4.3            |
-| 7             | 2.5.0                  |
+| 4             | 2.2                    |
+| 5             | 2.3                    |
+| 6             | 2.4                    |
+| 7             | 2.5                    |
 
 :::info
 For specific version compatibility information, see [Runtime release notes](runtime-release-notes.md).

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -23,8 +23,8 @@ For more information about the features that are available in Astro Runtime rele
 
 Astro Runtime versions are released regularly and use [semantic versioning](https://semver.org/). Astronomer ships major, minor, and patch releases of Astro Runtime in the format of `major.minor.patch`.
 
-- **Major** versions are released for significant feature additions. This includes new major or minor versions of Apache Airflow as well as API or DAG specification changes that are not backwards-compatible.
-- **Minor** versions are released for functional changes. This includes API or DAG specification changes that are backwards-compatible. This includes new minor versions of `astronomer-providers`, and `openlineage-airflow`.
+- **Major** versions are released for significant feature additions. This includes new major or minor versions of Apache Airflow, as well as API or DAG specification changes that are not backwards-compatible.
+- **Minor** versions are released for functional changes. This includes API or DAG specification changes that are backwards-compatible, as well as new minor versions of `astronomer-providers` and `openlineage-airflow`.
 - **Patch** versions are released for bug and security fixes that resolve unwanted behavior. This includes new patch versions of Apache Airflow, `astronomer-providers`, and `openlineage-airflow`.
 
 Every version of Astro Runtime correlates to an Apache Airflow version. All Deployments on Astro must run only one version of Astro Runtime, but you can run different versions of Astro Runtime on different Deployments within a given cluster or Workspace. See [Create a Deployment](create-deployment.md#create-a-deployment).
@@ -42,7 +42,7 @@ This table lists Astro Runtime releases and their associated Apache Airflow vers
 | 4             | 2.2.4-2.2.5            |
 | 5             | 2.3.0-2.3.4            |
 | 6             | 2.4.0-2.4.1            |
-| 7             | 2.5.0            |
+| 7             | 2.5.0                  |
 
 :::info
 For specific version compatibility information, see [Runtime release notes](runtime-release-notes.md).

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -24,7 +24,7 @@ For more information about the features that are available in Astro Runtime rele
 Astro Runtime versions are released regularly and use [semantic versioning](https://semver.org/). Astronomer ships major, minor, and patch releases of Astro Runtime in the format of `major.minor.patch`.
 
 - **Major** versions are released for significant feature additions. This includes new major or minor versions of Apache Airflow, as well as API or DAG specification changes that are not backwards-compatible.
-- **Minor** versions are released for functional changes. This includes API or DAG specification changes that are backwards-compatible, which may include new minor versions of `astronomer-providers` and `openlineage-airflow`.
+- **Minor** versions are released for functional changes. This includes API or DAG specification changes that are backwards-compatible, which might include new minor versions of `astronomer-providers` and `openlineage-airflow`.
 - **Patch** versions are released for bug and security fixes that resolve unwanted behavior. This includes new patch versions of Apache Airflow, `astronomer-providers`, and `openlineage-airflow`.
 
 Every version of Astro Runtime correlates to an Apache Airflow version. All Deployments on Astro must run only one version of Astro Runtime, but you can run different versions of Astro Runtime on different Deployments within a given cluster or Workspace. See [Create a Deployment](create-deployment.md#create-a-deployment).

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -122,7 +122,7 @@ The following table lists the operating systems and architectures supported by e
 | ------------- | ------------------------------------- | -------------   |
 | 4             | Debian 11.3 (bullseye)                | AMD64           |
 | 5             | Debian 11.3 (bullseye)                | AMD64           |
-| 6        | Debian 11.3 (bullseye)                | AMD64 and ARM64 |
+| 6             | Debian 11.3 (bullseye)                | AMD64 and ARM64 |
 | 7             | Debian 11.3 (bullseye)                | AMD64 and ARM64 |
 
 Astro Runtime 6.0.4 and later images are multi-arch and support AMD64 and ARM64 processor architectures for local development. Docker automatically uses the correct processor architecture based on the computer you are using.

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -41,7 +41,7 @@ This table lists Astro Runtime releases and their associated Apache Airflow vers
 | ------------- | ---------------------- |
 | 4             | 2.2.4-2.2.5            |
 | 5             | 2.3.0-2.3.4            |
-| 6             | 2.4.0-2.4.1            |
+| 6             | 2.4.0-2.4.3            |
 | 7             | 2.5.0                  |
 
 :::info

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -23,8 +23,8 @@ For more information about the features that are available in Astro Runtime rele
 
 Astro Runtime versions are released regularly and use [semantic versioning](https://semver.org/). Astronomer ships major, minor, and patch releases of Astro Runtime in the format of `major.minor.patch`.
 
-- **Major** versions are released for significant feature additions. This includes new major or minor versions of Apache Airflow, as well as API or DAG specification changes that are not backwards-compatible.
-- **Minor** versions are released for functional changes. This includes API or DAG specification changes that are backwards-compatible, which might include new minor versions of `astronomer-providers` and `openlineage-airflow`.
+- **Major** versions are released for significant feature additions. This includes new major or minor versions of Apache Airflow, as well as API or DAG specification changes that are not backward compatible.
+- **Minor** versions are released for functional changes. This includes API or DAG specification changes that are backward compatible, which might include new minor versions of `astronomer-providers` and `openlineage-airflow`.
 - **Patch** versions are released for bug and security fixes that resolve unwanted behavior. This includes new patch versions of Apache Airflow, `astronomer-providers`, and `openlineage-airflow`.
 
 Every version of Astro Runtime correlates to an Apache Airflow version. All Deployments on Astro must run only one version of Astro Runtime, but you can run different versions of Astro Runtime on different Deployments within a given cluster or Workspace. See [Create a Deployment](create-deployment.md#create-a-deployment).
@@ -44,7 +44,7 @@ This table lists Astro Runtime releases and their associated Apache Airflow vers
 | 6             | 2.4                    |
 | 7             | 2.5                    |
 
-For specific version compatibility information, see [Runtime release notes](runtime-release-notes.md).
+For version compatibility information, see the [Runtime release notes](runtime-release-notes.md).
 
 ## Default environment variables
 

--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -20,7 +20,7 @@ To meet the unique needs of different operating environments, Astro Runtime vers
 - **Stable:** Includes the latest Astronomer and Apache Airflow features, available on release
 - **Long-term Support (LTS):** Includes additional testing, stability, and maintenance for a core set of features
 
-Each Astro Runtime version, such as Runtime version `5`, is associated with an Astro Runtime stable release channel. The LTS release channel is a subset of the stable release channel and includes additional stability, reliability, and support. For more information on how Astro Runtime is versioned, see [Runtime versioning](runtime-image-architecture.md#runtime-versioning).
+Each major Astro Runtime version is associated with an Astro Runtime stable release channel. The LTS release channel is a subset of the stable release channel and includes additional stability, reliability, and support. For more information on how Astro Runtime is versioned, see [Runtime versioning](runtime-image-architecture.md#runtime-versioning).
 
 For users that want to keep up with the latest Astronomer and Airflow features on an incremental basis, we recommend upgrading to new versions of Astro Runtime as soon as they are made generally available. This should be regardless of release channel. New versions of Runtime are issued regularly and include timely support for the latest major, minor, and patch versions of Airflow.
 

--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -83,18 +83,18 @@ The following table contains the exact lifecycle for each published version of A
 
 | Runtime Version                                 | Apache Airflow version | Release Date       | End of Maintenance Date |
 | ----------------------------------------------- | ---------------------- | ------------------ | ----------------------- |
-| [4](runtime-release-notes.md#astro-runtime-420) | 2.2.4-2.2.5            | March 10, 2022     | September 2023          |
-| [5](runtime-release-notes.md#astro-runtime-500) | 2.3.0-2.3.4            | April 30, 2022     | October 2023            |
-| [6](runtime-release-notes.md#astro-runtime-600) | 2.4.0-2.4.3            | September 19, 2022 | March 2024              |
-| [7](runtime-release-notes.md#astro-runtime-700) | 2.5.0                  | December 3, 2022   | June 2023               |
+| [4](runtime-release-notes.md#astro-runtime-420) | 2.2                    | March 10, 2022     | September 2023          |
+| [5](runtime-release-notes.md#astro-runtime-500) | 2.3                    | April 30, 2022     | October 2023            |
+| [6](runtime-release-notes.md#astro-runtime-600) | 2.4                    | September 19, 2022 | March 2024              |
+| [7](runtime-release-notes.md#astro-runtime-700) | 2.5                    | December 3, 2022   | June 2023               |
 
 ### Long-term support (LTS) releases 
 
 | Runtime Version                                 | Apache Airflow version | Release Date       | End of Maintenance Date |
 | ----------------------------------------------- | ---------------------- | ------------------ | ----------------------- |
-| [4](runtime-release-notes.md#astro-runtime-420) | 2.2.4-2.2.5            | March 10, 2022     | September 2023          |
-| [5](runtime-release-notes.md#astro-runtime-500) | 2.3.0-2.3.4            | April 30, 2022     | October 2023            |
-| [6](runtime-release-notes.md#astro-runtime-600) | 2.4.0-2.4.3            | September 19, 2022 | March 2024              |
+| [4](runtime-release-notes.md#astro-runtime-420) | 2.2                    | March 10, 2022     | September 2023          |
+| [5](runtime-release-notes.md#astro-runtime-500) | 2.3                    | April 30, 2022     | October 2023            |
+| [6](runtime-release-notes.md#astro-runtime-600) | 2.4                    | September 19, 2022 | March 2024              |
 
 :::info
 For specific version compatibility information, see [Runtime release notes](runtime-release-notes.md).

--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -20,7 +20,7 @@ To meet the unique needs of different operating environments, Astro Runtime vers
 - **Stable:** Includes the latest Astronomer and Apache Airflow features, available on release
 - **Long-term Support (LTS):** Includes additional testing, stability, and maintenance for a core set of features
 
-Each Astro Runtime version defined as a `major.minor` pair, such as Runtime version `5.1`, is associated with an Astro Runtime stable release channel. The LTS release channel is a subset of the stable release channel and includes additional stability, reliability, and support. For more information on how Astro Runtime is versioned, see [Runtime versioning](runtime-image-architecture.md#runtime-versioning).
+Each Astro Runtime version, such as Runtime version `5`, is associated with an Astro Runtime stable release channel. The LTS release channel is a subset of the stable release channel and includes additional stability, reliability, and support. For more information on how Astro Runtime is versioned, see [Runtime versioning](runtime-image-architecture.md#runtime-versioning).
 
 For users that want to keep up with the latest Astronomer and Airflow features on an incremental basis, we recommend upgrading to new versions of Astro Runtime as soon as they are made generally available. This should be regardless of release channel. New versions of Runtime are issued regularly and include timely support for the latest major, minor, and patch versions of Airflow.
 
@@ -35,7 +35,7 @@ The maintenance period for an Astro Runtime version depends on its release chann
 | Stable          | 6 months or 3 months after the next major Runtime release (whichever is longer) |
 | LTS             | 18 months                                                                       |
 
-For each `major.minor` pair, only the latest patch is supported at any given time. If you report an issue with an Astro Runtime patch version that is not latest, the Astronomer Support team will always ask that you upgrade as a first step to resolution. For example, we encourage any user who reports an issue with Astro Runtime 4.0.2 to first upgrade to the latest 4.0.x version as soon as it's generally available.
+For each Runtime version, only the latest patch is supported at any given time. If you report an issue with an Astro Runtime patch version that is not latest, the Astronomer Support team will always ask that you upgrade as a first step to resolution. For example, we encourage any user who reports an issue with Astro Runtime 4.0.2 to first upgrade to the latest 4.x.y version as soon as it's generally available.
 
 Within the maintenance window of each Astro Runtime version, the following is true:
 
@@ -81,23 +81,23 @@ The following table contains the exact lifecycle for each published version of A
 
 ### Stable releases
 
-| Runtime Version                                     | Apache Airflow version | Release Date       | End of Maintenance Date |
-| --------------------------------------------------- | ---------------------- | ------------------ | ----------------------- |
-| [4.2.x](runtime-release-notes.md#astro-runtime-420) | 2.2.4-2.2.5            | March 10, 2022     | September 2023          |
-| [5.0.x](runtime-release-notes.md#astro-runtime-500) | 2.3.0-2.3.4            | April 30, 2022     | October 2023            |
-| [6.0.x](runtime-release-notes.md#astro-runtime-600) | 2.4.0-2.4.3            | September 19, 2022 | March 2024              |
-| [7.0.x](runtime-release-notes.md#astro-runtime-700) | 2.5.0                  | December 3, 2022   | June 2023               |
+| Runtime Version                                 | Apache Airflow version | Release Date       | End of Maintenance Date |
+| ----------------------------------------------- | ---------------------- | ------------------ | ----------------------- |
+| [4](runtime-release-notes.md#astro-runtime-420) | 2.2.4-2.2.5            | March 10, 2022     | September 2023          |
+| [5](runtime-release-notes.md#astro-runtime-500) | 2.3.0-2.3.4            | April 30, 2022     | October 2023            |
+| [6](runtime-release-notes.md#astro-runtime-600) | 2.4.0-2.4.3            | September 19, 2022 | March 2024              |
+| [7](runtime-release-notes.md#astro-runtime-700) | 2.5.0                  | December 3, 2022   | June 2023               |
 
 ### Long-term support (LTS) releases 
 
-| Runtime Version                                     | Apache Airflow version | Release Date       | End of Maintenance Date |
-| --------------------------------------------------- | ---------------------- | ------------------ | ----------------------- |
-| [4.2.x](runtime-release-notes.md#astro-runtime-420) | 2.2.4-2.2.5            | March 10, 2022     | September 2023          |
-| [5.0.x](runtime-release-notes.md#astro-runtime-500) | 2.3.0-2.3.4            | April 30, 2022     | October 2023            |
-| [6.0.x](runtime-release-notes.md#astro-runtime-600) | 2.4.0-2.4.3            | September 19, 2022 | March 2024              |
+| Runtime Version                                 | Apache Airflow version | Release Date       | End of Maintenance Date |
+| ----------------------------------------------- | ---------------------- | ------------------ | ----------------------- |
+| [4](runtime-release-notes.md#astro-runtime-420) | 2.2.4-2.2.5            | March 10, 2022     | September 2023          |
+| [5](runtime-release-notes.md#astro-runtime-500) | 2.3.0-2.3.4            | April 30, 2022     | October 2023            |
+| [6](runtime-release-notes.md#astro-runtime-600) | 2.4.0-2.4.3            | September 19, 2022 | March 2024              |
 
 :::info
-Each Runtime version in a given minor series supports only a single version of Apache Airflow. For specific version compatibility information, see [Runtime release notes](runtime-release-notes.md).
+For specific version compatibility information, see [Runtime release notes](runtime-release-notes.md).
 :::
 
 If you have any questions or concerns, contact [Astronomer support](https://cloud.astronomer.io/support).

--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -35,7 +35,7 @@ The maintenance period for an Astro Runtime version depends on its release chann
 | Stable          | 6 months or 3 months after the next major Runtime release (whichever is longer) |
 | LTS             | 18 months                                                                       |
 
-For each major Runtime version, only the latest `minor.patch` version is supported at any given time. If you report an issue with an Astro Runtime version that is not latest, the Astronomer Support team will always ask that you upgrade as a first step to resolution. For example, we encourage any user who reports an issue with Astro Runtime 4.0.2 to first upgrade to the latest 4.x.y version as soon as it's generally available.
+For each major Runtime version, only the latest `minor.patch` version is supported at any given time. If you report an issue with an Astro Runtime version that is not latest, the Astronomer Support team will always ask that you upgrade as a first step to resolution. For example, any user who reports an issue with Astro Runtime 4.0.2 will be asked to upgrade to the latest 4.x.y version as soon as it's generally available.
 
 Within the maintenance window of each Astro Runtime version, the following is true:
 
@@ -97,7 +97,7 @@ The following table contains the exact lifecycle for each published version of A
 | [6](runtime-release-notes.md#astro-runtime-600) | 2.4                    | September 19, 2022 | March 2024              |
 
 :::info
-For specific version compatibility information, see [Runtime release notes](runtime-release-notes.md).
+For version compatibility information, see the [Runtime release notes](runtime-release-notes.md).
 :::
 
 If you have any questions or concerns, contact [Astronomer support](https://cloud.astronomer.io/support).

--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -35,7 +35,7 @@ The maintenance period for an Astro Runtime version depends on its release chann
 | Stable          | 6 months or 3 months after the next major Runtime release (whichever is longer) |
 | LTS             | 18 months                                                                       |
 
-For each Runtime release channel, only the latest minor.patch version is supported at any given time. If you report an issue with an Astro Runtime version that is not latest, the Astronomer Support team will always ask that you upgrade as a first step to resolution. For example, we encourage any user who reports an issue with Astro Runtime 4.0.2 to first upgrade to the latest 4.x.y version as soon as it's generally available.
+For each major Runtime version, only the latest `minor.patch` version is supported at any given time. If you report an issue with an Astro Runtime version that is not latest, the Astronomer Support team will always ask that you upgrade as a first step to resolution. For example, we encourage any user who reports an issue with Astro Runtime 4.0.2 to first upgrade to the latest 4.x.y version as soon as it's generally available.
 
 Within the maintenance window of each Astro Runtime version, the following is true:
 

--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -35,7 +35,7 @@ The maintenance period for an Astro Runtime version depends on its release chann
 | Stable          | 6 months or 3 months after the next major Runtime release (whichever is longer) |
 | LTS             | 18 months                                                                       |
 
-For each Runtime version, only the latest patch is supported at any given time. If you report an issue with an Astro Runtime patch version that is not latest, the Astronomer Support team will always ask that you upgrade as a first step to resolution. For example, we encourage any user who reports an issue with Astro Runtime 4.0.2 to first upgrade to the latest 4.x.y version as soon as it's generally available.
+For each Runtime release channel, only the latest minor.patch version is supported at any given time. If you report an issue with an Astro Runtime version that is not latest, the Astronomer Support team will always ask that you upgrade as a first step to resolution. For example, we encourage any user who reports an issue with Astro Runtime 4.0.2 to first upgrade to the latest 4.x.y version as soon as it's generally available.
 
 Within the maintenance window of each Astro Runtime version, the following is true:
 


### PR DESCRIPTION
We are now supporting Runtime based on the major version, making it realistic for us to make updates to OL/astronomer-providers be minor Runtime releases.