### PR TITLE
Add admonition about Azure Single Server

### DIFF
--- a/software/install-azure-standard.md
+++ b/software/install-azure-standard.md
@@ -21,6 +21,12 @@ Install Astronomer Software on Azure to deploy and scale [Apache Airflow](https:
 * PostgreSQL superuser permissions
 * If your organization uses Azure Database for PostgreSQL as the database backend, you need to enable the `pg_trgm` extension using the Azure portal or the Azure CLI before you install Astronomer Software. If you don't enable the `pg_trgm` extension, the install will fail. For more information about enabling the `pg_trgm` extension, see [PostgreSQL extensions in Azure Database for PostgreSQL - Flexible Server](https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-extensions).
 
+:::caution
+
+Astronomer Software is not compatible with Azure Single Server.
+
+:::
+
 ## Step 1: Choose a base domain
 
 All Astronomer services will be tied to a base domain of your choice, under which you will need the ability to add and edit DNS records.


### PR DESCRIPTION
* User had issues with setting up Azure with Astronomer Software, but after a long troubleshooting process, realized they were using Azure Single Server which is not supported. 
* Added admonition to list of prerequisites in Install Azure page (https://docs.astronomer.io/software/install-azure)