### PR TITLE
Tiny PR: update default providers list

### DIFF
--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -74,22 +74,22 @@ Because this DAG is essential to Astro's managed service, you are not charged fo
 
 The latest version of the Astro Runtime image has the following open source provider packages pre-installed. Providers marked with an asterisk (`*`) are installed only in Astro Runtime and not installed by default on Apache Airflow.
 
-- Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/) (`*`)
-- Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/) (`*`)
-- Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/) (`*`)
+- Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/)`*`
+- Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/)`*`
+- Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/)`*`
 - Celery [`apache-airflow-providers-celery`](https://pypi.org/project/apache-airflow-providers-celery/)
 - Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
 - Common SQL [`apache-airflow-providers-common-sql`](https://pypi.org/project/apache-airflow-providers-common-sql/)
-- Datadog [`apache-airflow-providers-datadog](https://pypi.org/project/apache-airflow-providers-datadog/) (`*`)
-- Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/) (`*`)
+- Datadog [`apache-airflow-providers-datadog](https://pypi.org/project/apache-airflow-providers-datadog/)`*`
+- Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/)`*`
 - FTP [`apache-airflow-providers-ftp`](https://pypi.org/project/apache-airflow-providers-ftp/) 
-- Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/) (`*`)
+- Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/)`*`
 - HTTP [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-http/)
 - IMAP [`apache-airflow-providers-imap`](https://pypi.org/project/apache-airflow-providers-imap/)
-- Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/) (`*`)
-- [OpenLineage](https://pypi.org/project/openlineage-airflow/) (this package installs an Airflow plugin) (`*`)
-- PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/) (`*`)
-- Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/) (`*`)
+- Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/)`*`
+- [OpenLineage](https://pypi.org/project/openlineage-airflow/) (this package installs an Airflow plugin)`*`
+- PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/)`*`
+- Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/)`*`
 - SQLite [`apache-airflow-providers-sqlite`](https://pypi.org/project/apache-airflow-providers-sqlite/)
 
 ### Provider package versioning

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -74,24 +74,23 @@ Because this DAG is essential to Astro's managed service, you are not charged fo
 
 The latest version of the Astro Runtime image has the following open source provider packages pre-installed. Providers marked with an asterisk (`*`) are installed only in Astro Runtime and not installed by default on Apache Airflow.
 
-- Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/)
-- Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/)
-- Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/)
-- Celery [`apache-airflow-providers-celery`](https://pypi.org/project/apache-airflow-providers-celery/) (pre-installed OSS)
-- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/) (pre-installed OSS)
-- Common SQL [`apache-airflow-providers-common-sql`](https://pypi.org/project/apache-airflow-providers-common-sql/) (pre-installed OSS)
-- Datadog [`apache-airflow-providers-datadog](https://pypi.org/project/apache-airflow-providers-datadog/)
-- Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/)
-- FTP [`apache-airflow-providers-ftp`](https://pypi.org/project/apache-airflow-providers-ftp/) (pre-installed OSS)
-- Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/)
-- HTTP [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-http/) (pre-installed OSS)
-- IMAP [`apache-airflow-providers-imap`](https://pypi.org/project/apache-airflow-providers-imap/) (pre-installed OSS)
-- Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/)
-- PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/)
-- Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/)
-- SQLite [`apache-airflow-providers-sqlite`](https://pypi.org/project/apache-airflow-providers-sqlite/) (pre-installed OSS)
-
-Additionally, the Astro Runtime image contains a plugin to interact with [OpenLineage](https://pypi.org/project/openlineage-airflow/). 
+- Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/) (`*`)
+- Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/) (`*`)
+- Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/) (`*`)
+- Celery [`apache-airflow-providers-celery`](https://pypi.org/project/apache-airflow-providers-celery/)
+- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
+- Common SQL [`apache-airflow-providers-common-sql`](https://pypi.org/project/apache-airflow-providers-common-sql/)
+- Datadog [`apache-airflow-providers-datadog](https://pypi.org/project/apache-airflow-providers-datadog/) (`*`)
+- Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/) (`*`)
+- FTP [`apache-airflow-providers-ftp`](https://pypi.org/project/apache-airflow-providers-ftp/) 
+- Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/) (`*`)
+- HTTP [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-http/)
+- IMAP [`apache-airflow-providers-imap`](https://pypi.org/project/apache-airflow-providers-imap/)
+- Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/) (`*`)
+- [OpenLineage](https://pypi.org/project/openlineage-airflow/) (this package installs an Airflow plugin) (`*`)
+- PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/) (`*`)
+- Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/) (`*`)
+- SQLite [`apache-airflow-providers-sqlite`](https://pypi.org/project/apache-airflow-providers-sqlite/)
 
 ### Provider package versioning
 

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -72,24 +72,26 @@ Because this DAG is essential to Astro's managed service, you are not charged fo
 
 ## Provider packages
 
-The latest version of the Astro Runtime image has the following open source provider packages pre-installed:
+The latest version of the Astro Runtime image has the following open source provider packages pre-installed. Providers marked with (pre-installed OSS) are pre-installed in open-source Airflow.
 
 - Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/)
 - Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/)
 - Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/)
-- Celery [`apache-airflow-providers-celery`](https://pypi.org/project/apache-airflow-providers-celery/)
-- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
-- Common SQL [`apache-airflow-providers-common-sql`](https://pypi.org/project/apache-airflow-providers-common-sql/)
+- Celery [`apache-airflow-providers-celery`](https://pypi.org/project/apache-airflow-providers-celery/) (pre-installed OSS)
+- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/) (pre-installed OSS)
+- Common SQL [`apache-airflow-providers-common-sql`](https://pypi.org/project/apache-airflow-providers-common-sql/) (pre-installed OSS)
 - Datadog [`apache-airflow-providers-datadog](https://pypi.org/project/apache-airflow-providers-datadog/)
 - Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/)
-- FTP [`apache-airflow-providers-ftp`](https://pypi.org/project/apache-airflow-providers-ftp/)
+- FTP [`apache-airflow-providers-ftp`](https://pypi.org/project/apache-airflow-providers-ftp/) (pre-installed OSS)
 - Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/)
-- HTTP [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-http/)
-- IMAP [`apache-airflow-providers-imap`](https://pypi.org/project/apache-airflow-providers-imap/)
+- HTTP [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-http/) (pre-installed OSS)
+- IMAP [`apache-airflow-providers-imap`](https://pypi.org/project/apache-airflow-providers-imap/) (pre-installed OSS)
 - Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/)
 - PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/)
 - Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/)
-- SQLite [`apache-airflow-providers-sqlite`](https://pypi.org/project/apache-airflow-providers-sqlite/)
+- SQLite [`apache-airflow-providers-sqlite`](https://pypi.org/project/apache-airflow-providers-sqlite/) (pre-installed OSS)
+
+Additionally, the Astro Runtime image contains a plugin to interact with [OpenLineage](https://pypi.org/project/openlineage-airflow/). 
 
 ### Provider package versioning
 

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -72,7 +72,7 @@ Because this DAG is essential to Astro's managed service, you are not charged fo
 
 ## Provider packages
 
-The latest version of the Astro Runtime image has the following open source provider packages pre-installed. Providers marked with (pre-installed OSS) are pre-installed in open-source Airflow.
+The latest version of the Astro Runtime image has the following open source provider packages pre-installed. Providers marked with an asterisk (`*`) are installed only in Astro Runtime and not installed by default on Apache Airflow.
 
 - Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/)
 - Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/)

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -72,9 +72,9 @@ Because this DAG is essential to Astro's managed service, you are not charged fo
 
 ## Provider packages
 
-The latest version of the Astro Runtime image has the following open source provider packages pre-installed. Providers marked with an asterisk (`*`) are installed only in Astro Runtime and not installed by default on Apache Airflow.
+The latest version of the Astro Runtime image has the following open source provider packages pre-installed. Providers marked with an asterisk (*) are installed only in Astro Runtime and not installed by default on Apache Airflow.
 
-- Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/) `*`
+- Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/)*
 - Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/) `*`
 - Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/) `*`
 - Celery [`apache-airflow-providers-celery`](https://pypi.org/project/apache-airflow-providers-celery/)

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -75,7 +75,7 @@ Because this DAG is essential to Astro's managed service, you are not charged fo
 The latest version of the Astro Runtime image has the following open source provider packages pre-installed. Providers marked with an asterisk (*) are installed only in Astro Runtime and not installed by default on Apache Airflow.
 
 - Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/)*
-- Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/) *
+- Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/)*
 - Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/) *
 - Celery [`apache-airflow-providers-celery`](https://pypi.org/project/apache-airflow-providers-celery/)
 - Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -87,7 +87,7 @@ The latest version of the Astro Runtime image has the following open source prov
 - HTTP [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-http/)
 - IMAP [`apache-airflow-providers-imap`](https://pypi.org/project/apache-airflow-providers-imap/)
 - Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/) `*`
-- [OpenLineage](https://pypi.org/project/openlineage-airflow/) (this package installs an Airflow plugin) `*`
+- OpenLineage [`openlineage-airflow`](https://pypi.org/project/openlineage-airflow/) (this package installs an Airflow plugin) `*`
 - PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/) `*`
 - Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/) `*`
 - SQLite [`apache-airflow-providers-sqlite`](https://pypi.org/project/apache-airflow-providers-sqlite/)

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -72,21 +72,24 @@ Because this DAG is essential to Astro's managed service, you are not charged fo
 
 ## Provider packages
 
-All Astro Runtime images have the following open source provider packages pre-installed:
+The latest version of the Astro Runtime image has the following open source provider packages pre-installed:
 
 - Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/)
 - Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/)
 - Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/)
-- Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/)
 - Celery [`apache-airflow-providers-celery`](https://pypi.org/project/apache-airflow-providers-celery/)
+- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
+- Common SQL [`apache-airflow-providers-common-sql`](https://pypi.org/project/apache-airflow-providers-common-sql/)
+- Datadog [`apache-airflow-providers-datadog](https://pypi.org/project/apache-airflow-providers-datadog/)
+- Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/)
+- FTP [`apache-airflow-providers-ftp`](https://pypi.org/project/apache-airflow-providers-ftp/)
 - Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/)
 - HTTP [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-http/)
-- Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
+- IMAP [`apache-airflow-providers-imap`](https://pypi.org/project/apache-airflow-providers-imap/)
+- Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/)
 - PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/)
 - Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/)
-- Snowflake [`apache-airflow-providers-snowflake`](https://pypi.org/project/apache-airflow-providers-snowflake/)
-- OpenLineage with Airflow [`openlineage-airflow`](https://pypi.org/project/openlineage-airflow/)
-- Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/)
+- SQLite [`apache-airflow-providers-sqlite`](https://pypi.org/project/apache-airflow-providers-sqlite/)
 
 ### Provider package versioning
 

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -87,9 +87,9 @@ The latest version of the Astro Runtime image has the following open source prov
 - HTTP [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-http/)
 - IMAP [`apache-airflow-providers-imap`](https://pypi.org/project/apache-airflow-providers-imap/)
 - Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/)*
-- OpenLineage [`openlineage-airflow`](https://pypi.org/project/openlineage-airflow/) (this package installs an Airflow plugin)*
+- OpenLineage [`openlineage-airflow`](https://pypi.org/project/openlineage-airflow/) (Installs an Airflow plugin)*
 - PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/)*
-- Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/) *
+- Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/)*
 - SQLite [`apache-airflow-providers-sqlite`](https://pypi.org/project/apache-airflow-providers-sqlite/)
 
 ### Provider package versioning

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -75,21 +75,21 @@ Because this DAG is essential to Astro's managed service, you are not charged fo
 The latest version of the Astro Runtime image has the following open source provider packages pre-installed. Providers marked with an asterisk (*) are installed only in Astro Runtime and not installed by default on Apache Airflow.
 
 - Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/)*
-- Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/) `*`
-- Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/) `*`
+- Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/) *
+- Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/) *
 - Celery [`apache-airflow-providers-celery`](https://pypi.org/project/apache-airflow-providers-celery/)
 - Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
 - Common SQL [`apache-airflow-providers-common-sql`](https://pypi.org/project/apache-airflow-providers-common-sql/)
-- Datadog [`apache-airflow-providers-datadog](https://pypi.org/project/apache-airflow-providers-datadog/) `*`
-- Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/) `*`
+- Datadog [`apache-airflow-providers-datadog](https://pypi.org/project/apache-airflow-providers-datadog/) *
+- Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/) *
 - FTP [`apache-airflow-providers-ftp`](https://pypi.org/project/apache-airflow-providers-ftp/) 
-- Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/) `*`
+- Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/) *
 - HTTP [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-http/)
 - IMAP [`apache-airflow-providers-imap`](https://pypi.org/project/apache-airflow-providers-imap/)
-- Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/) `*`
-- OpenLineage [`openlineage-airflow`](https://pypi.org/project/openlineage-airflow/) (this package installs an Airflow plugin) `*`
-- PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/) `*`
-- Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/) `*`
+- Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/) *
+- OpenLineage [`openlineage-airflow`](https://pypi.org/project/openlineage-airflow/) (this package installs an Airflow plugin) *
+- PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/) *
+- Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/) *
 - SQLite [`apache-airflow-providers-sqlite`](https://pypi.org/project/apache-airflow-providers-sqlite/)
 
 ### Provider package versioning

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -76,19 +76,19 @@ The latest version of the Astro Runtime image has the following open source prov
 
 - Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/)*
 - Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/)*
-- Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/) *
+- Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/)*
 - Celery [`apache-airflow-providers-celery`](https://pypi.org/project/apache-airflow-providers-celery/)
 - Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
 - Common SQL [`apache-airflow-providers-common-sql`](https://pypi.org/project/apache-airflow-providers-common-sql/)
-- Datadog [`apache-airflow-providers-datadog](https://pypi.org/project/apache-airflow-providers-datadog/) *
-- Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/) *
+- Datadog [`apache-airflow-providers-datadog](https://pypi.org/project/apache-airflow-providers-datadog/)*
+- Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/)*
 - FTP [`apache-airflow-providers-ftp`](https://pypi.org/project/apache-airflow-providers-ftp/) 
-- Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/) *
+- Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/)*
 - HTTP [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-http/)
 - IMAP [`apache-airflow-providers-imap`](https://pypi.org/project/apache-airflow-providers-imap/)
-- Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/) *
-- OpenLineage [`openlineage-airflow`](https://pypi.org/project/openlineage-airflow/) (this package installs an Airflow plugin) *
-- PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/) *
+- Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/)*
+- OpenLineage [`openlineage-airflow`](https://pypi.org/project/openlineage-airflow/) (this package installs an Airflow plugin)*
+- PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/)*
 - Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/) *
 - SQLite [`apache-airflow-providers-sqlite`](https://pypi.org/project/apache-airflow-providers-sqlite/)
 

--- a/astro/runtime-image-architecture.md
+++ b/astro/runtime-image-architecture.md
@@ -74,22 +74,22 @@ Because this DAG is essential to Astro's managed service, you are not charged fo
 
 The latest version of the Astro Runtime image has the following open source provider packages pre-installed. Providers marked with an asterisk (`*`) are installed only in Astro Runtime and not installed by default on Apache Airflow.
 
-- Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/)`*`
-- Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/)`*`
-- Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/)`*`
+- Amazon [`apache-airflow-providers-amazon`](https://pypi.org/project/apache-airflow-providers-amazon/) `*`
+- Astronomer Providers [`astronomer-providers`](https://pypi.org/project/astronomer-providers/) `*`
+- Astro Python SDK [`astro-sdk-python`](https://pypi.org/project/astro-sdk-python/) `*`
 - Celery [`apache-airflow-providers-celery`](https://pypi.org/project/apache-airflow-providers-celery/)
 - Cloud Native Computing Foundation (CNCF) Kubernetes [`apache-airflow-providers-cncf-kubernetes`](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/)
 - Common SQL [`apache-airflow-providers-common-sql`](https://pypi.org/project/apache-airflow-providers-common-sql/)
-- Datadog [`apache-airflow-providers-datadog](https://pypi.org/project/apache-airflow-providers-datadog/)`*`
-- Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/)`*`
+- Datadog [`apache-airflow-providers-datadog](https://pypi.org/project/apache-airflow-providers-datadog/) `*`
+- Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/) `*`
 - FTP [`apache-airflow-providers-ftp`](https://pypi.org/project/apache-airflow-providers-ftp/) 
-- Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/)`*`
+- Google [`apache-airflow-providers-google`](https://pypi.org/project/apache-airflow-providers-google/) `*`
 - HTTP [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-http/)
 - IMAP [`apache-airflow-providers-imap`](https://pypi.org/project/apache-airflow-providers-imap/)
-- Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/)`*`
-- [OpenLineage](https://pypi.org/project/openlineage-airflow/) (this package installs an Airflow plugin)`*`
-- PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/)`*`
-- Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/)`*`
+- Microsoft Azure [`apache-airflow-providers-microsoft-azure`](https://pypi.org/project/apache-airflow-providers-microsoft-azure/) `*`
+- [OpenLineage](https://pypi.org/project/openlineage-airflow/) (this package installs an Airflow plugin) `*`
+- PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/) `*`
+- Redis [`apache-airflow-providers-redis`](https://pypi.org/project/apache-airflow-providers-redis/) `*`
 - SQLite [`apache-airflow-providers-sqlite`](https://pypi.org/project/apache-airflow-providers-sqlite/)
 
 ### Provider package versioning


### PR DESCRIPTION
Noticed this list was out of date because I was looking for common SQL in it :)

Was a bit surprised to not see OL anymore in the default Runtime providers. Reference on a vanilla 8.7.0 image:

![Screenshot 2023-07-17 at 15 59 18](https://github.com/astronomer/docs/assets/90063506/8889270e-ede9-43d3-9072-262c9f47da08)
