### PR TITLE
Fix page content min-height issue on large screens

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -173,6 +173,10 @@ html[data-theme="dark"] {
   }
 }
 
+#__docusaurus {
+  min-height: 100vh;
+}
+
 h1,
 h2,
 h3,
@@ -587,7 +591,7 @@ html[data-theme="dark"] aside.theme-doc-sidebar-container {
 
 @media screen and (min-width: 997px) {
 
-  .sidebar_node_modules-\@docusaurus-theme-classic-lib-theme-DocSidebar-Desktop-styles-module {
+  div[class*="sidebar_"]{
     min-height: 100vh;
   }
 


### PR DESCRIPTION
This PR is a small edit to make sure the page content is at least `100vh` to solve an issue with shifting content on larger screens.