### PR TITLE
Add important tip to Hashicorp Vault & CLI section to Import Conns/Vars

### DIFF
--- a/astro/import-export-connections-variables.md
+++ b/astro/import-export-connections-variables.md
@@ -31,7 +31,7 @@ For security reasons, you can't bulk import or export connections from the Airfl
 
 ### Using the Astro CLI (Local environments only)
 
-Use [`astro dev object export`](cli/astro-dev-object-export.md), [`astro dev object import`](cli/astro-dev-object-import.md) and [`astro dev run`](cli/astro-dev-run.md) to import and export connections and variables from a local Airflow environment to various formats. For example:
+Use [`astro dev object export`](cli/astro-dev-object-export.md), [`astro dev object import`](cli/astro-dev-object-import.md), and [`astro dev run`](cli/astro-dev-run.md) to import and export connections and variables from a local Airflow environment to various formats. For example:
 
 - To export all Airflow objects including connections, variables, and pools to your Astro project `.env` file in a URI format, run:
     

--- a/astro/import-export-connections-variables.md
+++ b/astro/import-export-connections-variables.md
@@ -17,7 +17,7 @@ Based on the [management strategy for your connections and variables](manage-con
 
 When you use the Airflow UI to store your Airflow connections and variables, they are stored in Airflow's metadata database. If your variables are stored in Airflow's metadata database, you can use the Airflow UI to import and export them in bulk.
 
-### Using Airflow UI
+### Using the Airflow UI
 
 To export variables from a local Airflow environment or Astro Deployment, go to **Admin** in the Airflow UI, click **Variables** and select the variables you want to export. Then, click **Export** in the **Actions** dropdown menu. This exports a file named `variables.json` to your local computer.
 
@@ -29,36 +29,27 @@ To import variables to a local Airflow environment or Astro Deployment from a `j
 
 For security reasons, you can't bulk import or export connections from the Airflow UI.
 
-### Using Astro CLI
+### Using the Astro CLI (Local environments only)
 
-You can also use Astro CLI to import or export connections and variables to STDOUT or a file in URI, JSON or YAML format. For example:
+Use [`astro dev object export`](cli/astro-dev-object-export.md), [`astro dev object import`](cli/astro-dev-object-import.md) and [`astro dev run`](cli/astro-dev-run.md) to import and export connections and variables from a local Airflow environment to various formats. For example:
 
-- Export all airflow objects including connections and variables to `.env` file in URI format
+- To export all Airflow objects including connections, variables, and pools to your Astro project `.env` file in a URI format, run:
+    
     ```bash 
     astro dev object export --env-export 
     ```
-- Print the connections in the default URI format to STDOUT.
-    ```bash
-    astro dev run connections export - --file-format=env
-    ```
-- Print the connections in JSON format to STDOUT
+
+- To print only your connections connections in JSON format to STDOUT, run:
+
     ```bash
     astro dev run connections export - --file-format=env --serialization-format=json
     ```
-- Export connections in JSON format to conns.json in your Astro project's include dir
-    ```bash
-    astro dev run connections export --file-format=json /usr/local/airflow/include/conns.json
-    ```
-- Export connections in YAML format to conns.yaml in your Astro project's include directory
-    ```bash
-    astro dev run connections export --file-format=yaml /usr/local/airflow/include/conns.yaml
-    ```
-- Import all Airflow objects from `myairflowobjects.yaml` to a locally running Airflow environment
+
+- To import all Airflow objects from a file named `myairflowobjects.yaml` to a locally running Airflow environment, run:
+    
     ```bash
     astro dev object import --settingsfile="myairflowobjects.yaml"
     ```
-
-See [`astro dev object export`](cli/astro-dev-object-export.md), [`astro dev object import`](cli/astro-dev-object-import.md) and [`astro dev run`](cli/astro-dev-run.md) for more details.
 
 ## From a secrets backend
 

--- a/astro/import-export-connections-variables.md
+++ b/astro/import-export-connections-variables.md
@@ -17,6 +17,8 @@ Based on the [management strategy for your connections and variables](manage-con
 
 When you use the Airflow UI to store your Airflow connections and variables, they are stored in Airflow's metadata database. If your variables are stored in Airflow's metadata database, you can use the Airflow UI to import and export them in bulk.
 
+### Using Airflow UI
+
 To export variables from a local Airflow environment or Astro Deployment, go to **Admin** in the Airflow UI, click **Variables** and select the variables you want to export. Then, click **Export** in the **Actions** dropdown menu. This exports a file named `variables.json` to your local computer.
 
 ![Export Variables](/img/docs/airflow-ui-export-vars.png)
@@ -26,6 +28,37 @@ To import variables to a local Airflow environment or Astro Deployment from a `j
 ![Import Variables](/img/docs/airflow-ui-import-vars.png)
 
 For security reasons, you can't bulk import or export connections from the Airflow UI.
+
+### Using Astro CLI
+
+You can also use Astro CLI to import or export connections and variables to STDOUT or a file in URI, JSON or YAML format. For example:
+
+- Export all airflow objects including connections and variables to `.env` file in URI format
+    ```bash 
+    astro dev object export --env-export 
+    ```
+- Print the connections in the default URI format to STDOUT.
+    ```bash
+    astro dev run connections export - --file-format=env
+    ```
+- Print the connections in JSON format to STDOUT
+    ```bash
+    astro dev run connections export - --file-format=env --serialization-format=json
+    ```
+- Export connections in JSON format to conns.json in your Astro project's include dir
+    ```bash
+    astro dev run connections export --file-format=json /usr/local/airflow/include/conns.json
+    ```
+- Export connections in YAML format to conns.yaml in your Astro project's include directory
+    ```bash
+    astro dev run connections export --file-format=yaml /usr/local/airflow/include/conns.yaml
+    ```
+- Import all Airflow objects from `myairflowobjects.yaml` to a locally running Airflow environment
+    ```bash
+    astro dev object import --settingsfile="myairflowobjects.yaml"
+    ```
+
+See [`astro dev object export`](cli/astro-dev-object-export.md), [`astro dev object import`](cli/astro-dev-object-import.md) and [`astro dev run`](cli/astro-dev-run.md) for more details.
 
 ## From a secrets backend
 

--- a/astro/secrets-backend.md
+++ b/astro/secrets-backend.md
@@ -224,34 +224,37 @@ To start, create an Airflow variable or connection in Vault that you want to sto
 
 To store an Airflow variable in Vault as a secret, run the following Vault CLI command with your own values:
 
-```sh
-vault secrets enable -path=secret -version=2 kv
-vault kv put secret/variables/<your-variable-key> value=<your-variable-value>
+```bash
+vault secrets enable -path=<my-airflow-mount> -version=2 kv
+vault kv put -mount=<my-airflow-mount> <my-variables-path>/<my-variable-name> value=<my-value-value>
 ```
 
-To store a connection in Vault as a secret, run the following Vault CLI command with your own values:
+To store a connection in Vault as a secret in URI representation, run the following Vault CLI command with your own values:
 
-```sh
-vault secrets enable -path=secret -version=2 kv
-vault kv put secret/connections/<your-connection-id> conn_uri=<connection-type>://<connection-login>:<connection-password>@<connection-host>:5432
+```bash
+vault secrets enable -path=<my-airflow-mount> -version=2 kv
+vault kv put -mount=<my-airflow-mount> <my-connections-path>/<my-connection-name> conn_uri=<connection-type>://<connection-login>:<connection-password>@<connection-host>:<connection-port>
 ```
 
-To confirm that your secret was written to Vault successfully, run:
-
-```sh
-# For variables
-$ vault kv get secret/variables/<your-variable-key>
-# For connections
-$ vault kv get secret/connections/<your-connection-id>
-```
+To import your connections in URI format, see [Import and export connections](import-export-connections-variables.md#using-the-astro-cli-local-environments-only).
 
 :::tip important
 
-For Airflow variables, the name of the key for the Vault secret you create must be `value`. For example, if you are creating a secret called secret/variables/my-var, the **key** must be named `value` and **value** will be your variable's value.
+Please note that even though Vault allows to create a custom key name for your secrets, Airflow requires the Key name to be `value` for Airflow variables and `conn_uri` for Airflow connections as shown in the commands above.
 
-For Airflow connections, the name of the key for the Vault secret you create must be `conn_uri`. For example, if you are creating a secret called secret/connections/my-conn, the **key** must be named `conn_uri` and **value** will be your connection's URI. See [Import and export connections](import-export-connections-variables.md#using-astro-cli) to export your connection in URI format.
+For example, `vault kv put -mount=my-mount my_secret foo=bar` is a valid Vault CLI command to store your secret, where `foo` is the Key and `bar` is the Value, but Airflow will not be able to parse it.
 
 :::
+
+To confirm that your secret was written to Vault successfully, run:
+
+```bash
+# For variables
+$ vault kv get -mount=<my-airflow-mount> <my-variables-path>/<my-variable-name>
+
+# For connections
+$ vault kv get -mount=<my-airflow-mount> <my-connections-path>/<my-connection-name>
+```
 
 #### Set up Vault locally
 

--- a/astro/secrets-backend.md
+++ b/astro/secrets-backend.md
@@ -245,6 +245,14 @@ $ vault kv get secret/variables/<your-variable-key>
 $ vault kv get secret/connections/<your-connection-id>
 ```
 
+:::tip important
+
+For Airflow variables, the name of the key for the Vault secret you create must be `value`. For example, if you are creating a secret called secret/variables/my-var, the **key** must be named `value` and **value** will be your variable's value.
+
+For Airflow connections, the name of the key for the Vault secret you create must be `conn_uri`. For example, if you are creating a secret called secret/connections/my-conn, the **key** must be named `conn_uri` and **value** will be your connection's URI. See [Import and export connections](import-export-connections-variables.md#using-astro-cli) to export your connection in URI format.
+
+:::
+
 #### Set up Vault locally
 
 In your Astro project, add the [Hashicorp Airflow provider](https://airflow.apache.org/docs/apache-airflow-providers-hashicorp/stable/index.html) to your project by adding the following to your `requirements.txt` file:


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/2550

@jwitz This PR was originally supposed to just add a note to HAshicorp Vault, but when I went to link the import as URI section, I realized we did not create that separately. I tried to address that as part of this PR since it was linked. Please let me know if that is okay, happy to do it separately. 

That section on Astro CLI will also be useful to link with our How-to connections. 

Thanks!

