### PR TITLE
[2.6] Add ContinuousTimetable to the scheduling guide

### DIFF
--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -121,7 +121,7 @@ Custom timetables can be registered as part of an Airflow plugin. They must be a
 
 ### Continuous timetable
 
-As of Airflow 2.6 you can run a DAG continuously using a pre-defined timetable. To use the [ContinuousTimetable](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/timetables/simple/index.html#module-airflow.timetables.simple.ContinuousTimetable), set the schedule of your DAG to `"@continuous"` and set `max_active_runs` to 1.
+As of Airflow 2.6, you can run a DAG continuously with a pre-defined timetable. To use the [ContinuousTimetable](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/timetables/simple/index.html#module-airflow.timetables.simple.ContinuousTimetable), set the schedule of your DAG to `"@continuous"` and set `max_active_runs` to 1.
 
 ```python
 @dag(
@@ -132,11 +132,11 @@ As of Airflow 2.6 you can run a DAG continuously using a pre-defined timetable. 
 )
 ```
 
-This DAG will run continuously by scheduling a new run as soon as the previous run has completed, regardless of whether the previous run succeeded or failed. Using a ContinuousTimetable is especially useful when [sensors](what-is-a-sensor.md) or [deferrable operators](deferrable-operators.md) are used to wait for highly irregular events in external data tools.
+This schedule will create one continuous DAG run, with a new run starting as soon as the previous run has completed, regardless of whether the previous run succeeded or failed. Using a ContinuousTimetable is especially useful when [sensors](what-is-a-sensor.md) or [deferrable operators](deferrable-operators.md) are used to wait for highly irregular events in external data tools.
 
 :::caution
 
-Be aware that Airflow is designed to handle orchestration of data pipelines in batches and this feature is not intended to be used for streaming or low-latency processes. If you need to run pipelines more frequently than every minute, consider using Airflow in combination with tools designed specifically for that purpose like for example [Apache Kafka](airflow-kafka.md).
+Airflow is designed to handle orchestration of data pipelines in batches, and this feature is not intended for streaming or low-latency processes. If you need to run pipelines more frequently than every minute, consider using Airflow in combination with tools designed specifically for that purpose like [Apache Kafka](airflow-kafka.md).
 
 :::
 

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -136,7 +136,7 @@ This DAG will always be running and automatically scheduling its next run, whene
 
 :::caution
 
-Be aware that Airflow should not be used for streaming or low-latency processes. See the [Best practices](#best-practices) section for more information.
+Be aware that Airflow should not be used for streaming or low-latency processes.
 
 :::
 

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -132,7 +132,7 @@ In Airflow 2.6 the possibility of having a DAG run continuously with a pre-defin
 )
 ```
 
-This DAG will always be running and automatically scheduling its next run, whenever it has finished. Using a ContinuousTimetable is especially useful when [sensors](what-is-a-sensor.md) or [deferrable operators](deferrable-operators.md) are used to wait for highly irregular events in external data tools.
+This DAG will always be running and automatically scheduling its next run, whenever it has finished, irrespective of whether the DAG run succeeded or failed. Using a ContinuousTimetable is especially useful when [sensors](what-is-a-sensor.md) or [deferrable operators](deferrable-operators.md) are used to wait for highly irregular events in external data tools.
 
 :::caution
 

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -136,7 +136,7 @@ This DAG will run continuously by scheduling a new run as soon as the previous r
 
 :::caution
 
-Be aware that Airflow should not be used for streaming or low-latency processes.
+Be aware that Airflow is designed to handle orchestration of data pipelines in batches and this feature is not intended to be used for streaming or low-latency processes. If you need to run pipelines more frequently than every minute, consider using Airflow in combination with tools designed specifically for that purpose like for example [Apache Kafka](airflow-kafka.md).
 
 :::
 

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -119,6 +119,27 @@ Custom timetables can be registered as part of an Airflow plugin. They must be a
 - `next_dagrun_info`: Returns the data interval for the DAG's regular schedule
 - `infer_manual_data_interval`: Returns the data interval when the DAG is manually triggered
 
+### Continuous timetable
+
+In Airflow 2.6 the possibility of having a DAG run continuously with a pre-defined timetable was introduced. To use the [ContinuousTimetable](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/timetables/simple/index.html#module-airflow.timetables.simple.ContinuousTimetable), set the schedule of your DAG to `"@continuous"` and make sure `max_active_runs` is set to 1.
+
+```python
+@dag(
+    start_date=datetime(2023, 4, 18),
+    schedule="@continuous",
+    max_active_runs=1,  
+    catchup=False,
+)
+```
+
+This DAG will always be running and automatically scheduling its next run, whenever it has finished. Using a ContinuousTimetable is especially useful when [sensors](what-is-a-sensor.md) or [deferrable operators](deferrable-operators.md) are used to wait for highly irregular events in external data tools.
+
+:::caution
+
+Be aware that Airflow should not be used for streaming or low-latency processes. See the [Best practices](#best-practices) section for more information.
+
+:::
+
 ### Example custom timetable
 
 For this implementation, you'll run your DAG at 6:00 and 16:30. Because this schedule has run times with differing hours and minutes, it can't be represented by a single cron expression. So, you'll implement this schedule with a custom timetable.

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -121,7 +121,7 @@ Custom timetables can be registered as part of an Airflow plugin. They must be a
 
 ### Continuous timetable
 
-In Airflow 2.6 the possibility of having a DAG run continuously with a pre-defined timetable was introduced. To use the [ContinuousTimetable](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/timetables/simple/index.html#module-airflow.timetables.simple.ContinuousTimetable), set the schedule of your DAG to `"@continuous"` and make sure `max_active_runs` is set to 1.
+As of Airflow 2.6 you can run a DAG continuously using a pre-defined timetable. To use the [ContinuousTimetable](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/timetables/simple/index.html#module-airflow.timetables.simple.ContinuousTimetable), set the schedule of your DAG to `"@continuous"` and make sure `max_active_runs` is set to 1.
 
 ```python
 @dag(
@@ -132,7 +132,7 @@ In Airflow 2.6 the possibility of having a DAG run continuously with a pre-defin
 )
 ```
 
-This DAG will always be running and automatically scheduling its next run, whenever it has finished, irrespective of whether the DAG run succeeded or failed. Using a ContinuousTimetable is especially useful when [sensors](what-is-a-sensor.md) or [deferrable operators](deferrable-operators.md) are used to wait for highly irregular events in external data tools.
+This DAG will run continuously by scheduling a new run as soon as the previous run has completed, regardless of whether the previous run succeeded or failed. Using a ContinuousTimetable is especially useful when [sensors](what-is-a-sensor.md) or [deferrable operators](deferrable-operators.md) are used to wait for highly irregular events in external data tools.
 
 :::caution
 

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -121,7 +121,7 @@ Custom timetables can be registered as part of an Airflow plugin. They must be a
 
 ### Continuous timetable
 
-As of Airflow 2.6 you can run a DAG continuously using a pre-defined timetable. To use the [ContinuousTimetable](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/timetables/simple/index.html#module-airflow.timetables.simple.ContinuousTimetable), set the schedule of your DAG to `"@continuous"` and make sure `max_active_runs` is set to 1.
+As of Airflow 2.6 you can run a DAG continuously using a pre-defined timetable. To use the [ContinuousTimetable](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/timetables/simple/index.html#module-airflow.timetables.simple.ContinuousTimetable), set the schedule of your DAG to `"@continuous"` and set `max_active_runs` to 1.
 
 ```python
 @dag(


### PR DESCRIPTION
Resolves: #2162 

Adding the ContinuousTimetable, I thought this was a one line addition at first but since you also net to set max_active_tasks and it is a very useful feature albeit needing a do not stream warning I thought it makes sense to have a subsection on it :)

Happy side effect: I might be learning how to spell continuous, maybe, hopefully.