### PR TITLE
Add cleanup task to SDK DAG example

### DIFF
--- a/code-samples/dags/astro-python-sdk-etl/astro_python_sdk_etl.py
+++ b/code-samples/dags/astro-python-sdk-etl/astro_python_sdk_etl.py
@@ -77,6 +77,7 @@ def example_s3_to_snowflake_etl():
         columns=["sell", "list", "variable", "value"],
     )
     record_results.set_upstream(create_results_table)
+    # Delete temporary and unnamed tables
     aql.cleanup()
 
 example_s3_to_snowflake_etl_dag = example_s3_to_snowflake_etl()

--- a/code-samples/dags/astro-python-sdk-etl/astro_python_sdk_etl.py
+++ b/code-samples/dags/astro-python-sdk-etl/astro_python_sdk_etl.py
@@ -77,7 +77,6 @@ def example_s3_to_snowflake_etl():
         columns=["sell", "list", "variable", "value"],
     )
     record_results.set_upstream(create_results_table)
-
     aql.cleanup()
 
 example_s3_to_snowflake_etl_dag = example_s3_to_snowflake_etl()

--- a/code-samples/dags/astro-python-sdk-etl/astro_python_sdk_etl.py
+++ b/code-samples/dags/astro-python-sdk-etl/astro_python_sdk_etl.py
@@ -79,5 +79,6 @@ def example_s3_to_snowflake_etl():
     record_results.set_upstream(create_results_table)
     # Delete temporary and unnamed tables
     aql.cleanup()
+    
 
 example_s3_to_snowflake_etl_dag = example_s3_to_snowflake_etl()

--- a/code-samples/dags/astro-python-sdk-etl/astro_python_sdk_etl.py
+++ b/code-samples/dags/astro-python-sdk-etl/astro_python_sdk_etl.py
@@ -79,6 +79,6 @@ def example_s3_to_snowflake_etl():
     record_results.set_upstream(create_results_table)
     # Delete temporary and unnamed tables
     aql.cleanup()
-    
+
 
 example_s3_to_snowflake_etl_dag = example_s3_to_snowflake_etl()

--- a/code-samples/dags/astro-python-sdk-etl/astro_python_sdk_etl.py
+++ b/code-samples/dags/astro-python-sdk-etl/astro_python_sdk_etl.py
@@ -78,5 +78,6 @@ def example_s3_to_snowflake_etl():
     )
     record_results.set_upstream(create_results_table)
 
+    aql.cleanup()
 
 example_s3_to_snowflake_etl_dag = example_s3_to_snowflake_etl()


### PR DESCRIPTION
Add cleanup tasks so any temp tables created by example DAG will be cleaned up at the end of the DAG run.