### PR TITLE
Update test-and-troubleshoot-locally.md

### DIFF
--- a/astro/test-and-troubleshoot-locally.md
+++ b/astro/test-and-troubleshoot-locally.md
@@ -107,7 +107,7 @@ curl -X GET localhost:8080/api/v1/<endpoint> --user "admin:admin"
 import requests
 
 response = requests.get(
-   url="localhost:8080/api/v1/<endpoint>",
+   url="http://localhost:8080/api/v1/<endpoint>",
    auth=("admin", "admin")
 )
 ```


### PR DESCRIPTION
doesn't work without the `http://`