### PR TITLE
One sentence addition to the logging guide

### DIFF
--- a/learn/logging.md
+++ b/learn/logging.md
@@ -75,7 +75,7 @@ If you run Airflow locally, logging information is accessible in the following l
 
 - Scheduler: Logs are printed to the console and accessible in `$AIRFLOW_HOME/logs/scheduler`.
 - Webserver and Triggerer: Logs are printed to the console.
-- Task: Logs can be viewed in the Airflow UI or at `$AIRFLOW_HOME/logs/`.
+- Task: Logs can be viewed in the Airflow UI or at `$AIRFLOW_HOME/logs/`. When testing individual tasks with `astro dev run tasks test <dag_id> <task_id>` the logs will be printed directly to the console.
 - Metadata database: Logs are handled differently depending on which database you use.
 
 ### Docker Airflow environment


### PR DESCRIPTION
This was inspired by this SO question: https://stackoverflow.com/questions/75079621/how-to-watch-tasks-logs-via-cli-in-airflow/75082784#75082784

I think it could be useful for people who are debugging individual tasks to know there is a way to do see the logs without needing to check the UI or files in a folder (I didn't know about this before checking the Airflow CLI docs more closely because of this question). 