### PR TITLE
Change WORKSPACE_MEMBER to WORKSPACE_VIEWER and other related changes

### DIFF
--- a/astro/cli/astro-workspace-team-add.md
+++ b/astro/cli/astro-workspace-team-add.md
@@ -22,7 +22,7 @@ To find a Team ID in the Cloud UI, click Astronomer logo in the upper left corne
 
 | Option    | Description                                          | Valid Values                                                                               |
 | --------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `--role`  | The Team's role in the Workspace.                    | Possible values are either `WORKSPACE_MEMBER`, `WORKSPACE_OPERATOR`, or `WORKSPACE_OWNER`. |
+| `--role`  | The Team's role in the Workspace.                    | Possible values are either `WORKSPACE_VIEWER`, `WORKSPACE_EDITOR`, or `WORKSPACE_ADMIN`. |
 
 ## Related commands
 

--- a/astro/cli/astro-workspace-team-update.md
+++ b/astro/cli/astro-workspace-team-update.md
@@ -22,7 +22,7 @@ To find a Team ID in the Cloud UI, click Astronomer logo in the upper left corne
 
 | Option    | Description                                          | Valid Values                                                                               |
 | --------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `--role`  | The Team's role in the Workspace.                    | Possible values are either `WORKSPACE_MEMBER`, `WORKSPACE_OPERATOR`, or `WORKSPACE_OWNER`. |
+| `--role`  | The Team's role in the Workspace.                    | Possible values are either `WORKSPACE_VIEWER`, `WORKSPACE_EDITOR`, or `WORKSPACE_ADMIN`. |
 
 ## Related commands
 

--- a/astro/cli/astro-workspace-token-add.md
+++ b/astro/cli/astro-workspace-token-add.md
@@ -19,7 +19,7 @@ astro workspace token add
 | Option            | Description                                                                                                                             | Valid Values  |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `--org-token-name`   | The name of the Organization API token you want to add to your Workspace.                                                                                                      | Any string enclosed in quotations    |
-| `--enforce-ci-cd` | The Workspace role to grant to the Organization API token. | One of `WORKSPACE_MEMBER`, `WORKSPACE_OPERATOR` or `WORKSPACE_OWNER` |
+| `--enforce-ci-cd` | The Workspace role to grant to the Organization API token. | One of `WORKSPACE_VIEWER`, `WORKSPACE_OPERATOR` or `WORKSPACE_OWNER` |
 
 ## Related commands
 

--- a/astro/cli/astro-workspace-token-create.md
+++ b/astro/cli/astro-workspace-token-create.md
@@ -22,12 +22,12 @@ astro workspace token create
 | `--description` |The description for the token | Any string surrounded by quotations |
 | `--expiration` | The expiration date for the token. By default there is no expiration date. | Any integer between 1 and 3650, used to represent days |
 | `--name` | The name for the token. | Any string surrounded by quotations |
-| `--role`  | The token's role in the Workspace.                | Possible values are either `WORKSPACE_MEMBER`, `WORKSPACE_OPERATOR`, or `WORKSPACE_OWNER`. |
+| `--role`  | The token's role in the Workspace.                | Possible values are either `WORKSPACE_VIEWER`, `WORKSPACE_EDITOR`, or `WORKSPACE_ADMIN`. |
 
 ## Examples
 
 ```sh
-astro workspace token create --name "My production API token" --role WORKSPACE_MEMBER
+astro workspace token create --name "My production API token" --role WORKSPACE_VIEWER
 ```
 
 ## Related commands

--- a/astro/cli/astro-workspace-token-update.md
+++ b/astro/cli/astro-workspace-token-update.md
@@ -23,12 +23,12 @@ astro workspace token update <flags>
 | `--expiration` | The expiration date for the token. By default there is no expiration date. | Any integer between 1 and 3650, used to represent days |
 | `--name` | The current name for the token. | Any string surrounded by quotations |
 | `--new-name` | The updated name for the token. | Any string surrounded by quotations |
-| `--role`  | The token's role in the Workspace.                | Possible values are either `WORKSPACE_MEMBER`, `WORKSPACE_OPERATOR`, or `WORKSPACE_OWNER`. |
+| `--role`  | The token's role in the Workspace.                | Possible values are either `WORKSPACE_VIEWER`, `WORKSPACE_EDITOR`, or `WORKSPACE_ADMIN`. |
 
 ## Examples
 
 ```sh
-astro workspace token update --new-name "My updated API token" --role WORKSPACE_MEMBER
+astro workspace token update --new-name "My updated API token" --role WORKSPACE_VIEWER
 ```
 
 ## Related commands

--- a/astro/cli/astro-workspace-user-add.md
+++ b/astro/cli/astro-workspace-user-add.md
@@ -38,7 +38,7 @@ astro workspace user add <email>
 | Option    | Description                                          | Valid Values                                                                               |
 | --------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | `<email-address>` | The email address of the user that you want to add to the Workspace. | Any valid email address                                                                            |
-| `--role`  | The user's role in the Workspace.                    | Possible values are either `WORKSPACE_MEMBER`, `WORKSPACE_OPERATOR`, or `WORKSPACE_OWNER`. |
+| `--role`  | The user's role in the Workspace.                    | Possible values are either `WORKSPACE_VIEWER`, `WORKSPACE_EDITOR`, or `WORKSPACE_ADMIN`. |
 
 ## Related commands
 

--- a/astro/cli/astro-workspace-user-update.md
+++ b/astro/cli/astro-workspace-user-update.md
@@ -36,7 +36,7 @@ astro workspace user update --role <user-role>
 | Option                | Description                                          | Valid Values                                                                     |
 | --------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------- |
 | `<email>`             | The email address of the user whose role you want to update. | Any valid email                                                                  |
-| `--role` (_Required_) | The user's role in the Workspace.                    | Valid values are `WORKSPACE_MEMBER`, `WORKSPACE_OPERATOR`, or `WORKSPACE_OWNER`. |
+| `--role` (_Required_) | The user's role in the Workspace.                    | Valid values are `WORKSPACE_VIEWER`, `WORKSPACE_EDITOR`, or `WORKSPACE_ADMIN`. |
 
 ## Related commands
 

--- a/astro/user-permissions.md
+++ b/astro/user-permissions.md
@@ -9,12 +9,12 @@ To better protect your data pipelines and cloud infrastructure, Astro provides r
 
 You can also apply roles to API tokens to limit the scope of their actions in CI/CD and automation pipelines. See [Manage Deployments as code](manage-deployments-as-code.md).
 
-Astro has hierarchical RBAC. Within a given Workspace or Organization, senior roles have their own permissions in addition to the permissions granted to lower roles. For example, a user or API token with Organization Owner permissions inherits Organization Billing Admin and Organization Member permissions because those roles are lower in the hierarchy. 
+Astro has hierarchical RBAC. Within a given Workspace or Organization, senior roles have their own permissions in addition to the permissions granted to lower roles. For example, a user or API token with Organization Owner permissions inherits Organization Billing Admin and Organization Member permissions because those roles are lower in the hierarchy.
 
-The Astro role hierarchies in order of inheritance are: 
+The Astro role hierarchies in order of inheritance are:
 
-- Organization Owner > Organization Billing Admin > Organization Member 
-- Workspace Admin > Workspace Editor > Workspace Member
+- Organization Owner > Organization Billing Admin > Organization Member
+- Workspace Admin > Workspace Editor > Workspace Viewer
 
 Additionally, Organization Owners inherit Workspace Admin permissions for all Workspaces in the Organization.
 
@@ -24,18 +24,18 @@ An Organization role grants a user or API token some level of access to an Astro
 
 | Permission                                                       | **Organization Member** | **Organization Billing Admin** | **Organization Owner** |
 | ---------------------------------------------------------------- | ----------------------- | ------------------------------ | ---------------------- |
-| View Organization details and user membership                    | ✔️                       | ✔️                              | ✔️                      |
-| View lineage metadata in the **Lineage** tab                     | ✔️                       | ✔️                              | ✔️                      |
-| Update Organization billing information and settings             |                         | ✔️                              | ✔️                      |
-| View usage for all Workspaces in the **Usage** tab               |                         | ✔️                              | ✔️                      |
-| Create a new Workspace                                           |                         |                                | ✔️                      |
-| Workspace Admin permissions to all Workspaces                    |                         |                                | ✔️                      |
-| Update roles and permissions of existing Organization users      |                         |                                | ✔️                      |
-| Invite a new user to an Organization                             |                         |                                | ✔️                      |
-| Remove a user from an Organization                               |                         |                                | ✔️                      |
-| Create, update, and delete Organization API tokens                                   |                         |                                | ✔️                      |
-| Access, regenerate, and delete single sign-on (SSO) bypass links |                         |                                | ✔️                      |
-| Create, update, and delete a Team  |                         |                               | ✔️                      |
+| View Organization details and user membership                    | ✔️                      | ✔️                             | ✔️                     |
+| View lineage metadata in the **Lineage** tab                     | ✔️                      | ✔️                             | ✔️                     |
+| Update Organization billing information and settings             |                         | ✔️                             | ✔️                     |
+| View usage for all Workspaces in the **Usage** tab               |                         | ✔️                             | ✔️                     |
+| Create a new Workspace                                           |                         |                                | ✔️                     |
+| Workspace Admin permissions to all Workspaces                    |                         |                                | ✔️                     |
+| Update roles and permissions of existing Organization users      |                         |                                | ✔️                     |
+| Invite a new user to an Organization                             |                         |                                | ✔️                     |
+| Remove a user from an Organization                               |                         |                                | ✔️                     |
+| Create, update, and delete Organization API tokens               |                         |                                | ✔️                     |
+| Access, regenerate, and delete single sign-on (SSO) bypass links |                         |                                | ✔️                     |
+| Create, update, and delete a Team                                |                         |                                | ✔️                     |
 
 To manage users in a organization, see [Manage users](add-user.md). To manage the Organization permissions of your API tokens, see [Organization API tokens](organization-api-tokens.md).
 
@@ -43,28 +43,31 @@ To manage users in a organization, see [Manage users](add-user.md). To manage th
 
 A Workspace role grants a user or API token some level of access to a specific Workspace. All Deployments in a Workspace will be accessible to the user or API token based on it's Workspace role. The following table lists the available Workspace roles:
 
-| Permission                                          | **Workspace Member** | **Workspace Editor** | **Workspace Admin** |
-| --------------------------------------------------- | -------------------- | -------------------- | ------------------- |
-| View Workspace users                                | ✔️                    | ✔️                    | ✔️                   |
-| View all Deployments in the Cloud UI                | ✔️                    | ✔️                    | ✔️                   |
-| View DAGs in the Airflow UI                         | ✔️                    | ✔️                    | ✔️                   |
-| View Airflow task logs                              | ✔️                    | ✔️                    | ✔️                   |
-| View Astro Cloud IDE projects                       | ✔️                    | ✔️                    | ✔️                   |
-| Update Deployment configurations                    |                      | ✔️                    | ✔️                   |
-| Manually trigger DAG and task runs                  |                      | ✔️                    | ✔️                   |
-| Pause or unpause a DAG                              |                      | ✔️                    | ✔️                   |
-| Clear/mark a task instance or DAG run               |                      | ✔️                    | ✔️                   |
-| Push code to Deployments                            |                      | ✔️                    | ✔️                   |
-| Create and Delete Deployments                       |                      | ✔️                    | ✔️                   |
-| Create, Update and Delete Environment Variables     |                      | ✔️                    | ✔️                   |
-| Create, update, and delete Astro Cloud IDE projects |                      | ✔️                    | ✔️                   |
-| View Airflow connections and Variables              |                      |                      | ✔️                   |
-| Update Airflow connections and Variables            |                      |                      | ✔️                   |
-| Create, Update, and Delete API Keys                  |                      |                      | ✔️                   |
-| Update user roles and permissions                   |                      |                      | ✔️                   |
-| Invite users to a Workspace                         |                      |                      | ✔️                   |
-| Assign Teams to or remove from Workspaces    |                      |                      | ✔️                   |
-| Create, update and delete Workspace API tokens                         |                      |                      | ✔️                   |
+| Permission                                                           | **Workspace Viewer** | **Workspace Editor** | **Workspace Admin** |
+| -------------------------------------------------------------------- | -------------------- | -------------------- | ------------------- |
+| View Workspace users                                                 | ✔️                   | ✔️                   | ✔️                  |
+| View all Deployments in the Cloud UI                                 | ✔️                   | ✔️                   | ✔️                  |
+| View DAGs in the Airflow UI                                          | ✔️                   | ✔️                   | ✔️                  |
+| View Airflow task logs                                               | ✔️                   | ✔️                   | ✔️                  |
+| View Astro Cloud IDE projects                                        | ✔️                   | ✔️                   | ✔️                  |
+| Update Deployment configurations                                     |                      | ✔️                   | ✔️                  |
+| Manually trigger DAG and task runs                                   |                      | ✔️                   | ✔️                  |
+| Pause or unpause a DAG                                               |                      | ✔️                   | ✔️                  |
+| Clear/mark a task instance or DAG run                                |                      | ✔️                   | ✔️                  |
+| Push code to Deployments                                             |                      | ✔️                   | ✔️                  |
+| Create and Delete Deployments                                        |                      | ✔️                   | ✔️                  |
+| Create, Update and Delete Environment Variables                      |                      | ✔️                   | ✔️                  |
+| Create, update, and delete Astro Cloud IDE projects                  |                      | ✔️                   | ✔️                  |
+| Delete DAG or task instance runs                                     |                      |                      | ✔️                  |
+| View Airflow connections, variables, and pools                       |                      |                      | ✔️                  |
+| Update Airflow connections, variables and pools                      |                      |                      | ✔️                  |
+| View Datasets menu                                                   |                      |                      | ✔️                  |
+| View Airflow reports, such as Jobs, Audit logs, Task instances, etc. |                      |                      | ✔️                  |
+| Create, Update, and Delete API Keys                                  |                      |                      | ✔️                  |
+| Update user roles and permissions                                    |                      |                      | ✔️                  |
+| Invite users to a Workspace                                          |                      |                      | ✔️                  |
+| Assign Teams to or remove from Workspaces                            |                      |                      | ✔️                  |
+| Create, update and delete Workspace API tokens                       |                      |                      | ✔️                  |
 
 To manage a user's Workspace permissions, see [Manage users](add-user.md#add-a-user-to-a-workspace).
 

--- a/sidebarsAstro.js
+++ b/sidebarsAstro.js
@@ -160,11 +160,10 @@ module.exports = {
                 "manage-domains",
                 "add-user", 
                 "manage-teams", 
-                "user-permissions",
               ],
             },
             "organization-api-tokens",
-            "audit-logs",
+            "audit-logs"
           ],
         },
         {
@@ -214,6 +213,7 @@ module.exports = {
           ],
         },
         "manage-billing",
+        "user-permissions"
       ],
     },
     {


### PR DESCRIPTION
This PR addresses the concerns raised in this [issue](https://github.com/astronomer/docs/issues/2585) and the following:

- removing all references of `WORKSPACE_MEMBER`, and `WORKSPACE_OPERATOR` 
- moving User permissions reference at the top level in Administration menu for easy access because it contains permissions for Organizations and workspaces and hence Airflow Deployments. 