### PR TITLE
remove worker-au from deployment create/update commands

### DIFF
--- a/astro/cli/astro-deployment-create.md
+++ b/astro/cli/astro-deployment-create.md
@@ -31,11 +31,7 @@ Create a Deployment on Astro. This command is functionally identical to using th
 astro deployment create
 ```
 
-:::tip
-
-To create a deployment with a custom worker queue use a deployment file and the `--deployment-file` flag. See [Deployments as Code documentation](manage-deployments-as-code.md) for more information
-
-:::
+Some Deployment configurations can be set only by using the `--deployment-file` flag to apply a Deployment file. See [Manage Deployments as code](manage-deployments-as-code.md).
 
 ## Options
 

--- a/astro/cli/astro-deployment-create.md
+++ b/astro/cli/astro-deployment-create.md
@@ -31,6 +31,12 @@ Create a Deployment on Astro. This command is functionally identical to using th
 astro deployment create
 ```
 
+:::tip
+
+To create a deployment with a custom worker queue use a deployment file and the `--deployment-file` flag. See [Deployments as Code documentation](manage-deployments-as-code.md) for more information
+
+:::
+
 ## Options
 
 | Option                      | Description                                                                                                                                 | Possible Values                                                                             |
@@ -42,7 +48,6 @@ astro deployment create
 | `-n`,`--name`               | The name of the Deployment                                                                                                                  | Any string. Multiple-word descriptions should be specified in quotations                    |
 | `-v`,`--runtime-version`    | The Astro Runtime version for the Deployment                                                                                                | Any supported version of Astro Runtime. Major, minor, and patch versions must be specified. |
 | `-s`,`--scheduler-au`       | The number of AU to allocate towards the Deployment's Scheduler(s). The default is`5`.                                                      | Integer between `0` and `24`                                                                |
-| `-a`,`--worker-au`          | The number of AU to allocate towards the Deployment's worker(s). The default is `10`.                                                       | Integer between `0` and `175`                                                               |
 | `-r`,`--scheduler-replicas` | The number of scheduler replicas for the Deployment. The default is `1`.                                                                    | Integer between `0` and `4`                                                                 |
 | `--wait`                    | The time to wait for the new Deployment to have a [healthy](deployment-metrics.md#deployment-health) status before completing the command . | None                                                                                        |
 | `--workspace-id`            | The Workspace in which to create a Deployment. If not specified, your current Workspace is assumed.                                         | Any valid Workspace ID                                                                      |

--- a/astro/cli/astro-deployment-update.md
+++ b/astro/cli/astro-deployment-update.md
@@ -54,7 +54,6 @@ After setting the variables, this command works for a Deployment and you don't n
 | `-d`,`--description`           | The description for the Deployment                                                     | Any string. Multiple-word descriptions should be specified in quotations (`"`) |
 | `-l`,`--name`                  | The Deployment's name                                                                  | Any string. Multiple-word descriptions should be specified in quotations       |
 | `-s`,`--scheduler-au`          | The number of AU to allocate towards the Deployment's Scheduler(s). The default is`5`. | Integer between `0` and `24`                                                   |
-| `-a`,`--worker-au`             | The number of AU to allocate towards the Deployment's worker(s). The default is `10`.  | Integer between `0` and `175`                                                  |
 | `-r`,`--scheduler-replicas`    | The number of scheduler replicas for the Deployment. The default is `1`.               | Integer between `0` and `4`                                                    |
 | `-f`,`--force`          | Force a Deployment update                             | None                                                                             |
 | `-w`,`--workspace-id`          | Specify a Workspace to update a Deployment outside of your current Workspace           | Any valid Workspace ID                                                         |


### PR DESCRIPTION
Remove worker au flags from deployment create/update commands. Worker resources were replaced by worker queues