### PR TITLE
[Tiny PR] Add caution for OL in Astro alerts

### DIFF
--- a/astro/alerts.md
+++ b/astro/alerts.md
@@ -13,12 +13,19 @@ Astro alerts provide an additional level of observability to Airflow's notificat
 
 Unlike Airflow callbacks and SLAs, Astro alerts require no changes to DAG code. Follow this guide to set up your Slack, PagerDuty, or email to receive alerts from Astro and then configure your Deployment to send alerts.
 
+:::caution
+
+To use Astro Alerts for a Deployment, Openlineage must be enabled. By default, every Astro Deployment has this enabled. If you have it disabled, see [Enable/Disable OpenLineage](./set-up-data-lineage.md/#enabledisable-openlineage) to turn it back on.
+
+:::
+
 To configure Airflow notifications, see [Airflow email notifications](airflow-email-notifications.md) and [Manage Airflow DAG notifications](https://docs.astronomer.io/learn/error-notifications-in-airflow).
 
 ## Prerequisites
 
 - An [Astro project](develop-project.md).
 - An [Astro Deployment](create-deployment.md). Your Deployment must run Astro Runtime 7.1.0 or later to configure Astro alerts.
+- Your Astro Deployment should have Open Lineage enabled. 
 - A Slack workspace, PagerDuty service, or email address.
 
 <!-- Sensitive header used in product - do not change without a redirect-->

--- a/astro/alerts.md
+++ b/astro/alerts.md
@@ -13,9 +13,9 @@ Astro alerts provide an additional level of observability to Airflow's notificat
 
 Unlike Airflow callbacks and SLAs, Astro alerts require no changes to DAG code. Follow this guide to set up your Slack, PagerDuty, or email to receive alerts from Astro and then configure your Deployment to send alerts.
 
-:::caution
+:::info
 
-To use Astro Alerts for a Deployment, Openlineage must be enabled. By default, every Astro Deployment has this enabled. If you have it disabled, see [Enable/Disable OpenLineage](./set-up-data-lineage.md/#enabledisable-openlineage) to turn it back on.
+Astro alerts requires OpenLineage. By default, every Astro Deployment has OpenLineage enabled. If you disabled OpenLineage in your Deployment, you need to enable it to use Astro alerts. See [Enable/Disable OpenLineage](set-up-data-lineage.md#enabledisable-openlineage).
 
 :::
 
@@ -24,8 +24,7 @@ To configure Airflow notifications, see [Airflow email notifications](airflow-em
 ## Prerequisites
 
 - An [Astro project](develop-project.md).
-- An [Astro Deployment](create-deployment.md). Your Deployment must run Astro Runtime 7.1.0 or later to configure Astro alerts.
-- Your Astro Deployment should have Open Lineage enabled. 
+- An [Astro Deployment](create-deployment.md). Your Deployment must run Astro Runtime 7.1.0 or later to configure Astro alerts, and it must also have [OpenLineage enabled](set-up-data-lineage.md#enabledisable-openlineage). 
 - A Slack workspace, PagerDuty service, or email address.
 
 <!-- Sensitive header used in product - do not change without a redirect-->

--- a/astro/set-up-data-lineage.md
+++ b/astro/set-up-data-lineage.md
@@ -268,7 +268,7 @@ To disable it, add the following line to your `Dockerfile`:
 
 Deploy your Astro project for the changes to take effect in your Deployment.
 
-To enable OpenLineage, you can either set `ENV OPENLINEAGE_DISABLED = False` or remove this line from your `Dockerfile`.
+To re-enable OpenLineage, you can either set `ENV OPENLINEAGE_DISABLED = False` or remove this line from your `Dockerfile`.
 
 ## View SQL source code
 

--- a/astro/set-up-data-lineage.md
+++ b/astro/set-up-data-lineage.md
@@ -269,9 +269,10 @@ To disable it, add the following line to your `Dockerfile`:
 Deploy your Astro project for the changes to take effect in your Deployment.
 
 To re-enable OpenLineage, you can either set `ENV OPENLINEAGE_DISABLED = False` or remove this line from your `Dockerfile`.
+
 :::tip Alternate setup
 
-If you choose to add environment variable to your `.env` file for local Airflow, remember to set it for your Astro Deployment using the [Cloud UI](environment-variables.md#set-environment-variables-in-the-cloud-ui) or [Astro CLI](cli/astro-deployment-variable-create.md). 
+If you choose to add `OPENLINEAGE_DISABLED = True` to your `.env` file for local Airflow to disable OpenLineage, remember to set it for your Astro Deployment using the [Cloud UI](environment-variables.md#set-environment-variables-in-the-cloud-ui) or [Astro CLI](cli/astro-deployment-variable-create.md).
 
 :::
 

--- a/astro/set-up-data-lineage.md
+++ b/astro/set-up-data-lineage.md
@@ -257,6 +257,20 @@ In your Spark application, set the following properties to configure your lineag
 
 To confirm that your setup is successful, run a Spark job after you save your configuration. After you run this model, click **Lineage** in the Cloud UI and then click **Runs** in the left menu. Your recent Spark job run appears in the table of most recent runs.
 
+
+## Enable/Disable OpenLineage
+
+In Astro, OpenLineage is used to extract lineage metadata for your Airflow operators and to configure Astro Alerts. By default, OpenLineage is enabled for your Astro Deployment. 
+
+To disable it, add the following line to your `Dockerfile`:
+
+`ENV OPENLINEAGE_DISABLED = True`
+
+Then, restart your Astro project for the changes to take effect.
+
+To enable OpenLineage, you can either set `ENV OPENLINEAGE_DISABLED = False` or remove this line from your `Dockerfile`.
+
+
 ## View SQL source code
 
 The SQL source code view for [supported Airflow operators](https://openlineage.io/docs/integrations/about/#capability-matrix) in the Cloud UI  **Lineage** page is off by default for all Workspace users. To enable the source code view, set the following [environment variable](environment-variables.md) for each Astro Deployment:

--- a/astro/set-up-data-lineage.md
+++ b/astro/set-up-data-lineage.md
@@ -269,6 +269,11 @@ To disable it, add the following line to your `Dockerfile`:
 Deploy your Astro project for the changes to take effect in your Deployment.
 
 To re-enable OpenLineage, you can either set `ENV OPENLINEAGE_DISABLED = False` or remove this line from your `Dockerfile`.
+:::tip Alternate setup
+
+If you choose to add environment variable to your `.env` file for local Airflow, remember to set it for your Astro Deployment using the [Cloud UI](environment-variables.md#set-environment-variables-in-the-cloud-ui) or [Astro CLI](cli/astro-deployment-variable-create.md). 
+
+:::
 
 ## View SQL source code
 

--- a/astro/set-up-data-lineage.md
+++ b/astro/set-up-data-lineage.md
@@ -260,16 +260,15 @@ To confirm that your setup is successful, run a Spark job after you save your co
 
 ## Enable/Disable OpenLineage
 
-In Astro, OpenLineage is used to extract lineage metadata for your Airflow operators and to configure Astro Alerts. By default, OpenLineage is enabled for your Astro Deployment. 
+Astro uses OpenLineage to extract lineage metadata for your Airflow operators and to send Astro alerts. By default, OpenLineage is enabled for all Astro Deployments. 
 
 To disable it, add the following line to your `Dockerfile`:
 
 `ENV OPENLINEAGE_DISABLED = True`
 
-Then, restart your Astro project for the changes to take effect.
+Deploy your Astro project for the changes to take effect in your Deployment.
 
 To enable OpenLineage, you can either set `ENV OPENLINEAGE_DISABLED = False` or remove this line from your `Dockerfile`.
-
 
 ## View SQL source code
 


### PR DESCRIPTION
This PR adds a `caution` in Astro alerts page that it needs OL to be enabled.
- Also we did not have it in our docs that how OL can be enabled or disabled. 

I am also creating a followup issue for fixing the organization of OL because the set-up-data-lineage page is too big and has repetitive headings.