### PR TITLE
Update kubernetes-executor.md to highlight link to default resource values

### DIFF
--- a/astro/kubernetes-executor.md
+++ b/astro/kubernetes-executor.md
@@ -9,7 +9,11 @@ On Astro, you can configure Kubernetes executor in the following ways:
 - Change the resource usage for the default Pods on which your tasks run in the Cloud UI.
 - Customize individual Pods for tasks, including CPU and memory requests, using a `pod_override` configuration in your DAG code. 
 
-This document describes how to configure individual task Pods for different use cases. To configure defaults for all Kubernetes executor task Pods, see [Configure Kubernetes Pod resources](configure-deployment-resources.md#configure-kubernetes-pod-resources).
+:::info
+
+This document describes how to configure individual task Pods for different use cases. To configure defaults for all Kubernetes executor task pods, see [Configure Kubernetes Pod resources](configure-deployment-resources.md#configure-kubernetes-pod-resources).
+
+:::
 
 ## Customize a task's Kubernetes Pod
 


### PR DESCRIPTION
I was searching for this information, but I wasn't able to easily find it. I think we should make it harder to gloss over.