### PR TITLE
Remove deprecated instructions to build against different python versions

### DIFF
--- a/software/customize-image.md
+++ b/software/customize-image.md
@@ -501,42 +501,6 @@ Ensure that the name of the package on the private repository does not clash wit
 </TabItem>
 </Tabs>
 
-## Build with a different Python version (_Astronomer Certified only_)
-
-:::info
-
-To use a different Python version with Astro Runtime, you have to run your tasks using the KubernetesPodOperator. See [Run the KubernetesPodOperator on Astronomer Software](kubepodoperator.md).
-
-:::
-
-While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3.7, and 3.8, AC Docker images have been tested and built only for Python 3.7.
-
-To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you need to create a custom version of the image, specify the `PYTHON_MAJOR_MINOR_VERSION` build argument, and push the custom image to an existing Docker registry. To do so:
-
-1. Using `docker build`, build a custom [Astronomer Certified Docker image](https://github.com/astronomer/ap-airflow) and specify `PYTHON_MAJOR_MINOR_VERSION` for the version of Python you'd like to support. For example, the command for building a custom Astronomer Certified image for Airflow 2.0.0 with Python 3.8 would look something like this:
-
-    ```sh
-    docker build --build-arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t <your-registry>/ap-airflow:<image-tag> https://github.com/astronomer/ap-airflow.git#master:2.0.0/buster
-    ```
-
-    We recommend using an image tag that indicates the image is using a different Python version, such as `2.0.0-buster-python3.8`.
-
-    > **Note:** To use a different version of Airflow, update the URL to point towards the desired Airflow version. For instance, if you're running Airflow 1.10.14, the GitHub URL here would be: `https://github.com/astronomer/ap-airflow.git#master:1.10.14/buster`
-
-2. Push the custom image to your Docker registry. Based on the example in the previous step, the command to do so would look something like this:
-
-    ```sh
-    docker push <your-registry>/ap-airflow:<image-tag>
-    ```
-
-3. Update the `FROM` line of your `Dockerfile` to reference the custom image. Based on the previous example, the line would read:
-
-    ```
-    FROM <your-registry>/ap-airflow:<image-tag>
-    ```
-
-> **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify `alpine3.10` instead of `buster` in the GitHub URL.
-
 ## Add a CA certificate to an Astro Runtime image
 
 If you need your Astro deployment to communicate securely with a remote service using a certificate signed by an untrusted or internal certificate authority (CA), you need to add the CA certificate to the trust store inside the image.

--- a/software_versioned_docs/version-0.28/customize-image.md
+++ b/software_versioned_docs/version-0.28/customize-image.md
@@ -513,33 +513,3 @@ Ensure that the name of the package on the private repository does not clash wit
 
 </TabItem>
 </Tabs>
-
-## Build with a Different Python Version (_Astronomer Certified Only_)
-
-While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3.7, and 3.8, AC Docker images have been tested and built only for Python 3.7.
-
-To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you need to create a custom version of the image, specify the `PYTHON_MAJOR_MINOR_VERSION` build argument, and push the custom image to an existing Docker registry. To do so:
-
-1. Using `docker build`, build a custom [Astronomer Certified Docker image](https://github.com/astronomer/ap-airflow) and specify `PYTHON_MAJOR_MINOR_VERSION` for the version of Python you'd like to support. For example, the command for building a custom Astronomer Certified image for Airflow 2.0.0 with Python 3.8 would look something like this:
-
-    ```sh
-    docker build --build-arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t <your-registry>/ap-airflow:<image-tag> https://github.com/astronomer/ap-airflow.git#master:2.0.0/buster
-    ```
-
-    We recommend using an image tag that indicates the image is using a different Python version, such as `2.0.0-buster-python3.8`.
-
-    > **Note:** To use a different version of Airflow, update the URL to point towards the desired Airflow version. For instance, if you're running Airflow 1.10.14, the GitHub URL here would be: `https://github.com/astronomer/ap-airflow.git#master:1.10.14/buster`
-
-2. Push the custom image to your Docker registry. Based on the example in the previous step, the command to do so would look something like this:
-
-    ```sh
-    docker push <your-registry>/ap-airflow:<image-tag>
-    ```
-
-3. Update the `FROM` line of your `Dockerfile` to reference the custom image. Based on the previous example, the line would read:
-
-    ```
-    FROM <your-registry>/ap-airflow:<image-tag>
-    ```
-
-> **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify `alpine3.10` instead of `buster` in the GitHub URL.

--- a/software_versioned_docs/version-0.29/customize-image.md
+++ b/software_versioned_docs/version-0.29/customize-image.md
@@ -517,33 +517,3 @@ Ensure that the name of the package on the private repository does not clash wit
 
 </TabItem>
 </Tabs>
-
-## Build with a different Python version (_Astronomer Certified only_)
-
-While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3.7, and 3.8, AC Docker images have been tested and built only for Python 3.7.
-
-To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you need to create a custom version of the image, specify the `PYTHON_MAJOR_MINOR_VERSION` build argument, and push the custom image to an existing Docker registry. To do so:
-
-1. Using `docker build`, build a custom [Astronomer Certified Docker image](https://github.com/astronomer/ap-airflow) and specify `PYTHON_MAJOR_MINOR_VERSION` for the version of Python you'd like to support. For example, the command for building a custom Astronomer Certified image for Airflow 2.0.0 with Python 3.8 would look something like this:
-
-    ```sh
-    docker build --build-arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t <your-registry>/ap-airflow:<image-tag> https://github.com/astronomer/ap-airflow.git#master:2.0.0/buster
-    ```
-
-    We recommend using an image tag that indicates the image is using a different Python version, such as `2.0.0-buster-python3.8`.
-
-    > **Note:** To use a different version of Airflow, update the URL to point towards the desired Airflow version. For instance, if you're running Airflow 1.10.14, the GitHub URL here would be: `https://github.com/astronomer/ap-airflow.git#master:1.10.14/buster`
-
-2. Push the custom image to your Docker registry. Based on the example in the previous step, the command to do so would look something like this:
-
-    ```sh
-    docker push <your-registry>/ap-airflow:<image-tag>
-    ```
-
-3. Update the `FROM` line of your `Dockerfile` to reference the custom image. Based on the previous example, the line would read:
-
-    ```
-    FROM <your-registry>/ap-airflow:<image-tag>
-    ```
-
-> **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify `alpine3.10` instead of `buster` in the GitHub URL.

--- a/software_versioned_docs/version-0.30/customize-image.md
+++ b/software_versioned_docs/version-0.30/customize-image.md
@@ -501,42 +501,6 @@ Ensure that the name of the package on the private repository does not clash wit
 </TabItem>
 </Tabs>
 
-## Build with a different Python version (_Astronomer Certified only_)
-
-:::info
-
-To use a different Python version with Astro Runtime, you have to run your tasks using the KubernetesPodOperator. See [Run the KubernetesPodOperator on Astronomer Software](kubepodoperator.md).
-
-:::
-
-While the Astronomer Certified (AC) Python Wheel supports Python versions 3.6, 3.7, and 3.8, AC Docker images have been tested and built only for Python 3.7.
-
-To run Astronomer Certified on Docker with Python versions 3.6 or 3.8, you need to create a custom version of the image, specify the `PYTHON_MAJOR_MINOR_VERSION` build argument, and push the custom image to an existing Docker registry. To do so:
-
-1. Using `docker build`, build a custom [Astronomer Certified Docker image](https://github.com/astronomer/ap-airflow) and specify `PYTHON_MAJOR_MINOR_VERSION` for the version of Python you'd like to support. For example, the command for building a custom Astronomer Certified image for Airflow 2.0.0 with Python 3.8 would look something like this:
-
-    ```sh
-    docker build --build-arg PYTHON_MAJOR_MINOR_VERSION=3.8 -t <your-registry>/ap-airflow:<image-tag> https://github.com/astronomer/ap-airflow.git#master:2.0.0/buster
-    ```
-
-    We recommend using an image tag that indicates the image is using a different Python version, such as `2.0.0-buster-python3.8`.
-
-    > **Note:** To use a different version of Airflow, update the URL to point towards the desired Airflow version. For instance, if you're running Airflow 1.10.14, the GitHub URL here would be: `https://github.com/astronomer/ap-airflow.git#master:1.10.14/buster`
-
-2. Push the custom image to your Docker registry. Based on the example in the previous step, the command to do so would look something like this:
-
-    ```sh
-    docker push <your-registry>/ap-airflow:<image-tag>
-    ```
-
-3. Update the `FROM` line of your `Dockerfile` to reference the custom image. Based on the previous example, the line would read:
-
-    ```
-    FROM <your-registry>/ap-airflow:<image-tag>
-    ```
-
-> **Note:** Astronomer Certified Docker images for Apache Airflow 1.10.14+ are Debian-based only. To run Docker images based on Alpine-Linux for Airflow versions 1.10.7, 1.10.10, or 1.10.12, specify `alpine3.10` instead of `buster` in the GitHub URL.
-
 ## Add a CA certificate to an Astro Runtime image
 
 If you need your Astro deployment to communicate securely with a remote service using a certificate signed by an untrusted or internal certificate authority (CA), you need to add the CA certificate to the trust store inside the image.


### PR DESCRIPTION
These instructions have been found to not work as expected https://astronomer.slack.com/archives/C015V2JFKT5/p1673543622350979

[Originating Slack discussion](https://astronomer.slack.com/archives/C015V2JFKT5/p1673543622350979). 