### PR TITLE
Update runtime-version-lifecycle-policy.md

### DIFF
--- a/astro/runtime-version-lifecycle-policy.md
+++ b/astro/runtime-version-lifecycle-policy.md
@@ -84,7 +84,6 @@ The following table contains the exact lifecycle for each published version of A
 | [4](runtime-release-notes.md#astro-runtime-420) | 2.2             | March 10, 2022     | September 2023          |     |
 | [5](runtime-release-notes.md#astro-runtime-500) | 2.3             | April 30, 2022     | April 2024              | ✔️   |
 | [6](runtime-release-notes.md#astro-runtime-600) | 2.4             | September 19, 2022 | March 2024              | ✔️   |
-| [7](runtime-release-notes.md#astro-runtime-700) | 2.5             | December 3, 2022   | July 2023               |     |
 | [8](runtime-release-notes.md#astro-runtime-800) | 2.6             | April 30, 2023     | October 2023            |     |
 | [9](runtime-release-notes.md#astro-runtime-900) | 2.7             | August 18, 2023    | January 2025            | ✔️   |
 


### PR DESCRIPTION
Remove Astro Runtime 7, especially because you need to be able to scroll to the right to see that it's actually passed it's EOL