### PR TITLE
Tiny PR: add note about double-checking Astro version in first DAG doc

### DIFF
--- a/astro/create-first-dag.md
+++ b/astro/create-first-dag.md
@@ -99,7 +99,7 @@ DAG-only deploys are an Astro feature that you can use to quickly update your As
     astro login astronomer.io
     ```
 
-    After running this command, you are prompted to open your web browser and enter your credentials to the Cloud UI. The Cloud UI then automatically authenticates you to the CLI. The next time you log in, you can run `astro login` without specifying a domain.
+    After running this command, you are prompted to open your web browser and enter your credentials to the Cloud UI. The Cloud UI then automatically authenticates you to the CLI. The next time you log in, you can run `astro login` without specifying a domain. If you run into issues with the login command, double-check that you have the [latest Astro CLI version](cli/install-cli.md#upgrade-the-cli) installed.
 
 2. Run the following command to enable DAG-only code deploys on your Deployment.
    


### PR DESCRIPTION
Hey, I know this is an important doc and this might have been discussed before but I've wondered if there should be a note about making sure you are on the latest version of the Astro CLI when running `astro login`. I see that it says "latest version" in the requirements but a dev advocate from a database tool I am working with on a shared blog post recently ran into this and did not realize an outdated astro Cli version was why she could not log in properly. 

Feel free to close and disregard if you disagree! :) 