### PR TITLE
[2.6] Adding pandas serialization in standard XCom to the pass data guide and the custom XCom backend tutorial

### DIFF
--- a/learn/airflow-passing-data-between-tasks.md
+++ b/learn/airflow-passing-data-between-tasks.md
@@ -67,19 +67,21 @@ You can view your XComs in the Airflow UI by going to **Admin** > **XComs**. You
 
 XComs should be used to pass small amounts of data between tasks. For example, task metadata, dates, model accuracy, or single value query results are all ideal data to use with XCom.
 
-While there is nothing stopping you from passing small data sets with XCom, be very careful when doing so. This is not what XCom was designed for, and using it to pass data like pandas dataframes can degrade the performance of your DAGs and take up storage in the metadata database.
+While there is nothing stopping you from passing larger amounts of data with XCom, be very careful when doing so and consider using [a custom XCom backend](custom-xcom-backends-tutorial.md) while paying close attention to appropriately [scaling your Airflow resources](airflow-scaling-workers.md).
 
-XCom cannot be used for passing large data sets between tasks. The limit for the size of the XCom is determined by which metadata database you are using:
+When using the standard XCom backend, the size-limit for an XCom is determined by the metadata database you are using. Common sizes are: 
 
 - Postgres: 1 Gb
 - SQLite: 2 Gb
 - MySQL: 64 Kb
 
-You can see that these limits aren't very big. And even if you think your data might meet the maximum allowable limit, don't use XComs. Instead, use intermediary data storage, which is more appropriate for larger amounts of data.  
+You can see that these limits aren't very big. If you think your data passed via XCom might exceed the size of your metadata database, either use a custom XCom backend or [intermediary data storage](#intermediary-data-storage).
+
+The second limitation in using the standard XCom backend is that only certain types of data can be serialized. Airflow supports JSON serialization, as well as serialization of Pandas dataframes in version 2.6+, if you need to serialize data of additional types you can do so by using a [custom XCom backend](custom-xcom-backends-tutorial.md).
 
 ### Custom XCom backends
 
-[Custom XCom Backends](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/xcoms.html#custom-xcom-backends) are a new feature available in Airflow 2.0 and greater. Using an XCom backend means you can push and pull XComs to and from an external system such as S3, GCS, or HDFS rather than the default of Airflow's metadata database. You can also implement your own serialization and deserialization methods to define how XComs are handled. This is a concept in its own right and you can learn more by reading [Custom XCom Backends](custom-xcom-backends-tutorial.md).
+Using a [custom XCom backend](custom-xcom-backends-tutorial.md) means you can push and pull XComs to and from an external system such as S3, GCS, or HDFS rather than the default of Airflow's metadata database. You can also implement your own serialization and deserialization methods to define how XComs are handled. This is a concept in its own right and you can learn more by reading [Custom XCom Backends](custom-xcom-backends-tutorial.md).
 
 ### Example DAG using XComs
 

--- a/learn/airflow-passing-data-between-tasks.md
+++ b/learn/airflow-passing-data-between-tasks.md
@@ -67,9 +67,9 @@ You can view your XComs in the Airflow UI by going to **Admin** > **XComs**. You
 
 XComs should be used to pass small amounts of data between tasks. For example, task metadata, dates, model accuracy, or single value query results are all ideal data to use with XCom.
 
-While there is nothing stopping you from passing larger amounts of data with XCom, be very careful when doing so and consider using [a custom XCom backend](custom-xcom-backends-tutorial.md) while paying close attention to appropriately [scaling your Airflow resources](airflow-scaling-workers.md).
+While you can technically pass large amounts of data with XCom, be very careful when doing so and consider using [a custom XCom backend](custom-xcom-backends-tutorial.md) and [scaling your Airflow resources](airflow-scaling-workers.md).
 
-When using the standard XCom backend, the size-limit for an XCom is determined by the metadata database you are using. Common sizes are: 
+When you use the standard XCom backend, the size-limit for an XCom is determined by your metadata database. Common sizes are: 
 
 - Postgres: 1 Gb
 - SQLite: 2 Gb
@@ -77,7 +77,7 @@ When using the standard XCom backend, the size-limit for an XCom is determined b
 
 You can see that these limits aren't very big. If you think your data passed via XCom might exceed the size of your metadata database, either use a custom XCom backend or [intermediary data storage](#intermediary-data-storage).
 
-The second limitation in using the standard XCom backend is that only certain types of data can be serialized. Airflow supports JSON serialization, as well as serialization of Pandas dataframes in version 2.6+, if you need to serialize other data types you can do so by using a [custom XCom backend](custom-xcom-backends-tutorial.md).
+The second limitation in using the standard XCom backend is that only certain types of data can be serialized. Airflow supports JSON serialization, as well as Pandas dataframe serialization in version 2.6 and later. If you need to serialize other data types you can do so using a [custom XCom backend](custom-xcom-backends-tutorial.md).
 
 ### Custom XCom backends
 

--- a/learn/airflow-passing-data-between-tasks.md
+++ b/learn/airflow-passing-data-between-tasks.md
@@ -77,7 +77,7 @@ When using the standard XCom backend, the size-limit for an XCom is determined b
 
 You can see that these limits aren't very big. If you think your data passed via XCom might exceed the size of your metadata database, either use a custom XCom backend or [intermediary data storage](#intermediary-data-storage).
 
-The second limitation in using the standard XCom backend is that only certain types of data can be serialized. Airflow supports JSON serialization, as well as serialization of Pandas dataframes in version 2.6+, if you need to serialize data of additional types you can do so by using a [custom XCom backend](custom-xcom-backends-tutorial.md).
+The second limitation in using the standard XCom backend is that only certain types of data can be serialized. Airflow supports JSON serialization, as well as serialization of Pandas dataframes in version 2.6+, if you need to serialize other data types you can do so by using a [custom XCom backend](custom-xcom-backends-tutorial.md).
 
 ### Custom XCom backends
 

--- a/learn/airflow-passing-data-between-tasks.md
+++ b/learn/airflow-passing-data-between-tasks.md
@@ -81,7 +81,7 @@ The second limitation in using the standard XCom backend is that only certain ty
 
 ### Custom XCom backends
 
-Using a [custom XCom backend](custom-xcom-backends-tutorial.md) means you can push and pull XComs to and from an external system such as S3, GCS, or HDFS rather than the default of Airflow's metadata database. You can also implement your own serialization and deserialization methods to define how XComs are handled. This is a concept in its own right and you can learn more by reading [Custom XCom Backends](custom-xcom-backends-tutorial.md).
+Using a [custom XCom backend](custom-xcom-backends-tutorial.md) means you can push and pull XComs to and from an external system such as S3, GCS, or HDFS rather than the default of Airflow's metadata database. You can also implement your own serialization and deserialization methods to define how XComs are handled. To learn how to implement a custom XCom backend follow this [step-by-step tutorial](custom-xcom-backends-tutorial.md).
 
 ### Example DAG using XComs
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -696,7 +696,7 @@ To test your custom XCom backend you will run a simple DAG which pushes a random
 
 A powerful feature of custom XCom backends is the possibility to create custom serialization and deserialization methods. This is particularly useful for handling objects that cannot be JSON-serialized. In this step, you will create a new custom XCom backend that can save the contents of a [Pandas](https://pandas.pydata.org/) dataframe as a CSV file. Being serialized as CSV, the content of the XCom becomes accessible to CSV query tools like [csvq](https://mithrandie.github.io/csvq/).
 
-Note that as of Airflow 2.6, Pandas dataframes can be serialized by XCom using `pyarrow`. This step is still useful if you are using an older version of Airflow, and to highlight the general process for creating a custom serialization method.
+Note that as of Airflow 2.6, Pandas dataframes can be serialized by the standard XCom backend using `pyarrow`. This step is still useful if you are using an older version of Airflow, and to highlight the general process for creating a custom serialization method.
 
 :::info
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -19,8 +19,8 @@ Common reasons to use a custom XCom backend include:
 
 - Needing more storage space for XCom than the metadata database can offer.
 - Running a production environment where you require custom retention, deletion, and backup policies for XComs. With a custom XCom backend, you don't need to worry about periodically cleaning up the metadata database.
-- Utilizing custom serialization and deserialization methods. By default, Airflow uses JSON serialization, which puts limits on the type of data that you can pass through XComs. Pickling is also available, but it has [known security implications](https://docs.python.org/3/library/pickle.html). A custom XCom backend allows you to implement your own serialization and deserialization methods.
-- Accessing XCom without accessing the metadata database.  
+- Utilizing custom serialization and deserialization methods. By default, Airflow uses JSON serialization and, as of Airflow 2.6 can serialize Pandas dataframes via [pyarrow](https://pypi.org/project/pyarrow/). To circumvent this limitation in local development there is the option to serialize data via [pickling](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#enable-xcom-pickling), which is often not suitable for production due to [known security implications](https://docs.python.org/3/library/pickle.html). A custom XCom backend allows you to implement your own serialization and deserialization methods.
+- Accessing XCom without accessing the metadata database.
 
 After you complete this tutorial, you'll be able to:
 
@@ -694,7 +694,7 @@ To test your custom XCom backend you will run a simple DAG which pushes a random
 
 ## Step 6: Create a custom serialization method to handle Pandas dataframes
 
-A powerful feature of custom XCom backends is the possibility to create custom serialization and deserialization methods. This is particularly useful for handling objects that cannot be JSON-serialized. In this step, you will create a new custom XCom backend that can save the contents of a [Pandas](https://pandas.pydata.org/) dataframe as a CSV file.
+A powerful feature of custom XCom backends is the possibility to create custom serialization and deserialization methods. This is particularly useful for handling objects that cannot be JSON-serialized or if you want to serialize Pandas dataframes using a different method than `pyarrow`. In this step, you will create a new custom XCom backend that can save the contents of a [Pandas](https://pandas.pydata.org/) dataframe as a CSV file. Being serialized as CSV, the content of the XCom becomes accessible to CSV query tools like [csvq](https://mithrandie.github.io/csvq/).
 
 :::info
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -19,7 +19,7 @@ Common reasons to use a custom XCom backend include:
 
 - Needing more storage space for XCom than the metadata database can offer.
 - Running a production environment where you require custom retention, deletion, and backup policies for XComs. With a custom XCom backend, you don't need to worry about periodically cleaning up the metadata database.
-- Utilizing custom serialization and deserialization methods. By default, Airflow uses JSON serialization and, as of Airflow 2.6, can serialize Pandas dataframes via [pyarrow](https://pypi.org/project/pyarrow/). To circumvent this limitation in local development there is the option to serialize data via [pickling](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#enable-xcom-pickling), which is often not suitable for production due to [known security implications](https://docs.python.org/3/library/pickle.html). A custom XCom backend allows you to implement your own serialization and deserialization methods.
+- Utilizing custom serialization and deserialization methods. By default, Airflow uses JSON serialization, which limits the types of data you can pass through XComs. To circumvent this limitation in local development you can serialize data via [pickling](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#enable-xcom-pickling), which is often not suitable for production due to [known security implications](https://docs.python.org/3/library/pickle.html). A custom XCom backend allows you to implement your own serialization and deserialization methods.
 - Accessing XCom without accessing the metadata database.
 
 After you complete this tutorial, you'll be able to:
@@ -694,7 +694,9 @@ To test your custom XCom backend you will run a simple DAG which pushes a random
 
 ## Step 6: Create a custom serialization method to handle Pandas dataframes
 
-A powerful feature of custom XCom backends is the possibility to create custom serialization and deserialization methods. This is particularly useful for handling objects that cannot be JSON-serialized or if you want to serialize Pandas dataframes using a different method than `pyarrow`. In this step, you will create a new custom XCom backend that can save the contents of a [Pandas](https://pandas.pydata.org/) dataframe as a CSV file. Being serialized as CSV, the content of the XCom becomes accessible to CSV query tools like [csvq](https://mithrandie.github.io/csvq/).
+A powerful feature of custom XCom backends is the possibility to create custom serialization and deserialization methods. This is particularly useful for handling objects that cannot be JSON-serialized. In this step, you will create a new custom XCom backend that can save the contents of a [Pandas](https://pandas.pydata.org/) dataframe as a CSV file. Being serialized as CSV, the content of the XCom becomes accessible to CSV query tools like [csvq](https://mithrandie.github.io/csvq/).
+
+Note that as of Airflow 2.6, Pandas dataframes can be serialized by XCom using `pyarrow`. This step is still useful if you are using an older version of Airflow, and to highlight the general process for creating a custom serialization method.
 
 :::info
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -19,7 +19,7 @@ Common reasons to use a custom XCom backend include:
 
 - Needing more storage space for XCom than the metadata database can offer.
 - Running a production environment where you require custom retention, deletion, and backup policies for XComs. With a custom XCom backend, you don't need to worry about periodically cleaning up the metadata database.
-- Utilizing custom serialization and deserialization methods. By default, Airflow uses JSON serialization, which limits the types of data you can pass through XComs. To circumvent this limitation in local development you can serialize data via [pickling](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#enable-xcom-pickling), which is often not suitable for production due to [known security implications](https://docs.python.org/3/library/pickle.html). A custom XCom backend allows you to implement your own serialization and deserialization methods.
+- Utilizing custom serialization and deserialization methods. By default, Airflow uses JSON serialization, which limits the types of data you can pass through XComs. You can serialize other types of data using [pickling](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#enable-xcom-pickling), however this method is not suitable for production due to [security issues](https://docs.python.org/3/library/pickle.html). A custom XCom backend allows you to implement your own serialization and deserialization methods that are suitable for production workflows.
 - Accessing XCom without accessing the metadata database.
 
 After you complete this tutorial, you'll be able to:
@@ -694,9 +694,9 @@ To test your custom XCom backend you will run a simple DAG which pushes a random
 
 ## Step 6: Create a custom serialization method to handle Pandas dataframes
 
-A powerful feature of custom XCom backends is the possibility to create custom serialization and deserialization methods. This is particularly useful for handling objects that cannot be JSON-serialized. In this step, you will create a new custom XCom backend that can save the contents of a [Pandas](https://pandas.pydata.org/) dataframe as a CSV file. Being serialized as CSV, the content of the XCom becomes accessible to CSV query tools like [csvq](https://mithrandie.github.io/csvq/).
+A powerful feature of custom XCom backends is the possibility to create custom serialization and deserialization methods. This is particularly useful for handling objects that cannot be JSON-serialized. In this step, you will create a new custom XCom backend that can save the contents of a [Pandas](https://pandas.pydata.org/) dataframe as a CSV file. When you serialize your data as a CSV file, you can query it with tools like [csvq](https://mithrandie.github.io/csvq/).
 
-Note that as of Airflow 2.6, Pandas dataframes can be serialized by the standard XCom backend using `pyarrow`. This step is still useful if you are using an older version of Airflow, and to highlight the general process for creating a custom serialization method.
+Note that as of Airflow 2.6, Pandas dataframes can be serialized by the standard XCom backend using `pyarrow`. This step is still useful if you are using an older version of Airflow.
 
 :::info
 

--- a/learn/custom-xcom-backends-tutorial.md
+++ b/learn/custom-xcom-backends-tutorial.md
@@ -19,7 +19,7 @@ Common reasons to use a custom XCom backend include:
 
 - Needing more storage space for XCom than the metadata database can offer.
 - Running a production environment where you require custom retention, deletion, and backup policies for XComs. With a custom XCom backend, you don't need to worry about periodically cleaning up the metadata database.
-- Utilizing custom serialization and deserialization methods. By default, Airflow uses JSON serialization and, as of Airflow 2.6 can serialize Pandas dataframes via [pyarrow](https://pypi.org/project/pyarrow/). To circumvent this limitation in local development there is the option to serialize data via [pickling](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#enable-xcom-pickling), which is often not suitable for production due to [known security implications](https://docs.python.org/3/library/pickle.html). A custom XCom backend allows you to implement your own serialization and deserialization methods.
+- Utilizing custom serialization and deserialization methods. By default, Airflow uses JSON serialization and, as of Airflow 2.6, can serialize Pandas dataframes via [pyarrow](https://pypi.org/project/pyarrow/). To circumvent this limitation in local development there is the option to serialize data via [pickling](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#enable-xcom-pickling), which is often not suitable for production due to [known security implications](https://docs.python.org/3/library/pickle.html). A custom XCom backend allows you to implement your own serialization and deserialization methods.
 - Accessing XCom without accessing the metadata database.
 
 After you complete this tutorial, you'll be able to:


### PR DESCRIPTION
Almost missed this very neat PR. Standard XCom now serializes pd.DataFrame objects via pyarrow. I added that to the passing data guide, as well as made some changes to the wording in the `when to use xcom` section. 
In the custom XCom backend guide step 6 shows how to write a custom serialization method for pandas dataframes. I think eventually it might make sense to revisit that and change the step to serialize a different datatype, for the moment this is still probably going to be a common usecase and the method shown is via CSV, which people who want to be able to query their XCom stored in a blob storage will probably prefer to a pyarrow serialization. But let me know if you disagree and I should change the data type in step 6 :) 