### PR TITLE
Make the Hosted Tab the First Tab

### DIFF
--- a/astro/create-cluster.md
+++ b/astro/create-cluster.md
@@ -29,12 +29,27 @@ To create an Astro cluster on AWS, Microsoft Azure, or Google Cloud Platform (GC
 ## AWS
 
 <Tabs
-    defaultValue="byoc"
-    groupId= "byoc"
+    defaultValue="astronomer hosted data plane"
+    groupId= "astronomer hosted data plane"
     values={[
-        {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
+        {label: 'Bring Your Own Cloud', value: 'byoc'},
     ]}>
+<TabItem value="astronomer hosted data plane">
+
+### Submit a request to Astronomer support
+
+To create a new Astro cluster on the hosted cloud, submit a request to [Astronomer support](astro-support.md). In your request, provide the following information for every new cluster that you want to provision:
+
+- Your preferred cluster installation region. See [Supported regions](resource-reference-aws.md#aws-region).
+- Optional. Your preferred worker instance type for your first cluster. See [Worker node types](resource-reference-aws.md#worker-node-types).
+- Optional. Your VPC peering requirements. See [VPC peering prerequisites](install-aws#vpc-peering-prerequisites-optional).
+- The email address of your first Astro user.
+
+If you don't specify your configuration preferences, Astronomer support creates a cluster with a default configuration.
+
+</TabItem>
+
 <TabItem value="byoc">
 
 ### Submit a request to Astronomer support
@@ -112,49 +127,17 @@ To create a cluster in one of these regions, complete the following additional s
 
 </TabItem>
 
-<TabItem value="astronomer hosted data plane">
-
-### Submit a request to Astronomer support
-
-To create a new Astro cluster on the hosted cloud, submit a request to [Astronomer support](astro-support.md). In your request, provide the following information for every new cluster that you want to provision:
-
-- Your preferred cluster installation region. See [Supported regions](resource-reference-aws.md#aws-region).
-- Optional. Your preferred worker instance type for your first cluster. See [Worker node types](resource-reference-aws.md#worker-node-types).
-- Optional. Your VPC peering requirements. See [VPC peering prerequisites](install-aws#vpc-peering-prerequisites-optional).
-- The email address of your first Astro user.
-
-If you don't specify your configuration preferences, Astronomer support creates a cluster with a default configuration.
-
-</TabItem>
-
 </Tabs>
 
 ## Azure
 
 <Tabs
-    defaultValue="byoc"
-    groupId= "byoc"
+    defaultValue="astronomer hosted data plane"
+    groupId= "astronomer hosted data plane"
     values={[
-        {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
+        {label: 'Bring Your Own Cloud', value: 'byoc'},
     ]}>
-<TabItem value="byoc">
-
-### Submit a request to Astronomer support
-
-To create a new Astro cluster on Azure for your Organization, submit a request to [Astronomer support](astro-support.md). In your request, provide the following information for every new cluster that you want to provision:
-
-- Your preferred Astro cluster name.
-- The Azure region that you want to host your cluster in.
-- Your preferred node instance type.
-- Your preferred maximum node count.
-
-If you don't specify configuration preferences, Astronomer support creates a cluster with `Standard_D4d_v5 nodes`, one Postgres Flexible Server instance (`D4ds_v4`), and a maximum node count of 20 in `CentralUS`. If you're using Virtual Private Cloud (VPC) peering, a CIDR block (RFC 1918 IP Space) with the default CIDR range `172.20.0.0/19` is implemented.
-
-For information on all supported regions and configurations, see [Resources required for Astro on Azure](resource-reference-azure.md).  
-
-</TabItem>
-
 <TabItem value="astronomer hosted data plane">
 
 :::info
@@ -176,34 +159,34 @@ If you don't specify your configuration preferences, Astronomer support creates 
 
 </TabItem>
 
+<TabItem value="byoc">
+
+### Submit a request to Astronomer support
+
+To create a new Astro cluster on Azure for your Organization, submit a request to [Astronomer support](astro-support.md). In your request, provide the following information for every new cluster that you want to provision:
+
+- Your preferred Astro cluster name.
+- The Azure region that you want to host your cluster in.
+- Your preferred node instance type.
+- Your preferred maximum node count.
+
+If you don't specify configuration preferences, Astronomer support creates a cluster with `Standard_D4d_v5 nodes`, one Postgres Flexible Server instance (`D4ds_v4`), and a maximum node count of 20 in `CentralUS`. If you're using Virtual Private Cloud (VPC) peering, a CIDR block (RFC 1918 IP Space) with the default CIDR range `172.20.0.0/19` is implemented.
+
+For information on all supported regions and configurations, see [Resources required for Astro on Azure](resource-reference-azure.md).  
+
+</TabItem>
+
 </Tabs>
 
 ## GCP
 
 <Tabs
-    defaultValue="byoc"
-    groupId= "byoc"
+    defaultValue="astronomer hosted data plane"
+    groupId= "astronomer hosted data plane"
     values={[
-        {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
+        {label: 'Bring Your Own Cloud', value: 'byoc'},
     ]}>
-<TabItem value="byoc">
-
-### Submit a request to Astronomer support
-
-To create a new Astro cluster on Google Cloud Platform (GCP) for your Organization, submit a request to [Astronomer support](astro-support.md). In your request, provide the following information for every new cluster that you want to provision:
-
-- Your preferred Astro cluster name.
-- The GCP region that you want to host your cluster in.
-- Your preferred node instance type.
-- Your preferred CloudSQL instance type.
-- Your preferred maximum node count.
-- Your preferred VPC CIDR.
-
-If you don't specify configuration preferences, Astronomer support creates a cluster with a VPC CIDR of 172.20.0.0/22, `e2-medium-4 nodes`, one Medium General Purpose CloudSQL instance (4vCPU, 16GB), and a maximum node count of 20 in `us-central1`.  For information on all supported regions and configurations, see [Resources required for Astro on GCP](resource-reference-gcp.md). 
-
-</TabItem>
-
 <TabItem value="astronomer hosted data plane">
 
 :::info
@@ -222,6 +205,23 @@ To create a new Astro cluster on the hosted cloud, submit a request to [Astronom
 - The email address of your first Astro user.
 
 If you don't specify your configuration preferences, Astronomer support creates a cluster with a default configuration.
+
+</TabItem>
+
+<TabItem value="byoc">
+
+### Submit a request to Astronomer support
+
+To create a new Astro cluster on Google Cloud Platform (GCP) for your Organization, submit a request to [Astronomer support](astro-support.md). In your request, provide the following information for every new cluster that you want to provision:
+
+- Your preferred Astro cluster name.
+- The GCP region that you want to host your cluster in.
+- Your preferred node instance type.
+- Your preferred CloudSQL instance type.
+- Your preferred maximum node count.
+- Your preferred VPC CIDR.
+
+If you don't specify configuration preferences, Astronomer support creates a cluster with a VPC CIDR of 172.20.0.0/22, `e2-medium-4 nodes`, one Medium General Purpose CloudSQL instance (4vCPU, 16GB), and a maximum node count of 20 in `us-central1`.  For information on all supported regions and configurations, see [Resources required for Astro on GCP](resource-reference-gcp.md). 
 
 </TabItem>
 

--- a/astro/install-aws.md
+++ b/astro/install-aws.md
@@ -27,12 +27,63 @@ For a list of the AWS resources and configurations that Astronomer supports, see
 ## Set up
 
 <Tabs
-    defaultValue="byoc"
-    groupId= "byoc"
+    defaultValue="astronomer hosted data plane"
+    groupId= "astronomer hosted data plane"
     values={[
         {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
     ]}>
+<TabItem value="astronomer hosted data plane">
+
+When providing hosted services, Astronomer adheres to industry best practices and standards, including the Health Insurance Portability and Accountability Act (HIPAA), Service Organization Control 2 (SOC2), and  General Data Protection Regulation (GDPR). 
+
+### Prerequisites
+
+The setup process assumes that you've already provided Astronomer support with the following information: 
+
+- Your preferred cluster installation region. See the supported region lists for [AWS](resource-reference-aws.md#aws-region).
+- Optional. Your preferred worker instance type for your first cluster. See [AWS cluster configurations](resource-reference-aws.md#worker-node-types).
+- Optional. Your VPC peering requirements for [AWS](install-aws.md#vpc-peering-prerequisites-optional-2).
+- The email address of your first Astro user.
+
+If you haven't provided this information to Astronomer support, contact your Astronomer representative.
+
+#### VPC peering prerequisites (Optional)
+
+If any AWS resources are on a private network, you can choose between two options:
+
+- Allow traffic through the public internet and use allow-lists for communication.
+- Create a VPC Peering connection between the Astronomer VPC and the VPCs for your broader network.
+
+If you want to continue with the second option, you'll additionally need to provide Astronomer support with:
+
+- A CIDR block (RFC 1918 IP Space) no smaller than a `/19` range. You must ensure it does not overlap with the AWS VPC(s) that you will be peering with later. The default CIDR range is `172.20.0.0/19`.
+- VPC Name / ID for peering with Astronomer (accessible through the [AWS VPC console](https://console.aws.amazon.com/vpc/)).
+- The IP addresses of your DNS servers.
+
+### Astronomer support creates the cluster
+
+Astronomer support creates your first Astro cluster in a dedicated AWS account after you've provided your setup information.
+
+Wait for confirmation that the installation is successful before you access Astro and create a Deployment.
+
+### Access Astro
+
+1. Optional. If you haven't created an Astronomer account, go to https://cloud.astronomer.io/ and create an account.
+
+2. Go to https://cloud.astronomer.io, enter your email address, and then click **Continue**.
+
+3. Select one of the following options to access the Cloud UI:
+
+    - Enter your password and click **Continue**.
+    - To authenticate with an identity provider (IdP), click **Continue with SSO**, enter your username and password, and then click **Sign In**.
+    - To authenticate with your GitHub account, click **Continue with GitHub**, enter your username or email address, enter your password, and then click **Sign in**.
+    - To authenticate with your Google account, click **Continue with Google**, choose an account, enter your username and password, and then click **Sign In**.
+
+    If you're the first person in an Organization to authenticate, you're added as a Workspace Admin to a new Workspace named after your Organization. You can add other team members to the Workspace without the assistance of Astronomer support. See [Add a user](add-user.md). To integrate an identity provider (IdP) with Astro, see [Set up an identity provider](configure-idp.md).
+
+</TabItem>
+
 <TabItem value="byoc">
 
 To install Astro in a dedicated AWS account owned by your organization, you'll complete the following tasks:
@@ -193,57 +244,6 @@ When VPC peering with Astronomer is complete, configure and validate the followi
 
 - Egress Routes on Astronomer Route Table
 - [Network ACLs](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html#nacl-tasks) and/or [Security Group](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html#working-with-security-groups) rules of your resources
-
-</TabItem>
-
-<TabItem value="astronomer hosted data plane">
-
-When providing hosted services, Astronomer adheres to industry best practices and standards, including the Health Insurance Portability and Accountability Act (HIPAA), Service Organization Control 2 (SOC2), and  General Data Protection Regulation (GDPR). 
-
-### Prerequisites
-
-The setup process assumes that you've already provided Astronomer support with the following information: 
-
-- Your preferred cluster installation region. See the supported region lists for [AWS](resource-reference-aws.md#aws-region).
-- Optional. Your preferred worker instance type for your first cluster. See [AWS cluster configurations](resource-reference-aws.md#worker-node-types).
-- Optional. Your VPC peering requirements for [AWS](install-aws.md#vpc-peering-prerequisites-optional-2).
-- The email address of your first Astro user.
-
-If you haven't provided this information to Astronomer support, contact your Astronomer representative.
-
-#### VPC peering prerequisites (Optional)
-
-If any AWS resources are on a private network, you can choose between two options:
-
-- Allow traffic through the public internet and use allow-lists for communication.
-- Create a VPC Peering connection between the Astronomer VPC and the VPCs for your broader network.
-
-If you want to continue with the second option, you'll additionally need to provide Astronomer support with:
-
-- A CIDR block (RFC 1918 IP Space) no smaller than a `/19` range. You must ensure it does not overlap with the AWS VPC(s) that you will be peering with later. The default CIDR range is `172.20.0.0/19`.
-- VPC Name / ID for peering with Astronomer (accessible through the [AWS VPC console](https://console.aws.amazon.com/vpc/)).
-- The IP addresses of your DNS servers.
-
-### Astronomer support creates the cluster
-
-Astronomer support creates your first Astro cluster in a dedicated AWS account after you've provided your setup information.
-
-Wait for confirmation that the installation is successful before you access Astro and create a Deployment.
-
-### Access Astro
-
-1. Optional. If you haven't created an Astronomer account, go to https://cloud.astronomer.io/ and create an account.
-
-2. Go to https://cloud.astronomer.io, enter your email address, and then click **Continue**.
-
-3. Select one of the following options to access the Cloud UI:
-
-    - Enter your password and click **Continue**.
-    - To authenticate with an identity provider (IdP), click **Continue with SSO**, enter your username and password, and then click **Sign In**.
-    - To authenticate with your GitHub account, click **Continue with GitHub**, enter your username or email address, enter your password, and then click **Sign in**.
-    - To authenticate with your Google account, click **Continue with Google**, choose an account, enter your username and password, and then click **Sign In**.
-
-    If you're the first person in an Organization to authenticate, you're added as a Workspace Admin to a new Workspace named after your Organization. You can add other team members to the Workspace without the assistance of Astronomer support. See [Add a user](add-user.md). To integrate an identity provider (IdP) with Astro, see [Set up an identity provider](configure-idp.md).
 
 </TabItem>
 

--- a/astro/install-aws.md
+++ b/astro/install-aws.md
@@ -17,8 +17,8 @@ import TabItem from '@theme/TabItem';
 
 The Astro data plane on Amazon Web Services (AWS) runs on Elastic Kubernetes Service (EKS). You have two options to install Astro on AWS:
 
-- Bring Your Own Cloud -  Create an Astro cluster in a dedicated AWS account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
 - Hosted - Create an Astro cluster in a dedicated AWS account that's hosted and owned by Astronomer. This removes the complexity of adding another AWS account to your network.
+- Bring Your Own Cloud -  Create an Astro cluster in a dedicated AWS account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
 
 With the two options, the user experience is identical and Astronomer is responsible for managing Astro. The differences between the two options are security and networking.
 

--- a/astro/install-aws.md
+++ b/astro/install-aws.md
@@ -30,8 +30,8 @@ For a list of the AWS resources and configurations that Astronomer supports, see
     defaultValue="astronomer hosted data plane"
     groupId= "astronomer hosted data plane"
     values={[
-        {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
+        {label: 'Bring Your Own Cloud', value: 'byoc'},
     ]}>
 <TabItem value="astronomer hosted data plane">
 

--- a/astro/install-azure.md
+++ b/astro/install-azure.md
@@ -17,8 +17,8 @@ import TabItem from '@theme/TabItem';
 
 You have two options to install Astro on Azure:
 
-- Bring Your Own Cloud -  Create an Astro cluster in a dedicated Azure account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
 - Hosted - Create an Astro cluster in a dedicated Azure account that's hosted and owned by Astronomer. This removes the complexity of adding another Azure account to your network.
+- Bring Your Own Cloud -  Create an Astro cluster in a dedicated Azure account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
 
 To complete the installation process, you'll:
 

--- a/astro/install-azure.md
+++ b/astro/install-azure.md
@@ -36,8 +36,8 @@ For more information about managing Azure subscriptions with the Azure CLI, see 
     defaultValue="astronomer hosted data plane"
     groupId= "astronomer hosted data plane"
     values={[
-        {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
+        {label: 'Bring Your Own Cloud', value: 'byoc'},
     ]}>
 <TabItem value="astronomer hosted data plane">
 

--- a/astro/install-azure.md
+++ b/astro/install-azure.md
@@ -33,12 +33,56 @@ For more information about managing Azure subscriptions with the Azure CLI, see 
 ## Set up
 
 <Tabs
-    defaultValue="byoc"
-    groupId= "byoc"
+    defaultValue="astronomer hosted data plane"
+    groupId= "astronomer hosted data plane"
     values={[
         {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
     ]}>
+<TabItem value="astronomer hosted data plane">
+
+:::info
+
+This feature is currently Private Preview. Contact [Astronomer support](https://cloud.astronomer.io/support) to enable it.
+
+:::
+
+When providing hosting services, Astronomer adheres to industry best practices and standards including the Health Insurance Portability and Accountability Act (HIPAA), Service Organization Control 2 (SOC2), and  General Data Protection Regulation (GDPR). 
+
+### Prerequisites
+
+The setup process assumes that you've already provided Astronomer support with the following information: 
+
+- Your preferred cluster installation region. See the supported region lists for [Azure](resource-reference-azure.md#supported-regions).
+- Optional. Your preferred worker instance type for your first cluster. See [Azure cluster configurations](resource-reference-azure.md#worker-node-pools).
+- Optional. Your VNet peering requirements for [Azure](install-azure#vnet-peering-prerequisites-optional).
+- The email address of your first Astro user.
+
+If you haven't provided this information to Astronomer support, contact your Astronomer representative. 
+
+### Astronomer support creates the cluster
+
+Astronomer support creates your first Astro cluster in a dedicated Azure account after you've provided your setup information.
+
+Wait for confirmation that the installation is successful before you access Astro and create a Deployment.
+
+### Access Astro
+
+1. Optional. If you haven't created an Astronomer account, go to https://cloud.astronomer.io/ and create an account.
+
+2. Go to https://cloud.astronomer.io, enter your email address, and then click **Continue**.
+
+3. Select one of the following options to access the Cloud UI:
+
+    - Enter your password and click **Continue**.
+    - To authenticate with an identity provider (IdP), click **Continue with SSO**, enter your username and password, and then click **Sign In**.
+    - To authenticate with your GitHub account, click **Continue with GitHub**, enter your username or email address, enter your password, and then click **Sign in**.
+    - To authenticate with your Google account, click **Continue with Google**, choose an account, enter your username and password, and then click **Sign In**.
+
+    If you're the first person in an Organization to authenticate, you're added as a Workspace Admin to a new Workspace named after your Organization. You can add other team members to the Workspace without the assistance of Astronomer support. See [Add a user](add-user.md). To integrate an identity provider (IdP) with Astro, see [Set up an identity provider](configure-idp.md).
+
+</TabItem>
+
 <TabItem value="byoc">
 
 ### Prerequisites
@@ -222,50 +266,6 @@ If you don't specify a preferred configuration for your organization, Astronomer
 After you provide Astronomer support with the setup information for your organization, Astronomer support creates your first cluster on Azure.
 
 Wait for confirmation from Astronomer support that the cluster has been created before creating a Deployment.
-
-</TabItem>
-
-<TabItem value="astronomer hosted data plane">
-
-:::info
-
-This feature is currently Private Preview. Contact [Astronomer support](https://cloud.astronomer.io/support) to enable it.
-
-:::
-
-When providing hosting services, Astronomer adheres to industry best practices and standards including the Health Insurance Portability and Accountability Act (HIPAA), Service Organization Control 2 (SOC2), and  General Data Protection Regulation (GDPR). 
-
-### Prerequisites
-
-The setup process assumes that you've already provided Astronomer support with the following information: 
-
-- Your preferred cluster installation region. See the supported region lists for [Azure](resource-reference-azure.md#supported-regions).
-- Optional. Your preferred worker instance type for your first cluster. See [Azure cluster configurations](resource-reference-azure.md#worker-node-pools).
-- Optional. Your VNet peering requirements for [Azure](install-azure#vnet-peering-prerequisites-optional).
-- The email address of your first Astro user.
-
-If you haven't provided this information to Astronomer support, contact your Astronomer representative. 
-
-### Astronomer support creates the cluster
-
-Astronomer support creates your first Astro cluster in a dedicated Azure account after you've provided your setup information.
-
-Wait for confirmation that the installation is successful before you access Astro and create a Deployment.
-
-### Access Astro
-
-1. Optional. If you haven't created an Astronomer account, go to https://cloud.astronomer.io/ and create an account.
-
-2. Go to https://cloud.astronomer.io, enter your email address, and then click **Continue**.
-
-3. Select one of the following options to access the Cloud UI:
-
-    - Enter your password and click **Continue**.
-    - To authenticate with an identity provider (IdP), click **Continue with SSO**, enter your username and password, and then click **Sign In**.
-    - To authenticate with your GitHub account, click **Continue with GitHub**, enter your username or email address, enter your password, and then click **Sign in**.
-    - To authenticate with your Google account, click **Continue with Google**, choose an account, enter your username and password, and then click **Sign In**.
-
-    If you're the first person in an Organization to authenticate, you're added as a Workspace Admin to a new Workspace named after your Organization. You can add other team members to the Workspace without the assistance of Astronomer support. See [Add a user](add-user.md). To integrate an identity provider (IdP) with Astro, see [Set up an identity provider](configure-idp.md).
 
 </TabItem>
 

--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -13,8 +13,8 @@ import TabItem from '@theme/TabItem';
 
 This is where you'll find instructions for installing Astro on the Google Cloud Platform (GCP). You have two options to install Astro on GCP:
 
-- Bring Your Own Cloud -  Create an Astro cluster in a dedicated GCP account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
 - Hosted - Create an Astro cluster in a dedicated GCP account that's hosted and owned by Astronomer. This removes the complexity of adding another GCP account to your network.
+- Bring Your Own Cloud -  Create an Astro cluster in a dedicated GCP account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
 
 To complete the installation process, you'll:
 

--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -29,12 +29,56 @@ For more information about managing Google Cloud projects, see [GCP documentatio
 ## Set up
 
 <Tabs
-    defaultValue="byoc"
-    groupId= "byoc"
+    defaultValue="astronomer hosted data plane"
+    groupId= "astronomer hosted data plane"
     values={[
         {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
     ]}>
+<TabItem value="astronomer hosted data plane">
+
+:::info
+
+This feature is currently Private Preview. Contact [Astronomer support](https://cloud.astronomer.io/support) to enable it.
+
+:::
+
+When providing hosting services, Astronomer adheres to industry best practices and standards including the Health Insurance Portability and Accountability Act (HIPAA), Service Organization Control 2 (SOC2), and  General Data Protection Regulation (GDPR). 
+
+### Prerequisites
+
+The setup process assumes that you've already provided Astronomer support with the following information: 
+
+- Your preferred cluster installation region. See the supported region lists for [GCP](resource-reference-gcp.md#supported-regions).
+- Optional. Your preferred worker instance type for your first cluster. See [GCP cluster configurations](resource-reference-gcp.md#supported-cluster-configurations).
+- Optional. Your VPC peering requirements for [GCP](install-gcp#vpc-peering-with-astronomer).
+- The email address of your first Astro user.
+
+If you haven't provided this information to Astronomer support, contact your Astronomer representative. 
+
+### Astronomer support creates the cluster
+
+Astronomer support creates your first Astro cluster in a dedicated GCP account after you've provided your setup information.
+
+Wait for confirmation that the installation is successful before you access Astro and create a Deployment.
+
+### Access Astro
+
+1. Optional. If you haven't created an Astronomer account, go to https://cloud.astronomer.io/ and create an account.
+
+2. Go to https://cloud.astronomer.io/, enter your email address, and then click **Continue**.
+
+3. Select one of the following options to access the Cloud UI:
+
+    - Enter your password and click **Continue**.
+    - To authenticate with an identity provider (IdP), click **Continue with SSO**, enter your username and password, and then click **Sign In**.
+    - To authenticate with your GitHub account, click **Continue with GitHub**, enter your username or email address, enter your password, and then click **Sign in**.
+    - To authenticate with your Google account, click **Continue with Google**, choose an account, enter your username and password, and then click **Sign In**.
+
+    If you're the first person in an Organization to authenticate, you're added as a Workspace Admin to a new Workspace named after your Organization. You can add other team members to the Workspace without the assistance of Astronomer support. See [Add a user](add-user.md). To integrate an identity provider (IdP) with Astro, see [Set up an identity provider](configure-idp.md).
+
+</TabItem>
+
 <TabItem value="byoc">
 
 ### Prerequisites
@@ -152,50 +196,6 @@ When VPC peering with Astronomer is complete, configure and validate the followi
 
 - [Egress routes](https://cloud.google.com/vpc/docs/routes#routing_in)
 - [Network ACLs](https://cloud.google.com/storage/docs/access-control/lists) or [Security Group](https://cloud.google.com/identity/docs/how-to/update-group-to-security-group) rules of your resources
-
-</TabItem>
-
-<TabItem value="astronomer hosted data plane">
-
-:::info
-
-This feature is currently Private Preview. Contact [Astronomer support](https://cloud.astronomer.io/support) to enable it.
-
-:::
-
-When providing hosting services, Astronomer adheres to industry best practices and standards including the Health Insurance Portability and Accountability Act (HIPAA), Service Organization Control 2 (SOC2), and  General Data Protection Regulation (GDPR). 
-
-### Prerequisites
-
-The setup process assumes that you've already provided Astronomer support with the following information: 
-
-- Your preferred cluster installation region. See the supported region lists for [GCP](resource-reference-gcp.md#supported-regions).
-- Optional. Your preferred worker instance type for your first cluster. See [GCP cluster configurations](resource-reference-gcp.md#supported-cluster-configurations).
-- Optional. Your VPC peering requirements for [GCP](install-gcp#vpc-peering-with-astronomer).
-- The email address of your first Astro user.
-
-If you haven't provided this information to Astronomer support, contact your Astronomer representative. 
-
-### Astronomer support creates the cluster
-
-Astronomer support creates your first Astro cluster in a dedicated GCP account after you've provided your setup information.
-
-Wait for confirmation that the installation is successful before you access Astro and create a Deployment.
-
-### Access Astro
-
-1. Optional. If you haven't created an Astronomer account, go to https://cloud.astronomer.io/ and create an account.
-
-2. Go to https://cloud.astronomer.io/, enter your email address, and then click **Continue**.
-
-3. Select one of the following options to access the Cloud UI:
-
-    - Enter your password and click **Continue**.
-    - To authenticate with an identity provider (IdP), click **Continue with SSO**, enter your username and password, and then click **Sign In**.
-    - To authenticate with your GitHub account, click **Continue with GitHub**, enter your username or email address, enter your password, and then click **Sign in**.
-    - To authenticate with your Google account, click **Continue with Google**, choose an account, enter your username and password, and then click **Sign In**.
-
-    If you're the first person in an Organization to authenticate, you're added as a Workspace Admin to a new Workspace named after your Organization. You can add other team members to the Workspace without the assistance of Astronomer support. See [Add a user](add-user.md). To integrate an identity provider (IdP) with Astro, see [Set up an identity provider](configure-idp.md).
 
 </TabItem>
 

--- a/astro/install-gcp.md
+++ b/astro/install-gcp.md
@@ -32,8 +32,8 @@ For more information about managing Google Cloud projects, see [GCP documentatio
     defaultValue="astronomer hosted data plane"
     groupId= "astronomer hosted data plane"
     values={[
-        {label: 'Bring Your Own Cloud', value: 'byoc'},
         {label: 'Hosted', value: 'astronomer hosted data plane'},
+        {label: 'Bring Your Own Cloud', value: 'byoc'},
     ]}>
 <TabItem value="astronomer hosted data plane">
 


### PR DESCRIPTION
Astronomer is making the hosted model the preferred choice. This PR moves the **Hosted** tab to the first position in the installation and cluster docs.

It _might_ be premature, but this was a quick edit.