### PR TITLE
Update migrate-to-runtime.md

### DIFF
--- a/software/migrate-to-runtime.md
+++ b/software/migrate-to-runtime.md
@@ -7,7 +7,7 @@ description: Run an upgrade progress to migrate your Software Deployment from As
 
 import {siteVariables} from '@site/src/versions';
 
-Astro Runtime builds on the reliability of Astronomer Certified (AC) with new features that center on usability and performance.
+Astro Runtime builds on the reliability of Astronomer Certified (AC) with new features that center on usability and performance. Beginning with Astronomer Software 0.29, Astro Runtime is available for Astronomer Software users.
 
 Migrating a Deployment to Astro Runtime is similar to the standard upgrade process. There are no known disruptions when migrating a Deployment from AC to the equivalent version of Astro Runtime.
 

--- a/software/migrate-to-runtime.md
+++ b/software/migrate-to-runtime.md
@@ -7,7 +7,7 @@ description: Run an upgrade progress to migrate your Software Deployment from As
 
 import {siteVariables} from '@site/src/versions';
 
-Astro Runtime builds on the reliability of Astronomer Certified (AC) with new features that center on usability and performance. Beginning with Astronomer Software 0.29, Astro Runtime is available for Astronomer Software users.
+Astro Runtime builds on the reliability of Astronomer Certified (AC) with new features that center on usability and performance. Astro Runtime is available with Astronomer Software 0.29 and later.
 
 Migrating a Deployment to Astro Runtime is similar to the standard upgrade process. There are no known disruptions when migrating a Deployment from AC to the equivalent version of Astro Runtime.
 

--- a/software/migrate-to-runtime.md
+++ b/software/migrate-to-runtime.md
@@ -7,9 +7,13 @@ description: Run an upgrade progress to migrate your Software Deployment from As
 
 import {siteVariables} from '@site/src/versions';
 
-Astro Runtime builds on the reliability of Astronomer Certified (AC) with new features that center on usability and performance. Astro Runtime is available with Astronomer Software 0.29 and later.
+Astro Runtime builds on the reliability of Astronomer Certified (AC) with new features that center on usability and performance.
 
 Migrating a Deployment to Astro Runtime is similar to the standard upgrade process. There are no known disruptions when migrating a Deployment from AC to the equivalent version of Astro Runtime.
+
+## Prerequisites
+
+To migrate to Astro Runtime, you must have Astronomer Software 0.29 or later. See [Upgrade Astronomer](upgrade-astronomer.md).
 
 ## Differences between Astro Runtime and Astronomer Certified
 


### PR DESCRIPTION
While these docs are for 0.31, it was unclear to me that Software users needed to first upgrade Astronomer Software to at least 0.29 in order to migrate to Astro Runtime