### PR TITLE
Update instances of Bring your own cloud

### DIFF
--- a/astro/create-cluster.md
+++ b/astro/create-cluster.md
@@ -32,7 +32,7 @@ To create an Astro cluster on AWS, Microsoft Azure, or Google Cloud Platform (GC
     defaultValue="byoc"
     groupId= "byoc"
     values={[
-        {label: 'Bring your own cloud', value: 'byoc'},
+        {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
     ]}>
 <TabItem value="byoc">
@@ -135,7 +135,7 @@ If you don't specify your configuration preferences, Astronomer support creates 
     defaultValue="byoc"
     groupId= "byoc"
     values={[
-        {label: 'Bring your own cloud', value: 'byoc'},
+        {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
     ]}>
 <TabItem value="byoc">
@@ -184,7 +184,7 @@ If you don't specify your configuration preferences, Astronomer support creates 
     defaultValue="byoc"
     groupId= "byoc"
     values={[
-        {label: 'Bring your own cloud', value: 'byoc'},
+        {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
     ]}>
 <TabItem value="byoc">

--- a/astro/install-aws.md
+++ b/astro/install-aws.md
@@ -17,7 +17,7 @@ import TabItem from '@theme/TabItem';
 
 The Astro data plane on Amazon Web Services (AWS) runs on Elastic Kubernetes Service (EKS). You have two options to install Astro on AWS:
 
-- Bring your own cloud -  Create an Astro cluster in a dedicated AWS account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
+- Bring Your Own Cloud -  Create an Astro cluster in a dedicated AWS account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
 - Hosted - Create an Astro cluster in a dedicated AWS account that's hosted and owned by Astronomer. This removes the complexity of adding another AWS account to your network.
 
 With the two options, the user experience is identical and Astronomer is responsible for managing Astro. The differences between the two options are security and networking.
@@ -30,7 +30,7 @@ For a list of the AWS resources and configurations that Astronomer supports, see
     defaultValue="byoc"
     groupId= "byoc"
     values={[
-        {label: 'Bring your own cloud', value: 'byoc'},
+        {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
     ]}>
 <TabItem value="byoc">

--- a/astro/install-azure.md
+++ b/astro/install-azure.md
@@ -31,7 +31,7 @@ For more information about managing Azure subscriptions with the Azure CLI, see 
     defaultValue="byoc"
     groupId= "byoc"
     values={[
-        {label: 'Bring your own cloud', value: 'byoc'},
+        {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
     ]}>
 <TabItem value="byoc">

--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -29,7 +29,7 @@ For more information about managing Google Cloud projects, see [GCP documentatio
     defaultValue="byoc"
     groupId= "byoc"
     values={[
-        {label: 'Bring your own cloud', value: 'byoc'},
+        {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
     ]}>
 <TabItem value="byoc">


### PR DESCRIPTION
As per a discussion in [PR 1714](https://github.com/astronomer/docs/issues/1714), updated instances of _Bring your own cloud_ to _Bring Your Own Cloud_. Bring Your Own Cloud is now considered an official Astronomer service and therefore requires initial capitalization.