### PR TITLE
Remove Cloud IDE public preview banner

### DIFF
--- a/astro/cloud-ide/deploy-project.md
+++ b/astro/cloud-ide/deploy-project.md
@@ -5,14 +5,6 @@ id: deploy-project
 description: Learn how to use the Astro Cloud IDE's built-in GitHub support to manage your data pipelines and deploy them to Astro.
 ---
 
-:::caution
-
-<!-- id to make it easier to remove: cloud-ide-preview-banner -->
-
-The Cloud IDE is currently in [Public Preview](feature-previews.md).
-
-:::
-
 After you create a project in the Cloud IDE, you can deploy it to Astro and run tasks on a schedule using one of the following options:
 
 - Download your pipelines' Python files from the Cloud IDE, copy them to an existing Astro project, and deploy your project to Astro.

--- a/astro/cloud-ide/overview.md
+++ b/astro/cloud-ide/overview.md
@@ -14,14 +14,6 @@ import LinkCard from '@site/src/components/LinkCard';
   A cloud-based, notebook-inspired IDE for writing and testing data pipelines. No Airflow knowledge or local setup is required.
 </p>
 
-:::caution
-
-<!-- id to make it easier to remove: cloud-ide-preview-banner -->
-
-The Cloud IDE is currently in [Public Preview](feature-previews.md).
-
-:::
-
 The Astro Cloud IDE is a notebook-inspired development environment for writing and testing data pipelines with Astro. The Cloud IDE lowers the barrier to entry for new Apache Airflow users and improves the development experience for experienced users.
 
 One of the biggest barriers to using Airflow is writing boilerplate code for basic actions such as creating dependencies, passing data between tasks, and connecting to external services. You can configure all of these with the Cloud UI so that you only need to write the Python or SQL code that executes your work.

--- a/astro/cloud-ide/quickstart.md
+++ b/astro/cloud-ide/quickstart.md
@@ -4,14 +4,6 @@ title: Astro Cloud IDE quickstart
 id: quickstart
 ---
 
-:::caution
-
-<!-- id to make it easier to remove: cloud-ide-preview-banner -->
-
-The Cloud IDE is currently in [Public Preview](feature-previews.md).
-
-:::
-
 Use this quickstart to create and run your first project with the Cloud IDE.
 
 ## Time to complete

--- a/astro/cloud-ide/security.md
+++ b/astro/cloud-ide/security.md
@@ -4,13 +4,6 @@ title: Astro Cloud IDE security & data governance
 id: security
 ---
 
-:::caution
-
-<!-- id to make it easier to remove: cloud-ide-preview-banner -->
-The Cloud IDE is currently in [Public Preview](feature-previews.md).
-
-:::
-
 ## Security
 
 The Cloud IDE is a fully managed service that runs in an Astronomer-managed private cluster. All infrastructure is managed by Astronomer. Infrastructure is tightly scoped to organizations, so your code and data is never exposed to other organizations.

--- a/astro/release-notes.md
+++ b/astro/release-notes.md
@@ -757,14 +757,6 @@ Most importantly, the Astro Cloud IDE was developed to make it easier for new Ai
 
 To create your first project in the Astro Cloud IDE, see the [Cloud IDE quickstart](cloud-ide/quickstart.md). To deploy your project to Astro, see [Deploy your Cloud IDE project to Astro](cloud-ide/deploy-project.md).
 
-:::info
-
-<!-- id to make it easier to remove: cloud-ide-preview-banner -->
-
-The Cloud IDE is currently in [Public Preview](feature-previews.md).
-
-:::
-
 ### Additional improvements
 
 - In the Cloud UI, cluster selection menus are now alphabetized.


### PR DESCRIPTION
The Cloud IDE goes GA on Tuesday, July 25. This PR should be merged alongside the Astro release.