### PR TITLE
Show .env file in Astro project structure

### DIFF
--- a/astro/create-project.md
+++ b/astro/create-project.md
@@ -42,6 +42,7 @@ To run Airflow pipelines on Astro, you first need to create an Astro project. An
 
     ```
     .
+    ├── .env # Local environment variables
     ├── dags # Where your DAGs go
     │   ├── example-dag-basic.py # Example DAG that showcases a simple ETL data pipeline
     │   └── example-dag-advanced.py # Example DAG that showcases more advanced Airflow features, such as the TaskFlow API

--- a/software/create-project.md
+++ b/software/create-project.md
@@ -29,6 +29,7 @@ This generates the following files:
 
 ```py
 .
+├── .env # Local environment variables
 ├── dags # Where your DAGs go
 │   └── example-dag.py # An example DAG that comes with the initialized project
 ├── Dockerfile # For the Astronomer Runtime Docker image and runtime overrides


### PR DESCRIPTION
The Astro skeleton project includes a `.env` file for local environment variables. I suggest showing that in the project structure to make users aware of the feature.