### PR TITLE
Fix astro registry CLI command docs

### DIFF
--- a/astro/cli/astro-registry-dag-add.md
+++ b/astro/cli/astro-registry-dag-add.md
@@ -1,8 +1,8 @@
 ---
-sidebar_label: "astro registry add dag"
-title: "astro registry add dag"
-id: astro-registry-add-dag
-description: Reference documentation for astro registry add dag.
+sidebar_label: "astro registry dag add"
+title: "astro registry dag add"
+id: astro-registry-dag-add
+description: Reference documentation for astro registry dag add.
 hide_table_of_contents: true
 ---
 
@@ -11,7 +11,7 @@ Download a DAG from the [Astronomer Registry](https://registry.astronomer.io/) t
 ## Usage 
 
 ```sh
-astro registry add dag
+astro registry dag add
 ```
 
 When you run the command, the CLI prompts you for a DAG ID to download. To retrieve the DAG name, open the DAG in the Astronomer registry and copy the URL between `dags/` and `/versions`. For example, in the URL `https://registry.astronomer.io/dags/upload_files_to_s3/versions/1.0.0`, copy `upload_files_to_s3`.
@@ -27,11 +27,11 @@ When you run the command, the CLI prompts you for a DAG ID to download. To retri
 ## Examples
 
 ```sh
-# Download version 1.2.0 of a DAG called 'upload_files_to_s3'
-astro registry add dag upload_files_to_s3 --version 1.2.0
+# Download version 1.0.0 of a DAG called 'upload_files_to_s3'
+astro registry dag add upload_files_to_s3 --version 1.0.0
 ```
 
 ## Related commands
 
-- [astro registry add provider](cli/astro-registry-add-provider.md)
+- [astro registry provider add](cli/astro-registry-provider-add.md)
 - [astro dev start](cli/astro-dev-start.md)

--- a/astro/cli/astro-registry-provider-add.md
+++ b/astro/cli/astro-registry-provider-add.md
@@ -1,8 +1,8 @@
 ---
-sidebar_label: "astro registry add provider"
-title: "astro registry add provider"
+sidebar_label: "astro registry provider add"
+title: "astro registry provider add"
 id: astro-registry-provider-add
-description: Reference documentation for astro registry add provider.
+description: Reference documentation for astro registry provider add.
 hide_table_of_contents: true
 ---
 
@@ -11,7 +11,7 @@ Download a provider package from the [Astronomer Registry](https://registry.astr
 ## Usage 
 
 ```sh
-astro registry add provider
+astro registry provider add
 ```
 
 When you run the command, the CLI prompts you for a provider to download. To retrieve the provider name, open the provider in the Astronomer registry and copy the URL between `providers/` and `/versions`. For example, in the URL `https://registry.astronomer.io/providers/apache-airflow-providers-airbyte/versions/3.3.1`, copy `apache-airflow-providers-airbyte`. 

--- a/astro/cli/astro-registry-provider-add.md
+++ b/astro/cli/astro-registry-provider-add.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: "astro registry add provider"
 title: "astro registry add provider"
-id: astro-registry-add-provider
+id: astro-registry-provider-add
 description: Reference documentation for astro registry add provider.
 hide_table_of_contents: true
 ---
@@ -27,10 +27,10 @@ When you run the command, the CLI prompts you for a provider to download. To ret
 
 ```sh
 # Download version 1.2.0 of a provider
-astro registry add provider apache-airflow-providers-airbyte --version 1.2.0
+astro registry provider add apache-airflow-providers-airbyte --version 1.2.0
 ```
 
 ## Related commands
 
-- [astro registry add dag](cli/astro-registry-add-dag.md)
+- [astro registry dag add](cli/astro-registry-dag-add.md)
 - [astro dev start](cli/astro-dev-start.md)

--- a/astro/cli/release-notes.md
+++ b/astro/cli/release-notes.md
@@ -36,8 +36,8 @@ You can now manage [Organization API tokens](organization-api-tokens.md) using t
 
 You can now use the following commands to download resources from the Astronomer Registry:
 
-- [`astro registry add dag`](cli/astro-registry-add-dag.md)
-- [`astro registry add provider`](cli/astro-registry-add-provider.md)
+- [`astro registry dag add`](cli/astro-registry-dag-add.md)
+- [`astro registry provider add`](cli/astro-registry-provider-add.md)
 
 The Astro registry contains DAGs and provider packages that are ready to use out of the box. Use these commands to quickly add resources to an Astro project, which you can then run locally or on Astro.
 

--- a/sidebarsAstro.js
+++ b/sidebarsAstro.js
@@ -415,8 +415,8 @@ module.exports = {
           type: "category",
           label: "astro registry",
           items: [
-            "cli/astro-registry-add-dag",
-            "cli/astro-registry-add-provider"
+            "cli/astro-registry-dag-add",
+            "cli/astro-registry-provider-add"
           ],
         },
         'cli/astro-run',


### PR DESCRIPTION
Hey :) 
Found out that it is `astro registry dag add` instead of `astro registry add dag` and the same for adding a provider. :)
Also the `upload_files_to_s3` DAG does not have a 1.2.0 version yet