### PR TITLE
add note on deployment id

### DIFF
--- a/astro/ci-cd-templates/github-actions.md
+++ b/astro/ci-cd-templates/github-actions.md
@@ -536,3 +536,5 @@ The Astronomer [Deploy Action](https://github.com/astronomer/deploy-action/tree/
           with:
             deployment-id: <main-deployment-id>
     ```
+
+ **Note:** All four workflow files need to have the same Deployment ID specified. The action uses this deployment ID and the current git branch to create, delete, and deploy to the correct Deployment Preview.

--- a/astro/ci-cd-templates/github-actions.md
+++ b/astro/ci-cd-templates/github-actions.md
@@ -537,4 +537,4 @@ The Astronomer [Deploy Action](https://github.com/astronomer/deploy-action/tree/
             deployment-id: <main-deployment-id>
     ```
 
- **Note:** All four workflow files need to have the same Deployment ID specified. The action uses this deployment ID and the current git branch to create, delete, and deploy to the correct Deployment Preview.
+    All four workflow files must have the same Deployment ID specified. The actions use this Deployment ID to create and delete preview Deployments based on your main Deployment.


### PR DESCRIPTION
add note on deployment id to deployment preview docs. I found when working with customers they were confused why the same deployment id was used in every script