### PR TITLE
Fix KPO code formatting and highlighting

### DIFF
--- a/astro/kubernetespodoperator.md
+++ b/astro/kubernetespodoperator.md
@@ -191,22 +191,22 @@ If your Docker image is hosted in an Amazon ECR repository, add a permissions po
 4. Click **Edit policy JSON**.
 5. Copy and paste the following policy into the **Edit JSON** pane:
 
-    ```JSON   
+    ```json
     {
-    "Version": "2008-10-17",
-    "Statement": [
-        {
-        "Sid": "AllowImagePullAstro",
-        "Effect": "Allow",
-        "Principal": {
-            "AWS": "arn:aws:iam::<AstroAccountID>:root"
-        },
-        "Action": [
-            "ecr:GetDownloadUrlForLayer",
-            "ecr:BatchGetImage"
+        "Version": "2008-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowImagePullAstro",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn:aws:iam::<AstroAccountID>:root"
+                },
+                "Action": [
+                    "ecr:GetDownloadUrlForLayer",
+                    "ecr:BatchGetImage"
+                ]
+            }
         ]
-        }
-    ]
     }
     ```
 6. Replace `<AstroAccountID>` with your Astro AWS account ID. 

--- a/astro/kubernetespodoperator.md
+++ b/astro/kubernetespodoperator.md
@@ -107,7 +107,7 @@ To run a task run the KubernetesPodOperator that utilizes ephemeral storage:
 1. Create a [worker queue](configure-worker-queues.md) with `m5d` workers. See [Modify a cluster](modify-cluster.md) for instructions on adding `m5d` workers to your cluster.
 2. Mount and [emptyDir volume](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir-configuration-example) to the KubernetesPodOperator. For example:
 
-    ```python{5-14,26-27}
+    ```python {5-14,26-27}
     from airflow.configuration import conf
     from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
     from kubernetes.client import models as k8s
@@ -124,17 +124,17 @@ To run a task run the KubernetesPodOperator that utilizes ephemeral storage:
     ]
 
     example_volume_test = KubernetesPodOperator(
-    namespace=namespace,
-    image="<your-docker-image>",
-    cmds=["<commands-for-image>"],
-    arguments=["<arguments-for-image>"],
-    labels={"<pod-label>": "<label-name>"},
-    name="<pod-name>",
-    resources=compute_resources,
-    task_id="<task-name>",
-    get_logs=True,
-    volume_mounts=volume_mounts,
-    volumes=[volume],
+        namespace=namespace,
+        image="<your-docker-image>",
+        cmds=["<commands-for-image>"],
+        arguments=["<arguments-for-image>"],
+        labels={"<pod-label>": "<label-name>"},
+        name="<pod-name>",
+        resources=compute_resources,
+        task_id="<task-name>",
+        get_logs=True,
+        volume_mounts=volume_mounts,
+        volumes=[volume],
     )
     ```
  


### PR DESCRIPTION
A code example in the KPO doc is not properly indented + there's no syntax highlighting.

**Before:**
<img width="1138" alt="image" src="https://user-images.githubusercontent.com/6249654/209839395-8e8f89f0-cc82-485a-8ee3-8e0049169cbf.png">

**After:**
<img width="1111" alt="image" src="https://user-images.githubusercontent.com/6249654/209840140-c0fe6791-5301-4dc4-a0ac-f1c8355953a7.png">

Also fixed the json formatting down below:

**Before:**
![image](https://user-images.githubusercontent.com/6249654/209998611-9b4fa9f9-2fd9-4a86-a959-846a7472f038.png)

**After:**
![image](https://user-images.githubusercontent.com/6249654/209999112-69975a37-dbde-4d5c-89c4-9f4a4da8d57d.png)
