### PR TITLE
Link checker fixes

### DIFF
--- a/learn/airflow-branch-operator.md
+++ b/learn/airflow-branch-operator.md
@@ -335,4 +335,4 @@ There is much more to the BranchPythonOperator than simply choosing one task ove
 - What if you want to trigger a DAG Run only if the previous one succeeded?
 
 For more guidance and best practices on common use cases like the ones above, try out Astronomer's
-[Academy Course on Branching](https://academy.astronomer.io/branching-course) for free today.
+[Academy Course on Branching](https://academy.astronomer.io/astro-runtime-branching) for free today.

--- a/learn/airflow-database.md
+++ b/learn/airflow-database.md
@@ -215,7 +215,7 @@ print(req.text)
 
 Cross-DAG dependencies are a powerful tool to take your data orchestration to the next level. Retrieving data about cross-DAG dependencies from the metadata database can be useful for programmatically implementing custom solutions, for example to make sure downstream DAGs are paused if an upstream DAG is paused. These dependencies can be visualized in the Airflow UI under **Browse** -> **DAG Dependencies**, but they are not accessible through the Airflow REST API.
 
-To programmatically access this information, you can use SQLAlchemy with [Airflow models](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/index.html) to access data from the metadata database. Note that if you are running Airflow in a Dockerized setting, you have to run the script below from within your scheduler container.
+To programmatically access this information, you can use SQLAlchemy with [Airflow models](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/dag/index.html) to access data from the metadata database. Note that if you are running Airflow in a Dockerized setting, you have to run the script below from within your scheduler container.
 
 ```python
 from sqlalchemy import create_engine

--- a/learn/airflow-sql.md
+++ b/learn/airflow-sql.md
@@ -276,4 +276,4 @@ You've learned how to interact with your SQL database from Airflow. There are so
 - What if you want to retrieve data with the PostgresOperator?
 - Is it scalable?
 
-Find out more on Astronomer's [Academy Course on Airflow SQL](https://academy.astronomer.io/airflow-sql) for free today.
+Find out more on Astronomer's [Airflow: Branching](https://academy.astronomer.io/astro-runtime-branching) course for free today.

--- a/learn/error-notifications-in-airflow.md
+++ b/learn/error-notifications-in-airflow.md
@@ -269,7 +269,7 @@ t1 = PythonOperator(
 
 ### Example pre-built notifier: Slack
 
-An example of a community provided pre-built notifier is the [SlackNotifier](https://airflow.apache.org/docs/apache-airflow-providers-slack/latest/_api/airflow/providers/slack/notifications/slack_notifier/index.html). 
+An example of a community provided pre-built notifier is the [SlackNotifier](https://airflow.apache.org/docs/apache-airflow-providers-slack/stable/_api/airflow/providers/slack/notifications/slack/index.html#module-airflow.providers.slack.notifications.slack). 
 
 It can be imported from the Slack provider package and used with any `*_callback` function:
 


### PR DESCRIPTION
https://github.com/astronomer/docs/issues/2749

Was fixing an unrelated broken link issue, and went to check on the link checker issue. We'd gotten to a lot of the Astro related links earlier this week, but was fixing as I went. 

Software links in separate PR.

**Learn related links from link checker issue**
Errors in learn/airflow-database.md
[404] https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/index.html | Failed: Network error: Not Found

Errors in learn/airflow-sql.md
[404] https://academy.astronomer.io/airflow-sql | Failed: Network error: Not Found

Errors in learn/airflow-branch-operator.md
[404] https://academy.astronomer.io/branching-course | Failed: Network error: Not Found

Errors in learn/subdags.md
[404] https://academy.astronomer.io/airflow-grouping | Failed: Network error: Not Found

Errors in learn/error-notifications-in-airflow.md
[404] https://airflow.apache.org/docs/apache-airflow-providers-slack/latest/_api/airflow/providers/slack/notifications/slack_notifier/index.html | Failed: Network error: Not Found