### PR TITLE
Update Deployment creation options

### DIFF
--- a/astro/cloud-ide/run-sql.md
+++ b/astro/cloud-ide/run-sql.md
@@ -73,6 +73,33 @@ In your SQL cell, click **Dependencies** and select a cell to be upstream of you
 
 To make your SQL cell an upstream dependency for another cell, click **Dependencies** for the other cell and select the name of your SQL cell. 
 
+## Create data dependencies for a SQL cell
+
+You can use the output of other cells in your project within a SQL function. You define these dependencies in SQL using jinja templating, and the Cloud IDE automatically renders the dependencies in your project code and in the **Pipeline** view of your project.
+
+For example, if you have a SQL cell using **In-memory SQL** to query a dataframe output of a Python cell, the Python cell is automatically marked as an upstream dependency for your SQL cell.
+
+### Pass a value from a Python cell to a SQL cell 
+
+If a Python cell returns a pandas DataFrame, you can pass the DataFrame to a SQL cell as a table by calling the name of the Python cell. Call the name of the Python cell using double curly braces, also known as jinja templating. Pandas DataFrames are automatically converted to SQL tables when they are passed to SQL cells.
+
+For example, a SQL cell containing the following query is dependent on a Python cell named `my_dataframe`.
+
+```sql
+select * from {{my_dataframe}} -- my_dataframe is a Python cell
+where col_a > 10
+```
+
+### Pass a value from a SQL cell to a SQL cell 
+
+You can pass the results of a `SELECT` statement to a SQL cell by calling the name of the SQL cell containing the `SELECT` statement. Call the name of the SQL cell using double curly braces, also known as jinja templating.
+
+For example, a SQL cell containing the following query is dependent on a SQL cell named `my_table`.
+
+```sql
+select * from {{my_table}} -- my_table is another SQL cell
+```
+
 ## View complete code for SQL cells
 
 To view your SQL cell within the context of an Airflow DAG, click **Code**. The Airflow DAG includes your SQL query as well as all of the code required to run it on Airflow.

--- a/astro/cloud-ide/run-sql.md
+++ b/astro/cloud-ide/run-sql.md
@@ -73,33 +73,6 @@ In your SQL cell, click **Dependencies** and select a cell to be upstream of you
 
 To make your SQL cell an upstream dependency for another cell, click **Dependencies** for the other cell and select the name of your SQL cell. 
 
-## Create data dependencies for a SQL cell
-
-You can use the output of other cells in your project within a SQL function. You define these dependencies in SQL using jinja templating, and the Cloud IDE automatically renders the dependencies in your project code and in the **Pipeline** view of your project.
-
-For example, if you have a SQL cell using **In-memory SQL** to query a dataframe output of a Python cell, the Python cell is automatically marked as an upstream dependency for your SQL cell.
-
-### Pass a value from a Python cell to a SQL cell 
-
-If a Python cell returns a pandas DataFrame, you can pass the DataFrame to a SQL cell as a table by calling the name of the Python cell. Call the name of the Python cell using double curly braces, also known as jinja templating. Pandas DataFrames are automatically converted to SQL tables when they are passed to SQL cells.
-
-For example, a SQL cell containing the following query is dependent on a Python cell named `my_dataframe`.
-
-```sql
-select * from {{my_dataframe}} -- my_dataframe is a Python cell
-where col_a > 10
-```
-
-### Pass a value from a SQL cell to a SQL cell 
-
-You can pass the results of a `SELECT` statement to a SQL cell by calling the name of the SQL cell containing the `SELECT` statement. Call the name of the SQL cell using double curly braces, also known as jinja templating.
-
-For example, a SQL cell containing the following query is dependent on a SQL cell named `my_table`.
-
-```sql
-select * from {{my_table}} -- my_table is another SQL cell
-```
-
 ## View complete code for SQL cells
 
 To view your SQL cell within the context of an Airflow DAG, click **Code**. The Airflow DAG includes your SQL query as well as all of the code required to run it on Airflow.

--- a/astro/create-deployment.md
+++ b/astro/create-deployment.md
@@ -11,11 +11,16 @@ id: create-deployment
 
 An Astro Deployment is an Astro Runtime environment that is powered by the core components of Apache Airflow, including the Airflow webserver, scheduler, and one or more workers.
 
-You can create a Deployment from a Workspace on Astro. After you create a Deployment, you can deploy DAGs to it from the Astro CLI or from a continuous delivery (CI/CD) process. All DAGs and tasks on Astro are executed within a Deployment.
+The most basic way to create a Deployment is through the Cloud UI. After you create a Deployment, you can deploy DAGs to it from the Astro CLI or from a continuous delivery (CI/CD) process. All DAGs and tasks on Astro are executed within a Deployment.
 
 ![Deployment creation screen example](/img/docs/create-deployment.png)
 
-Every Deployment is hosted on a single Astro cluster with its own dedicated resources, which you can customize to meet the unique requirements of your Organization. Every Astro cluster operates with a primary database that hosts the individual databases for each Deployment.  To restrict communication between Deployments, resources for each Deployment are isolated within a corresponding Kubernetes namespace. See [Deployment network isolation](data-protection.md#deployment-network-isolation).
+Every Deployment is hosted on a single Astro cluster with its own dedicated resources, which you can customize to meet the unique requirements of your Organization. Every Astro cluster operates with a primary database that hosts the individual databases for each Deployment. To restrict communication between Deployments, resources for each Deployment are isolated within a corresponding Kubernetes namespace. See [Deployment network isolation](data-protection.md#deployment-network-isolation).
+
+This document explains how to create Deployments through the Cloud UI. To create Deployments programmatically using the Astro CLI, see:
+
+- [Astro CLI reference guide](cli/astro-deployment-create.md)
+- [Manage Deployments as code](manage-deployments-as-code.md)
 
 ## Prerequisites
 
@@ -29,13 +34,14 @@ If you prefer, you can also run `astro deployment create` to create a Deployment
 
 :::
 
-1. In the Cloud UI, select a Workspace.
+1. In the Cloud UI, go to **Deployments**.
 
-2. On the **Deployments** page, click **+ Deployment**.
+2. Click **+ Deployment**.
 
     ![Deployment creation button](/img/docs/create-button.png)
 
 3. Complete the following fields:
+
     - **Basic**  
 
         - **Name**: Enter a name for your Deployment.

--- a/astro/create-deployment.md
+++ b/astro/create-deployment.md
@@ -13,9 +13,9 @@ An Astro Deployment is an Airflow environment that is powered by [Astro Runtime]
 
 There are three ways to create a Deployment: 
 
-- Using the Cloud UI. This is the most basic way to create a Deployment and is the focus of this document.
-- Using [`astro deployment create`](cli/astro-deployment-create.md).
-- Using a Deployment template file. See [Manage Deployments as code](manage-deployments-as-code.md).
+- Manually, using the Cloud UI. This is the most basic way to create a Deployment and is the focus of this document.
+- Programmatically, using a Deployment template file. See [Manage Deployments as code](manage-deployments-as-code.md).
+- Programmatically, using [`astro deployment create`](cli/astro-deployment-create.md).
 
 After you create a Deployment, you can deploy DAGs to it using the Astro CLI on your local machine or a continuous integration/continuous delivery (CI/CD) tool. All DAGs and tasks on Astro are executed within a Deployment.
 

--- a/astro/create-deployment.md
+++ b/astro/create-deployment.md
@@ -38,7 +38,9 @@ This document explains how to create Deployments through the Cloud UI. To create
 
 5. Click **Create Deployment**.
 
-     A confirmation message appears indicating that the Deployment is in progress. Select the **Deployments** link to go to the **Deployments** page. The Deployment status is **Creating** until all underlying components in your Astro cluster are healthy, including the Airflow webserver and scheduler. During this time, the Airflow UI is unavailable and you can't deploy code or modify Deployment settings. When the Deployment is ready, the status changes to **Healthy**.
+     A confirmation message appears indicating that the Deployment is in progress. The Deployment status is **Creating** until all underlying components in your Astro cluster are healthy, including the Airflow webserver and scheduler. During this time, the Airflow UI is unavailable and you can't deploy code or modify Deployment settings. When the Deployment is ready, the status changes to **Healthy**.
+     
+You can continue to access your other Deployments by selecting the **Deployments** link.
     
     For more information about possible Deployment health statuses, see [Deployment health](deployment-metrics.md#deployment-health).
 

--- a/astro/create-deployment.md
+++ b/astro/create-deployment.md
@@ -9,13 +9,13 @@ id: create-deployment
   <meta name="og:description" content="Learn how to create an Astro Deployment. After you’ve created a Deployment, you can deploy DAGs to it from the Astro command-line interface (CLI), or from a continuous integration and continuous delivery (CI/CD) pipeline." />
 </head>
 
-An Astro Deployment is an Astro Runtime environment that is powered by the core components of Apache Airflow, including the Airflow webserver, scheduler, and one or more workers.
+An Astro Deployment is an Airflow environment that is powered by [Astro Runtime](runtime-image-architecture.md). It runs all core Airflow components, including the Airflow webserver, scheduler, and workers, plus additional tooling for reliability and observability.
 
-The most basic way to create a Deployment is through the Cloud UI. After you create a Deployment, you can deploy DAGs to it from the Astro CLI or from a continuous delivery (CI/CD) process. All DAGs and tasks on Astro are executed within a Deployment.
+The most basic way to create a Deployment is through the Cloud UI. After you create a Deployment, you can deploy DAGs to it using the Astro CLI on your local machine or a continuous integration/continuous delivery (CI/CD) tool. All DAGs and tasks on Astro are executed within a Deployment.
 
 ![Deployment creation screen example](/img/docs/create-deployment.png)
 
-Every Deployment is hosted on a single Astro cluster with its own dedicated resources, which you can customize to meet the unique requirements of your Organization. Every Astro cluster operates with a primary database that hosts the individual databases for each Deployment. To restrict communication between Deployments, resources for each Deployment are isolated within a corresponding Kubernetes namespace. See [Deployment network isolation](data-protection.md#deployment-network-isolation).
+Every Deployment is hosted on an Astro cluster with its own dedicated resources, which you can customize to fine-tune your resource usage. To restrict communication between Deployments, resources for each Deployment are isolated within a corresponding Kubernetes namespace. See [Deployment network isolation](data-protection.md#deployment-network-isolation).
 
 This document explains how to create Deployments through the Cloud UI. To create Deployments programmatically using the Astro CLI, see:
 

--- a/astro/create-deployment.md
+++ b/astro/create-deployment.md
@@ -13,8 +13,6 @@ An Astro Deployment is an Airflow environment that is powered by [Astro Runtime]
 
 The most basic way to create a Deployment is through the Cloud UI. After you create a Deployment, you can deploy DAGs to it using the Astro CLI on your local machine or a continuous integration/continuous delivery (CI/CD) tool. All DAGs and tasks on Astro are executed within a Deployment.
 
-![Deployment creation screen example](/img/docs/create-deployment.png)
-
 Every Deployment is hosted on an Astro cluster with its own dedicated resources, which you can customize to fine-tune your resource usage. To restrict communication between Deployments, resources for each Deployment are isolated within a corresponding Kubernetes namespace. See [Deployment network isolation](data-protection.md#deployment-network-isolation).
 
 This document explains how to create Deployments through the Cloud UI. To create Deployments programmatically using the Astro CLI, see:
@@ -28,47 +26,17 @@ This document explains how to create Deployments through the Cloud UI. To create
 
 ## Create a Deployment
 
-:::cli
-
-If you prefer, you can also run `astro deployment create` to create a Deployment. See [CLI Command Reference](cli/astro-deployment-create.md).
-
-:::
-
 1. In the Cloud UI, go to **Deployments**.
 
 2. Click **+ Deployment**.
 
     ![Deployment creation button](/img/docs/create-button.png)
 
-3. Complete the following fields:
+3. Enter a **Name** for the Deployment.
 
-    - **Basic**  
+4. (Optional) Configure other details for your Deployment, including cluster, executor, and worker resources. If you have no specific resource requirements for running Airflow, the default configurations should work in most cases. For all available Deployment options, see [Configure Deployment resources](configure-deployment-resources.md).
 
-        - **Name**: Enter a name for your Deployment.
-        - **Description**: Optional. Enter a description for your Deployment.
-        
-    - **Cluster**
-
-        - **Cluster**: Choose whether you want to run your Deployment in a **Standard cluster** or **Dedicated cluster**. If you don't have specific networking or cloud requirements, Astronomer recommends using the default **Standard cluster** configurations.
-
-        To configure and use dedicated clusters, see [Create a dedicated cluster](create-dedicated-cluster.md). If you don't have the option of choosing between standard or dedicated, you are an Astro Hybrid user and must choose a cluster that has been configured for your Organization. See [Manage Hybrid clusters](manage-hybrid-clusters.md).
-
-    - **Execution** 
-
-        - **Executor**: Select an executor to run your scheduled tasks. The Celery executor runs multiple tasks in a single worker and is a good choice for most teams. The Kubernetes executor runs each task in an isolated Kubernetes Pod and is a good option for teams that want fine-grained control over the execution environment for each of their tasks. For more information about the benefits and limitations of each executor, see [Choose an executor](configure-deployment-resources.md#choose-an-executor).
-        - **Worker queue**: (Celery executor only) Configure the `default` worker queue for your Deployment. A worker queue is a group of identically-configured workers responsible for running your tasks. The default options for the `default` worker queue are suitable for most workloads. See [Worker queues](configure-deployment-resources.md#worker-queues).
-        - **Kubernetes Executor and KPO Pods**: (Optional, Hosted only) If you're using the Kubernetes executor or KubernetesPodOperator, configure the default Pods that tasks run in. See [Configure Kubernetes Pod resources](configure-deployment-resources.md#configure-kubernetes-pod-resources).
-        
-    - **Advanced**
-
-        - **Astro Runtime/ Airflow Version**: Choose which Astro Runtime version you want your Deployment to run. By default, the latest version of Astro Runtime is selected. The Astro Runtime versions available in the Cloud UI are limited to patches for the most recent major and minor releases. Deprecated versions of Astro Runtime aren't available.
-        To upgrade the Astro Runtime version for your Deployment, you’ll need to update your Docker image in your Astro project directory. See [Upgrade Astro Runtime](upgrade-runtime.md).
-
-        - **Scheduler**: Select the amount of resources you want your Deployment scheduler to use. The scheduler is responsible for queueing and scheduling your Airflow tasks. See [Configure Deployment resources](configure-deployment-resources.md#scheduler-resources) for more information.
-    
-    These are the essential fields for configuring a Deployment. You can optionally configure additional details for your Deployment based on resource usage, user permissions, and resiliency. For all available Deployment options, see [Configure Deployment resources](configure-deployment-resources.md).
-
-4. Click **Create Deployment**.
+5. Click **Create Deployment**.
 
      A confirmation message appears indicating that the Deployment is in progress. Select the **Deployments** link to go to the **Deployments** page. The Deployment status is **Creating** until all underlying components in your Astro cluster are healthy, including the Airflow webserver and scheduler. During this time, the Airflow UI is unavailable and you can't deploy code or modify Deployment settings. When the Deployment is ready, the status changes to **Healthy**.
     

--- a/astro/create-deployment.md
+++ b/astro/create-deployment.md
@@ -11,14 +11,15 @@ id: create-deployment
 
 An Astro Deployment is an Airflow environment that is powered by [Astro Runtime](runtime-image-architecture.md). It runs all core Airflow components, including the Airflow webserver, scheduler, and workers, plus additional tooling for reliability and observability.
 
-The most basic way to create a Deployment is through the Cloud UI. After you create a Deployment, you can deploy DAGs to it using the Astro CLI on your local machine or a continuous integration/continuous delivery (CI/CD) tool. All DAGs and tasks on Astro are executed within a Deployment.
+There are three ways to create a Deployment: 
 
-Every Deployment is hosted on an Astro cluster with its own dedicated resources, which you can customize to fine-tune your resource usage. To restrict communication between Deployments, resources for each Deployment are isolated within a corresponding Kubernetes namespace. See [Deployment network isolation](data-protection.md#deployment-network-isolation).
+- Using the Cloud UI. This is the most basic way to create a Deployment and is the focus of this document.
+- Using [`astro deployment create`](cli/astro-deployment-create.md).
+- Using a Deployment template file. See [Manage Deployments as code](manage-deployments-as-code.md).
 
-This document explains how to create Deployments through the Cloud UI. To create Deployments programmatically using the Astro CLI, see:
+After you create a Deployment, you can deploy DAGs to it using the Astro CLI on your local machine or a continuous integration/continuous delivery (CI/CD) tool. All DAGs and tasks on Astro are executed within a Deployment.
 
-- [`astro deployment create`](cli/astro-deployment-create.md)
-- [Manage Deployments as code](manage-deployments-as-code.md)
+Every Deployment is hosted on an Astro cluster with its own dedicated resources that you can [customize](configure-deployment-resources.md) to fine-tune your resource usage. To restrict communication between Deployments, resources for each Deployment are isolated within a corresponding Kubernetes namespace. See [Deployment network isolation](data-protection.md#deployment-network-isolation).
 
 ## Prerequisites
 

--- a/astro/create-deployment.md
+++ b/astro/create-deployment.md
@@ -17,7 +17,7 @@ Every Deployment is hosted on an Astro cluster with its own dedicated resources,
 
 This document explains how to create Deployments through the Cloud UI. To create Deployments programmatically using the Astro CLI, see:
 
-- [Astro CLI reference guide](cli/astro-deployment-create.md)
+- [`astro deployment create`](cli/astro-deployment-create.md)
 - [Manage Deployments as code](manage-deployments-as-code.md)
 
 ## Prerequisites

--- a/astro/create-deployment.md
+++ b/astro/create-deployment.md
@@ -43,7 +43,7 @@ Every Deployment is hosted on an Astro cluster with its own dedicated resources 
      
 You can continue to access your other Deployments by selecting the **Deployments** link.
     
-    For more information about possible Deployment health statuses, see [Deployment health](deployment-metrics.md#deployment-health).
+For more information about possible Deployment health statuses, see [Deployment health](deployment-metrics.md#deployment-health).
 
 ## Next steps
 

--- a/astro/create-deployment.md
+++ b/astro/create-deployment.md
@@ -14,8 +14,8 @@ An Astro Deployment is an Airflow environment that is powered by [Astro Runtime]
 There are three ways to create a Deployment: 
 
 - Manually, using the Cloud UI. This is the most basic way to create a Deployment and is the focus of this document.
-- Programmatically, using a Deployment template file. See [Manage Deployments as code](manage-deployments-as-code.md).
 - Programmatically, using [`astro deployment create`](cli/astro-deployment-create.md).
+- Programmatically, using a Deployment template file. See [Manage Deployments as code](manage-deployments-as-code.md#create-a-deployment-from-a-template-file).
 
 After you create a Deployment, you can deploy DAGs to it using the Astro CLI on your local machine or a continuous integration/continuous delivery (CI/CD) tool. All DAGs and tasks on Astro are executed within a Deployment.
 


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/2606

I don't think we need to "elaborate" on the programmatic options in this doc. Those are complex tools for complex use cases, and this doc is more meant to help explain each item in the Cloud UI configuration screen that a user might want to know more about. Toploading it with too much expository info/ strategy info might frustrate users who just want to get started with a Deployment