### PR TITLE
Add clarification for logs

### DIFF
--- a/software/export-task-logs.md
+++ b/software/export-task-logs.md
@@ -75,7 +75,7 @@ To revert to the default behavior and export task logs using a Fluentd Daemonset
 
 ## Use an external Elasticsearch instance for Airflow task log management
 
-Add Airflow task logs from your Astronomer Deployment to an existing Elasticsearch instance on [Elastic Cloud](https://www.elastic.co/cloud/) to centralize log management and analysis. Centralized log management allows you to quickly identify, troubleshoot, and resolve task failure issues. Although these examples use Elastic Cloud, you can also use AWS Managed OpenSearch Service or any other elastic service (managed or hosted). With an external Elasticsearch instance configured for Astronomer Software, you can see the logs in your Elasticsearch instance and browse the logs from the Astronomer Software interface.
+Add Airflow task logs from your Astronomer Deployment to an existing Elasticsearch instance on [Elastic Cloud](https://www.elastic.co/cloud/) to centralize log management and analysis. Centralized log management allows you to quickly identify, troubleshoot, and resolve task failure issues. Although these examples use Elastic Cloud, you can also use AWS Managed OpenSearch Service or any other elastic service (managed or hosted). With an external Elasticsearch instance configured for Astronomer Software, you can see the logs in your Elasticsearch instance and browse the logs from the Software UI.
 
 ### Create an Elastic Deployment and endpoint
 

--- a/software/export-task-logs.md
+++ b/software/export-task-logs.md
@@ -75,7 +75,7 @@ To revert to the default behavior and export task logs using a Fluentd Daemonset
 
 ## Use an external Elasticsearch instance for Airflow task log management
 
-Add Airflow task logs from your Astronomer Deployment to an existing Elasticsearch instance on [Elastic Cloud](https://www.elastic.co/cloud/) to centralize log management and analysis. Centralized log management allows you to quickly identify, troubleshoot, and resolve task failure issues. Although these examples use Elastic Cloud, you can also use AWS Managed OpenSearch Service.
+Add Airflow task logs from your Astronomer Deployment to an existing Elasticsearch instance on [Elastic Cloud](https://www.elastic.co/cloud/) to centralize log management and analysis. Centralized log management allows you to quickly identify, troubleshoot, and resolve task failure issues. Although these examples use Elastic Cloud, you can also use AWS Managed OpenSearch Service or any other elastic service (managed or hosted). With an external Elasticsearch instance configured for Astronomer Software, you will be able to see the logs in your Elasticsearch instance as well as maintain the functionality to browse the logs from the Astronomer Software interface.
 
 ### Create an Elastic Deployment and endpoint
 

--- a/software/export-task-logs.md
+++ b/software/export-task-logs.md
@@ -75,7 +75,7 @@ To revert to the default behavior and export task logs using a Fluentd Daemonset
 
 ## Use an external Elasticsearch instance for Airflow task log management
 
-Add Airflow task logs from your Astronomer Deployment to an existing Elasticsearch instance on [Elastic Cloud](https://www.elastic.co/cloud/) to centralize log management and analysis. Centralized log management allows you to quickly identify, troubleshoot, and resolve task failure issues. Although these examples use Elastic Cloud, you can also use AWS Managed OpenSearch Service or any other elastic service (managed or hosted). With an external Elasticsearch instance configured for Astronomer Software, you will be able to see the logs in your Elasticsearch instance as well as maintain the functionality to browse the logs from the Astronomer Software interface.
+Add Airflow task logs from your Astronomer Deployment to an existing Elasticsearch instance on [Elastic Cloud](https://www.elastic.co/cloud/) to centralize log management and analysis. Centralized log management allows you to quickly identify, troubleshoot, and resolve task failure issues. Although these examples use Elastic Cloud, you can also use AWS Managed OpenSearch Service or any other elastic service (managed or hosted). With an external Elasticsearch instance configured for Astronomer Software, you can see the logs in your Elasticsearch instance and browse the logs from the Astronomer Software interface.
 
 ### Create an Elastic Deployment and endpoint
 


### PR DESCRIPTION
As per [this ticket](https://astronomer.zendesk.com/agent/tickets/24782), there is some confusion when it comes to integrating an external Elasticsearch instance. Hopefully this clarifies that using the external elasticsearch does not sacrifice the ability to see the logs from the Software interface. This was originally specified in the [KB](https://astronomer.zendesk.com/knowledge/articles/4415725074835/en-us?brand_id=360001488713) but didn't make it into the docs.