### PR TITLE
Add note about workload identity with KPO

### DIFF
--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -97,6 +97,12 @@ Authorization is the process of verifying a user or service's permissions before
 
 To allow data pipelines running on GCP to access Google Cloud services in a secure and manageable way, Google recommends using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity). All Astro clusters on GCP have Workload Identity enabled by default. Each Astro Deployment is associated with a Google service account that's created by Astronomer and is bound to an identity from your Google Cloud project's fixed workload identity pool.
 
+:::note
+
+When connecting with Workload Identity from tasks using the Kubernetes Pod Operator (KPO), please first contact Astronomer support to enable the KPO service account binding.
+
+:::
+
 To grant a Deployment on Astro access to external data services on GCP, such as BigQuery:
 
 1. In the Cloud UI, select your Deployment, then click **Details**

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -97,9 +97,9 @@ Authorization is the process of verifying a user or service's permissions before
 
 To allow data pipelines running on GCP to access Google Cloud services in a secure and manageable way, Google recommends using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity). All Astro clusters on GCP have Workload Identity enabled by default. Each Astro Deployment is associated with a Google service account that's created by Astronomer and is bound to an identity from your Google Cloud project's fixed workload identity pool.
 
-:::note
+:::info
 
-When connecting with Workload Identity from tasks using the Kubernetes Pod Operator (KPO), please first contact Astronomer support to enable the KPO service account binding.
+If you want to connect with Workload Identity from tasks using the KubernetesPodOperator (KPO), please first contact [Astronomer support](https://cloud.astronomer.io/support) to enable the KPO service account binding.
 
 :::
 


### PR DESCRIPTION
Based on [this KB](https://support.astronomer.io/hc/en-us/articles/19342421333779), we first need to bind the KPO k8s SA to the IAM SA before the user can use workload identity from a KPO task.

This can be removed once [this change](https://github.com/astronomer/astro/issues/15134) goes live.