### PR TITLE
Improve Software Airgap Instructions and Examples

### DIFF
--- a/software/install-airgapped.md
+++ b/software/install-airgapped.md
@@ -201,7 +201,7 @@ To complete this setup:
         spec:
           containers:
           - name: astronomer-releases
-            image: <use same image as es-ingress-controller>
+            image: ap-nginx-es
             resources:
               requests:
                 memory: "32Mi"

--- a/software/install-airgapped.md
+++ b/software/install-airgapped.md
@@ -201,7 +201,7 @@ To complete this setup:
         spec:
           containers:
           - name: astronomer-releases
-            image: 012345678910.dkr.ecr.us-east-1.amazonaws.com/nginx:stable # Replace with own image
+            image: <use same image as es-ingress-controller>
             resources:
               requests:
                 memory: "32Mi"
@@ -210,7 +210,7 @@ To complete this setup:
                 memory: "128Mi"
                 cpu: "500m"
             ports:
-            - containerPort: 80
+            - containerPort: 8080
             volumeMounts:
             - name: astronomer-certified
               mountPath: /usr/share/nginx/html/astronomer-certified
@@ -237,7 +237,7 @@ To complete this setup:
         app: astronomer-releases
       ports:
       - port: 80
-        targetPort: 80
+        targetPort: 8080
     ```
 
     Note the Docker image in the deployment and ensure that this is also accessible from within your environment.

--- a/software/install-airgapped.md
+++ b/software/install-airgapped.md
@@ -238,6 +238,24 @@ To complete this setup:
       ports:
       - port: 80
         targetPort: 8080
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: astronomer-astronomer-releases-nginx-policy
+    spec:
+      ingress:
+      - from:
+        - namespaceSelector: {}
+          podSelector: {}
+        ports:
+        - port: 8080
+          protocol: TCP
+      podSelector:
+        matchLabels:
+          app: astronomer-releases
+      policyTypes:
+      - Ingress
     ```
 
     Note the Docker image in the deployment and ensure that this is also accessible from within your environment.


### PR DESCRIPTION
The previous instructions did not specify how to source the nginx image and left it to customers to source their own copy. This pdated yaml document contains configuration changes to make it work with one of the images we ship by default and is a drop-in replacement functionality wise for customers. It also adds a NetworkPolicy that allows access to that container since we are denying access by default to containers that don't have a network policy defined.