### PR TITLE
Update Default Value for `AIRFLOW__LOGGING__REMOTE_LOGGING`

### DIFF
--- a/astro/platform-variables.md
+++ b/astro/platform-variables.md
@@ -22,7 +22,7 @@ If you need to set one of these variables for a particular use case, contact [As
 | Environment Variable                       | Description                                                                                                          | Value                                   |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
 |`AIRFLOW__LOGGING__DAG_PROCESSOR_LOG_TARGET`| Routes scheduler logs to stdout                                                                                      | `stdout`                                |
-| `AIRFLOW__LOGGING__REMOTE_LOGGING`         | Enables remote logging                                                                                               | `True`                                  |
+| `AIRFLOW__LOGGING__REMOTE_LOGGING`         | Enables remote logging                                                                                               | `True` (AWS)   `False` (Azure and GCP)                              |
 | `AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER` | Location of remote logging storage                                                                                   | `baseLogFolder`                         |
 | `AIRFLOW_CONN_ASTRO_S3_LOGGING`            | Connection URI for writing task logs to Astro's managed S3 bucket                                                    | `<Connection-URI>`                      |
 | `AIRFLOW__LOGGING__ENCRYPT_S3_LOGS`        | Determines whether to use server-side encryption for S3 logs                                                         | `False`                                 |


### PR DESCRIPTION
[Slack conversation](https://astronomer.slack.com/archives/C015V2JFKT5/p1674059567736019) for this update.

@jwitz this might not the best method to define the different default values. An additional footnote _might_ be better. Also, A SME who can validate this change needs to be identified.