### PR TITLE
add code for deploying to Astro

### DIFF
--- a/astro/migrate-gcc.mdx
+++ b/astro/migrate-gcc.mdx
@@ -151,6 +151,10 @@ If you used CI/CD to deploy code to your source Airflow environment, read the fo
 
 If you currently store Airflow variables or connections in a secrets backend, you need to integrate your secrets backend with Astro to access those objects from your migrated DAGs. See [Configure a Secrets Backend](secrets-backend.md) for setup steps.
 
+### Set up DAG-Only Deploy from GCS Bucket 
+
+If you would like to continue deploying DAGs from GCS Bucket directly to your Airflow Deployment, you can setup the CI/CD to push the DAGs to the bucket and then follow the steps [here](https://docs.astronomer.io/astro/ci-cd#cloud-storage-to-astro-dag-based-deploys) using Google Cloud Functions for deploying to Astro.
+
 #### Instance permissions and trust policies
 
 You can utilize Workload Identity or Service Account Keys to grant your Astro Deployment the same level of access to Google Services as your source Airflow environment. See [Connect GCP - Authorization options](connect-gcp.md#authentication-options).

--- a/astro/migrate-mwaa.mdx
+++ b/astro/migrate-mwaa.mdx
@@ -156,6 +156,10 @@ If you used CI/CD to deploy code to your source Airflow environment, read the fo
 
 If you currently store Airflow variables or connections in a secrets backend, you need to integrate your secrets backend with Astro to access those objects from your migrated DAGs. See [Configure a Secrets Backend](secrets-backend.md) for setup steps.
 
+### Set up DAG-Only Deploy from S3 Bucket 
+
+If you would like to continue deploying DAGs from S3 Bucket directly to your Airflow Deployment, you can setup the CI/CD to push the DAGs to the bucket and then follow the steps [here](https://docs.astronomer.io/astro/ci-cd#cloud-storage-to-astro-dag-based-deploys) using AWS Lambda for deploying to Astro.
+
 ## Step 8: Test locally and check for import errors
 
 Depending on how thoroughly you want to test your Airflow environment, you have a few options for testing your project locally before deploying to Astro.


### PR DESCRIPTION
This PR adds example to the CI/CD Page on how to deploy from GCS/S3 bucket to Astro using DAG-only Deploys. This is a DRAFT PR. I am still thinking where should it fit. It could best fit in the newly released MWAA/GCC Migration doc as well. 