### PR TITLE
fix connection id argument is misnamed

### DIFF
--- a/learn/airflow-mongodb.md
+++ b/learn/airflow-mongodb.md
@@ -110,7 +110,7 @@ from airflow.providers.mongo.hooks.mongo import MongoHook
 from pendulum import datetime
 
 def uploadtomongo(ti, **context):
-    hook = MongoHook(mongo_conn_id='mongo_default')
+    hook = MongoHook(conn_id='mongo_default')
     client = hook.get_conn()
     db = client.MyDB # Replace "MyDB" if you want to load data to a different database
     currency_collection=db.currency_collection


### PR DESCRIPTION
According to the constructor signature, the connection id argument is not mongo_conn_id but conn_id

<pre>
class MongoHook(BaseHook):
    def __init__(self, conn_id: str = default_conn_name, *args, **kwargs) -> None:
        super().__init__()
        self.mongo_conn_id = conn_id
<pre>