### PR TITLE
Fix kubernetes providers package name

### DIFF
--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -68,7 +68,7 @@ All Astro Runtime images have the following open source provider packages pre-in
 - Celery [`apache-airflow-providers-celery`](https://pypi.org/project/apache-airflow-providers-celery/)
 - Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/)
 - HTTP [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-http/)
-- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
+- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
 - PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/)
 - Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/)
 - StatsD [`apache-airflow-statsd`](https://pypi.org/project/statsd/)

--- a/software/runtime-image-architecture.md
+++ b/software/runtime-image-architecture.md
@@ -57,7 +57,7 @@ All Astro Runtime images have the following open source provider packages pre-in
 - Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/)
 - Google [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-google/)
 - HTTP [`apache-airflow-password`](https://pypi.org/project/http/)
-- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
+- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
 - PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/)
 - Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/)
 - StatsD [`apache-airflow-statsd`](https://pypi.org/project/statsd/)

--- a/software_versioned_docs/version-0.29/runtime-image-architecture.md
+++ b/software_versioned_docs/version-0.29/runtime-image-architecture.md
@@ -56,7 +56,7 @@ All Astro Runtime images have the following open source provider packages pre-in
 - Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/)
 - Google [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-google/)
 - HTTP [`apache-airflow-password`](https://pypi.org/project/http/)
-- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
+- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
 - PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/)
 - Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/)
 - StatsD [`apache-airflow-statsd`](https://pypi.org/project/statsd/)

--- a/software_versioned_docs/version-0.30/runtime-image-architecture.md
+++ b/software_versioned_docs/version-0.30/runtime-image-architecture.md
@@ -56,7 +56,7 @@ All Astro Runtime images have the following open source provider packages pre-in
 - Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/)
 - Google [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-google/)
 - HTTP [`apache-airflow-password`](https://pypi.org/project/http/)
-- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
+- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
 - PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/)
 - Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/)
 - StatsD [`apache-airflow-statsd`](https://pypi.org/project/statsd/)


### PR DESCRIPTION
Following up on https://github.com/astronomer/docs/pull/1890, it turns out I also forgot to add "providers-" to the Kubernetes providers package name. This PR now really fixes the misspelled kubernetes package names.