### PR TITLE
Add Search Keyboard Shortcut to SearchBar Text

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -384,10 +384,6 @@ html .DocSearch-Button .DocSearch-Search-Icon {
   color: black !important;
 }
 
-.DocSearch-Button-Keys {
-  opacity: 0;
-}
-
 .DocSearch {
   --docsearch-searchbox-background: none;
   --docsearch-searchbox-focus-background: var(--ifm-color-white);

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -155,7 +155,7 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
   });
   const translatedSearchLabel = translate({
     id: 'theme.SearchBar.label',
-    message: 'Find what you\'re looking for',
+    message: 'Find what you\'re looking for (Ctrl/Cmd ⌘ + K)',
     description: 'The ARIA label and placeholder for search button',
   });
   return (

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -155,7 +155,7 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
   });
   const translatedSearchLabel = translate({
     id: 'theme.SearchBar.label',
-    message: 'Find what you\'re looking for (Ctrl/Cmd ⌘ + K)',
+    message: 'Find what you\'re looking for',
     description: 'The ARIA label and placeholder for search button',
   });
   return (


### PR DESCRIPTION
This PR adds back the keyboard shortcut to bring up search in the SearchBar.

<img width="524" alt="Screenshot 2023-08-23 at 11 02 56 AM" src="https://github.com/astronomer/docs/assets/96535736/934f3693-85b9-495d-aad1-816b1487e5b9">
