### PR TITLE
Fix elasticsearch config indentation

### DIFF
--- a/software/export-task-logs.md
+++ b/software/export-task-logs.md
@@ -128,16 +128,16 @@ After you've created an Elastic deployment and endpoint, you have two options to
 
  ```yaml
  global:
-    fluentdEnabled: true
-    customLogging:
-    enabled: true
-    scheme: https
-    # host endpoint copied from elasticsearch console with https
-    # and port number removed.
-    host: "<host-URL>"
-    port: "9243"
-    # encoded credentials from above step 1
-    secret: "<encoded credentials>"    
+   fluentdEnabled: true
+   customLogging:
+     enabled: true
+     scheme: https
+     # host endpoint copied from elasticsearch console with https
+     # and port number removed.
+     host: "<host-URL>"
+     port: "9243"
+     # encoded credentials from above step 1
+     secret: "<encoded credentials>"    
  ```
 3. Add the following entry to your `config.yaml` file to disable internal logging:
 

--- a/software/export-task-logs.md
+++ b/software/export-task-logs.md
@@ -163,16 +163,16 @@ After you've created an Elastic deployment and endpoint, you have two options to
 
  ```yaml
  global:
-    fluentdEnabled: true
-    customLogging:
-    enabled: true
-    scheme: https
-    # host endpoint copied from elasticsearch console with https
-    # and port number removed.
-    host: "<host-URL>"
-    port: "9243"
-    # kubernetes secret containing credentials
-    secretName: elasticcreds   
+   fluentdEnabled: true
+   customLogging:
+     enabled: true
+     scheme: https
+     # host endpoint copied from elasticsearch console with https
+     # and port number removed.
+     host: "<host-URL>"
+     port: "9243"
+     # kubernetes secret containing credentials
+     secretName: elasticcreds   
  ```
 3. Add the following entry to your `config.yaml` file to disable internal logging:
 


### PR DESCRIPTION
Indentation was wrong and would cause a problem if used in this format.

Indentation now matches https://astronomer.zendesk.com/knowledge/articles/4415725074835/en-us?brand_id=360001488713