### PR TITLE
Fix GCP link to MWAA

### DIFF
--- a/astro/migrate-mwaa.mdx
+++ b/astro/migrate-mwaa.mdx
@@ -13,7 +13,7 @@ import DirectorySetup from "./migration-partials/directory-setup.mdx";
 import FinalStep from "./migration-partials/final-step.mdx";
 import Deploy from "./migration-partials/deploy.mdx";
 
-This is where you'll find instructions for migrating an Airflow environment from [Amazon Managed Workflows for Apache Airflow (MWAA)](https://cloud.google.com/composer/docs/concepts/overview) to Astro.
+This is where you'll find instructions for migrating an Airflow environment from [Amazon Managed Workflows for Apache Airflow (MWAA)](https://aws.amazon.com/managed-workflows-for-apache-airflow/resources/) to Astro.
 
 To complete the migration process, you will:
 


### PR DESCRIPTION
Link on MWAA was pointing to GCP docs. Fixed to direct to MWAA. 

Confirmed in slack this is correct link: https://astronomer.slack.com/archives/C015V2JFKT5/p1680711647069789