### PR TITLE
Quick fix

### DIFF
--- a/astro/cli/astro-context-list.md
+++ b/astro/cli/astro-context-list.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
 View a list of domains for all Astronomer installations that you have access to. An Astronomer installation will appear on this list if you have authenticated to it at least once using `astro login`.
 
-If you're an Astro user, you should only see `cloud.astronomer.io` on this list.
+If you're an Astro user, you should only see `astronomer.io` on this list.
 
 ## Usage
 


### PR DESCRIPTION
An Astro user should only see `astronomer.io` not `cloud.astronomer.io`