### PR TITLE
Move 'Intro to Airflow'

### DIFF
--- a/sidebarsLearn.js
+++ b/sidebarsLearn.js
@@ -7,9 +7,10 @@ module.exports = {
       link: {
         type: 'generated-index',
         title: 'Get started',
-        description: 'Get started with Airflow.',
+        description: 'Get started with Apache Airflow.',
       },
       items: [
+        'intro-to-airflow',
         'airflow-quickstart',
         {
           type: 'category',
@@ -47,7 +48,6 @@ module.exports = {
             'connections',
             'dags',
             'what-is-a-hook',
-            'intro-to-airflow',
             'managing-airflow-code',
             'airflow-openlineage',
             'what-is-an-operator',


### PR DESCRIPTION
Found myself looking for this doc elsewhere in the menu. Since it's an intro, should it be in our getting started menu?

Also, kind of confusing to have `Tutorials` in getting started but then a separate `Airflow tutorials` section elsewhere in the menu. I wonder if we could just remove the `tutorials` header there, or maybe just keep part 1 and throw part 2 into the main tutorials menu?