### PR TITLE
Fix DocSearch Placeholder Text Contrast

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -364,8 +364,9 @@ html .DocSearch {
 
 html .DocSearch-Button-Placeholder {
   font-size: 0.85rem;
-  color: #bfafeb;
 }
+
+html .DocSearch-Button-Placeholder,
 html .DocSearch-Button .DocSearch-Search-Icon {
   color: #BFAFEB;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -364,7 +364,7 @@ html .DocSearch {
 
 html .DocSearch-Button-Placeholder {
   font-size: 0.85rem;
-  color: #6E6F73;
+  color: #bfafeb;
 }
 html .DocSearch-Button .DocSearch-Search-Icon {
   color: #BFAFEB;
@@ -372,7 +372,10 @@ html .DocSearch-Button .DocSearch-Search-Icon {
 
 .DocSearch-Button:active .DocSearch-Search-Icon,
 .DocSearch-Button:focus .DocSearch-Search-Icon,
-.DocSearch-Button:hover .DocSearch-Search-Icon {
+.DocSearch-Button:hover .DocSearch-Search-Icon,
+.DocSearch-Button:active .DocSearch-Button-Placeholder,
+.DocSearch-Button:focus .DocSearch-Button-Placeholder,
+.DocSearch-Button:hover .DocSearch-Button-Placeholder, {
   color: black;
 }
 


### PR DESCRIPTION
This PR fixes the contrast of the placeholder text in the top nav search bar to be WCAG + ADA compliant.

<img width="475" alt="image" src="https://user-images.githubusercontent.com/96535736/217269095-1e5b869c-35b7-4cc9-98cd-b5d939526215.png">

Focus/Hover State:
<img width="472" alt="image" src="https://user-images.githubusercontent.com/96535736/217269363-44141bc0-3929-48f1-ac09-2d72f807391e.png">
