### PR TITLE
Update previous release notes

### DIFF
--- a/astro/release-notes.md
+++ b/astro/release-notes.md
@@ -104,6 +104,7 @@ For a list of all instance types available for GCP, see [Supported worker node p
 - The default CIDR range for new AWS clusters has been reduced from /19 to /20.
 - You can now submit a **Request type** in the [Cloud UI support form](https://cloud.astronomer.io/support). When you choose a request type, the form updates to help you submit the most relevant information for your support request.
 - You can no longer delete a Workspace if there are any Astro Cloud IDE projects still in the Workspace.
+- Organization Role permissions have changed so that only Organization Owners can create Workspaces.
 
 ### Bug fixes
 

--- a/astro/release-notes.md
+++ b/astro/release-notes.md
@@ -104,7 +104,7 @@ For a list of all instance types available for GCP, see [Supported worker node p
 - The default CIDR range for new AWS clusters has been reduced from /19 to /20.
 - You can now submit a **Request type** in the [Cloud UI support form](https://cloud.astronomer.io/support). When you choose a request type, the form updates to help you submit the most relevant information for your support request.
 - You can no longer delete a Workspace if there are any Astro Cloud IDE projects still in the Workspace.
-- Organization Role permissions have changed so that only Organization Owners can create Workspaces.
+- Organization role permissions have changed so that only Organization Owners can create Workspaces.
 
 ### Bug fixes
 


### PR DESCRIPTION
- Adds detail about organization owners are the only user type that can create a workspace that was omitted from the March 28 release notes. 
- Other requested change in issue (updating workspace types table) had been previously resolved.

https://github.com/astronomer/astro/issues/11699