### PR TITLE
Increase menu__list bottom padding

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -567,7 +567,7 @@ html[data-theme='dark'] .alert--cli {
 }
 
 .menu__list {
-  padding-bottom: 4rem;
+  padding-bottom: 18rem;
 }
 
 html .DocSearch {

--- a/src/theme/DocSidebar/Desktop/Content/styles.module.css
+++ b/src/theme/DocSidebar/Desktop/Content/styles.module.css
@@ -21,7 +21,7 @@ html[data-theme="light"] .menu__listBottom {
   position: absolute;
   background: white;
   bottom: 0;
-  width: calc(100% - 20px);
+  width: calc(100% - 26px);
   padding: 2rem 0;
 }
 
@@ -32,7 +32,7 @@ html[data-theme="dark"] .menu__listBottom {
   position: absolute;
   background: #1b1b1d;
   bottom: 0;
-  width: calc(100% - 20px);
+  width: calc(100% - 26px);
   padding: 2rem 0;
 }
 


### PR DESCRIPTION
This PR adds some extra bottom padding to `.menu__list` to account for the bottom CTA links being absolute positioned. This helps ensure longer navigation lists, such as "Integrations" for the Learn sidebar, don't get hidden behind the bottom section.

Before
<img width="314" alt="Screenshot 2023-03-21 at 16 26 43" src="https://user-images.githubusercontent.com/96535736/226658660-5f33971e-84a0-4814-8eb3-851df4d76508.png">

After
<img width="326" alt="image" src="https://user-images.githubusercontent.com/96535736/226658862-47c3a80f-46d2-4371-b35b-43add8dbb338.png">

