### PR TITLE
Add Kenten and me as codeowners for code-samples/dags

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,5 @@
 /software/ @jwitz @paolaperaza @lzdanski
 
 /learn/ @TJaniF @kentdanas @jwitz @paolaperaza @lzdanski
+
+/code-samples/dags @TJaniF @kentdanas

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 /learn/ @TJaniF @kentdanas @jwitz @paolaperaza @lzdanski
 
-/code-samples/dags @TJaniF @kentdanas
+/code-samples/dags/ @TJaniF @kentdanas


### PR DESCRIPTION
I noticed I didn't get an email for a PR an external contributor made to change someone in a tutorial DAG. Thought it would make sense if Kenten and I are notified of these PRs :) 