### PR TITLE
Update GCP and AWS docs on how to get Workload Identity

### DIFF
--- a/astro/connect-aws.md
+++ b/astro/connect-aws.md
@@ -139,12 +139,12 @@ Authorization is the process of verifying a user or service's permissions before
 
 To grant an Astro cluster access to a service that is running in an AWS account not managed by Astronomer, use AWS IAM roles. IAM roles on AWS are often used to manage the level of access a specific user, object, or group of users has to a resource. This includes an Amazon S3 bucket, Redshift instance, or secrets backend.
 
-1. In the Cloud UI, select your Deployment and then go to the **Details** tab. Then, copy the `arn` given under **Workload Identity**.
+1. In the Cloud UI, select your Deployment and then click **Details**. Copy the `arn` given under **Workload Identity**.
 2. Create an IAM role in the AWS account that contains your AWS service. See [Creating a role to delegate permissions to an AWS service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html).
 3. In the AWS Management Console, go to the Identity and Access Management (IAM) dashboard.
 4. Click **Roles** and in the **Role name** column, select the role you created in step 2.
 5. Click the **Trust relationships** tab.
-6. Click **Edit trust policy** and paste the `arn` copied from Step 1 in the trust policy.
+6. Click **Edit trust policy** and paste the `arn` you copied from Step 1 in the trust policy.
 
     ```text {8}
     {
@@ -154,7 +154,7 @@ To grant an Astro cluster access to a service that is running in an AWS account 
                 "Effect": "Allow",
                 "Principal": {
                     "AWS": [
-                        "arn:aws:iam::012345678900:role/AirflowS3Logs-cl66604ph00tx0s2tb3v313qu"
+                        "arn:aws:iam::<dataplane-AWS-account-ID>:role/AirflowS3Logs-<cluster-ID>"
                     ]
                 },
                 "Action": "sts:AssumeRole"

--- a/astro/connect-aws.md
+++ b/astro/connect-aws.md
@@ -139,12 +139,12 @@ Authorization is the process of verifying a user or service's permissions before
 
 To grant an Astro cluster access to a service that is running in an AWS account not managed by Astronomer, use AWS IAM roles. IAM roles on AWS are often used to manage the level of access a specific user, object, or group of users has to a resource. This includes an Amazon S3 bucket, Redshift instance, or secrets backend.
 
-1. In the Cloud UI, click **Clusters** and then copy the value displayed in the **Cluster ID** column for the Astro cluster that needs access to AWS service resources.
+1. In the Cloud UI, select your Deployment and then go to the **Details** tab. Then, copy the `arn` given under **Workload Identity**.
 2. Create an IAM role in the AWS account that contains your AWS service. See [Creating a role to delegate permissions to an AWS service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html).
 3. In the AWS Management Console, go to the Identity and Access Management (IAM) dashboard.
 4. Click **Roles** and in the **Role name** column, select the role you created in step 2.
 5. Click the **Trust relationships** tab.
-6. Click **Edit trust policy** and update the `arn` value:
+6. Click **Edit trust policy** and paste the `arn` copied from Step 1 in the trust policy.
 
     ```text {8}
     {
@@ -154,7 +154,7 @@ To grant an Astro cluster access to a service that is running in an AWS account 
                 "Effect": "Allow",
                 "Principal": {
                     "AWS": [
-                        "arn:aws:iam::<dataplane-AWS-account-ID>:role/AirflowS3Logs-<cluster-ID>"
+                        "arn:aws:iam::012345678900:role/AirflowS3Logs-cl66604ph00tx0s2tb3v313qu"
                     ]
                 },
                 "Action": "sts:AssumeRole"
@@ -162,7 +162,6 @@ To grant an Astro cluster access to a service that is running in an AWS account 
         ]
     }
     ```
-    To locate your `<dataplane-AWS-account-ID>` and `<cluster-ID>`, in the Cloud UI click **Clusters**. The `<dataplane-AWS-account-ID>` is located in the **Account ID** column and the cluster ID is located in the **ID** column. 
     
     The Astro cluster data plane account includes the `AirflowLogsS3-<clusterid>` role. When you configure an [AWS Airflow Connection](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html) for a Deployment, use `"arn:aws:iam::<dataplane-AWS-account-ID>:role/AirflowS3Logs-<cluster-ID>"` as the value for `aws_arn`.
 

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -83,36 +83,14 @@ To allow data pipelines running on GCP to access Google Cloud services in a secu
 
 To grant a Deployment on Astro access to external data services on GCP, such as BigQuery:
 
-1. In the Cloud UI, select a Workspace, select a Deployment, and then copy the value in the **Namespace** field.
+1. In the Cloud UI, select your Deployment, and then go to the **Details** tab of the Deployment.
 
-2. Use the Deployment namespace value and the name of your Google Cloud project to identify the Google service account for your Deployment.
-
-    Google service accounts for Astro Deployments are formatted as follows:
-
-    ```text
-    astro-<deployment-namespace>@<gcp-account-id>.iam.gserviceaccount.com
-    ```
-    
-    To locate your Google Cloud account ID, in the Cloud UI click **Clusters**. The Google Cloud account ID is located in the **Account ID** column.
-
-    For example, for a Google Cloud project named `astronomer-prod` and a Deployment namespace defined as `nuclear-science-2730`, the service account for the Deployment would be:
-
-    ```text
-    astro-nuclear-science-2730@astronomer-prod.iam.gserviceaccount.com
-    ```
-  :::info
-
-  GCP has a 30-character limit for service account names. For Deployment namespaces which are longer than 24 characters, use only the first 24 characters when determining your service account name.
-
-  For example, if your Google Cloud project is named `astronomer-prod` and your Deployment namespace is `nuclear-scintillation-2730`, the service account name is:
-
-  ```text
-  astro-nuclear-scintillation-27@astronomer-prod.iam.gserviceaccount.com
+2. Copy the service account shown under **Workload Identity**. This service account will be used in Step 3 to grant access.
 
 3. Grant the Google service account for your Astro Deployment an IAM role that has access to your external data service. With the Google Cloud CLI, run:
 
     ```text
-    gcloud projects add-iam-policy-binding $GOOGLE_CLOUD_PROJECT --member=serviceAccount:astro-<deployment-namespace>@<gcp-project-name>.iam.gserviceaccount.com --role=roles/viewer
+    gcloud projects add-iam-policy-binding $GOOGLE_CLOUD_PROJECT --member=serviceAccount:<your-astro-service-account> --role=roles/viewer
     ```
 
     For instructions on how to grant your service account an IAM role in the Google Cloud console, see [Grant an IAM role](https://cloud.google.com/iam/docs/grant-role-console#grant_an_iam_role).

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -83,9 +83,9 @@ To allow data pipelines running on GCP to access Google Cloud services in a secu
 
 To grant a Deployment on Astro access to external data services on GCP, such as BigQuery:
 
-1. In the Cloud UI, select your Deployment, and then go to the **Details** tab of the Deployment.
+1. In the Cloud UI, select your Deployment, then click **Details**
 
-2. Copy the service account shown under **Workload Identity**. This service account will be used in Step 3 to grant access.
+2. Copy the service account shown under **Workload Identity**.
 
 3. Grant the Google service account for your Astro Deployment an IAM role that has access to your external data service. With the Google Cloud CLI, run:
 


### PR DESCRIPTION
With the new release from yesterday, now Workload Identity is available to be copied from the Cloud UI, hence updating our docs to reflect the same.