### PR TITLE
Add a warning about houston needing to be accessible for SCIM

### DIFF
--- a/software/integrate-auth-system.md
+++ b/software/integrate-auth-system.md
@@ -411,6 +411,10 @@ You can see the name you configured in `AUTH__OPENID_CONNECT__CUSTOM__DISPLAY_NA
 
 Astronomer Software supports integration with the open standard System for Cross-Domain Identity Management (SCIM). Using the SCIM protocol with Astronomer Software allows you to automatically provision and deprovision users and Teams based on templates for access and permissions. It also provides better observability through your identity provider for when users and Teams are created or modified across your organization.
 
+:::warning
+SCIM works by the IdP pushing updates to users & teams to Astronomer Software. For this to work, your Astronomer Software platform must be reachable from the internet. If you are running Astronomer Software without exposing it to the internet, there may be solutions for routing SCIM traffic depending on the combination of cloud provider and IdP. Please contact [Astronomer support](https://support.astronomer.io) for more information.
+:::
+
 <Tabs
     groupId="scim"
     defaultValue="okta"

--- a/software/integrate-auth-system.md
+++ b/software/integrate-auth-system.md
@@ -411,8 +411,8 @@ You can see the name you configured in `AUTH__OPENID_CONNECT__CUSTOM__DISPLAY_NA
 
 Astronomer Software supports integration with the open standard System for Cross-Domain Identity Management (SCIM). Using the SCIM protocol with Astronomer Software allows you to automatically provision and deprovision users and Teams based on templates for access and permissions. It also provides better observability through your identity provider for when users and Teams are created or modified across your organization.
 
-:::warning
-SCIM works by the IdP pushing updates to users & teams to Astronomer Software. For this to work, your Astronomer Software platform must be reachable from the internet. If you are running Astronomer Software without exposing it to the internet, there may be solutions for routing SCIM traffic depending on the combination of cloud provider and IdP. Please contact [Astronomer support](https://support.astronomer.io) for more information.
+:::info
+SCIM works because the IdP pushes updates about users and teams to Astronomer Software. This means your Astronomer Software platform must be connected to the internet to receive those updates. If you are running Astronomer Software without exposing it to the internet, there might be solutions for routing SCIM traffic depending on your combination of cloud provider and IdP. Please contact [Astronomer support](https://support.astronomer.io) for more information.
 :::
 
 <Tabs


### PR DESCRIPTION
[This user](https://astronomer.zendesk.com/agent/tickets/24116) did not realize that their Houston had to be accessible from the internet in order for the IdP to push SCIM updates.

We need to call this out. The actual solutions (e.g. [connecting Azure AD](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/on-premises-scim-provisioning)) are bespoke to each customers setup and are probably outside the scope of support as well.