### PR TITLE
Add mention of callbacks in link to learn guide

### DIFF
--- a/astro/airflow-email-notifications.md
+++ b/astro/airflow-email-notifications.md
@@ -5,13 +5,14 @@ id: airflow-email-notifications
 description: Set up email notifications for Airflow task successes and failures.
 ---
 
-Incorporating a notification framework is critical to the health of your data pipelines. In addition to [Astro alerts](alerts.md), you can configure the following Apacche Airflow notification types on Astro:
+Incorporating a notification framework is critical to the health of your data pipelines. In addition to [Astro alerts](alerts.md), you can configure the following Apache Airflow notification types on Astro:
 
 - Slack notifications
 - SLAs
 - Email notifications
+- Custom callbacks and notifiers
 
-Use this guide to integrate with an SMTP service to have Astro send email notifications whenever a task run fails. To configure DAG alerts for Slack and PagerDuty, see [Astro alerts](alerts.md). For best practices on configuring notifications in Airflow, see [Manage Airflow DAG notifications](https://docs.astronomer.io/learn/error-notifications-in-airflow).
+Use this guide to integrate with an SMTP service to have Astro send email notifications whenever a task run fails. To configure DAG alerts for Slack and PagerDuty, see [Astro alerts](alerts.md). For best practices and instructions on configuring other notifications in Airflow, including notifiers and custom callbacks, see [Manage Airflow DAG notifications](https://docs.astronomer.io/learn/error-notifications-in-airflow).
 
 ## Configure Airflow email notifications
 


### PR DESCRIPTION
Resolves #1987 

We published an update to our Learn DAG notifications guide with a full section on callbacks and notifiers for the Airflow 2.6 release. This PR is the other piece of closing #1987 to expand a bit on what types of notifications are possible in Astro and link out to the guide.