### PR TITLE
Clarify P1, P2, and P3 support levels

### DIFF
--- a/astro/astro-support.md
+++ b/astro/astro-support.md
@@ -25,9 +25,9 @@ The following are the best practices for submitting support requests in the Clou
 
 To help Astronomer support respond effectively to your support request, it's important that you correctly identify the severity of your issue. The following are the categories that Astronomer uses to determine the severity of your support request:
 
-**P1:** Critical impact. A deployment is completely unavailable or a DAG that was previously working in production is no longer working.
+**P1:** Critical impact. A Deployment is completely unavailable, or a DAG that was previously working in production is no longer working.
 
-Because P1 tickets are handled with the highest levels of urgency, if Astronomer Support responds on a P1 ticket and subsequently does not hear back for 2 hours, the ticket priority will be changed to P2.
+P1 tickets are handled with the highest levels of urgency, if Astronomer Support responds on a P1 ticket and subsequently does not hear back for 2 hours, the ticket priority will be automatically changed to P2.
 
 Additionally, if the immediate problem is solved but there are follow up investigations ongoing, those follow ups will be conducted in a separate ticket at a lower priority.
 
@@ -35,7 +35,7 @@ Additionally, if the immediate problem is solved but there are follow up investi
 
 Examples:
 
-- A newly deployed production DAG is not working, even though it was tested in a lower environment.
+- A newly deployed production DAG is not working, even though it was tested in another Astro Deployment (e.g. dev or test) beforehand.
 - The Airflow UI is unavailable.
 - You are unable to deploy code to your Deployment, but existing DAGs and tasks are running as expected.
 - You need to [modify a Hybrid cluster setting](manage-hybrid-clusters.md) that is required for running tasks, such as adding a new worker instance type.

--- a/astro/astro-support.md
+++ b/astro/astro-support.md
@@ -45,7 +45,7 @@ Examples:
 
 Examples:
 
-- A DAG that has been deployed to an Astro deployment for the first time, or is on a local development environment, is unexpectedly not working.
+- A newly deployed DAG is not working in a development Deployment, even though it ran successfully in a local environment using the Astro CLI.
 - You need to [modify a Hybrid cluster setting](manage-hybrid-clusters.md) that affects your cluster's performance but isn't required to run tasks, such as changing the size of your cluster's database or adding a new VPC peering connection.
 - Astro CLI usage is impaired (for example, there are incompatibility errors between installed packages).
 - There is an Airflow issue that has a code-based solution.

--- a/astro/astro-support.md
+++ b/astro/astro-support.md
@@ -25,17 +25,15 @@ The following are the best practices for submitting support requests in the Clou
 
 To help Astronomer support respond effectively to your support request, it's important that you correctly identify the severity of your issue. The following are the categories that Astronomer uses to determine the severity of your support request:
 
-**P1:** Critical impact, service is unusable in production.
+**P1:** Critical impact, a deployment is completely unavailable or a DAG that was previously working in production is no longer working.
+
+Because P1 tickets are handled with the highest levels of urgency, if Astronomer Support responds on a P1 ticket and subsequently does not hear back for 2 hours, the ticket priority will be changed to P2.
+
+**P2:** High impact. Ability to use Astro is severely impaired but does not affect critical, previously working pipelines in production.
 
 Examples:
 
-- Your tasks are not running and restarting them didn't fix the issue.
-- Astronomer is experiencing an incident or downtime that is affecting your data pipelines in production.
-
-**P2:** High impact. Ability to use Astro is severely impaired but does not affect critical pipelines in production.
-
-Examples:
-
+- A newly deployed production DAG is not working, even though it was tested in a lower environment.
 - The Airflow UI is unavailable.
 - You are unable to deploy code to your Deployment, but existing DAGs and tasks are running as expected.
 - You need to [modify a Hybrid cluster setting](manage-hybrid-clusters.md) that is required for running tasks, such as adding a new worker instance type.
@@ -45,12 +43,12 @@ Examples:
 
 Examples:
 
-- There is a bug in the Software UI.
-- You need to [modify a Hybrid cluster setting](manage-hybrid-clusters.md) that affects your cluster's performance but isn't required to run task, such as changing the size of your cluster's database or adding a new VPC peering connection.
+- A DAG that has been deployed to an Astro deployment for the first time, or is on a local development environment, is unexpectedly not working.
+- You need to [modify a Hybrid cluster setting](manage-hybrid-clusters.md) that affects your cluster's performance but isn't required to run tasks, such as changing the size of your cluster's database or adding a new VPC peering connection.
 - Astro CLI usage is impaired (for example, there are incompatibility errors between installed packages).
 - There is an Airflow issue that has a code-based solution.
 - You received a log alert on Astronomer.
-- You have lost use of a Public Preview feature that does not affect general services. 
+- You have lost use of a Public Preview feature that does not affect general services.
 
 **P4:** Low impact. Astro is fully usable but you have a question for our team.
 

--- a/astro/astro-support.md
+++ b/astro/astro-support.md
@@ -50,7 +50,7 @@ Examples:
 - Astro CLI usage is impaired (for example, there are incompatibility errors between installed packages).
 - There is an Airflow issue that has a code-based solution.
 - You received a log alert on Astronomer.
-- You have lost use of a Public Preview feature that does not affect general services.
+- You have lost the ability to use a [Public Preview](https://docs.astronomer.io/astro/feature-previews) feature that does not affect general services.
 
 **P4:** Low impact. Astro is fully usable but you have a question for our team.
 

--- a/astro/astro-support.md
+++ b/astro/astro-support.md
@@ -35,7 +35,7 @@ Additionally, if the immediate problem is solved but there are follow up investi
 
 Examples:
 
-- A newly deployed production DAG is not working, even though it was tested in another Astro Deployment (e.g. dev or test) beforehand.
+- A newly deployed production DAG is not working, even though it ran successfully in a development or test environment.
 - The Airflow UI is unavailable.
 - You are unable to deploy code to your Deployment, but existing DAGs and tasks are running as expected.
 - You need to [modify a Hybrid cluster setting](manage-hybrid-clusters.md) that is required for running tasks, such as adding a new worker instance type.

--- a/astro/astro-support.md
+++ b/astro/astro-support.md
@@ -25,9 +25,11 @@ The following are the best practices for submitting support requests in the Clou
 
 To help Astronomer support respond effectively to your support request, it's important that you correctly identify the severity of your issue. The following are the categories that Astronomer uses to determine the severity of your support request:
 
-**P1:** Critical impact, a deployment is completely unavailable or a DAG that was previously working in production is no longer working.
+**P1:** Critical impact. A deployment is completely unavailable or a DAG that was previously working in production is no longer working.
 
 Because P1 tickets are handled with the highest levels of urgency, if Astronomer Support responds on a P1 ticket and subsequently does not hear back for 2 hours, the ticket priority will be changed to P2.
+
+Additionally, if the immediate problem is solved but there are follow up investigations ongoing, those follow ups will be conducted in a separate ticket at a lower priority.
 
 **P2:** High impact. Ability to use Astro is severely impaired but does not affect critical, previously working pipelines in production.
 

--- a/software/support.md
+++ b/software/support.md
@@ -24,17 +24,15 @@ The following are the best practices for submitting support requests in the Astr
 
 To help Astronomer support respond effectively to your support request, it's important that you correctly identify the severity of your issue. The following are the categories that Astronomer uses to determine the severity of your support request:
 
-**P1:** Critical impact, service is unusable in production.
+**P1:** Critical impact, a deployment is completely unavailable or a DAG that was previously working in production is no longer working.
+
+Because P1 tickets are handled with the highest levels of urgency, if Astronomer Support responds on a P1 ticket and subsequently does not hear back for 2 hours, the ticket priority will be changed to P2.
+
+**P2:** High impact. Ability to use Astronomer Software is severely impaired but does not affect critical, previously working pipelines in production.
 
 Examples:
 
-- Your tasks are not running and restarting them didn't fix the issue.
-- Astronomer Software is experiencing an incident or downtime that is affecting your production data pipelines.
-
-**P2:** High impact. Ability to use Astronomer Software is severely impaired but does not affect critical production pipelines.
-
-Examples:
-
+- A newly deployed production DAG is not working, even though it was tested in a lower environment.
 - The Airflow UI is unavailable.
 - You are unable to deploy code to your Deployment, but existing DAGs and tasks are running as expected.
 - Task logs are missing in the Airflow UI.
@@ -43,6 +41,7 @@ Examples:
 
 Examples:
 
+- A DAG that has been deployed for the first time, or is on a local development environment, is unexpectedly not working.
 - There is a bug in the Software UI.
 - Astro CLI usage is impaired (for example, there are incompatibility errors between installed packages).
 - There is an Airflow issue that has a code-based solution.

--- a/software/support.md
+++ b/software/support.md
@@ -24,15 +24,15 @@ The following are the best practices for submitting support requests in the Astr
 
 To help Astronomer support respond effectively to your support request, it's important that you correctly identify the severity of your issue. The following are the categories that Astronomer uses to determine the severity of your support request:
 
-**P1:** Critical impact, a deployment is completely unavailable or a DAG that was previously working in production is no longer working.
+**P1:** Critical impact. A Deployment is completely unavailable, or a DAG that was previously working in production is no longer working.
 
-Because P1 tickets are handled with the highest levels of urgency, if Astronomer Support responds on a P1 ticket and subsequently does not hear back for 2 hours, the ticket priority will be changed to P2.
+P1 tickets are handled with the highest levels of urgency, if Astronomer Support responds on a P1 ticket and subsequently does not hear back for 2 hours, the ticket priority will be automatically changed to P2.
 
 **P2:** High impact. Ability to use Astronomer Software is severely impaired but does not affect critical, previously working pipelines in production.
 
 Examples:
 
-- A newly deployed production DAG is not working, even though it was tested in a lower environment.
+- A newly deployed production DAG is not working, even though it was tested in another Astro Deployment (e.g. dev or test) beforehand.
 - The Airflow UI is unavailable.
 - You are unable to deploy code to your Deployment, but existing DAGs and tasks are running as expected.
 - Task logs are missing in the Airflow UI.


### PR DESCRIPTION
We have quite specific expectations of what should be a ticket at each priority level. Especially for P1 tickets, our processes for handling these tickets only makes sense in the context of certain kinds of issues. Without this level of specificity, we do get tickets labeled higher than they should be because, understandably, everyone feels their own issue is high priority. This PR attempts to clarify on the existing process.