### PR TITLE
Add apache-airflow-providers-ssh to list of no longer pre-installed packages

### DIFF
--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -56,6 +56,7 @@ Astro Runtime now includes fewer default dependencies to save on memory usage. T
 - `apache-airflow-providers-microsoft-mssql`
 - `apache-airflow-providers-sftp`
 - `apache-airflow-providers-snowflake`
+- `apache-airflow-providers-ssh`
 
 If your DAGs use any of these providers, ensure that the provider packages are listed in your Astro project `requirements.txt` file before upgrading. 
 


### PR DESCRIPTION
I checked the pre-installed `apache-airflow-providers-*` packages on both Astro Runtime 7.4.3 and 8.0.0 and found that `apache-airflow-providers-ssh` does come pre-installed with Astro Runtime 7.4.3, but no longer with 8.0.0. We should add that to the release notes.