### PR TITLE
Remove duplicate Usage section

### DIFF
--- a/astro/deployment-metrics.md
+++ b/astro/deployment-metrics.md
@@ -201,18 +201,6 @@ After you complete this setup, Astro automatically launches a sidecar container 
 
 To check the health of a Deployment's DogStatsD container, open the `datadog.dogstatsd.running` metric in the Datadog UI. If the Deployment's namespace appears under the metric's `host` tag key, its DogStatsD container is healthy and exporting metrics to Datadog.
 
-## Astro usage
-
-Use the **Usage** tab in the Cloud UI to review the number of successful task runs across Deployments in your Organization. Astro is priced based on successful task runs, so this view can help you monitor both Astro cost as well as Airflow usage in aggregate.
-
-![Usage tab in the Cloud UI](/img/docs/usage.png)
-
-The bar chart on the left shows your Organization's total task runs per day for the past 31 days, with each day's volume sorted by Deployment. Each color in the bar chart represents a different Deployment. To see each Deployment's number of successful task runs for a given day, you can hover over the bar chart for that day with your mouse.
-
-The legend on the right side of the menu shows the colors used for each Deployment. This legend shows each Deployment's total sum of successful task runs over the last 31 days. The daily numbers on the left bar chart add up to the monthly total per Deployment on the right.
-
-To export this data as a `.csv` file, click the **Export** button above the legend.
-
 ## See also
 
 - [Organization metrics](organization-metrics.md)


### PR DESCRIPTION
We already have Usage documented in https://docs.astronomer.io/astro/organization-metrics, removing it from the Deployment metrics page.