### PR TITLE
Update deprecated example

### DIFF
--- a/astro/set-up-data-lineage.md
+++ b/astro/set-up-data-lineage.md
@@ -247,7 +247,7 @@ In your Spark application, set the following properties to configure your lineag
    SparkSession.builder \
      .config('spark.jars.packages', 'io.openlineage:openlineage-spark:0.2.+')
      .config('spark.extraListeners', 'io.openlineage.spark.agent.OpenLineageSparkListener')
-     .config('spark.openlineage.host', 'https://astro-<your-astro-base-domain>.datakin.com')
+     .config('spark.openlineage.transport.url', 'https://astro-<your-astro-base-domain>.datakin.com')
      .config('spark.openlineage.apiKey', '<your-openlineage-api-key>')
      .config('spark.openlineage.namespace', '<namespace-name>') # Replace with the name of your Spark cluster.
      .getOrCreate()                                             # Astronomer recommends using a meaningful namespace such as `spark-dev` or `spark-prod`.


### PR DESCRIPTION
https://github.com/astronomer/docs/issues/2089

Changed `spark.openlineage.host` to `spark.openlineage.transport.url`