### PR TITLE
Create external link checking GitHub action

### DIFF
--- a/.github/workflows/linkCheck.yml
+++ b/.github/workflows/linkCheck.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with: 
-          args: --scheme 'https' --verbose --no-progress './**/*.md' 
+          args: --scheme 'https' --verbose --no-progress './astro/*.md' './software/*.md'  './learn/*.md'
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0

--- a/.github/workflows/linkCheck.yml
+++ b/.github/workflows/linkCheck.yml
@@ -1,0 +1,29 @@
+name: Links
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 1 * * 1"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.6.1
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with: 
+          args: --scheme 'https' --verbose --no-progress './**/*.md' 
+
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue


### PR DESCRIPTION
Lychee seems to have the support and options we need to make a truly useful external broken link checker. I also think it makes sense to run this as a cron job rather than as a PR check - it's rare to ship a broken link in new content and we don't want ancient links to prevent PRs from merging.