### PR TITLE
Replace smart quotes by straight quotes to avoid code errors

### DIFF
--- a/astro/develop-project.md
+++ b/astro/develop-project.md
@@ -480,7 +480,7 @@ This example assumes that the name of each of your Python packages is identical 
 2. Run the following command to create a new Docker image from your `Dockerfile`. Replace `<ssh-key>` with your SSH private key file name.
 
     ```sh
-    DOCKER_BUILDKIT=1 docker build -f Dockerfile --progress=plain --ssh=github=“$HOME/.ssh/<ssh-key>” -t $image_name .
+    DOCKER_BUILDKIT=1 docker build -f Dockerfile --progress=plain --ssh=github="$HOME/.ssh/<ssh-key>" -t $image_name .
     ```
 
 3. Optional. Test your DAGs locally. See [Restart your local environment](develop-project.md#restart-your-local-environment).
@@ -537,7 +537,7 @@ Make sure that the name of any privately hosted Python package doesn’t conflic
 3. After the `FROM` line specifying your Runtime image, add the following configuration:
 
     ```docker
-    LABEL maintainer=“Astronomer <humans@astronomer.io>”
+    LABEL maintainer="Astronomer <humans@astronomer.io>"
     ARG BUILD_NUMBER=-1
     LABEL io.astronomer.docker=true
     LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
@@ -559,7 +559,7 @@ Make sure that the name of any privately hosted Python package doesn’t conflic
     # Copy requirements directory
     COPY --from=stage2 /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
     COPY --from=stage2 /usr/local/bin /home/astro/.local/bin
-    ENV PATH=“/home/astro/.local/bin:$PATH”
+    ENV PATH="/home/astro/.local/bin:$PATH"
 
     COPY . .
     ```

--- a/software/export-task-logs.md
+++ b/software/export-task-logs.md
@@ -134,7 +134,7 @@ After you've created an Elastic deployment and endpoint, you have two options to
     scheme: https
     # host endpoint copied from elasticsearch console with https
     # and port number removed.
-    host: “<host-URL>”
+    host: "<host-URL>"
     port: "9243"
     # encoded credentials from above step 1
     secret: "<encoded credentials>"    
@@ -169,7 +169,7 @@ After you've created an Elastic deployment and endpoint, you have two options to
     scheme: https
     # host endpoint copied from elasticsearch console with https
     # and port number removed.
-    host: “<host-URL>”
+    host: "<host-URL>"
     port: "9243"
     # kubernetes secret containing credentials
     secretName: elasticcreds   

--- a/software_versioned_docs/version-0.29/export-task-logs.md
+++ b/software_versioned_docs/version-0.29/export-task-logs.md
@@ -133,7 +133,7 @@ After you've created an Elastic deployment and endpoint, you have two options to
     scheme: https
     # host endpoint copied from elasticsearch console with https
     # and port number removed.
-    host: “<host-URL>”
+    host: "<host-URL>"
     port: "9243"
     # encoded credentials from above step 1
     secret: "<encoded credentials>"    
@@ -168,7 +168,7 @@ After you've created an Elastic deployment and endpoint, you have two options to
     scheme: https
     # host endpoint copied from elasticsearch console with https
     # and port number removed.
-    host: “<host-URL>”
+    host: "<host-URL>"
     port: "9243"
     # kubernetes secret containing credentials
     secretName: elasticcreds   

--- a/software_versioned_docs/version-0.30/export-task-logs.md
+++ b/software_versioned_docs/version-0.30/export-task-logs.md
@@ -134,7 +134,7 @@ After you've created an Elastic deployment and endpoint, you have two options to
     scheme: https
     # host endpoint copied from elasticsearch console with https
     # and port number removed.
-    host: “<host-URL>”
+    host: "<host-URL>"
     port: "9243"
     # encoded credentials from above step 1
     secret: "<encoded credentials>"    
@@ -169,7 +169,7 @@ After you've created an Elastic deployment and endpoint, you have two options to
     scheme: https
     # host endpoint copied from elasticsearch console with https
     # and port number removed.
-    host: “<host-URL>”
+    host: "<host-URL>"
     port: "9243"
     # kubernetes secret containing credentials
     secretName: elasticcreds   


### PR DESCRIPTION
Follow-up on https://github.com/astronomer/docs/pull/1694. Smart quotes in code are not interpreted as quotes and therefore cause errors.