### PR TITLE
Correcting GCP Secrets Manager AIRFLOW__SECRETS__BACKEND_KWARGS

### DIFF
--- a/astro/secrets-backend.md
+++ b/astro/secrets-backend.md
@@ -362,7 +362,7 @@ ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_prefix": "airflow-connection
 
 ```text
 ENV AIRFLOW__SECRETS__BACKEND=airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend
-ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_prefix": "airflow-connections", "variables_prefix": "airflow-variables", "project-id": "<your-secret-managet-project-id>"}'
+ENV AIRFLOW__SECRETS__BACKEND_KWARGS='{"connections_prefix": "airflow-connections", "variables_prefix": "airflow-variables", "project_id": "<your-secret-managet-project-id>"}'
 ```
 
 


### PR DESCRIPTION
Correcting the GCP Secrets Manager `AIRFLOW__SECRETS__BACKEND_KWARGS` example to use `project_id` instead of `project-id`.