### PR TITLE
[Tiny PR] Fix typo in OL flag

### DIFF
--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -427,7 +427,7 @@ To learn more, see [What's New in Apache Airflow 2.5](https://www.astronomer.io/
 
 - Upgraded `astronomer-providers` to 1.15.1, which includes a collection of bug fixes and a new async sensor `SnowflakeSensorAsync`. See the [`astronomer-providers` changelog](https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst#1151-2023-03-09) for a complete list of changes.. 
 - Upgraded `openlineage-airflow` to 0.21.1, which includes a collection of bug fixes. See the [OpenLineage changelog](https://github.com/OpenLineage/OpenLineage/releases/tag/0.21.1) for a complete list of changes. 
-- When using Runtime in an Astronomer Software installation, OpenLineage and the Astronomer monitoring DAG are now disabled. OpenLineage can be re-enabled in your Deployment by setting the `OPENLINEAGE_URL` environment variable, or by setting the `OPENLINEAGE_DISABLE=False` environment variable.
+- When using Runtime in an Astronomer Software installation, OpenLineage and the Astronomer monitoring DAG are now disabled. OpenLineage can be re-enabled in your Deployment by setting the `OPENLINEAGE_URL` environment variable, or by setting the `OPENLINEAGE_DISABLED=False` environment variable.
 
 ## Astro Runtime 6.3.0
 


### PR DESCRIPTION
`OPENLINEAGE_DISABLED` flag was missing the `D` in the end in the Runtime release notes. 

Reference slack thread: https://astronomer.slack.com/archives/C015V2JFKT5/p1691061670691649