### PR TITLE
SEO - Update Meta Title for learn/dags

### DIFF
--- a/learn/dags.md
+++ b/learn/dags.md
@@ -6,6 +6,8 @@ id: dags
 ---
 
 <head>
+  <title>Introduction to Airflow DAGs in Python | Documentation</title>
+  <meta name="og:title" content=" Introduction to Airflow DAGs in Python | Documentation" />
   <meta name="description" content="Learn how to write DAGs and get tips on how to define an Airflow DAG in Python. Learn all about DAG parameters and their settings." />
   <meta name="og:description" content="Learn how to write DAGs and get tips on how to define an Airflow DAG in Python. Learn all about DAG parameters and their settings." />
 </head>


### PR DESCRIPTION
Requested title SEO test for the [Introduction to Airflow DAGs](https://docs.astronomer.io/learn/dags) page.

Current title: **Introduction to Airflow DAGs | Astronomer Documentation**
New title: **Introduction to Airflow DAGs in Python | Documentation**