### PR TITLE
Update rel-links

### DIFF
--- a/astro/ci-cd-templates/aws-codebuild.md
+++ b/astro/ci-cd-templates/aws-codebuild.md
@@ -13,7 +13,7 @@ If you use the [DAG-only deploy feature](astro/deploy-code#deploy-dags-only) on 
 
 ## Prerequisites
 
-- An [Astro project](create-project.md) hosted in a Git repository that AWS CodeBuild can access. See [Plan a build in AWS Codebuild](https://docs.aws.amazon.com/codebuild/latest/userguide/planning.html).
+- An [Astro project](create-first-dag.md#step-1-create-an-astro-project) hosted in a Git repository that AWS CodeBuild can access. See [Plan a build in AWS Codebuild](https://docs.aws.amazon.com/codebuild/latest/userguide/planning.html).
 - An [Astro Deployment](create-deployment.md).
 - A [Deployment API key ID and secret](api-keys.md) for each Deployment.
 - Access to AWS CodeBuild. See [Getting started with CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/getting-started-overview.html).

--- a/astro/ci-cd-templates/azure-devops.md
+++ b/astro/ci-cd-templates/azure-devops.md
@@ -13,7 +13,7 @@ If you use the [DAG-only deploy feature](astro/deploy-code#deploy-dags-only) on 
 
 ## Prerequisites
 
-- An [Astro project](create-project.md) hosted in a Git repository that Azure DevOps can access.
+- An [Astro project](create-first-dag.md#step-1-create-an-astro-project) hosted in a Git repository that Azure DevOps can access.
 - An [Astro Deployment](create-deployment.md).
 - A [Deployment API key ID and secret](api-keys.md).
 - Access to [Azure DevOps](https://dev.azure.com/).

--- a/astro/ci-cd-templates/bitbucket.md
+++ b/astro/ci-cd-templates/bitbucket.md
@@ -13,7 +13,7 @@ If you use the [DAG-only deploy feature](astro/deploy-code#deploy-dags-only) on 
 
 ## Prerequisites
 
-- An [Astro project](create-project.md) hosted in a Git repository that Bitbucket can access.
+- An [Astro project](create-first-dag.md#step-1-create-an-astro-project) hosted in a Git repository that Bitbucket can access.
 - An [Astro Deployment](create-deployment.md).
 - A [Deployment API key ID and secret](api-keys.md).
 - Access to [Bitbucket](https://bitbucket.org/product).

--- a/astro/ci-cd-templates/circleci.md
+++ b/astro/ci-cd-templates/circleci.md
@@ -13,7 +13,7 @@ If you use the [DAG-only deploy feature](astro/deploy-code#deploy-dags-only) on 
 
 ## Prerequisites
 
-- An [Astro project](create-project.md) hosted in a Git repository that CircleCI can access.
+- An [Astro project](create-first-dag.md#step-1-create-an-astro-project) hosted in a Git repository that CircleCI can access.
 - An [Astro Deployment](create-deployment.md).
 - A [Deployment API key ID and secret](api-keys.md).
 - Access to [CircleCI](https://circleci.com/).

--- a/astro/ci-cd-templates/drone.md
+++ b/astro/ci-cd-templates/drone.md
@@ -13,7 +13,7 @@ If you use the [DAG-only deploy feature](astro/deploy-code#deploy-dags-only) on 
 
 ## Prerequisites
 
-- An [Astro project](create-project.md) hosted in a Git repository that Drone can access.
+- An [Astro project](create-first-dag.md#step-1-create-an-astro-project) hosted in a Git repository that Drone can access.
 - An [Astro Deployment](create-deployment.md).
 - A [Deployment API key ID and secret](api-keys.md).
 - A functional Drone [server](https://docs.drone.io/server/overview/).

--- a/astro/ci-cd-templates/github-actions.md
+++ b/astro/ci-cd-templates/github-actions.md
@@ -24,7 +24,7 @@ For more information on each template or to configure your own, see [Template ov
 
 ## Prerequisites
 
-- An [Astro project](create-project.md) hosted in a GitHub repository.
+- An [Astro project](create-first-dag.md#step-1-create-an-astro-project) hosted in a GitHub repository.
 - An [Astro Deployment](create-deployment.md).
 - A [Deployment API key ID and secret](api-keys.md).
 - Access to [GitHub Actions](https://github.com/features/actions).

--- a/astro/ci-cd-templates/gitlab.md
+++ b/astro/ci-cd-templates/gitlab.md
@@ -13,7 +13,7 @@ If you use the [DAG-only deploy feature](astro/deploy-code#deploy-dags-only) on 
 
 ## Prerequisites
 
-- An [Astro project](create-project.md) hosted in a GitLab repository.
+- An [Astro project](create-first-dag.md#step-1-create-an-astro-project) hosted in a GitLab repository.
 - An [Astro Deployment](create-deployment.md).
 - A [Deployment API key ID and secret](api-keys.md) for each Deployment.
 

--- a/astro/ci-cd-templates/jenkins.md
+++ b/astro/ci-cd-templates/jenkins.md
@@ -22,7 +22,7 @@ For more information on each template or to configure your own, see [Template ov
 
 ## Prerequisites
 
-- An [Astro project](create-project.md) hosted in a Git repository that Jenkins can access.
+- An [Astro project](create-first-dag.md#step-1-create-an-astro-project) hosted in a Git repository that Jenkins can access.
 - An [Astro Deployment](create-deployment.md).
 - A [Deployment API key ID and secret](api-keys.md).
 - Access to [Jenkins](https://www.jenkins.io/).


### PR DESCRIPTION
Merge order has broken some links from the CI/CD restructure + Quickstart guide updates. 

