### PR TITLE
Add Astronomer provider pre-built XCom backends to XCom backends tutorial

### DIFF
--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -248,15 +248,15 @@ MINIO_IP=host.docker.internal:9000
 
 For Airflow to use your custom XCom backend, you need to define an XCom backend class which inherits from the `BaseXCom` class.
 
+:::info
+
+The Astronomer provider package contains a pre-built XCom backend for AWS S3 and GCP Cloud Storage with a set of added serialization methods. Refer to the [Use pre-built XCom backends](#use-pre-built-xcom-backends) section for implementation details. When using a pre-built XCom backend you will not have to create any new files in the `include` folder. When using a pre-built XCom backend you do not have to create any new files in the `include` folder and you can skip [Step 4](#step-4-define-a-custom-xcom-class-using-json-serialization) and Step 6 of this tutorial.
+
+:::
+
 1. In your Astro project, create a new file in the `include` directory called `xcom_backend_json.py`.
 
 2. Copy paste the following code into the file:
-
-:::info
-
-The Astronomer provider package contains a pre-built custom XCom backend for AWS S3 and GCP Cloud Storage with a set of added serialization methods. Refer to the [Use pre-built XCom backends](#use-pre-built-xcom-backends) section for implementation details.
-
-:::
 
 <Tabs
     defaultValue="aws"
@@ -698,7 +698,8 @@ A powerful feature of custom XCom backends is the possibility to create custom s
 
 :::info
 
-The Astronomer provider package contains a pre-built custom XCom backend for AWS S3 and GCP Cloud Storage with a set of added serialization methods, including for Pandas dataframes. Refer to the [Use pre-built XCom backends](#use-pre-built-xcom-backends) section for implementation details.
+The Astronomer provider package contains a pre-built XCom backend for AWS S3 and GCP Cloud Storage with added serialization methods for Pandas dataframes and datetime date objects. Refer to the [Use pre-built XCom backends](#use-pre-built-xcom-backends) section for implementation details. 
+When using a pre-built XCom backend you do not have to create any new files in the `include` folder and you can skip [Step 4](#step-4-define-a-custom-xcom-class-using-json-serialization) and Step 6 of this tutorial.
 
 :::
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -1279,17 +1279,17 @@ To use these Astronomer's XCom backends follow these steps:
     ]}>
 <TabItem value="aws">
 
-    ```text
-    AIRFLOW__CORE__XCOM_BACKEND=astronomer.providers.amazon.aws.xcom_backends.s3.S3XComBackend
-    ```
+```text
+AIRFLOW__CORE__XCOM_BACKEND=astronomer.providers.amazon.aws.xcom_backends.s3.S3XComBackend
+```
 
 </TabItem>
 
 <TabItem value="gcp">
 
-    ```text
-    AIRFLOW__CORE__XCOM_BACKEND=astronomer.providers.google.cloud.xcom_backends.gcs.GCSXComBackend
-    ```
+```text
+AIRFLOW__CORE__XCOM_BACKEND=astronomer.providers.google.cloud.xcom_backends.gcs.GCSXComBackend
+```
 
 </TabItem>
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -1267,7 +1267,7 @@ To use these Astronomer's XCom backends, follow these steps:
 
 2. Prepare your AWS S3 or GCP Cloud Storage as shown in [Step 2: Set up your object storage account](#step-2-set-up-your-object-storage-account).
 
-3. Create an Airflow connection as shown in [Step 3: Create a connection](#step-3-create-a-connection).
+3. Create an Airflow connection as shown in [Step 3: Create a connection](#step-3-create-a-connection). By default Astronomer's pre-built XCom backend will use the connection ID `aws_default` for a AWS S3 connection and `google_cloud_default` for a connection to GCP Cloud Storage. You can override the connection id used by setting the Airflow environment variable `CONNECTION_NAME` (AWS) or `XCOM_BACKEND_CONNECTION_NAME` (GCS).
 
 4. Open the .env file of your Astro Project and add the following line to set your XCom backend to the pre-built XCom class:
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -252,6 +252,12 @@ For Airflow to use your custom XCom backend, you need to define an XCom backend 
 
 2. Copy paste the following code into the file:
 
+:::info
+
+The Astronomer provider package contains a pre-built custom XCom backend for AWS S3 and GCP Cloud Storage with a set of added serialization methods. Refer to the [Use pre-built XCom backends](#use-pre-built-xcom-backends) section for implementation details.
+
+:::
+
 <Tabs
     defaultValue="aws"
     groupId= "step-4-define-a-custom-xcom-class-using-json-serialization"
@@ -689,6 +695,12 @@ To test your custom XCom backend you will run a simple DAG which pushes a random
 ## Step 6: Create a custom serialization method to handle Pandas dataframes
 
 A powerful feature of custom XCom backends is the possibility to create custom serialization and deserialization methods. This is particularly useful for handling objects that cannot be JSON-serialized. In this step, you will create a new custom XCom backend that can save the contents of a [Pandas](https://pandas.pydata.org/) dataframe as a CSV file.
+
+:::info
+
+The Astronomer provider package contains a pre-built custom XCom backend for AWS S3 and GCP Cloud Storage with a set of added serialization methods, including for Pandas dataframes. Refer to the [Use pre-built XCom backends](#use-pre-built-xcom-backends) section for implementation details.
+
+:::
 
 1. Create a second file in your `include` folder called `xcom_backend_pandas.py`.
 
@@ -1239,6 +1251,56 @@ def clear(
     # delete the XCom containing the reference string from metadata database
     query.delete()
 ```
+
+## Use pre-built XCom backends
+
+If you want to store your XCom in either AWS S3 or GCP Cloud Storage you can leverage the pre-built custom XCom backends in the [Astronomer provider](https://registry.astronomer.io/providers/astronomer-providers/versions/latest). Aside from saving your XComs in a remote storage, these XCom backends also contain custom serialization methods for Pandas dataframes and datetime date objects.
+
+To use these Astronomer's XCom backends follow these steps:
+
+1. Add the Astronomer provider to your `requirements.txt` file:
+
+    ```text
+    astronomer-providers
+    ```
+
+2. Prepare your AWS S3 or GCP Cloud Storage as shown in [Step 2: Set up your object storage account](#step-2-set-up-your-object-storage-account).
+
+3. Create an Airflow connection as shown in [Step 3: Create a connection](#step-3-create-a-connection).
+
+4. Open the .env file of your Astro Project and add the following line to set your XCom backend to the pre-built XCom class:
+
+<Tabs
+    defaultValue="aws"
+    groupId= "use-pre-built-xcom-backends"
+    values={[
+        {label: 'AWS S3', value: 'aws'},
+        {label: 'GCP Cloud Storage', value: 'gcp'},
+    ]}>
+<TabItem value="aws">
+
+    ```text
+    AIRFLOW__CORE__XCOM_BACKEND=astronomer.providers.amazon.aws.xcom_backends.s3.S3XComBackend
+    ```
+
+</TabItem>
+
+<TabItem value="gcp">
+
+    ```text
+    AIRFLOW__CORE__XCOM_BACKEND=astronomer.providers.google.cloud.xcom_backends.gcs.GCSXComBackend
+    ```
+
+</TabItem>
+
+</Tabs>
+
+
+:::info
+
+The pre-built XCom backends of the Astronomer provider offer the possibility to use gzip compression for all XComs uploaded. To enable gzip compression set `UPLOAD_CONTENT_AS_GZIP=True` in your .env file.
+
+:::
 
 ## Conclusion
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -1255,9 +1255,9 @@ def clear(
 
 ## Use pre-built XCom backends
 
-If you want to store your XComs in either AWS S3 or GCP Cloud Storage, you can use the pre-built custom XCom backends in the [Astronomer provider](https://registry.astronomer.io/providers/astronomer-providers/versions/latest) package. In addition to saving your XComs in a remote storage, these XCom backends also contain custom serialization methods for `pandas.DataFrame` and `datetime.date` objects.
+The [Astronomer provider package](https://registry.astronomer.io/providers/astronomer-providers/versions/latest) includes alternative XComs backends for AWS S3 and GCP Cloud Storage. In addition to saving your XComs in a remote storage, these XCom backends contain custom serialization methods for `pandas.DataFrame` and `datetime.date` objects, so you don't have to write them yourself.
 
-To use these Astronomer's XCom backends, follow these steps:
+To use these Astronomer's XCom backends, modify the core tutorial with the following changes:
 
 1. Add the Astronomer provider to your `requirements.txt` file:
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -1295,6 +1295,8 @@ AIRFLOW__CORE__XCOM_BACKEND=astronomer.providers.google.cloud.xcom_backends.gcs.
 
 </Tabs>
 
+5. Restart your Astro project, then continue at [Step 7: Run a DAG passing Pandas dataframes via XCom](#step-7-run-a-dag-passing-pandas-dataframes-via-xcom) of the tutorial.
+
 
 :::info
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -250,7 +250,7 @@ For Airflow to use your custom XCom backend, you need to define an XCom backend 
 
 :::info
 
-The Astronomer provider package contains a pre-built XCom backend for AWS S3 and GCP Cloud Storage with a set of added serialization methods. Refer to the [Use pre-built XCom backends](#use-pre-built-xcom-backends) section for implementation details. When using a pre-built XCom backend you will not have to create any new files in the `include` folder. When using a pre-built XCom backend you do not have to create any new files in the `include` folder and you can skip [Step 4](#step-4-define-a-custom-xcom-class-using-json-serialization) and Step 6 of this tutorial.
+The Astronomer provider package contains a pre-built XCom backend for AWS S3 and GCP Cloud Storage, with a set of added serialization methods. Refer to [Use pre-built XCom backends](#use-pre-built-xcom-backends) section for implementation details. When you use a pre-built XCom backend, you don't need to create any new files in the `include` folder and you can skip both [Step 4](#step-4-define-a-custom-xcom-class-using-json-serialization) and Step 6 of this tutorial.
 
 :::
 
@@ -1255,7 +1255,7 @@ def clear(
 
 ## Use pre-built XCom backends
 
-If you want to store your XComs in either AWS S3 or GCP Cloud Storage, you can leverage the pre-built custom XCom backends in the [Astronomer provider](https://registry.astronomer.io/providers/astronomer-providers/versions/latest) package. In addition to saving your XComs in a remote storage, these XCom backends also contain custom serialization methods for Pandas dataframes and datetime date objects.
+If you want to store your XComs in either AWS S3 or GCP Cloud Storage, you can use the pre-built custom XCom backends in the [Astronomer provider](https://registry.astronomer.io/providers/astronomer-providers/versions/latest) package. In addition to saving your XComs in a remote storage, these XCom backends also contain custom serialization methods for Pandas `dataframes` and `datetime` date objects.
 
 To use these Astronomer's XCom backends, follow these steps:
 
@@ -1267,9 +1267,9 @@ To use these Astronomer's XCom backends, follow these steps:
 
 2. Prepare your AWS S3 or GCP Cloud Storage as shown in [Step 2: Set up your object storage account](#step-2-set-up-your-object-storage-account).
 
-3. Create an Airflow connection as shown in [Step 3: Create a connection](#step-3-create-a-connection). By default Astronomer's pre-built XCom backend will use the connection ID `aws_default` for a AWS S3 connection and `google_cloud_default` for a connection to GCP Cloud Storage. You can override the connection id used by setting the Airflow environment variable `CONNECTION_NAME` (AWS) or `XCOM_BACKEND_CONNECTION_NAME` (GCS).
+3. Create an Airflow connection as shown in [Step 3: Create a connection](#step-3-create-a-connection). By default, Astronomer's pre-built XCom backend uses the connection ID `aws_default` for an AWS S3 connection and `google_cloud_default` for a GCP Cloud Storage connection. You can override which connection id the backend uses by setting the Airflow environment variable `CONNECTION_NAME` for AWS or `XCOM_BACKEND_CONNECTION_NAME` for GCS.
 
-4. Open the .env file of your Astro Project and add the following line to set your XCom backend to the pre-built XCom class:
+4. To set your XCom backend to the pre-built XCom class, open the .env file of your Astro Project and add the following line :
 
 <Tabs
     defaultValue="aws"

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -1259,17 +1259,15 @@ The [Astronomer provider package](https://registry.astronomer.io/providers/astro
 
 To use these Astronomer's XCom backends, modify the core tutorial with the following changes:
 
-1. Add the Astronomer provider to your `requirements.txt` file:
+- In [Step 1](#step-1-create-an-astro-project), add the Astronomer provider to your Astro project `requirements.txt` file:
 
     ```text
     astronomer-providers
     ```
 
-2. Prepare your AWS S3 or GCP Cloud Storage as shown in [Step 2: Set up your object storage account](#step-2-set-up-your-object-storage-account).
+- In [Step 3](#step-3-create-a-connection), use the connection ID `aws_default` for an AWS S3 connection and `google_cloud_default` for a GCP Cloud Storage connection. You can override which connection ID the backend uses by setting the Airflow environment variable `CONNECTION_NAME` for AWS or `XCOM_BACKEND_CONNECTION_NAME` for GCS.
 
-3. Create an Airflow connection as shown in [Step 3: Create a connection](#step-3-create-a-connection). By default, Astronomer's pre-built XCom backend uses the connection ID `aws_default` for an AWS S3 connection and `google_cloud_default` for a GCP Cloud Storage connection. You can override which connection id the backend uses by setting the Airflow environment variable `CONNECTION_NAME` for AWS or `XCOM_BACKEND_CONNECTION_NAME` for GCS.
-
-4. To set your XCom backend to the pre-built XCom class, open the .env file of your Astro Project and add the following line :
+- In [Step 4](#step-4-define-a-custom-xcom-class-using-json-serialization), do not define your own custom XCom class. When you open the Astro project `.env`, add the following line to use the pre-built XCom backend instead of your own:
 
 <Tabs
     defaultValue="aws"
@@ -1282,6 +1280,7 @@ To use these Astronomer's XCom backends, modify the core tutorial with the follo
 
 ```text
 AIRFLOW__CORE__XCOM_BACKEND=astronomer.providers.amazon.aws.xcom_backends.s3.S3XComBackend
+XCOM_BACKEND_BUCKET_NAME=<your-bucket-name>
 ```
 
 </TabItem>
@@ -1290,20 +1289,18 @@ AIRFLOW__CORE__XCOM_BACKEND=astronomer.providers.amazon.aws.xcom_backends.s3.S3X
 
 ```text
 AIRFLOW__CORE__XCOM_BACKEND=astronomer.providers.google.cloud.xcom_backends.gcs.GCSXComBackend
+XCOM_BACKEND_BUCKET_NAME=<your-bucket-name>
 ```
 
 </TabItem>
 
 </Tabs>
 
-5. Add a second environment variable in your .env file called `XCOM_BACKEND_BUCKET_NAME` and set it to the name of your S3 or GCS bucket.
+- Skip [Step 6](#step-6-create-a-custom-serialization-method-to-handle-pandas-dataframes). The pre-built XCom backend includes serialization methods out of the box.
 
-6. Restart your Astro project, then continue at [Step 7: Run a DAG passing Pandas dataframes via XCom](#step-7-run-a-dag-passing-pandas-dataframes-via-xcom) of the tutorial.
+:::tip
 
-
-:::info
-
-The pre-built XCom backends in the Astronomer provider offer the possibility of using gzip compression for all XComs uploaded. To enable gzip compression, set `UPLOAD_CONTENT_AS_GZIP=True` in your .env file.
+The Astronomer provider XCom backends support gzip compression for all XComs. To enable gzip compression, set `UPLOAD_CONTENT_AS_GZIP=True` in your Astro project  `.env` file.
 
 :::
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -1254,9 +1254,9 @@ def clear(
 
 ## Use pre-built XCom backends
 
-If you want to store your XCom in either AWS S3 or GCP Cloud Storage you can leverage the pre-built custom XCom backends in the [Astronomer provider](https://registry.astronomer.io/providers/astronomer-providers/versions/latest). Aside from saving your XComs in a remote storage, these XCom backends also contain custom serialization methods for Pandas dataframes and datetime date objects.
+If you want to store your XComs in either AWS S3 or GCP Cloud Storage ,you can leverage the pre-built custom XCom backends in the [Astronomer provider](https://registry.astronomer.io/providers/astronomer-providers/versions/latest) package. In addition to saving your XComs in a remote storage, these XCom backends also contain custom serialization methods for Pandas dataframes and datetime date objects.
 
-To use these Astronomer's XCom backends follow these steps:
+To use these Astronomer's XCom backends, follow these steps:
 
 1. Add the Astronomer provider to your `requirements.txt` file:
 
@@ -1300,7 +1300,7 @@ AIRFLOW__CORE__XCOM_BACKEND=astronomer.providers.google.cloud.xcom_backends.gcs.
 
 :::info
 
-The pre-built XCom backends of the Astronomer provider offer the possibility to use gzip compression for all XComs uploaded. To enable gzip compression set `UPLOAD_CONTENT_AS_GZIP=True` in your .env file.
+The pre-built XCom backends in the Astronomer provider offer the possibility of using gzip compression for all XComs uploaded. To enable gzip compression, set `UPLOAD_CONTENT_AS_GZIP=True` in your .env file.
 
 :::
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -250,7 +250,7 @@ For Airflow to use your custom XCom backend, you need to define an XCom backend 
 
 :::info
 
-The Astronomer provider package contains a pre-built XCom backend for AWS S3 and GCP Cloud Storage, with a set of added serialization methods. Refer to [Use pre-built XCom backends](#use-pre-built-xcom-backends) section for implementation details. When you use a pre-built XCom backend, you don't need to create any new files in the `include` folder and you can skip both [Step 4](#step-4-define-a-custom-xcom-class-using-json-serialization) and Step 6 of this tutorial.
+The Astronomer provider package contains a pre-built XCom backend for AWS S3 and GCP Cloud Storage, with a set of added serialization methods. Refer to [Use pre-built XCom backends](#use-pre-built-xcom-backends) section for implementation details. When you use a pre-built XCom backend, you don't need to create any new files in the `include` folder and you can skip both Step 4 and [Step 6](#step-6-create-a-custom-serialization-method-to-handle-pandas-dataframes) of this tutorial.
 
 :::
 
@@ -1255,7 +1255,7 @@ def clear(
 
 ## Use pre-built XCom backends
 
-If you want to store your XComs in either AWS S3 or GCP Cloud Storage, you can use the pre-built custom XCom backends in the [Astronomer provider](https://registry.astronomer.io/providers/astronomer-providers/versions/latest) package. In addition to saving your XComs in a remote storage, these XCom backends also contain custom serialization methods for Pandas `dataframes` and `datetime` date objects.
+If you want to store your XComs in either AWS S3 or GCP Cloud Storage, you can use the pre-built custom XCom backends in the [Astronomer provider](https://registry.astronomer.io/providers/astronomer-providers/versions/latest) package. In addition to saving your XComs in a remote storage, these XCom backends also contain custom serialization methods for `pandas.DataFrame` and `datetime.date` objects.
 
 To use these Astronomer's XCom backends, follow these steps:
 
@@ -1296,7 +1296,9 @@ AIRFLOW__CORE__XCOM_BACKEND=astronomer.providers.google.cloud.xcom_backends.gcs.
 
 </Tabs>
 
-5. Restart your Astro project, then continue at [Step 7: Run a DAG passing Pandas dataframes via XCom](#step-7-run-a-dag-passing-pandas-dataframes-via-xcom) of the tutorial.
+5. Add a second environment variable in your .env file called `XCOM_BACKEND_BUCKET_NAME` and set it to the name of your S3 or GCS bucket.
+
+6. Restart your Astro project, then continue at [Step 7: Run a DAG passing Pandas dataframes via XCom](#step-7-run-a-dag-passing-pandas-dataframes-via-xcom) of the tutorial.
 
 
 :::info

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -1255,7 +1255,7 @@ def clear(
 
 ## Use pre-built XCom backends
 
-If you want to store your XComs in either AWS S3 or GCP Cloud Storage ,you can leverage the pre-built custom XCom backends in the [Astronomer provider](https://registry.astronomer.io/providers/astronomer-providers/versions/latest) package. In addition to saving your XComs in a remote storage, these XCom backends also contain custom serialization methods for Pandas dataframes and datetime date objects.
+If you want to store your XComs in either AWS S3 or GCP Cloud Storage, you can leverage the pre-built custom XCom backends in the [Astronomer provider](https://registry.astronomer.io/providers/astronomer-providers/versions/latest) package. In addition to saving your XComs in a remote storage, these XCom backends also contain custom serialization methods for Pandas dataframes and datetime date objects.
 
 To use these Astronomer's XCom backends, follow these steps:
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -250,7 +250,7 @@ For Airflow to use your custom XCom backend, you need to define an XCom backend 
 
 :::info
 
-The Astronomer provider package contains a pre-built XCom backend for AWS S3 and GCP Cloud Storage, with a set of added serialization methods. Refer to [Use pre-built XCom backends](#use-pre-built-xcom-backends) section for implementation details. When you use a pre-built XCom backend, you don't need to create any new files in the `include` folder and you can skip both Step 4 and [Step 6](#step-6-create-a-custom-serialization-method-to-handle-pandas-dataframes) of this tutorial.
+The Astronomer provider package contains a pre-built XCom backend for AWS S3 and GCP Cloud Storage, with a set of added serialization methods. Refer to the [Use pre-built XCom backends](#use-pre-built-xcom-backends) section for implementation details. When you use a pre-built XCom backend, you don't need to create any new files in the `include` folder and you can skip both Step 4 and [Step 6](#step-6-create-a-custom-serialization-method-to-handle-pandas-dataframes) of this tutorial.
 
 :::
 
@@ -1255,9 +1255,9 @@ def clear(
 
 ## Use pre-built XCom backends
 
-The [Astronomer provider package](https://registry.astronomer.io/providers/astronomer-providers/versions/latest) includes alternative XComs backends for AWS S3 and GCP Cloud Storage. In addition to saving your XComs in a remote storage, these XCom backends contain custom serialization methods for `pandas.DataFrame` and `datetime.date` objects, so you don't have to write them yourself.
+The [Astronomer provider package](https://registry.astronomer.io/providers/astronomer-providers/versions/latest) includes alternative XComs backends for AWS S3 and GCP Cloud Storage. In addition to saving your XComs in a remote storage, these XCom backends contain serialization methods for `pandas.DataFrame` and `datetime.date` objects, so you don't have to write them yourself.
 
-To use these Astronomer's XCom backends, modify the core tutorial with the following changes:
+To use these pre-built XCom backends, modify the core tutorial with the following changes:
 
 - In [Step 1](#step-1-create-an-astro-project), add the Astronomer provider to your Astro project `requirements.txt` file:
 
@@ -1267,7 +1267,7 @@ To use these Astronomer's XCom backends, modify the core tutorial with the follo
 
 - In [Step 3](#step-3-create-a-connection), use the connection ID `aws_default` for an AWS S3 connection and `google_cloud_default` for a GCP Cloud Storage connection. You can override which connection ID the backend uses by setting the Airflow environment variable `CONNECTION_NAME` for AWS or `XCOM_BACKEND_CONNECTION_NAME` for GCS.
 
-- In [Step 4](#step-4-define-a-custom-xcom-class-using-json-serialization), do not define your own custom XCom class. When you open the Astro project `.env`, add the following line to use the pre-built XCom backend instead of your own:
+- In [Step 4](#step-4-define-a-custom-xcom-class-using-json-serialization), do not define your own custom XCom class. When you open the Astro project `.env`, add the following lines to use the pre-built XCom backend instead of your own:
 
 <Tabs
     defaultValue="aws"
@@ -1296,7 +1296,7 @@ XCOM_BACKEND_BUCKET_NAME=<your-bucket-name>
 
 </Tabs>
 
-- Skip [Step 6](#step-6-create-a-custom-serialization-method-to-handle-pandas-dataframes). The pre-built XCom backend includes serialization methods out of the box.
+- Skip [Step 6](#step-6-create-a-custom-serialization-method-to-handle-pandas-dataframes). The pre-built XCom backend includes a serialization method for `pandas.DataFrame` objects out of the box.
 
 :::tip
 


### PR DESCRIPTION
Resolves: #2042 

Adding the option to use pre-built XCom backends from the Astronomer provider to the tutorial. Initially I planned just to have a note in Step 4 but then thought it is cleaner to separate it out into its own section with a short step by step instruction and link to it from a note.

Open to different ways to structure this information of course :) 