### PR TITLE
Update Wording in User Add doc

### DIFF
--- a/astro/add-user.md
+++ b/astro/add-user.md
@@ -116,4 +116,4 @@ You can use the Astro CLI and a shell script to add multiple users to an Organiz
     ```sh
     sh path/to/add-users.sh path/to/users.txt
     ```
-6. Optional. To use this script as part of a CI/CD pipeline, create a Workspace API token and specify the environment variable `ASTRO_API_TOKEN=<your-token>` in your CI/CD environment. See [Manage Workspace API tokens](workspace-api-tokens.md). Note that you can use Workspace API tokens to manage users at the Workspace level but not at the Organization level.
+6. (Optional) To use this script as part of a CI/CD pipeline, create a Workspace API token and specify the environment variable `ASTRO_API_TOKEN=<your-token>` in your CI/CD environment. See [Manage Workspace API tokens](workspace-api-tokens.md). Note that you can use Workspace API tokens to manage users only at the Workspace level.

--- a/astro/add-user.md
+++ b/astro/add-user.md
@@ -116,4 +116,4 @@ You can use the Astro CLI and a shell script to add multiple users to an Organiz
     ```sh
     sh path/to/add-users.sh path/to/users.txt
     ```
-6. Optional. To use this script as part of a CI/CD pipeline, create a Workspace API token and specify the environment variable `ASTRO_API_TOKEN=<your-token>` in your CI/CD environment. See [Manage Workspace API tokens](workspace-api-tokens.md). Note that Workspace API tokens work only for inviting groups of users to a Workspace. 
+6. Optional. To use this script as part of a CI/CD pipeline, create a Workspace API token and specify the environment variable `ASTRO_API_TOKEN=<your-token>` in your CI/CD environment. See [Manage Workspace API tokens](workspace-api-tokens.md). Note that you can use Workspace API tokens to manage users at the Workspace level but not at the Organization level.


### PR DESCRIPTION
note is misleading and makes it seem that workspace tokens can only be used with the command `workspace user add`