### PR TITLE
Update airflow-email-notifications.md

### DIFF
--- a/astro/airflow-email-notifications.md
+++ b/astro/airflow-email-notifications.md
@@ -105,14 +105,14 @@ Use your existing Amazon SES instance to send Airflow notifications by email.
 7. In the Cloud UI, select a Workspace, click **Deployments**, and then select a Deployment.
 
 8. In the environment variables area, click **Edit Variables** and add these variables:
-    - `ENV AIRFLOW__SMTP__SMTP_HOST`: Enter the value you copied in step 5
-    - `ENV AIRFLOW__SMTP__SMTP_STARTTLS`: Enter `True`.
-    - `ENV AIRFLOW__SMTP__SMTP_SSL`: Enter `False`.
-    - `ENV AIRFLOW__SMTP__SMTP_USER`: Enter the value you copied in step 6.
-    - `ENV AIRFLOW__SMTP__SMTP_PASSWORD`: Enter the value you copied in step 6.
-    - `ENV AIRFLOW__SMTP__SMTP_PORT`: Enter `587`.
-    - `ENV AIRFLOW__SMTP__SMTP_MAIL_FROM`: Enter your from email.
-    - `ENV AIRFLOW__EMAIL__EMAIL_BACKEND`: Enter `airflow.utils.email.send_email_smtp`.
+    - `AIRFLOW__SMTP__SMTP_HOST`: Enter the value you copied in step 5
+    - `AIRFLOW__SMTP__SMTP_STARTTLS`: Enter `True`.
+    - `AIRFLOW__SMTP__SMTP_SSL`: Enter `False`.
+    - `AIRFLOW__SMTP__SMTP_USER`: Enter the value you copied in step 6.
+    - `AIRFLOW__SMTP__SMTP_PASSWORD`: Enter the value you copied in step 6.
+    - `AIRFLOW__SMTP__SMTP_PORT`: Enter `587`.
+    - `AIRFLOW__SMTP__SMTP_MAIL_FROM`: Enter your from email.
+    - `AIRFLOW__EMAIL__EMAIL_BACKEND`: Enter `airflow.utils.email.send_email_smtp`.
 
     See [Set environment variables on Astro](https://docs.astronomer.io/astro/environment-variables).
 


### PR DESCRIPTION
Adding environment variables via the cloud ui does not require the "ENV" prefix -- that's only for adding env vars via the Dockerfile.