### PR TITLE
Add page rank to crawl results

### DIFF
--- a/algolia-config.json
+++ b/algolia-config.json
@@ -3,10 +3,12 @@
   "start_urls": [
     {
       "url": "https://docs.astronomer.io/astro",
+      "selectors_key": "astro",
       "page_rank": 5
     },
     {
       "url": "https://docs.astronomer.io/software",
+      "selectors_key": "software",
       "page_rank": 1
     }
   ],

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -3,12 +3,10 @@
   "start_urls": [
     {
       "url": "https://docs.astronomer.io/astro",
-      "selectors_key": "astro",
       "page_rank": 5
     },
     {
       "url": "https://docs.astronomer.io/software",
-      "selectors_key": "software",
       "page_rank": 1
     }
   ],

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -6,6 +6,10 @@
       "page_rank": 5
     },
     {
+      "url": "https://docs.astronomer.io/learn",
+      "page_rank": 5
+    }
+    {
       "url": "https://docs.astronomer.io/software",
       "page_rank": 1
     }

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -1,7 +1,14 @@
 {
   "index_name": "published-docs",
   "start_urls": [
-    "https://docs.astronomer.io"
+    {
+      "url": "https://docs.astronomer.io/astro",
+      "page_rank": 5
+    },
+    {
+      "url": "https://docs.astronomer.io/software",
+      "page_rank": 1
+    }
   ],
   "stop_urls": [
     "(?:tab=)"

--- a/algolia-config.json
+++ b/algolia-config.json
@@ -8,7 +8,7 @@
     {
       "url": "https://docs.astronomer.io/learn",
       "page_rank": 5
-    }
+    },
     {
       "url": "https://docs.astronomer.io/software",
       "page_rank": 1


### PR DESCRIPTION
This is an attempt to add page ranking to our indices so that Software docs rarely if ever appear before Astro docs in the homepage search bar on https://docs.astronomer.io/

See https://docsearch.algolia.com/docs/legacy/config-file/#using-page-rank

I am worried that I'm misusing "selector key", but I also don't know how to test this without merging to main!