### PR TITLE
Fix for import code in Learn / Azure Container Instances

### DIFF
--- a/learn/airflow-azure-container-instances.md
+++ b/learn/airflow-azure-container-instances.md
@@ -82,7 +82,7 @@ In your Astro project `dags/` folder, create a new file called `aci-pipeline.py`
 
 ```python
 from airflow import DAG
-from airflow.providers.microsoft.azure.operators.azure_container_instances import AzureContainerInstancesOperator
+from airflow.providers.microsoft.azure.operators.container_instances import AzureContainerInstancesOperator
 from datetime import datetime, timedelta
 
 


### PR DESCRIPTION
The import is currently `airflow.providers.microsoft.azure.operators.azure_container_instances` but should be `airflow.providers.microsoft.azure.operators.container_instances`