### PR TITLE
Add pubDate to RSS channels and items

### DIFF
--- a/createRSSFeeds.mjs
+++ b/createRSSFeeds.mjs
@@ -12,6 +12,7 @@ let astroCLI = await fs.readFile('./astro/cli/release-notes.md', 'utf8');
 let software = await fs.readFile('./software/release-notes.md', 'utf8');
 let softwareRuntime = await fs.readFile('./astro/runtime-release-notes.md', 'utf8');
 
+let currentDate = new Date();
 
 // function to get all elements between two elements
 function nextUntil(elem, selector, filter) {
@@ -44,10 +45,14 @@ function getPosts(content) {
   // for each h2 create post with title, slug,
   // and get all the content between this h2 until the next h2
   H2s.map((h2) => {
+    const postContent = nextUntil(h2, 'h2');
+    const postDate = postContent.match(/(?<=Release date: ).*?(?=<.)/sg) || h2.textContent;
+    console.log(postDate)
     const post = {
       "title": h2.textContent,
       "slug": h2.textContent.toLowerCase().replace(/ /g, '-').replace(',', ''),
-      "content": `${nextUntil(h2, 'h2')}`
+      "content": postContent,
+      "pubDate": postDate
     };
     posts.push(post);
   })
@@ -65,6 +70,9 @@ async function createRssFeed(feedTitle, feedDescription, feedPageURL, content) {
             link: `${pageURL}#${post.slug.replace(/\./g, '')}`
           },
           {
+            guid: `${pageURL}#${post.slug.replace(/\./g, '')}`
+          },
+          {
             description: {
               _cdata: post.content,
             },
@@ -80,7 +88,7 @@ async function createRssFeed(feedTitle, feedDescription, feedPageURL, content) {
 
   const websiteURL = "https://docs.astronomer.io/";
   const feedSlug = feedTitle.replace(/ /g, "-",).toLowerCase();
-  const feedRSSLink = websiteURL + feedSlug + '.rss';
+  const feedRSSLink = websiteURL + feedSlug + '.xml';
 
   console.log(`📡 Creating ${feedTitle} RSS feed`);
 
@@ -108,6 +116,9 @@ async function createRssFeed(feedTitle, feedDescription, feedPageURL, content) {
           },
           {
             link: feedPageURL,
+          },
+          {
+            pubDate: currentDate.toUTCString()
           },
           { description: feedDescription },
           { language: "en-US" },

--- a/createRSSFeeds.mjs
+++ b/createRSSFeeds.mjs
@@ -47,7 +47,6 @@ function getPosts(content) {
   H2s.map((h2) => {
     const postContent = nextUntil(h2, 'h2');
     const postDate = postContent.match(/(?<=Release date: ).*?(?=<.)/sg) || h2.textContent;
-    console.log(postDate)
     const post = {
       "title": h2.textContent,
       "slug": h2.textContent.toLowerCase().replace(/ /g, '-').replace(',', ''),

--- a/static/_redirects
+++ b/static/_redirects
@@ -275,3 +275,8 @@
 /enterprise/0.25/* /software/0.25/overview
 /enterprise/0.23/* /software/0.23/overview
 /enterprise/0.16/* /software/0.16/overview
+
+# redirect .rss to .xml
+/astro-runtime-release-notes.rss /astro-runtime-release-notes.xml 301
+/astro-cli-release-notes.rss /astro-cli-release-notes.xml 301
+/astro-release-notes.rss /astro-release-notes.xml 301


### PR DESCRIPTION
This PR for our RSS feeds adds `<pubDate>` attributes to the feed channels equal to last build time as well as to feed items equal to their publish date. Also adds `<guid>` to each feed item. This should help aggregators stay up-to-date. 🙂 