### PR TITLE
Create exclusion pattern for tab URLs in Algolia

### DIFF
--- a/algolia-config.json
+++ b/algolia-config.json
@@ -4,7 +4,9 @@
     "https://docs.astronomer.io"
   ],
   "stop_urls": [
-    "(?=tab=)"
+    {
+    "url": "(?=tab=)"
+    }
   ],
   "selectors": {
     "lvl0": {

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -20,6 +20,9 @@
     "text": "article p, article li, article td:last-child"
   },
   "strip_chars": " .,;:#",
+  "exclusionPatterns": [
+     "?(tab=)"
+  ],
   "custom_settings": {
     "separatorsToIndex": "_",
     "attributesForFaceting": [

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -3,7 +3,9 @@
   "start_urls": [
     "https://docs.astronomer.io"
   ],
-  "stop_urls": [],
+  "stop_urls": [
+    "(?=tab=)"
+  ],
   "selectors": {
     "lvl0": {
       "selector": "(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]",
@@ -20,9 +22,6 @@
     "text": "article p, article li, article td:last-child"
   },
   "strip_chars": " .,;:#",
-  "exclusionPatterns": [
-     "?(tab=)"
-  ],
   "custom_settings": {
     "separatorsToIndex": "_",
     "attributesForFaceting": [


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/2468 (bluntly)

This PR should remove all duplicate indexes of docs by excluding any duplicate URLs that include tabIDs. Syntax is based on regex. Docs for config are here: https://docsearch.algolia.com/docs/legacy/config-file/#stop_urls-optional

The downside of this approach is that search results will no longer open the correct tab where content might be, so the content a user searches for and selects might be hidden behind a tab until they manually select it. The ideal solution would be:

- If tabs exist for a given topic, exclude the version of the URL without tabs
- It tabs don't exist for a topic, do not exclude the URL

But I don't really have the bandwidth to mess with regex like that and this will at least make our search not be broken in most uses.