### PR TITLE
Add caution for dag-only deploys and for ci/cd

### DIFF
--- a/astro/configure-deployment-resources.md
+++ b/astro/configure-deployment-resources.md
@@ -107,7 +107,12 @@ To update a Deployment's [Airflow configurations](https://airflow.apache.org/doc
 
 ## Enforce CI/CD deploys
 
-By default, Deployments accept code deploys from any authenticated source. When you enforce CI/CD deploys for a Deployment, the Deployment only accepts code deploys if they are triggered with a Deployment API key or Workspace token. 
+By default, Deployments accept code deploys from any authenticated source. When you enforce CI/CD deploys for a Deployment:
+
+- Your the Deployment only accepts code deploys if they are triggered with a Deployment API key or Workspace token or Organization token.
+- You cannot enable DAG-only deploy feature for your Deployment.
+
+Follow these steps to enforce CI/CD deploys:
 
 1. In the Cloud UI, select a Workspace, click **Deployments**, and then select a Deployment.
 2. Click the **Details** tab.

--- a/astro/configure-deployment-resources.md
+++ b/astro/configure-deployment-resources.md
@@ -109,10 +109,8 @@ To update a Deployment's [Airflow configurations](https://airflow.apache.org/doc
 
 By default, Deployments accept code deploys from any authenticated source. When you enforce CI/CD deploys for a Deployment:
 
-- Your the Deployment only accepts code deploys if they are triggered with a Deployment API key or Workspace token or Organization token.
-- You cannot enable DAG-only deploy feature for your Deployment.
-
-Follow these steps to enforce CI/CD deploys:
+- The Deployment accepts code deploys only if the deploys are triggered with a Deployment API key, Workspace API token, or Organization API token.
+- You can't enable [DAG-only deploys](deploy-dags.md) for the Deployment.
 
 1. In the Cloud UI, select a Workspace, click **Deployments**, and then select a Deployment.
 2. Click the **Details** tab.

--- a/astro/deploy-dags.md
+++ b/astro/deploy-dags.md
@@ -20,15 +20,12 @@ Enabling DAG-only deploys on Astro has a few benefits:
 
 Before you enable DAG-only deploys on a Deployment, ensure the following:
 
-- You have access to the Deployment's Astro project.
-- You can trigger deploys from your current machine with the Astro CLI.
-- Your Deployment does not have [CI/CD enforcement](configure-deployment-resources.md#enforce-cicd-deploys) enabled. You can also verify this using [Astro CLI's inspect](cli/astro-deployment-inspect.md) command.
+- You have access to the latest version of your Deployment's Astro project.
+- You can update your Deployment using the Astro CLI. 
+- Your Deployment does not have [CI/CD enforcement](configure-deployment-resources.md#enforce-cicd-deploys) enabled. You can confirm this from the Cloud UI or by running [`astro deployment inspect`](cli/astro-deployment-inspect.md) command.
+:::warning be careful
 
-You cannot enable the DAG-only deploy feature in the Cloud UI.
-
-:::caution 
-
-You must trigger a DAG-based deploy to your Astro Deployment using `astro deploy --dags` immediately after you enable the DAG-only deploy feature. This will ensure your DAGs are refreshed in your Airflow UI using the new deployment method.
+Carefully read and complete all of the following steps to ensure that your Deployment is not disrupted by enabling this feature. Crucially, you must trigger a DAG-based deploy to your Astro Deployment using `astro deploy --dags` immediately after you enable the DAG-only deploy feature. If you don't complete this step, your DAGs will not be refreshed in the Airflow UI until you update your Deployment. 
 
 :::
 
@@ -62,11 +59,16 @@ astro deploy --dags
 
 ## Disable DAG-only deploys on a Deployment
 
-If you have Workspace Admin permissions, you can turn off DAG-only deploys for a Deployment at any time if your organization doesn't benefit from faster deploys or prefers a deployment method that is exclusively based on building and deploying your Astro project as a Docker image. To determine if turning off DAG-only deploy functionality is the right choice for your organization, contact [Astronomer support](https://cloud.astronomer.io/support). 
+If you have Workspace Admin permissions, you can turn off DAG-only deploys for a Deployment at any time. To determine if turning off DAG-only deploy functionality is the right choice for your organization, contact [Astronomer support](https://cloud.astronomer.io/support). 
 
-:::caution
+Before you disable DAG-only deploys on a Deployment, ensure the following:
 
-You must trigger an image deploy to your Astro Deployment using `astro deploy` immediately after you disable the DAG-only deploy feature. This will ensure your DAGs are refreshed in your Airflow UI using the new deployment method.
+- You have access to the latest version of your Deployment's Astro project.
+- You can update your Deployment using the Astro CLI. 
+
+:::warning be careful
+
+Carefully read and complete all of the following steps to ensure that your Deployment is not disrupted by disabling this feature. Crucially, you must trigger an image deploy to your Astro Deployment using `astro deploy` immediately after you disable the DAG-only deploy feature. If you don't, your DAGs will be not be refreshed in the Airflow UI until you update your Deployment.
 
 :::
 

--- a/astro/deploy-dags.md
+++ b/astro/deploy-dags.md
@@ -18,7 +18,19 @@ Enabling DAG-only deploys on Astro has a few benefits:
 
 ## Enable DAG-only deploys on a Deployment
 
-Before you enable DAG-only deploys on a Deployment, ensure that you have access to the Deployment's Astro project and can trigger deploys from your current machine with the Astro CLI. You cannot enable the DAG-only deploy feature in the Cloud UI.
+Before you enable DAG-only deploys on a Deployment, ensure the following:
+
+- You have access to the Deployment's Astro project.
+- You can trigger deploys from your current machine with the Astro CLI.
+- Your Deployment does not have [CI/CD enforcement](configure-deployment-resources.md#enforce-cicd-deploys) enabled. You can also verify this using [Astro CLI's inspect](cli/astro-deployment-inspect.md) command.
+
+You cannot enable the DAG-only deploy feature in the Cloud UI.
+
+:::caution 
+
+You must trigger a DAG-based deploy to your Astro Deployment using `astro deploy --dags` immediately after you enable the DAG-only deploy feature. This will ensure your DAGs are refreshed in your Airflow UI using the new deployment method.
+
+:::
 
 1. Open your Deployment's Astro project.
 2. Run the following command to enable the feature on your Deployment:
@@ -52,7 +64,11 @@ astro deploy --dags
 
 If you have Workspace Admin permissions, you can turn off DAG-only deploys for a Deployment at any time if your organization doesn't benefit from faster deploys or prefers a deployment method that is exclusively based on building and deploying your Astro project as a Docker image. To determine if turning off DAG-only deploy functionality is the right choice for your organization, contact [Astronomer support](https://cloud.astronomer.io/support). 
 
-When you turn off DAG-only deploys, your DAGs might not reappear in the Airflow UI until you trigger a deploy. To make sure you can continue to access to your data, trigger an image deploy to Astro immediately after you turn off the DAG-only deploy feature. 
+:::caution
+
+You must trigger an image deploy to your Astro Deployment using `astro deploy` immediately after you disable the DAG-only deploy feature. This will ensure your DAGs are refreshed in your Airflow UI using the new deployment method.
+
+:::
 
 1. Run the following command to turn off DAG-only deploys:
 


### PR DESCRIPTION
This PR adds a CAUTION statement for triggering a deploy to your Astro Deployment to the following sections:

- Enable DAG-only deploy
- Disable DAG-only deploy 

In addition, it also:
- Adds a note in the Enable section that this cannot be done for CI/CD enforced deployments. 
- Adds a note to the CI/CD enforce section to indicate that DAG-only deploys cannot be enabled for CI/CD enforced Deployments.
