### PR TITLE
Add notes for --worker-au docs changes

### DIFF
--- a/astro/cli/astro-deployment-create.md
+++ b/astro/cli/astro-deployment-create.md
@@ -31,7 +31,9 @@ Create a Deployment on Astro. This command is functionally identical to using th
 astro deployment create
 ```
 
-Some Deployment configurations can be set only by using the `--deployment-file` flag to apply a Deployment file. See [Manage Deployments as code](manage-deployments-as-code.md).
+When you use `astro deployment create`, it creates a Deployment with a default Worker Queue that uses default worker types.
+
+Some Deployment configurations, including worker queue and worker type, can be set only by using the `--deployment-file` flag to apply a Deployment file. See [Manage Deployments as code](manage-deployments-as-code.md).
 
 ## Options
 

--- a/astro/cli/astro-deployment-update.md
+++ b/astro/cli/astro-deployment-update.md
@@ -28,7 +28,7 @@ Update the configuration for a Deployment on Astro.
 
 :::note
 
-To update existing worker queues or to create new queues, you must update update you Deployment with a [`--deployment-file`](manage-deployments-as-code.md#create-a-template-file-from-an-existing-deployment).
+To update existing worker queues or to create new queues for an existing Deployment, you must update your Deployment by using the `--deployment-file` flag to update a [Deployment file](manage-deployments-as-code.md#create-a-template-file-from-an-existing-deployment).
 
 :::
 

--- a/astro/cli/astro-deployment-update.md
+++ b/astro/cli/astro-deployment-update.md
@@ -24,7 +24,13 @@ The behavior and format of this command differs depending on what Astronomer pro
 <TabItem value="astro">
 
 
-Update the configuration for a Deployment on Astro. This command is functionally identical to using **Edit Configuration** to modify a Deployment in the Cloud UI.
+Update the configuration for a Deployment on Astro. 
+
+:::note
+
+To update existing worker queues or to create new queues, you must update update you Deployment with a [`--deployment-file`](manage-deployments-as-code.md#create-a-template-file-from-an-existing-deployment).
+
+:::
 
 ## Usage
 


### PR DESCRIPTION
* Added note to `astro deployment update` about worker queue update process requiring a deployment file.
* Added note to  `astro deployment create` about  how worker queue and worker types are created using the defaults. To change worker queue and worker types, users must use a deployment file. 
* Removed phrase about process being identical to UI flow. 

https://github.com/astronomer/docs/issues/1968