### PR TITLE
Remove incorrect reference to Airflow config

### DIFF
--- a/astro/environment-variables.md
+++ b/astro/environment-variables.md
@@ -111,7 +111,6 @@ On Astro, environment variables are applied and overridden in the following orde
 - Cloud UI
 - [.env (local development only)](develop-project.md#set-environment-variables-local-development)
 - Dockerfile
-- Default Airflow values
 
 For example, if you set `AIRFLOW__CORE__PARALLELISM` with one value in the Cloud UI and you set the same environment variable with another value in your `Dockerfile`, the value set in the Cloud UI takes precedence.
 


### PR DESCRIPTION
Default Airflow config isn't in env vars, and this section is about env var precedence.