### PR TITLE
Fix brackets & indentation in Jenkinsfile examples

### DIFF
--- a/astro/ci-cd.md
+++ b/astro/ci-cd.md
@@ -665,31 +665,30 @@ To automate code deploys to a single Deployment using [Jenkins](https://www.jenk
 2. At the root of your Git repository, add a [Jenkinsfile](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/) that includes the following script:
 
     <pre><code parentName="pre">{`pipeline {
-       agent any
-         stages {
-           stage('Deploy to Astronomer') {
-             when {
-              expression {
-                return env.GIT_BRANCH == "origin/main"
-              }
-             }
-             steps {
-                 checkout scm
-                 sh '''
-                   curl -LJO https://github.com/astronomer/astro-cli/releases/download/v${siteVariables.cliVersion}/astro_${siteVariables.cliVersion}_linux_amd64.tar.gz
-                   tar -zxvf astro_${siteVariables.cliVersion}_linux_amd64.tar.gz astro && rm astro_${siteVariables.cliVersion}_linux_amd64.tar.gz
-                   ./astro deploy
-                 '''
-               }
-             }
-           }
-         }
-       post {
-         always {
-           cleanWs()
-         }
-       }
-   }`}</code></pre>
+        agent any
+        stages {
+            stage('Deploy to Astronomer') {
+                when {
+                    expression {
+                        return env.GIT_BRANCH == "origin/main"
+                    }
+                }
+                steps {
+                    checkout scm
+                    sh '''
+                    curl -LJO https://github.com/astronomer/astro-cli/releases/download/v${siteVariables.cliVersion}/astro_${siteVariables.cliVersion}_linux_amd64.tar.gz
+                    tar -zxvf astro_${siteVariables.cliVersion}_linux_amd64.tar.gz astro && rm astro_${siteVariables.cliVersion}_linux_amd64.tar.gz
+                    ./astro deploy
+                    '''
+                }
+            }
+        }
+        post {
+            always {
+                cleanWs()
+            }
+        }
+    }`}</code></pre>
 
     This Jenkinsfile triggers a code push to Astro every time a commit or pull request is merged to the `main` branch of your repository.
 
@@ -715,45 +714,44 @@ To automate code deploys across multiple Deployments using [Jenkins](https://www
 2. At the root of your Git repository, add a [Jenkinsfile](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/) that includes the following script:
 
     <pre><code parentName="pre">{`pipeline {
-       agent any
-         stages {
-           stage('Set Environment Variables') {
-              steps {
-                  script {
-                      if (env.GIT_BRANCH == 'main') {
-                          echo "The git branch is ${siteVariables.jenkinsenv}";
-                          env.ASTRONOMER_KEY_ID = env.PROD_ASTRONOMER_KEY_ID;
-                          env.ASTRONOMER_KEY_SECRET = env.PROD_ASTRONOMER_KEY_SECRET;
-                          env.ASTRONOMER_DEPLOYMENT_ID = env.PROD_DEPLOYMENT_ID;
-                      } else if (env.GIT_BRANCH == 'dev') {
-                          echo "The git branch is ${siteVariables.jenkinsenv}";
-                          env.ASTRONOMER_KEY_ID = env.DEV_ASTRONOMER_KEY_ID;
-                          env.ASTRONOMER_KEY_SECRET = env.DEV_ASTRONOMER_KEY_SECRET;
-                          env.ASTRONOMER_DEPLOYMENT_ID = env.DEV_DEPLOYMENT_ID;
-                      } else {
-                          echo "This git branch ${siteVariables.jenkinsenv} is not configured in this pipeline."
-                      }
-                  }
-              }
-           }
-           stage('Deploy to Astronomer') {
-             steps {
-                 checkout scm
-                 sh '''
-                   curl -LJO https://github.com/astronomer/astro-cli/releases/download/v${siteVariables.cliVersion}/astro_${siteVariables.cliVersion}_linux_amd64.tar.gz
-                   tar -zxvf astro_${siteVariables.cliVersion}_linux_amd64.tar.gz astro && rm astro_${siteVariables.cliVersion}_linux_amd64.tar.gz
-                   ./astro deploy
-                 '''
-             }
-           }
-         }
-       post {
-         always {
-           cleanWs()
-         }
-       }
-      }
-   }`}</code></pre>
+        agent any
+        stages {
+            stage('Set Environment Variables') {
+                steps {
+                    script {
+                        if (env.GIT_BRANCH == 'main') {
+                            echo "The git branch is ${siteVariables.jenkinsenv}";
+                            env.ASTRONOMER_KEY_ID = env.PROD_ASTRONOMER_KEY_ID;
+                            env.ASTRONOMER_KEY_SECRET = env.PROD_ASTRONOMER_KEY_SECRET;
+                            env.ASTRONOMER_DEPLOYMENT_ID = env.PROD_DEPLOYMENT_ID;
+                        } else if (env.GIT_BRANCH == 'dev') {
+                            echo "The git branch is ${siteVariables.jenkinsenv}";
+                            env.ASTRONOMER_KEY_ID = env.DEV_ASTRONOMER_KEY_ID;
+                            env.ASTRONOMER_KEY_SECRET = env.DEV_ASTRONOMER_KEY_SECRET;
+                            env.ASTRONOMER_DEPLOYMENT_ID = env.DEV_DEPLOYMENT_ID;
+                        } else {
+                            echo "This git branch ${siteVariables.jenkinsenv} is not configured in this pipeline."
+                        }
+                    }
+                }
+            }
+            stage('Deploy to Astronomer') {
+                steps {
+                    checkout scm
+                    sh '''
+                    curl -LJO https://github.com/astronomer/astro-cli/releases/download/v${siteVariables.cliVersion}/astro_${siteVariables.cliVersion}_linux_amd64.tar.gz
+                    tar -zxvf astro_${siteVariables.cliVersion}_linux_amd64.tar.gz astro && rm astro_${siteVariables.cliVersion}_linux_amd64.tar.gz
+                    ./astro deploy
+                    '''
+                }
+            }
+        }
+        post {
+            always {
+                cleanWs()
+            }
+        }
+    }`}</code></pre>
 
     This Jenkinsfile triggers a code push to an Astro Deployment every time a commit or pull request is merged to the `dev` or `main` branch of your repository.
 
@@ -775,35 +773,35 @@ Use the following template to implement DAG-only deploys with Jenkins.
 2. At the root of your Git repository, add a [Jenkinsfile](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/) that includes the following script:
 
     <pre><code parentName="pre">{`pipeline {
-       agent any
-         stages {
-          stage('Dag Only Deploy to Astronomer') {
-            when {
-            expression {
-             return env.GIT_BRANCH == "origin/main"
-           }
-          }
-          steps {
-              checkout scm
-              sh '''
-                curl -LJO https://github.com/astronomer/astro-cli/releases/download/v${siteVariables.cliVersion}/astro_${siteVariables.cliVersion}_linux_amd64.tar.gz
-                tar -zxvf astro_${siteVariables.cliVersion}_linux_amd64.tar.gz astro && rm astro_${siteVariables.cliVersion}_linux_amd64.tar.gz
-                files=($(git diff-tree HEAD --name-only --no-commit-id))
-                find="dags"
-                if [[ ${siteVariables.jenkinsenv1} =~ (^|[[:space:]])"$find"($|[[:space:]]) && ${siteVariables.jenkinsenv2} -eq 1 ]]; then
-                  ./astro deploy --dags;
-                else
-                  ./astro deploy;
-                fi
-              '''
-          }
+        agent any
+        stages {
+            stage('Dag Only Deploy to Astronomer') {
+                when {
+                    expression {
+                        return env.GIT_BRANCH == "origin/main"
+                    }
+                }
+                steps {
+                    checkout scm
+                    sh '''
+                    curl -LJO https://github.com/astronomer/astro-cli/releases/download/v${siteVariables.cliVersion}/astro_${siteVariables.cliVersion}_linux_amd64.tar.gz
+                    tar -zxvf astro_${siteVariables.cliVersion}_linux_amd64.tar.gz astro && rm astro_${siteVariables.cliVersion}_linux_amd64.tar.gz
+                    files=($(git diff-tree HEAD --name-only --no-commit-id))
+                    find="dags"
+                    if [[ ${siteVariables.jenkinsenv1} =~ (^|[[:space:]])"$find"($|[[:space:]]) && ${siteVariables.jenkinsenv2} -eq 1 ]]; then
+                    ./astro deploy --dags;
+                    else
+                    ./astro deploy;
+                    fi
+                    '''
+                }
+            }
         }
+        post {
+            always {
+                cleanWs()
+            }
         }
-         post {
-           always {
-           cleanWs()
-      }
-     }
     }`}</code></pre>
 
 

--- a/software/ci-cd.md
+++ b/software/ci-cd.md
@@ -369,25 +369,25 @@ workflows:
 
 ```yaml
 pipeline {
- agent any
-   stages {
-     stage('Deploy to astronomer') {
-       when { branch 'master' }
-       steps {
-         script {
-           sh 'docker build -t registry.$BASE_DOMAIN/$RELEASE_NAME/airflow:ci-${BUILD_NUMBER} .'
-           sh 'docker run --rm registry.$BASE_DOMAIN/$RELEASE_NAME/airflow:ci-${BUILD_NUMBER} /bin/bash -c "pytest tests'
-           sh 'docker login registry.$BASE_DOMAIN -u _ -p $SERVICE_ACCOUNT_KEY'
-           sh 'docker push registry.$BASE_DOMAIN/$RELEASE_NAME/airflow:ci-${BUILD_NUMBER}'
-         }
-       }
-     }
-   }
- post {
-   always {
-     cleanWs()
-   }
- }
+    agent any
+    stages {
+        stage('Deploy to astronomer') {
+            when { branch 'master' }
+            steps {
+                script {
+                    sh 'docker build -t registry.$BASE_DOMAIN/$RELEASE_NAME/airflow:ci-${BUILD_NUMBER} .'
+                    sh 'docker run --rm registry.$BASE_DOMAIN/$RELEASE_NAME/airflow:ci-${BUILD_NUMBER} /bin/bash -c "pytest tests'
+                    sh 'docker login registry.$BASE_DOMAIN -u _ -p $SERVICE_ACCOUNT_KEY'
+                    sh 'docker push registry.$BASE_DOMAIN/$RELEASE_NAME/airflow:ci-${BUILD_NUMBER}'
+                }
+            }
+        }
+    }
+    post {
+        always {
+            cleanWs()
+        }
+    }
 }
 ```
 


### PR DESCRIPTION
We have two invalid Jenkinsfile examples due to incorrect brackets. This PR fixes those examples and sets a consistent indentation (4 whitespaces) for all Jenkinsfile examples to improve readability.

Used https://www.tutorialspoint.com/execute_groovy_online.php for validation.

https://docs.astronomer.io/astro/ci-cd#jenkins-image-only-deploys Before:
![image](https://user-images.githubusercontent.com/6249654/215457450-de29fddb-61e1-4c36-8165-89f2b46c0109.png)

After:
![image](https://user-images.githubusercontent.com/6249654/215457558-3cdc5a4b-8f87-418b-9025-4bdf1bcce7f7.png)
