### PR TITLE
Tiny PR Adding a note about astro dev run being local in the Variables guide

### DIFF
--- a/learn/airflow-variables.md
+++ b/learn/airflow-variables.md
@@ -72,6 +72,8 @@ astro dev run variables set my_var my_value
 astro dev run variables set -j my_json_var '{"key": "value"}'
 ```
 
+Note that [`astro dev run`](https://docs.astronomer.io/astro/cli/astro-dev-run) executes Airflow commands in your local Astro CLI scheduler container and cannot be applied to Deployments running on Astro. To set Airflow variables for an Astro Deployment, either create them in the Deployments Airflow UI or via an [environment variable](https://docs.astronomer.io/astro/environment-variables).
+
 </TabItem>
 
 <TabItem value="airflow">

--- a/learn/airflow-variables.md
+++ b/learn/airflow-variables.md
@@ -72,7 +72,7 @@ astro dev run variables set my_var my_value
 astro dev run variables set -j my_json_var '{"key": "value"}'
 ```
 
-Note that [`astro dev run`](https://docs.astronomer.io/astro/cli/astro-dev-run) executes Airflow commands in your local Astro CLI scheduler container and cannot be applied to Deployments running on Astro. To set Airflow variables for an Astro Deployment, either create them in the Deployments Airflow UI or via an [environment variable](https://docs.astronomer.io/astro/environment-variables).
+Note that [`astro dev run`](https://docs.astronomer.io/astro/cli/astro-dev-run) executes Airflow commands only in your local Airflow environment and can't be used on Astro Deployments. To set Airflow variables for an Astro Deployment, either create them using the Deployment's Airflow UI or using [Astro environment variables](https://docs.astronomer.io/astro/environment-variables).
 
 </TabItem>
 


### PR DESCRIPTION
Thanks @fritz-astronomer for catching this. :)

Added an explanation that astro dev run is a local command and does not work for Deployments. 