### PR TITLE
Replace deleted branch names with working tag names

### DIFF
--- a/archived_software_docs/version-0.16/upgrade-to-0-23.md
+++ b/archived_software_docs/version-0.16/upgrade-to-0-23.md
@@ -134,7 +134,7 @@ If you encounter an issue during your upgrade that requires you to recover your 
 
 1. Apply the rollback automation script by running the following command:
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/release-0.23/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback-0.16-to-0.23.yaml
+kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/v0.23.18/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback-0.16-to-0.23.yaml
 ```
 This restores the platform database and the Helm state of the Astronomer Helm chart.
 

--- a/archived_software_docs/version-0.25/upgrade-astronomer.md
+++ b/archived_software_docs/version-0.25/upgrade-astronomer.md
@@ -290,5 +290,5 @@ Before upgrading to 0.25, ensure that the following software is updated to the a
 Upgrading to 0.25 requires a non-standard upgrade script. Ignore Step 4 in the standard upgrade process and run the following command instead:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/release-0.25/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
+kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/v0.25.15-final/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
 ```

--- a/archived_software_docs/version-0.26/upgrade-astronomer.md
+++ b/archived_software_docs/version-0.26/upgrade-astronomer.md
@@ -245,5 +245,5 @@ Before upgrading to 0.25, ensure that the following software is updated to the a
 Upgrading to 0.25 requires a non-standard upgrade script. Ignore Step 4 in the standard upgrade process and run the following command instead:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/release-0.25/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
+kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/v0.25.15-final/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
 ```

--- a/archived_software_docs/version-0.27/upgrade-astronomer.md
+++ b/archived_software_docs/version-0.27/upgrade-astronomer.md
@@ -245,5 +245,5 @@ Before upgrading to 0.25, ensure that the following software is updated to the a
 Upgrading to 0.25 requires a non-standard upgrade script. Ignore Step 4 in the standard upgrade process and run the following command instead:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/release-0.25/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
+kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/v0.25.15-final/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
 ```

--- a/archived_software_docs/version-0.28/upgrade-astronomer.md
+++ b/archived_software_docs/version-0.28/upgrade-astronomer.md
@@ -297,5 +297,5 @@ Before upgrading to 0.25, ensure that the following software is updated to the a
 Upgrading to 0.25 requires a non-standard upgrade script. Ignore Step 4 in the standard upgrade process and run the following command instead:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/release-0.25/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
+kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/v0.25.15-final/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
 ```

--- a/archived_software_docs/version-0.29/upgrade-astronomer.md
+++ b/archived_software_docs/version-0.29/upgrade-astronomer.md
@@ -295,5 +295,5 @@ Before upgrading to 0.25, ensure that the following software is updated to the a
 Upgrading to 0.25 requires a non-standard upgrade script. Ignore Step 4 in the standard upgrade process and run the following command instead:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/release-0.25/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
+kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/v0.25.15-final/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
 ```

--- a/archived_software_docs/version-0.31/upgrade-astronomer.md
+++ b/archived_software_docs/version-0.31/upgrade-astronomer.md
@@ -362,5 +362,5 @@ Before upgrading to 0.25, ensure that the following software is updated to the a
 Upgrading to 0.25 requires a non-standard upgrade script. Ignore Step 4 in the standard upgrade process and run the following command instead:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/release-0.25/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
+kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/v0.25.15-final/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
 ```

--- a/software/upgrade-astronomer.md
+++ b/software/upgrade-astronomer.md
@@ -379,5 +379,5 @@ Before upgrading to 0.25, ensure that the following software is updated to the a
 Upgrading to 0.25 requires a non-standard upgrade script. Ignore Step 4 in the standard upgrade process and run the following command instead:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/release-0.25/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
+kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/v0.25.15-final/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
 ```

--- a/software_versioned_docs/version-0.30/upgrade-astronomer.md
+++ b/software_versioned_docs/version-0.30/upgrade-astronomer.md
@@ -320,5 +320,5 @@ Before upgrading to 0.25, ensure that the following software is updated to the a
 Upgrading to 0.25 requires a non-standard upgrade script. Ignore Step 4 in the standard upgrade process and run the following command instead:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/release-0.25/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
+kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/v0.25.15-final/migrations/scripts/lts-to-lts/0.23-to-0.25/manifests/upgrade-0.23-to-0.25.yaml
 ```


### PR DESCRIPTION
Closes https://github.com/astronomer/docs/issues/2521 by replacing deleted branch names in broken URLs with working tag names.

These versions are deprecated, but some folks including CRE engineers still use these docs.