### PR TITLE
Software: Add required annotation for azure load-balancer

### DIFF
--- a/software/install-azure-standard.md
+++ b/software/install-azure-standard.md
@@ -324,6 +324,7 @@ nginx:
   ingressAnnotations:
     # required for azure load balancer post Kubernetes 1.22
     service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/healthz"
+
 astronomer:
   houston:
     config:

--- a/software/install-azure-standard.md
+++ b/software/install-azure-standard.md
@@ -321,8 +321,9 @@ nginx:
   # IP address the nginx ingress should bind to
   loadBalancerIP: ~
   # Dict of arbitrary annotations to add to the nginx ingress. For full configuration options, see https://docs.nginx.com/nginx-ingress-controller/configuration/ingress-resources/advanced-configuration-with-annotations/
-  ingressAnnotations: {}
-
+  ingressAnnotations:
+    # required for azure load balancer post Kubernetes 1.22
+    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/healthz"
 astronomer:
   houston:
     config:

--- a/software_versioned_docs/version-0.30/install-azure-standard.md
+++ b/software_versioned_docs/version-0.30/install-azure-standard.md
@@ -311,8 +311,9 @@ nginx:
   # IP address the nginx ingress should bind to
   loadBalancerIP: ~
   # Dict of arbitrary annotations to add to the nginx ingress. For full configuration options, see https://docs.nginx.com/nginx-ingress-controller/configuration/ingress-resources/advanced-configuration-with-annotations/
-  ingressAnnotations: {}
-
+  ingressAnnotations:
+    # required for azure load balancer post Kubernetes 1.22
+    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/healthz"
 astronomer:
   houston:
     config:

--- a/software_versioned_docs/version-0.30/install-azure-standard.md
+++ b/software_versioned_docs/version-0.30/install-azure-standard.md
@@ -314,6 +314,7 @@ nginx:
   ingressAnnotations:
     # required for azure load balancer post Kubernetes 1.22
     service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/healthz"
+    
 astronomer:
   houston:
     config:


### PR DESCRIPTION
This annotation is apparently required for all currently supported versions of Software on AKS  (e.g. > 1.22) but has never been included in our docs.