### PR TITLE
add required CIDR to the main Prereq section for reducing back-and-forth

### DIFF
--- a/astro/install-aws-hybrid.md
+++ b/astro/install-aws-hybrid.md
@@ -5,7 +5,7 @@ id: install-aws-hybrid
 sidebar_custom_props: { icon: 'img/aws.png' }
 toc_min_heading_level: 2
 toc_max_heading_level: 2
-description: "If you have an existing Amazon Web Services (AWS) instance, use these instructions to complete an Astro installation. This is where you’ll find the prerequisites and the process you’ll need to follow to allow Astronomer support to provision your network resources."
+Use this document to complete the installation of Astro Hybrid in an Amazon Web Services (AWS) account.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -25,32 +25,30 @@ To install Astro, Astronomer will create an Astro cluster in a dedicated AWS acc
 
 For a list of the AWS resources and configurations that Astronomer supports, see [AWS resource reference](resource-reference-aws-hybrid.md). For more information about the shared responsibility model, see [Shared responsibility model](shared-responsibility-model.md).
 
-To complete the setup for the installation, you'll:
+To complete the installation, you'll:
 
-- Create an [Astronomer account](#access-astro).
-- Create a new AWS account with the required [AWS resources](resource-reference-aws-hybrid.md).
-- From the Cloud UI, retrieve the [external ID for your Organization](#retrieve-an-external-id-from-the-cloud-ui).
-- In the new AWS account, create a [cross-account IAM role `astronomer-remote-management`](#create-a-cross-account-role) for Astro using Astronomer provided [CloudFormation template](https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://astro-cross-account-role-template.s3.us-east-2.amazonaws.com/astronomer-remote-management-stack.yaml&stackName=AstroCrossAccountRole).
-- Share [the setup information](#provide-setup-information-to-astronomer) with Astronomer.
+- Create an Astronomer account.
+- Create a new AWS account with the required AWS resources.
+- Create the IAM policies used by Astro. This includes a cross-account IAM role that Astro can assume and [Permissions boundaries for IAM entities](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html).
 
-When you've completed the setup process, Astronomer support will create infrastructure within your AWS account to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks. If you need more than one Astro cluster, contact [Astronomer support](https://cloud.astronomer.io/support).
+Astronomer support will create infrastructure within your AWS account to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks. If you need more than one Astro cluster, contact [Astronomer support](https://cloud.astronomer.io/support).
 
 ## Prerequisites
 
 - A [new AWS account](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/) with the minimum EC2 service quotas. For security reasons, AWS accounts with existing infrastructure aren't supported.
 
-- The following table lists the required [EC2 service quotas](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html).
+    The following table lists the required [EC2 service quotas](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html).
 
-  | QuotaCode  | QuotaName                                                        | Minimum Value  |
-  | -----------| ---------------------------------------------------------------- | ---------------|
-  | L-1216C47A | Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances | 40             |
-  | L-34B43A08 | All Standard (A, C, D, H, I, M, R, T, Z) Spot Instance Requests  | 40             |
+    | QuotaCode  | QuotaName                                                        | Minimum Value  |
+    | -----------| ---------------------------------------------------------------- | ---------------|
+    | L-1216C47A | Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances | 40             |
+    | L-34B43A08 | All Standard (A, C, D, H, I, M, R, T, Z) Spot Instance Requests  | 40             |
 
   These quotas are required to mitigate near term capacity risks and simplify the Astro onboarding experience. Refer to [AWS documentation](https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html) to modify or increase a specific quota.
 
-- A CIDR block with `/20` range is required for the Astro Data Plane. If you do not have any preferred CIDR block, Astro will provision a VPC using a default of `172.20.0.0/20`. This will be used to for 2 public subnets and 2 private subnets. See [AWS resource reference](resource-reference-aws-hybrid.md) for details.
+- A CIDR block with a range of `/20`. If you don't have a preferred CIDR block, Astro will provision a VPC using a default of `172.20.0.0/20`. Astro uses this VPC for 2 public subnets and 2 private subnets. See [AWS resource reference](resource-reference-aws-hybrid.md).
 
-- Admin Access to the [AWS console to create stack](https://console.aws.amazon.com/cloudformation/home) using CloudFormation.
+- Admin access to create a stack using [CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-cli-creating-stack.html).
 
 - The following domains added to your organization's allowlist for any user and CI/CD environments:
     - `https://cloud.astronomer.io/`

--- a/astro/install-aws-hybrid.md
+++ b/astro/install-aws-hybrid.md
@@ -5,7 +5,7 @@ id: install-aws-hybrid
 sidebar_custom_props: { icon: 'img/aws.png' }
 toc_min_heading_level: 2
 toc_max_heading_level: 2
-Use this document to complete the installation of Astro Hybrid in an Amazon Web Services (AWS) account.
+description: 'Use this document to complete the installation of Astro Hybrid in an Amazon Web Services (AWS) account.'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/astro/install-aws-hybrid.md
+++ b/astro/install-aws-hybrid.md
@@ -29,7 +29,7 @@ To complete the installation, you'll:
 
 - Create an Astronomer account.
 - Create a new AWS account with the required AWS resources.
-- Create the IAM policies used by Astro. This includes a cross-account IAM role that Astro can assume and [Permissions boundaries for IAM entities](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html).
+- Create the IAM policies used by Astro. This includes a cross-account IAM role that Astro can assume and [permissions boundaries for IAM entities](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html).
 
 Astronomer support will create infrastructure within your AWS account to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks. If you need more than one Astro cluster, contact [Astronomer support](https://cloud.astronomer.io/support).
 
@@ -48,7 +48,7 @@ Astronomer support will create infrastructure within your AWS account to host th
 
 - A CIDR block with a range of `/20`. If you don't have a preferred CIDR block, Astro will provision a VPC using a default of `172.20.0.0/20`. Astro uses this VPC for 2 public subnets and 2 private subnets. See [AWS resource reference](resource-reference-aws-hybrid.md).
 
-- Admin access to create a stack using [CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-cli-creating-stack.html).
+- Permissions to create a stack using [CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-cli-creating-stack.html).
 
 - The following domains added to your organization's allowlist for any user and CI/CD environments:
     - `https://cloud.astronomer.io/`

--- a/astro/install-azure-hybrid.md
+++ b/astro/install-azure-hybrid.md
@@ -5,7 +5,7 @@ id: install-azure-hybrid
 sidebar_custom_props: { icon: 'img/azure.png' }
 toc_min_heading_level: 2
 toc_max_heading_level: 2
-description: 'Instructions for completing an Astro installation on an existing Microsoft Azure instance. This is where you’ll find the prerequisites and the process you’ll need to follow to allow Astronomer support to provision your network resources.'
+description: 'Use this document to complete the installation of Astro Hybrid in a Microsoft Azure subscription.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -34,7 +34,7 @@ When you've completed the setup process, Astronomer support create infrastructur
 
 ## Prerequisites
 
-- A new Azure subscription. For security reasons, Azure subscriptions with existing infrastructure aren't supported. Also, no [Azure policy](https://learn.microsoft.com/en-us/azure/governance/policy/overview) should be applicable to the [Azure management group](https://docs.microsoft.com/en-us/azure/governance/management-groups/overview) that the subscription is a part of. 
+- A new Azure subscription. For security reasons, Azure subscriptions with existing infrastructure aren't supported. Also, no [Azure policy](https://learn.microsoft.com/en-us/azure/governance/policy/overview) should be applicable to the subscription's [Azure management group](https://docs.microsoft.com/en-us/azure/governance/management-groups/overview).
 
 - [Microsoft Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) or [Azure Az PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps).
 
@@ -48,7 +48,7 @@ When you've completed the setup process, Astronomer support create infrastructur
     az vm list-skus --location centralus --size Standard_D --all --output table | grep -e 'Restrictions\|Standard_D4d_v5'
     ```  
   
-    If the VM types are unavailable, the output returns `Restrictions`. Please contact Microsoft Support to have these VMs enabled.
+    If the VM types are unavailable, the output returns `Restrictions`. Contact Microsoft Support to have these VMs enabled.
   
     ```
     ResourceType     Locations    Name                    Zones    Restrictions
@@ -203,7 +203,7 @@ After you've prepared your environment for data plane activation, provide Astron
 - Optional. Your preferred maximum node count. The default is 20.
 - Optional. Your custom CIDR ranges for Astronomer service connections. The default is `172.20.0.0/19`.
 
-See [Azure resource reference](resource-reference-azure-hybrid.md) for default and supported cluster configurations.
+See [Azure resource reference](resource-reference-azure-hybrid.md) for all supported cluster configurations.
 
 ## Astronomer support creates the cluster
 

--- a/astro/install-azure-hybrid.md
+++ b/astro/install-azure-hybrid.md
@@ -5,7 +5,7 @@ id: install-azure-hybrid
 sidebar_custom_props: { icon: 'img/azure.png' }
 toc_min_heading_level: 2
 toc_max_heading_level: 2
-description: 'Use this document to complete the installation of Astro Hybrid in a Microsoft Azure subscription.
+description: 'Use this document to complete the installation of Astro Hybrid in a Microsoft Azure subscription.'
 ---
 
 import Tabs from '@theme/Tabs';
@@ -23,26 +23,31 @@ To install Astro Hybrid on Azure, Astronomer will create an Astro cluster in a d
 
 To complete the installation, you'll:
 
-- Create an [Astronomer account](#access-astro).
-- Create a new Azure subscription with required [Azure resources](resource-reference-azure-hybrid.md).
-- Add the Astronomer service principal `astro-remote-mgmt` to your organization's Azure Active Directory (Azure AD).
-- Assign an `Owner` role to Astronomer's service principal in the new subscription.
-- Enable end-to-end encryption using `EncryptionAtHost` feature in the new subscription.
-- Share [the setup information](#provide-setup-information-to-astronomer) with Astronomer.
+- Create an Astronomer account.
+- Create a new Azure subscription with the required Azure resources.
+- Add the IAM service principal to Azure AD that'll be used by Astro.
 
-When you've completed the setup process, Astronomer support create infrastructure within your Azure subscription to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks. If you need more than one Astro cluster, contact [Astronomer support](https://cloud.astronomer.io/support).
+Astronomer support will create infrastructure within your AWS account to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks. If you need more than one Astro cluster, contact [Astronomer support](https://cloud.astronomer.io/support).
 
 ## Prerequisites
 
-- A new Azure subscription. For security reasons, Azure subscriptions with existing infrastructure aren't supported. Also, no [Azure policy](https://learn.microsoft.com/en-us/azure/governance/policy/overview) should be applicable to the subscription's [Azure management group](https://docs.microsoft.com/en-us/azure/governance/management-groups/overview).
+- A new [Azure subscription](https://learn.microsoft.com/en-us/dynamics-nav/how-to--sign-up-for-a-microsoft-azure-subscription). For security reasons, Azure subscriptions with existing infrastructure aren't supported. Also, no [Azure policy](https://learn.microsoft.com/en-us/azure/governance/policy/overview) should be applicable to the subscription's [Azure management group](https://docs.microsoft.com/en-us/azure/governance/management-groups/overview).
+
+- An Azure AD user with the following role assignments:
+
+    - `Application Administrator`. See [Understand roles in Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/roles/concept-understand-roles).
+
+    - `Owner` with permission to create and manage subscription resources of all types. See [Azure built-in roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles).
+
+    This Azure AD user is required for data plane activation. You can remove the user or modify their role assignments after the cluster is created.
 
 - [Microsoft Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) or [Azure Az PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps).
 
-- A CIDR block with `/19` range is required for the Astro Data Plane. If you do not have any preferred CIDR block, Astro will provision a VPC using a default of `172.20.0.0/19`. This will be used for 4 subnets for database, pods, nodes, and private endpoints. See [Azure resource reference](resource-reference-azure-hybrid.md) for details.
+- A CIDR block with a range of `/19`. If you don't have any preferred CIDR block, Astro will provision a VPC using a default of `172.20.0.0/19`. Astro uses this VPC for four subnets, one each for database, pods, nodes, and private endpoints. See [Azure resource reference](resource-reference-azure-hybrid.md) for details.
 
-- A minimum quota of 48 Standard Ddv5-series vCPUs in the deployment region. You can use Dv5-series vCPUs, but you'll need 96 total vCPUs composed of 48 Ddv5-series vCPUs and 48 Dv5-series vCPUs. To adjust your quota limits up or down, see [Increase VM-family vCPU quotas](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/per-vm-quota-requests).
+- A minimum quota of 48 Standard Ddv5-series vCPUs in the selected region. You can use Dv5-series vCPUs, but you'll need 96 total vCPUs composed of 48 Ddv5-series vCPUs and 48 Dv5-series vCPUs. To adjust your quota limits up or down, see [Increase VM-family vCPU quotas](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/per-vm-quota-requests).
 
-- Confirmation that the VM types are available in all Availability Zones in the selected region. For example, you can run the following Azure Az PowerShell command to confirm that the Standard_D4d_v5 VMs (the default for Astro) are available in the Central US region: 
+    Confirm that the VM types are available in all Availability Zones in the selected region. For example, you can run the following Azure Az PowerShell command to confirm that the Standard_D4d_v5 VMs (the default for Astro) are available in the `CentralUS` region: 
 
     ```  
     az vm list-skus --location centralus --size Standard_D --all --output table | grep -e 'Restrictions\|Standard_D4d_v5'
@@ -56,6 +61,7 @@ When you've completed the setup process, Astronomer support create infrastructur
     ```
 
 - A subscription to the [Astro status page](https://status.astronomer.io). This ensures that you're alerted when an incident occurs or when scheduled maintenance is planned.
+
 - The following domains added to your organization's allowlist for any user and CI/CD environments:
     - `https://cloud.astronomer.io/`
     - `https://api.astronomer.io/`

--- a/astro/install-azure-hybrid.md
+++ b/astro/install-azure-hybrid.md
@@ -21,7 +21,7 @@ To get started on Astro Hosted, see [Start a trial](trial.md).
 
 To install Astro Hybrid on Azure, Astronomer will create an Astro cluster in a dedicated Azure account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
 
-To complete the setup for the installation, you'll:
+To complete the installation, you'll:
 
 - Create an [Astronomer account](#access-astro).
 - Create a new Azure subscription with required [Azure resources](resource-reference-azure-hybrid.md).

--- a/astro/install-azure-hybrid.md
+++ b/astro/install-azure-hybrid.md
@@ -5,12 +5,8 @@ id: install-azure-hybrid
 sidebar_custom_props: { icon: 'img/azure.png' }
 toc_min_heading_level: 2
 toc_max_heading_level: 2
+description: 'Instructions for completing an Astro installation on an existing Microsoft Azure instance. This is where you’ll find the prerequisites and the process you’ll need to follow to allow Astronomer support to provision your network resources.'
 ---
-
-<head>
-  <meta name="description" content="Instructions for completing an Astro installation on an existing Microsoft Azure instance. This is where you’ll find the prerequisites and the process you’ll need to follow to allow Astronomer support to provision your network resources." />
-  <meta name="og:description" content="Instructions for completing an Astro installation on an existing Microsoft Azure instance. This is where you’ll find the prerequisites and the process you’ll need to follow to allow Astronomer support to provision your network resources." />
-</head>
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -25,35 +21,34 @@ To get started on Astro Hosted, see [Start a trial](trial.md).
 
 To install Astro Hybrid on Azure, Astronomer will create an Astro cluster in a dedicated Azure account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
 
-To complete the installation process, you'll:
+To complete the setup for the installation, you'll:
 
-- Add the Astronomer Service Principal to your Azure Active Directory (Azure AD) instance.
-- Assign the Astronomer Service Principal an Owner role to your subscription.
-- Register Microsoft Azure features.
+- Create an [Astronomer account](#access-astro).
+- Create a new Azure subscription with required [Azure resources](resource-reference-azure-hybrid.md).
+- Add the Astronomer service principal `astro-remote-mgmt` to your organization's Azure Active Directory (Azure AD).
+- Assign an `Owner` role to Astronomer's service principal in the new subscription.
+- Enable end-to-end encryption using `EncryptionAtHost` feature in the new subscription.
+- Share [the setup information](#provide-setup-information-to-astronomer) with Astronomer.
 
-When you've completed the installation process, Astronomer support creates a cluster within your Azure subscription to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks.
-
-For more information about managing Azure subscriptions with the Azure CLI, see [How to manage Azure subscriptions with the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/manage-azure-subscriptions-azure-cli).
+When you've completed the setup process, Astronomer support create infrastructure within your Azure subscription to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks. If you need more than one Astro cluster, contact [Astronomer support](https://cloud.astronomer.io/support).
 
 ## Prerequisites
 
-- A clean Azure subscription. For security reasons, Azure subscriptions with existing tooling running aren't supported. Also, the subscription must be included in an Azure management group that doesn't apply Azure policies. See [What are Azure management groups](https://docs.microsoft.com/en-us/azure/governance/management-groups/overview).
-- An Azure AD user with the following role assignments:
+- A new Azure subscription. For security reasons, Azure subscriptions with existing infrastructure aren't supported. Also, no [Azure policy](https://learn.microsoft.com/en-us/azure/governance/policy/overview) should be applicable to the [Azure management group](https://docs.microsoft.com/en-us/azure/governance/management-groups/overview) that the subscription is a part of. 
 
-    - `Application Administrator`. See [Understand roles in Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/roles/concept-understand-roles).
-    - `Owner` with permission to create and manage subscription resources of all types. See [Azure built-in roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles).
+- [Microsoft Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) or [Azure Az PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps).
 
-    This Azure AD user is required for data plane activation. You can remove the user or modify their role assignments after the cluster is created.
+- A CIDR block with `/19` range is required for the Astro Data Plane. If you do not have any preferred CIDR block, Astro will provision a VPC using a default of `172.20.0.0/19`. This will be used for 4 subnets for database, pods, nodes, and private endpoints. See [Azure resource reference](resource-reference-azure-hybrid.md) for details.
 
-- Microsoft Azure CLI or Azure Az PowerShell module.  See [How to install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) and [Install the Azure Az PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps).
 - A minimum quota of 48 Standard Ddv5-series vCPUs in the deployment region. You can use Dv5-series vCPUs, but you'll need 96 total vCPUs composed of 48 Ddv5-series vCPUs and 48 Dv5-series vCPUs. To adjust your quota limits up or down, see [Increase VM-family vCPU quotas](https://docs.microsoft.com/en-us/azure/azure-portal/supportability/per-vm-quota-requests).
-- Confirmation that the VM types are available in all Availability Zones in the selected region. For example, you run the following Azure Az PowerShell command to confirm that the Standard_D4d_v5 VMs (the default for Astro) are available in the Central US region: 
+
+- Confirmation that the VM types are available in all Availability Zones in the selected region. For example, you can run the following Azure Az PowerShell command to confirm that the Standard_D4d_v5 VMs (the default for Astro) are available in the Central US region: 
 
     ```  
     az vm list-skus --location centralus --size Standard_D --all --output table | grep -e 'Restrictions\|Standard_D4d_v5'
     ```  
   
-    If the VM types are unavailable, the output returns `Restrictions`. Contact Microsoft Support and ask to have the VMs enabled.
+    If the VM types are unavailable, the output returns `Restrictions`. Please contact Microsoft Support to have these VMs enabled.
   
     ```
     ResourceType     Locations    Name                    Zones    Restrictions
@@ -63,15 +58,13 @@ For more information about managing Azure subscriptions with the Azure CLI, see 
 - A subscription to the [Astro status page](https://status.astronomer.io). This ensures that you're alerted when an incident occurs or when scheduled maintenance is planned.
 - The following domains added to your organization's allowlist for any user and CI/CD environments:
     - `https://cloud.astronomer.io/`
-    - `https://astro-<your-org>.datakin.com/`
-    - `https://<your-org>.astronomer.run/`
     - `https://api.astronomer.io/`
     - `https://images.astronomer.cloud/`
     - `https://auth.astronomer.io/`
     - `https://updates.astronomer.io/`
     - `https://install.astronomer.io/`
-
-For more information about the resources required to run Astro on Azure, see [Azure Resource Reference](resource-reference-azure-hybrid.md).
+    - `https://<your-org>.astronomer.run/`
+    - `https://astro-<your-org>.datakin.com/`
 
 ### VNet peering prerequisites (Optional)
 
@@ -204,24 +197,21 @@ After you've prepared your environment for data plane activation, provide Astron
 
 - Your preferred Astro cluster name.
 - Your Azure TenantID and SubscriptionID.
+- Your preferred region. The default is `centralus`.
 - Optional. Your preferred node instance type. The default is Standard_D4d_v5.
 - Optional. Your preferred Postgres Flexible Server instance type. The default is Standard_D4ds_v4.
-- Optional. Your preferred maximum node count.
+- Optional. Your preferred maximum node count. The default is 20.
 - Optional. Your custom CIDR ranges for Astronomer service connections. The default is `172.20.0.0/19`.
 
-If you don't specify a preferred configuration for your organization, Astronomer support creates a cluster in `CentralUS` with the default configurations for Astro on Azure. See [Azure resource reference](resource-reference-azure-hybrid.md).
+See [Azure resource reference](resource-reference-azure-hybrid.md) for default and supported cluster configurations.
 
 ## Astronomer support creates the cluster
 
-After you provide Astronomer support with the setup information for your organization, Astronomer support creates your first cluster on Azure.
-
-Wait for confirmation from Astronomer support that the cluster has been created before creating a Deployment.
+After you provide Astronomer support with the setup information for your cluster, Astronomer support creates the cluster on Azure. Wait for confirmation from Astronomer support that the cluster has been created before creating a Deployment.
 
 ## Create a Deployment and confirm the install
 
-When Astronomer support confirms that your Astro cluster has been created, you can create a Deployment and start deploying DAGs. See [Create a Deployment](create-deployment.md). 
-
-To confirm a successful installation, in the Cloud UI select a Workspace and on the **Deployments** page click **Deployment**. The Astro cluster created by Astronomer support appears as an option in the **Cluster** list.
+When Astronomer support confirms that your Astro cluster has been created, you can confirm it in the [Cloud UI](https://cloud.astronomer.io) by clicking on the Astronomer icon in the top left corner, then click on **Clusters** to see your cluster. You can then [create a Deployment](create-first-DAG#step-1-create-a-deployment) and start to [develop and deploy your DAGs](create-first-DAG#step-2-create-an-astro-project).
 
 ## Next steps
 

--- a/astro/install-gcp-hybrid.md
+++ b/astro/install-gcp-hybrid.md
@@ -25,7 +25,7 @@ To complete the installation, you'll:
 
 - Create an Astronomer account.
 - Create a new Google Cloud project.
-- Enable Google Cloud APIs and add IAM service account that'll be used by Astro.
+- Enable Google Cloud APIs and add an IAM service account that will be used by Astro.
 
 Astronomer support will create infrastructure within your Google Cloud project to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks. If you need more than one Astro cluster, contact [Astronomer support](https://cloud.astronomer.io/support).
 

--- a/astro/install-gcp-hybrid.md
+++ b/astro/install-gcp-hybrid.md
@@ -2,7 +2,7 @@
 sidebar_label: 'GCP'
 title: 'Install Astro on GCP'
 id: install-gcp-hybrid
-description: Get started on Astro by creating your first Astro cluster on Google Cloud Platform (GCP).
+description: 'Use this document to complete the installation of Astro Hybrid in Google Cloud Project.'
 sidebar_custom_props: { icon: 'img/gcp.png' }
 toc_min_heading_level: 2
 toc_max_heading_level: 2
@@ -21,24 +21,23 @@ To get started on Astro Hosted, see [Start a trial](trial.md).
 
 To install Astro Hybrid on GCP, Astronomer support creates a cluster in a dedicated GCP account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
 
-To complete the setup for the installation, you'll:
+To complete the installation, you'll:
 
-- Create an [Astronomer account](#access-astro).
-- Create a new [Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
-- Activate your Astro data plane by enabling Google Cloud APIs and adding service accounts to your project's IAM.
-- Share [the setup information](#provide-setup-information-to-astronomer) with Astronomer.
+- Create an Astronomer account.
+- Create a new Google Cloud project.
+- Enable Google Cloud APIs and add IAM service account that'll be used by Astro.
 
-When you've completed the setup process, Astronomer will create infrastructure within your Google Cloud project to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks. If you need more than one Astro cluster, contact [Astronomer support](https://cloud.astronomer.io/support).
+Astronomer support will create infrastructure within your Google Cloud project to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks. If you need more than one Astro cluster, contact [Astronomer support](https://cloud.astronomer.io/support).
 
 ## Prerequisites
 
-- A [Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects) with billing enabled. For security reasons, the install process is not currently supported on a Google Cloud project that has other tooling running in it.
+- A [Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects) with billing enabled. For security reasons, Google Cloud project with existing infrastructure aren't supported.
 
 - A user with [Owner permissions](https://cloud.google.com/iam/docs/understanding-roles) in your project.
 
 - [Google Cloud Shell](https://cloud.google.com/shell).
 
-- CIDR blocks of ranges `/19`, `/20`, `/22`, and `/22` are required for the Astro Data Plane. If you do not have any preferred CIDR block, Astro will provision VPCs using a [default CIDR ranges](#vpc-peering-prerequisites-optional). See [GCP resource reference](resource-reference-azure-hybrid.md) for details.
+- CIDR blocks of with ranges `/19`, `/20`, `/22`, and `/22` are required for the Astro Data Plane. If you don't have any preferred CIDR block, Astro will provision VPCs using a [default CIDR ranges](#vpc-peering-prerequisites-optional). See [GCP resource reference](resource-reference-azure-hybrid.md) for details.
 
 - A minimum [CPU](https://cloud.google.com/compute/quotas#cpu_quota) quota of 48. To adjust your project's quota limits, see [Managing your quota using the Cloud console](https://cloud.google.com/docs/quota#managing_your_quota_console). To view the quota limits for a project, run `gcloud services enable compute.googleapis.com` in the Google Cloud CLI.
 
@@ -48,15 +47,14 @@ When you've completed the setup process, Astronomer will create infrastructure w
 
 - The following domains added to your organization's allowlist for any user and CI/CD environments:
     - `https://cloud.astronomer.io/`
-    - `https://astro-<your-org>.datakin.com/`
-    - `https://<your-org>.astronomer.run/`
     - `https://api.astronomer.io/`
     - `https://images.astronomer.cloud/`
     - `https://auth.astronomer.io/`
     - `https://updates.astronomer.io/`
     - `https://install.astronomer.io/`
+    - `https://astro-<your-org>.datakin.com/`
+    - `https://<your-org>.astronomer.run/`
 
-For more information about the resources required to run Astro on GCP, see [GCP Resource Reference](resource-reference-gcp-hybrid.md).
 
 ### VPC peering prerequisites (optional)
 

--- a/astro/install-gcp-hybrid.md
+++ b/astro/install-gcp-hybrid.md
@@ -19,7 +19,7 @@ To get started on Astro Hosted, see [Start a trial](trial.md).
 
 :::
 
-To install Astro Hybrid on GCP, Astronomer support creates a Astro cluster in a dedicated GCP account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
+To install Astro Hybrid on GCP, Astronomer support creates a cluster in a dedicated GCP account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
 
 To complete the setup for the installation, you'll:
 
@@ -111,7 +111,7 @@ The script uses your owner role to complete following actions:
     - `servicenetworking.googleapis.com`
     - `dns.googleapis.com`
     - `servicedirectory.googleapis.com`
-- Create a service account `astronomer@astro-remote-mgmt.iam.gserviceaccount.com` that Astro uses to access the data plane.
+- Create a service account called `astronomer@astro-remote-mgmt.iam.gserviceaccount.com` that Astro uses to access the data plane.
 
 
 ## Provide setup information to Astronomer

--- a/astro/install-gcp-hybrid.md
+++ b/astro/install-gcp-hybrid.md
@@ -19,26 +19,33 @@ To get started on Astro Hosted, see [Start a trial](trial.md).
 
 :::
 
-To install Astro Hybrid on GCP, Astronomer will create an Astro cluster in a dedicated GCP account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
+To install Astro Hybrid on GCP, Astronomer support creates a Astro cluster in a dedicated GCP account that's hosted and owned by your organization. This ensures that all data remains within your network and allows your organization to manage infrastructure billing.
 
-To complete the installation process, you'll:
+To complete the setup for the installation, you'll:
 
-- Create an account on Astro.
+- Create an [Astronomer account](#access-astro).
+- Create a new [Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
 - Activate your Astro data plane by enabling Google Cloud APIs and adding service accounts to your project's IAM.
-- Share information about your Google Cloud project with Astronomer.
+- Share [the setup information](#provide-setup-information-to-astronomer) with Astronomer.
 
-When you've completed the installation process, Astronomer will create a cluster within your Google Cloud project to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks.
-
-For more information about managing Google Cloud projects, see [GCP documentation](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
+When you've completed the setup process, Astronomer will create infrastructure within your Google Cloud project to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks. If you need more than one Astro cluster, contact [Astronomer support](https://cloud.astronomer.io/support).
 
 ## Prerequisites
 
 - A [Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects) with billing enabled. For security reasons, the install process is not currently supported on a Google Cloud project that has other tooling running in it.
+
 - A user with [Owner permissions](https://cloud.google.com/iam/docs/understanding-roles) in your project.
+
 - [Google Cloud Shell](https://cloud.google.com/shell).
+
+- CIDR blocks of ranges `/19`, `/20`, `/22`, and `/22` are required for the Astro Data Plane. If you do not have any preferred CIDR block, Astro will provision VPCs using a [default CIDR ranges](#vpc-peering-prerequisites-optional). See [GCP resource reference](resource-reference-azure-hybrid.md) for details.
+
 - A minimum [CPU](https://cloud.google.com/compute/quotas#cpu_quota) quota of 48. To adjust your project's quota limits, see [Managing your quota using the Cloud console](https://cloud.google.com/docs/quota#managing_your_quota_console). To view the quota limits for a project, run `gcloud services enable compute.googleapis.com` in the Google Cloud CLI.
+
 - A minimum [N2_CPU](https://cloud.google.com/compute/quotas#cpu_quota) quota of 24. To adjust your project's quota limits, see [Managing your quota using the Cloud console](https://cloud.google.com/docs/quota#managing_your_quota_console). To view the quota limits for a project, run `gcloud services enable compute.googleapis.com` in the Google Cloud CLI.
+
 - A subscription to the [Astro Status Page](https://status.astronomer.io). This ensures that you're alerted when an incident occurs or scheduled maintenance is required.
+
 - The following domains added to your organization's allowlist for any user and CI/CD environments:
     - `https://cloud.astronomer.io/`
     - `https://astro-<your-org>.datakin.com/`
@@ -90,7 +97,6 @@ Click the following button to open Google Cloud Shell and run a script to activa
 
 The script uses your owner role to complete following actions:
 
-- Create a service account role that Astro uses to access the data plane.
 - Enable the following required services for running the data plane:
 
     - `storage.googleapis.com`
@@ -105,6 +111,8 @@ The script uses your owner role to complete following actions:
     - `servicenetworking.googleapis.com`
     - `dns.googleapis.com`
     - `servicedirectory.googleapis.com`
+- Create a service account `astronomer@astro-remote-mgmt.iam.gserviceaccount.com` that Astro uses to access the data plane.
+
 
 ## Provide setup information to Astronomer
 


### PR DESCRIPTION
This PR handles these changes:
- Bring the required CIDR range to front and center in the Pre-req section to reduce back and forth.
- tries to make the 3 cloud instructions similar in the Overview section