### PR TITLE
Add task notes step to DAG docs tutorial

### DIFF
--- a/learn/custom-airflow-ui-docs-tutorial.md
+++ b/learn/custom-airflow-ui-docs-tutorial.md
@@ -329,7 +329,7 @@ tell_me_what_to_do = PythonOperator(
 
 Another way of adding information to your DAGs and tasks is to add notes to task instances and DAG runs from the Grid View in the Airflow UI. This feature is useful if you need to add information specific to a single run of your DAG. 
 
-1. Go to the **Grid View** of the `docs_example_dag.py` DAG you created in [Step 2](#step-2-create-a-new-dag).
+1. Go to the **Grid View** of the `docs_example_dag` DAG you created in [Step 2](#step-2-create-a-new-dag).
 
 2. Select a task instance or DAG run.
 

--- a/learn/custom-airflow-ui-docs-tutorial.md
+++ b/learn/custom-airflow-ui-docs-tutorial.md
@@ -325,6 +325,26 @@ tell_me_what_to_do = PythonOperator(
 
     ![All Task Docs](/img/guides/task_docs_all.png)
 
+## Step 5: Add notes to a task instance and DAG run
+
+Another way of adding information to your DAGs and tasks is to add notes to task instances and DAG runs from the Grid View in the Airflow UI. This feature is useful if you need to add information specific to a single run of your DAG. 
+
+1. Go to the **Grid View** of the `docs_example_dag.py` DAG you created in [Step 2](#step-2-create-a-new-dag).
+
+2. Select a task instance or DAG run.
+
+3. Click **Details** > **Task Instance Notes** or **DAG Run notes** > **Add Note**.
+
+4. Write a note and click **Save Note**.
+
+ ![Add task note](/img/guides/2_5_task_notes.png)
+
+:::note
+
+This feature is only available in Airflow version 2.5+. Ensure your Dockerfile is using at least version 7.0 of Astro runtime to complete this step.
+
+:::
+
 ## Conclusion
 
 Congratulations! You now know how to add fancy documentation to both your DAGs and your Airflow tasks.

--- a/learn/custom-airflow-ui-docs-tutorial.md
+++ b/learn/custom-airflow-ui-docs-tutorial.md
@@ -339,12 +339,6 @@ Starting in Airflow 2.5, you can add notes to task instances and DAG runs from t
 
  ![Add task note](/img/guides/2_5_task_notes.png)
 
-:::note
-
-This feature is only available in Airflow version 2.5+. Ensure your Dockerfile is using at least version 7.0 of Astro runtime to complete this step.
-
-:::
-
 ## Conclusion
 
 Congratulations! You now know how to add fancy documentation to both your DAGs and your Airflow tasks.

--- a/learn/custom-airflow-ui-docs-tutorial.md
+++ b/learn/custom-airflow-ui-docs-tutorial.md
@@ -327,7 +327,7 @@ tell_me_what_to_do = PythonOperator(
 
 ## Step 5: Add notes to a task instance and DAG run
 
-Another way of adding information to your DAGs and tasks is to add notes to task instances and DAG runs from the Grid View in the Airflow UI. This feature is useful if you need to add information specific to a single run of your DAG. 
+Starting in Airflow 2.5, you can add notes to task instances and DAG runs from the **Grid** view in the Airflow UI. This feature is useful if you need to share contextual information about a DAG or task run with your team, such as why a specific run failed.
 
 1. Go to the **Grid View** of the `docs_example_dag` DAG you created in [Step 2](#step-2-create-a-new-dag).
 


### PR DESCRIPTION
Resolves #1902 - we have docs on task/DAG run notes in our rerunning DAGs guide, but several folks have had trouble finding that. Adding this step to our DAG docs tutorial will hopefully be another useful place to document this feature.