### PR TITLE
Runtime 5.1 release notes

### DIFF
--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -171,7 +171,7 @@ For a complete list of commits, see the [Apache Airflow 2.4.0 release notes](htt
 
 ## Astro Runtime 5.1.0
 
-- Release date: January 4, 2022
+- Release date: January 4, 2023
 - Airflow version: 2.3.4
 
 ### Additional improvements

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -93,7 +93,6 @@ For a complete list of the changes, see the [Apache Airflow 2.4.3 release notes]
 - Upgraded `openlineage-airflow` to 0.16.1. This release includes the `DefaultExtractor`, which allows you to extract the default available OpenLineage data for external operators without needing to write a custom extractor. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/releases/tag/0.16.1) for more information. 
 - Upgraded `astronomer-providers` to 1.11.1, which includes bug fixes. For a complete list of the changes, see the [Astronomer Providers changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#1111-2022-10-28).
 
-
 ## Astro Runtime 6.0.3
 
 - Release date: October 24, 2022
@@ -169,6 +168,17 @@ For a complete list of commits, see the [Apache Airflow 2.4.0 release notes](htt
 
 - Upgraded `astronomer-providers` to 1.9.0, which includes two new deferrable versions of the operators from the dbt provider package. See the [Astronomer Providers changelog](https://github.com/astronomer/astronomer-providers/blob/1.9.0/CHANGELOG.rst).
 - Upgraded `openlineage-airflow` to version `0.14.1`. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md).
+
+## Astro Runtime 5.1.0
+
+- Release date: January 4, 2022
+- Airflow version: 2.3.4
+
+### Additional improvements
+
+- Upgraded `astronomer-providers` to 1.13.0, which includes a collection of minor enhancements and bug fixes. See the [`astronomer-providers` changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#1130-2022-12-16). 
+- Upgraded `openlineage-airflow` to 0.18.0, which includes new support for Airflow operators like the `SQLExecuteQueryOperator`. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/releases/tag/0.18.0) for more information. 
+- Airflow environments hosted on Astro now include a **Back to Astro** button in the Airflow UI. Use this button to return to the Deployment hosting the Airflow environment in the Cloud UI.
 
 ## Astro Runtime 5.0.13
 

--- a/software/runtime-release-notes.md
+++ b/software/runtime-release-notes.md
@@ -157,6 +157,16 @@ For a complete list of commits, see the [Apache Airflow 2.4.0 release notes](htt
 - Upgraded `astronomer-providers` to 1.9.0, which includes two new deferrable versions of the operators from the dbt provider package. See the [Astronomer Providers changelog](https://github.com/astronomer/astronomer-providers/blob/1.9.0/CHANGELOG.rst).
 - Upgraded `openlineage-airflow` to version `0.14.1`. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md).
 
+## Astro Runtime 5.1.0
+
+- Release date: January 4, 2022
+- Airflow version: 2.3.4
+
+### Additional improvements
+
+- Upgraded `astronomer-providers` to 1.13.0, which includes a collection of minor enhancements and bug fixes. See the [`astronomer-providers` changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#1130-2022-12-16). 
+- Upgraded `openlineage-airflow` to 0.18.0, which includes new support for Airflow operators like the `SQLExecuteQueryOperator`. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/releases/tag/0.18.0) for more information. 
+
 ## Astro Runtime 5.0.13
 
 - Release date: December 12, 2022

--- a/software/runtime-release-notes.md
+++ b/software/runtime-release-notes.md
@@ -159,7 +159,7 @@ For a complete list of commits, see the [Apache Airflow 2.4.0 release notes](htt
 
 ## Astro Runtime 5.1.0
 
-- Release date: January 4, 2022
+- Release date: January 4, 2023
 - Airflow version: 2.3.4
 
 ### Additional improvements

--- a/software_versioned_docs/version-0.29/runtime-release-notes.md
+++ b/software_versioned_docs/version-0.29/runtime-release-notes.md
@@ -159,7 +159,7 @@ For a complete list of commits, see the [Apache Airflow 2.4.0 release notes](htt
 
 ## Astro Runtime 5.1.0
 
-- Release date: January 4, 2022
+- Release date: January 4, 2023
 - Airflow version: 2.3.4
 
 ### Additional improvements

--- a/software_versioned_docs/version-0.29/runtime-release-notes.md
+++ b/software_versioned_docs/version-0.29/runtime-release-notes.md
@@ -9,7 +9,19 @@ description: Release notes for Astro Runtime, the differentiated Apache Airflow 
 
 Astro Runtime is a Docker image built and published by Astronomer that extends the Apache Airflow project to provide a differentiated data orchestration experience. This document provides a summary of changes made to each available version of Astro Runtime. Note that some changes to Runtime might be omitted based on their availability in Astronomer Software.
 
-For instructions on how to upgrade, read [Upgrade Airflow on Astronomer Software](manage-airflow-versions.md). For general product release notes, go to [Software release notes](release-notes.md). If you have any questions or a bug to report, reach out to [Astronomer support](https://support.astronomer.io).
+For upgrade instructions, see [Upgrade Airflow on Astronomer Software](manage-airflow-versions.md). For general product release notes, go to [Software release notes](release-notes.md). If you have any questions or a bug to report, contact [Astronomer support](https://support.astronomer.io).
+
+## Astro Runtime 7.1.0
+
+- Release date: December 21, 2022
+- Airflow version: 2.5.0
+
+### Additional improvements
+
+- Upgraded `astronomer-providers` to 1.13.0, which includes a collection of minor enhancements and bug fixes. See the [`astronomer-providers` changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#1130-2022-12-16). 
+- Upgraded `openlineage-airflow` to 0.18.0, which includes new support for Airflow operators like the `SQLExecuteQueryOperator`. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/releases/tag/0.18.0) for more information. 
+- Upgraded `apache-airflow-providers-microsoft-azure` to 5.0.1, which includes a bug fix to revert `offset` and `length` to be optional arguments.
+- Upgraded `certifi` to 2022.12.7.
 
 ## Astro Runtime 7.0.0 
 
@@ -18,13 +30,15 @@ For instructions on how to upgrade, read [Upgrade Airflow on Astronomer Software
 
 ### Airflow 2.5.0
 
-Astro Runtime 7.0.0 includes same-day support for Airflow 2.5.0, which includes a collection of new features, bug fixes, automatic changes, and deprecations. Key changes include:
+Astro Runtime 7.0.0 includes same-day support for Airflow 2.5.0, which includes a collection of new features, bug fixes, automatic changes, and deprecations. Features include:
 
-- Allow depth-first execution ([#27827](https://github.com/apache/airflow/pull/27827))
-- Add logic for XComArg to pull specific map indexes ([#27771](https://github.com/apache/airflow/pull/27771))
-- Metric for raw task return codes ([#27155](https://github.com/apache/airflow/pull/27155))
+- Add comments to task instances and DAG runs in the Airflow UI ([#26457](https://github.com/apache/airflow/pull/26457))
+- Clear all task instances in a task group with one click in the Airflow UI ([#26658](https://github.com/apache/airflow/pull/26658)), [#28003](https://github.com/apache/airflow/pull/28003))
+- Trigger a task when at least one upstream tasks is successful with new `one_done` trigger rule [#26146](https://github.com/apache/airflow/pull/26146)
+- New **Parsed at** metric in the DAG view of the Airflow UI [#27573](https://github.com/apache/airflow/pull/27573)
+- Filter datasets in Airflow UI based on recent update events [#26942](https://github.com/apache/airflow/pull/26942)
 
-For a complete list of commits, see the [Apache Airflow 2.5.0 release notes](https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-5-0-2022-12-02).
+To learn more, see [What's New in Apache Airflow 2.5](https://www.astronomer.io/blog/whats-new-in-apache-airflow-2-5/) and the [Apache Airflow 2.5.0 release notes](https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-5-0-2022-12-02).
 
 ### Additional improvements 
 
@@ -40,7 +54,7 @@ For a complete list of commits, see the [Apache Airflow 2.5.0 release notes](htt
 
 :::caution
 
-To deploy a project using Astro Runtime 6.0.4 or later from an Apple M1 computer to Astro, you must use Astro CLI version 1.4.0 or later or else the deploy will fail. See [Install the CLI](install-cli.md).
+To deploy a project using Astro Runtime 6.0.4 or later from an Apple M1 computer to Astro, you must use Astro CLI version 1.4.0 or later or else the deploy will fail. See [Install the Astro CLI](cli/install-cli.md).
 
 :::
 
@@ -48,7 +62,7 @@ Astro Runtime images now support both AMD64 and ARM64 processor architectures fo
 
 If you run the Astro CLI on a Mac computer that uses an ARM-based [Apple M1 Silicon chip](https://www.apple.com/newsroom/2020/11/apple-unleashes-m1/), you will see a significant performance improvement when running Airflow locally. For example, the time it takes to run `astro dev start` on average has decreased from over 5 minutes to less than 2 minutes.
 
-For more information on developing locally with the Astro CLI, see [Customize your image](customize-image.md)
+For more information on developing locally with the Astro CLI, see [Develop a Project](develop-project.md).
 
 ### Airflow 2.4.3 
 
@@ -64,6 +78,7 @@ For a complete list of the changes, see the [Apache Airflow 2.4.3 release notes]
 - Upgraded `openlineage-airflow` to 0.16.1. This release includes the `DefaultExtractor`, which allows you to extract the default available OpenLineage data for external operators without needing to write a custom extractor. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/releases/tag/0.16.1) for more information. 
 - Upgraded `astronomer-providers` to 1.11.1, which includes bug fixes. For a complete list of the changes, see the [Astronomer Providers changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#1111-2022-10-28).
 
+
 ## Astro Runtime 6.0.3
 
 - Release date: October 24, 2022
@@ -71,7 +86,7 @@ For a complete list of the changes, see the [Apache Airflow 2.4.3 release notes]
 
 ### Airflow 2.4.2
 
-Astro Runtime 6.0.3 includes same-day support for Airflow 2.4.2. The following are some of the changes included in Airflow 2.4.2:
+Astro Runtime 6.0.3 includes same-day support for Airflow 2.4.2. Some changes in Airflow 2.4.2 include:
 
 - Handle mapped tasks in task duration chart ([#26722](https://github.com/apache/airflow/pull/26722))
 - Make tracebacks opt-in ([#27059](https://github.com/apache/airflow/pull/27059))
@@ -87,11 +102,16 @@ For a complete list of commits, see the [Apache Airflow 2.4.2 release notes](htt
 - Release date: September 30, 2022
 - Airflow version: 2.4.1
 
-### Support for Apache Airflow 2.4.1
+### Airflow 2.4.1
 
-Astro Runtime 6.0.2 includes Airflow 2.4.1, which is limited to bug fixes. For a complete list of commits, see the [Apache Airflow 2.4.1 release notes](https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-4-1-2022-09-30).
+Astro Runtime 6.0.2 includes same-day support for Airflow 2.4.1, which includes a collection of bug fixes. Fixes include:
 
-### Backported bug fixes from Apache Airflow 2.4.2
+- Fix Deferrable stuck as scheduled during backfill ([#26205](https://github.com/apache/airflow/pull/26205))
+- Don't update backfill run from the scheduler ([#26342](https://github.com/apache/airflow/pull/26342))
+
+For a complete list of commits, see the [Apache Airflow 2.4.1 release notes](https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-4-1-2022-09-30).
+
+### Early access Airflow bug fixes
 
 Astro Runtime 6.0.2 includes the following bug fixes:
 
@@ -116,6 +136,54 @@ These changes were backported from Apache Airflow 2.4.2, which is not yet genera
 - Backported a fix to correct an issue where logs were not loading from Celery workers ([#26493](https://github.com/apache/airflow/pull/26493))
 - Fixed [CVE-2022-40674](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40674)
 
+## Astro Runtime 6.0.0
+
+- Release date: September 19, 2022
+- Airflow version: 2.4.0
+
+### Airflow 2.4 and data-aware scheduling
+
+Astro Runtime 6.0.0 provides same-day support for [Airflow 2.4.0](https://airflow.apache.org/blog/airflow-2.4.0/), which delivers significant new features for DAG scheduling. The most notable new features in Airflow 2.4.0 are:
+
+- [Data-aware scheduling](https://airflow.apache.org/docs/apache-airflow/2.4.0/concepts/datasets.html), which is a new method for scheduling a DAG based on when an upstream DAG modifies a specific dataset.
+- The [ExternalPythonOperator](https://airflow.apache.org/docs/apache-airflow/2.4.0/howto/operator/python.html#externalpythonoperator), which can execute Python code in a virtual environment with different Python libraries and dependencies than your core Airflow environment.
+- Automatic DAG registration. You no longer need to specify `as dag` when defining a DAG object.
+- Support for [zipping](https://airflow.apache.org/docs/apache-airflow/2.4.0/concepts/dynamic-task-mapping.html#combining-upstream-data-aka-zipping) dynamically mapped tasks.
+
+For a complete list of commits, see the [Apache Airflow 2.4.0 release notes](https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-4-0-2022-09-19).
+
+### Additional improvements
+
+- Upgraded `astronomer-providers` to 1.9.0, which includes two new deferrable versions of the operators from the dbt provider package. See the [Astronomer Providers changelog](https://github.com/astronomer/astronomer-providers/blob/1.9.0/CHANGELOG.rst).
+- Upgraded `openlineage-airflow` to version `0.14.1`. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md).
+
+## Astro Runtime 5.1.0
+
+- Release date: January 4, 2022
+- Airflow version: 2.3.4
+
+### Additional improvements
+
+- Upgraded `astronomer-providers` to 1.13.0, which includes a collection of minor enhancements and bug fixes. See the [`astronomer-providers` changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#1130-2022-12-16). 
+- Upgraded `openlineage-airflow` to 0.18.0, which includes new support for Airflow operators like the `SQLExecuteQueryOperator`. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/releases/tag/0.18.0) for more information. 
+
+## Astro Runtime 5.0.13
+
+- Release date: December 12, 2022
+- Airflow version: 2.3.4
+
+### Backported Airflow bug fixes
+
+Astro Runtime 5.0.13 includes the following bug fixes from later Apache Airflow releases:
+
+- Change the template to use human readable task_instance description ([#25960](https://github.com/apache/airflow/pull/25960))
+- Fix deadlock when chaining multiple empty mapped tasks ([#27964](https://github.com/apache/airflow/pull/27964))
+
+### Additional improvements
+
+- You can now run Astro Runtime images on Red Hat OpenShift.
+- You can now add comments to the `packages.txt` file of an Astro project.
+
 ## Astro Runtime 5.0.12
 
 - Release date: November 9, 2022
@@ -133,7 +201,7 @@ Astro Runtime 5.0.12 includes the following bug fixes from Apache Airflow 2.4.2:
 ## Astro Runtime 5.0.11
 
 - Release date: November 2, 2022
-- Airflow version: 2.3.4 
+- Airflow version: 2.3.4
 
 ### Backported Airflow bug fixes
 
@@ -152,20 +220,20 @@ Astro Runtime 5.0.11 includes the following bug fix from later Apache Airflow re
 
 ### Additional improvements
 
-- Upgraded `astronomer-providers` to 1.10.0, which includes two new deferrable versions of the operators `SFTPSensorAsync` and `ExternalDeploymentTaskSensorAsync`. See the [Astronomer Providers changelog](https://github.com/astronomer/astronomer-providers/blob/1.10.0/CHANGELOG.rst).
-- Upgraded `openlineage-airflow` to version 0.15.1. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md).
+- Upgraded `astronomer-providers` to 1.10.0, which includes two new deferrable versions of operators, `SFTPSensorAsync` and `ExternalDeploymentTaskSensorAsync`. See the [Astronomer Providers changelog](https://github.com/astronomer/astronomer-providers/blob/1.10.0/CHANGELOG.rst).
+- Upgraded `openlineage-airflow` to version `0.15.1`. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md).
 
 ### Bug fixes
 
 - Revert “Cache the custom secrets backend so the same instance gets re-used” ([#25556](https://github.com/apache/airflow/pull/25556))
-- Fixed faulty Kubernetes executor config serialization logic.
+- Fixed faulty Kubernetes executor config serialization logic
 
 ## Astro Runtime 5.0.9
 
 - Release date: September 20, 2022
 - Airflow version: 2.3.4
 
-### Backported fixes from Apache Airflow 2.4
+### Early access Airflow bug fixes
 
 - Fixed an issue where logs were not loading from Celery workers ([#26337](https://github.com/apache/airflow/pull/26337) and [#26493](https://github.com/apache/airflow/pull/26493))
 - Fixed CVE-2022-40754 ([#26409](https://github.com/apache/airflow/pull/26409))
@@ -178,26 +246,12 @@ Astro Runtime 5.0.11 includes the following bug fix from later Apache Airflow re
 - Upgraded `astronomer-providers` to 1.8.1, which includes various bug fixes. For a complete list of changes, see the [Astronomer Providers changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#181-2022-09-01).
 - Upgraded `openlineage-airflow` to 0.13.0, which includes fixes for Spark integrations. See the [Astronomer Providers changelog](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md#0141---2022-09-07).
 
-## Astro Runtime 6.0.0
-
-- Release date: September 19, 2022
-- Airflow version: 2.4.0
-
-### Support for Airflow 2.4 and data-aware scheduling
-
-Astro Runtime 6.0.0 provides support for [Airflow 2.4.0](https://airflow.apache.org/blog/airflow-2.4.0/), which delivers significant new features for DAG scheduling. The most notable new features in Airflow 2.4.0 are:
-
-- [Data-aware scheduling](https://airflow.apache.org/docs/apache-airflow/2.4.0/concepts/datasets.html), which is a new method for scheduling a DAG based on when an upstream DAG modifies a specific dataset.
-- The [ExternalPythonOperator](https://airflow.apache.org/docs/apache-airflow/2.4.0/howto/operator/python.html#externalpythonoperator), which can execute Python code in a virtual environment with different Python libraries and dependencies than your core Airflow environment.
-- Automatic DAG registration. You no longer need to specify `as dag` when defining a DAG object.
-- Support for [zipping](https://airflow.apache.org/docs/apache-airflow/2.4.0/concepts/dynamic-task-mapping.html#combining-upstream-data-aka-zipping) dynamically mapped tasks.
-
 ## Astro Runtime 5.0.8
 
 - Release date: August 23, 2022
 - Airflow version: 2.3.4
 
-### Support for Airflow 2.3.4
+### Airflow 2.3.4
 
 Astro Runtime 5.0.8 includes Airflow 2.3.4, which primarily includes bug fixes. For a complete list of commits, see the [Apache Airflow 2.3.4 release notes](https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-3-4-2022-08-23).
 
@@ -211,7 +265,7 @@ Astro Runtime 5.0.8 includes Airflow 2.3.4, which primarily includes bug fixes. 
 - Release date: August 16, 2022
 - Airflow version: 2.3.3
 
-### Backported fixes from Apache Airflow
+### Early access Airflow bug fixes
 
 Astro Runtime 5.0.7 includes the following bug fixes:
 
@@ -223,7 +277,8 @@ These changes were backported from Apache Airflow 2.3.4, which is not yet genera
 
 ### Additional improvements
 
-- Upgraded `openlineage-airflow` to version `0.12.0`, which includes support for Spark 3.3.0 and Apache Flink. For more information, see the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md).
+- The Cloud UI no longer shows source code for [supported Airflow operators](data-lineage-support-and-compatibility.md#supported-airflow-operators) by default. To reenable this feature for a given Deployment, create an [environment variable](environment-variables.md) with a key of `OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE` and a value of `False`.
+- Upgraded `openlineage-airflow` to version `0.12.0`, which includes support for Spark 3.3.0 and Apache Flink. For a list of all changes, see the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/blob/main/CHANGELOG.md).
 - Upgraded `astronomer-providers` to version `1.7.1`, which includes new deferrable operators and improvements to documentation. For more information, see the [Astronomer Providers changelog](https://github.com/astronomer/astronomer-providers/blob/1.7.1/CHANGELOG.rst).
 - Upgraded `apache-airflow-providers-amazon` to version `4.1.0`, which includes a bug fix for integrating with AWS Secrets Manager.
 
@@ -232,7 +287,7 @@ These changes were backported from Apache Airflow 2.3.4, which is not yet genera
 - Release date: July 11, 2022
 - Airflow version: 2.3.3
 
-### Support for Airflow 2.3.3
+### Airflow 2.3.3
 
 Astro Runtime 5.0.6 includes Airflow 2.3.3, which includes bug fixes and UI improvements. For a complete list of commits, see the [Apache Airflow 2.3.3 release notes](https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-3-3-2022-07-05).
 
@@ -250,14 +305,15 @@ Astro Runtime 5.0.6 includes Airflow 2.3.3, which includes bug fixes and UI impr
 - Release date: July 1, 2022
 - Airflow version: 2.3.2
 
-### Backported fixes from Airflow 2.3.3
+### Early access Airflow bug fixes
 
-Astro Runtime 5.0.5 includes several bug fixes and performance improvements that were backported from Airflow 2.3.3. Fixes include:
+Astro Runtime 5.0.5 includes the following bug fixes:
 
 - Fixed an issue where part of the **Grid** view of the Airflow UI would crash or become unavailable if a `GET` request to the Airflow REST API failed ([#24152](https://github.com/apache/airflow/pull/24152))
 - Improved the performance of the **Grid** view ([#24083](https://github.com/apache/airflow/pull/24083))
 - Fixed an issue where grids for task groups in the **Grid** view always showed data for the latest DAG run instead of the correct DAG run ([#24327](https://github.com/apache/airflow/pull/24327))
-- Fixed an issue where the scheduler could crash when using the Kubernetes executor after migrating from Airflow 2.2 to 2.3. ([#24117](https://github.com/apache/airflow/pull/24117))
+
+These changes were backported from Apache Airflow 2.3.3, which is not yet generally available.
 
 ### Additional improvements
 
@@ -271,17 +327,16 @@ Astro Runtime 5.0.5 includes several bug fixes and performance improvements that
 ### Additional improvements
 
 - Update `astronomer-providers` to v1.5.0. For more information, see the [Astronomer Providers Changelog](https://astronomer-providers.readthedocs.io/en/stable/changelog.html#id1).
+- Add support for Astro clusters with [Istio](https://istio.io/) enabled.
 
 ## Astro Runtime 5.0.3
 
 - Release date: June 4, 2022
 - Airflow version: 2.3.2
 
-### Support for Airflow 2.3.2
+### Airflow 2.3.2
 
-Astro Runtime 5.0.3 includes same-day support for Airflow 2.3.2, a release that follows Airflow 2.3.1 with a collection of bug fixes.
-
-Fixes include:
+Astro Runtime 5.0.3 includes support for Airflow 2.3.2, which includes:
 
 - Improvements to the Grid view of the Airflow UI, including faster load times for large DAGs and a fix for an issue where some tasks would not render properly ([#23947](https://github.com/apache/airflow/pull/23947))
 - Enable clicking on DAG owner in autocomplete dropdown ([#23804](https://github.com/apache/airflow/pull/23804))
@@ -300,7 +355,7 @@ For more information, see the [changelog for Apache Airflow 2.3.2](https://githu
 - Release date: May 27, 2022
 - Airflow version: 2.3.1
 
-### Support for Airflow 2.3.1
+### Airflow 2.3.1
 
 Astro Runtime 5.0.2 includes same-day support for Airflow 2.3.1, a release that follows Airflow 2.3.0 with a collection of bug fixes.
 
@@ -310,7 +365,7 @@ Fixes include:
 - Fix secrets rendered in Airflow UI when task is not executed ([#22754](https://github.com/apache/airflow/pull/22754))
 - Performance improvements for faster database migrations to Airflow 2.3
 
-For more information, see the [Apache Airflow changelog](https://github.com/apache/airflow/releases/tag/2.3.1).
+For more information, see the [changelog for Apache Airflow 2.3.1](https://github.com/apache/airflow/releases/tag/2.3.1).
 
 ### Additional improvements
 
@@ -324,7 +379,7 @@ For more information, see the [Apache Airflow changelog](https://github.com/apac
 
 ### Astronomer Providers 1.2.0
 
-Astro Runtime 5.0.1 includes v1.2.0 of the `astronomer-providers` package ([CHANGELOG](https://astronomer-providers.readthedocs.io/en/stable/)). This release includes 5 new [deferrable operators](deferrable-operators.md):
+Astro Runtime 5.0.1 includes v1.2.0 of the `astronomer-providers` package ([CHANGELOG](https://astronomer-providers.readthedocs.io/en/stable/)). This release includes 5 new [deferrable operators](https://docs.astronomer.io/learn/deferrable-operators):
 
     - `DataprocSubmitJobOperatorAsync`
     - `EmrContainerSensorAsync`
@@ -355,7 +410,23 @@ Astro Runtime 5.0.0 provides support for [Airflow 2.3.0](https://airflow.apache.
 
 For more information on Airflow 2.3, see ["Apache Airflow 2.3 — Everything You Need to Know"](https://www.astronomer.io/blog/apache-airflow-2-3-everything-you-need-to-know) by Astronomer.
 
-# Astro Runtime 4.2.8
+## Astro Runtime 4.2.9
+
+- Release date: December 12, 2022
+- Airflow version: 2.2.5
+
+### Backported Airflow bug fixes
+
+Astro Runtime 4.2.9 includes the following bug fixes from later Apache Airflow releases:
+
+- Change the template to use human readable task_instance description ([#25960](https://github.com/apache/airflow/pull/25960))
+
+### Additional improvements
+
+- You can now run Astro Runtime images on Red Hat OpenShift.
+- You can now add comments to the `packages.txt` file of an Astro project.
+
+## Astro Runtime 4.2.8
 
 - Release date: November 9, 2022
 - Airflow version: 2.2.5
@@ -444,7 +515,7 @@ Astro Runtime 4.2.1 upgrades the `astronomer-providers` package to v1.1.0 ([CHAN
     - `GCSUploadSessionCompleteSensorAsync`
     - `BigQueryTableExistenceSensorAsync`
 
-For more information about deferrable operators and how to use them, see [deferrable operators](deferrable-operators.md). To access the source code of this package, see the [Astronomer Providers GitHub repository](https://github.com/astronomer/astronomer-providers).
+For more information about deferrable operators and how to use them, see [Deferrable operators](https://docs.astronomer.io/learn/deferrable-operators). To access the source code of this package, see the [Astronomer Providers GitHub repository](https://github.com/astronomer/astronomer-providers).
 
 ### Additional improvements
 
@@ -459,7 +530,7 @@ For more information about deferrable operators and how to use them, see [deferr
 
 The `astronomer-providers` package is now installed on Astro Runtime by default. This package is an open source collection of Apache Airflow providers and modules that is maintained by Astronomer. It includes deferrable versions of popular operators such as `ExternalTaskSensor`, `DatabricksRunNowOperator`, and `SnowflakeOperator`.
 
-For more information, see [deferrable operators](deferrable-operators.md). To access the source code of this package, see the [Astronomer Providers GitHub repository](https://github.com/astronomer/astronomer-providers).
+For more information, see [Deferrable operators](https://docs.astronomer.io/learn/deferrable-operators). To access the source code of this package, see the [Astronomer Providers GitHub repository](https://github.com/astronomer/astronomer-providers).
 
 ### Additional improvements
 
@@ -497,7 +568,7 @@ Astro Runtime now also includes the following operators:
 - `SnowflakeOperatorAsync`
 - `FileSensorAsync`
 
-These are all [deferrable operators](deferrable-operators.md) built by Astronomer and available exclusively on Astro Runtime. They are pre-installed into the Astro Runtime Docker image and ready to use.
+These are all [deferrable operators](https://docs.astronomer.io/learn/deferrable-operators) built by Astronomer and available exclusively on Astro Runtime. They are pre-installed into the Astro Runtime Docker image and ready to use.
 
 ### Additional improvements
 
@@ -631,7 +702,7 @@ For more information on using timetables, read the [Apache Airflow Documentation
 
 Existing Airflow operators have to be re-written according to the deferrable operator framework. In addition to supporting those available in the open source project, Astronomer has built an exclusive collection of deferrable operators in Runtime 4.0.0. This collection includes the `DatabricksSubmitRunOperator`, the `DatabricksRunNowOperator`, and the `ExternalTaskSensor`. These are designed to be drop-in replacements for corresponding operators currently in use.
 
-As part of supporting deferrable operators, the triggerer is now available as a fully managed component on Astro. This means that you can start using deferrable operators in your DAGs as soon as you're ready. For more general information on deferrable operators, as well as how to use Astronomer's exclusive deferrable operators, read [deferrable operators](deferrable-operators.md).
+As part of supporting deferrable operators, the triggerer is now available as a fully managed component on Astro. This means that you can start using deferrable operators in your DAGs as soon as you're ready. For more general information on deferrable operators, as well as how to use Astronomer's exclusive deferrable operators, read [Deferrable operators](https://docs.astronomer.io/learn/deferrable-operators).
 
 ## Astro Runtime 3.0.4
 

--- a/software_versioned_docs/version-0.30/runtime-release-notes.md
+++ b/software_versioned_docs/version-0.30/runtime-release-notes.md
@@ -11,6 +11,40 @@ Astro Runtime is a Docker image built and published by Astronomer that extends t
 
 For upgrade instructions, see [Upgrade Airflow on Astronomer Software](manage-airflow-versions.md). For general product release notes, go to [Software release notes](release-notes.md). If you have any questions or a bug to report, contact [Astronomer support](https://support.astronomer.io).
 
+## Astro Runtime 7.1.0
+
+- Release date: December 21, 2022
+- Airflow version: 2.5.0
+
+### Additional improvements
+
+- Upgraded `astronomer-providers` to 1.13.0, which includes a collection of minor enhancements and bug fixes. See the [`astronomer-providers` changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#1130-2022-12-16). 
+- Upgraded `openlineage-airflow` to 0.18.0, which includes new support for Airflow operators like the `SQLExecuteQueryOperator`. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/releases/tag/0.18.0) for more information. 
+- Upgraded `apache-airflow-providers-microsoft-azure` to 5.0.1, which includes a bug fix to revert `offset` and `length` to be optional arguments.
+- Upgraded `certifi` to 2022.12.7.
+
+## Astro Runtime 7.0.0 
+
+- Release date: December 2, 2022 
+- Airflow version: 2.5.0
+
+### Airflow 2.5.0
+
+Astro Runtime 7.0.0 includes same-day support for Airflow 2.5.0, which includes a collection of new features, bug fixes, automatic changes, and deprecations. Features include:
+
+- Add comments to task instances and DAG runs in the Airflow UI ([#26457](https://github.com/apache/airflow/pull/26457))
+- Clear all task instances in a task group with one click in the Airflow UI ([#26658](https://github.com/apache/airflow/pull/26658)), [#28003](https://github.com/apache/airflow/pull/28003))
+- Trigger a task when at least one upstream tasks is successful with new `one_done` trigger rule [#26146](https://github.com/apache/airflow/pull/26146)
+- New **Parsed at** metric in the DAG view of the Airflow UI [#27573](https://github.com/apache/airflow/pull/27573)
+- Filter datasets in Airflow UI based on recent update events [#26942](https://github.com/apache/airflow/pull/26942)
+
+To learn more, see [What's New in Apache Airflow 2.5](https://www.astronomer.io/blog/whats-new-in-apache-airflow-2-5/) and the [Apache Airflow 2.5.0 release notes](https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-5-0-2022-12-02).
+
+### Additional improvements 
+
+- Upgraded `astronomer-providers` to 1.11.2, which includes a collection of bug fixes. See the [`astronomer-providers` changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#1112-2022-11-19). 
+- Upgraded `openlineage-airflow` to 0.17.0, which includes improvements to the OpenLineage spark integration and additional facets for the OpenLineage Python client. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/releases/tag/0.17.0) for more information.  
+
 ## Astro Runtime 6.0.3
 
 - Release date: October 24, 2022
@@ -62,6 +96,33 @@ These changes were backported from Apache Airflow 2.4.2, which is not yet genera
 - Fixed an issue where Astro users could not access task logs on Deployments using Runtime 6.0.0
 - Backported a fix to correct an issue where logs were not loading from Celery workers ([#26493](https://github.com/apache/airflow/pull/26493))
 - Fixed [CVE-2022-40674](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40674)
+
+## Astro Runtime 5.1.0
+
+- Release date: January 4, 2022
+- Airflow version: 2.3.4
+
+### Additional improvements
+
+- Upgraded `astronomer-providers` to 1.13.0, which includes a collection of minor enhancements and bug fixes. See the [`astronomer-providers` changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#1130-2022-12-16). 
+- Upgraded `openlineage-airflow` to 0.18.0, which includes new support for Airflow operators like the `SQLExecuteQueryOperator`. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/releases/tag/0.18.0) for more information. 
+
+## Astro Runtime 5.0.13
+
+- Release date: December 12, 2022
+- Airflow version: 2.3.4
+
+### Backported Airflow bug fixes
+
+Astro Runtime 5.0.13 includes the following bug fixes from later Apache Airflow releases:
+
+- Change the template to use human readable task_instance description ([#25960](https://github.com/apache/airflow/pull/25960))
+- Fix deadlock when chaining multiple empty mapped tasks ([#27964](https://github.com/apache/airflow/pull/27964))
+
+### Additional improvements
+
+- You can now run Astro Runtime images on Red Hat OpenShift.
+- You can now add comments to the `packages.txt` file of an Astro project.
 
 ## Astro Runtime 5.0.12
 

--- a/software_versioned_docs/version-0.30/runtime-release-notes.md
+++ b/software_versioned_docs/version-0.30/runtime-release-notes.md
@@ -99,7 +99,7 @@ These changes were backported from Apache Airflow 2.4.2, which is not yet genera
 
 ## Astro Runtime 5.1.0
 
-- Release date: January 4, 2022
+- Release date: January 4, 2023
 - Airflow version: 2.3.4
 
 ### Additional improvements


### PR DESCRIPTION
Only new content change is in the latest versions for `astro/runtime-release-notes` and `software/runtime-release-notes`. The other changes are just backports of release notes that didn't make it into old Software doc versions. 