### PR TITLE
mark workspace and deployment creation optional in mwaa and gcc migration docs

### DIFF
--- a/astro/migrate-gcc.mdx
+++ b/astro/migrate-gcc.mdx
@@ -59,11 +59,11 @@ gcloud composer environments update [GCC_ENVIRONMENT_NAME] \
 
 :::
 
-## Step 2: Create an Astro Workspace
+## Step 2: Create an Astro Workspace (Optional)
 
 <Workspaces />
 
-## Step 3: Create an Astro Deployment
+## Step 3: Create an Astro Deployment (Optional)
 
 <Deployments />
 

--- a/astro/migrate-mwaa.mdx
+++ b/astro/migrate-mwaa.mdx
@@ -71,11 +71,11 @@ To complete this setup from the command line:
     ```
 :::
 
-## Step 2: Create an Astro Workspace
+## Step 2: Create an Astro Workspace (Optional)
 
 <Workspaces />
 
-## Step 3: Create an Astro Deployment
+## Step 3: Create an Astro Deployment (Optional)
 
 <Deployments />
 

--- a/astro/migration-partials/deployments.mdx
+++ b/astro/migration-partials/deployments.mdx
@@ -3,7 +3,7 @@ import TabItem from "@theme/TabItem";
 
 A _Deployment_ is an Astro Runtime environment that is powered by the core components of Apache Airflow. In a Deployment, you can deploy and run DAGs, configure worker resources, and view metrics.
 
-You can choose to use an existing Deployment, or create a new one. But you must have at least one Deployment to complete your migration.
+You can choose to use an existing Deployment, or create a new one. However, you must have at least one Deployment to complete your migration.
 
 Before you create your Deployment, copy the following information from your source Airflow environment:
 

--- a/astro/migration-partials/deployments.mdx
+++ b/astro/migration-partials/deployments.mdx
@@ -3,6 +3,8 @@ import TabItem from "@theme/TabItem";
 
 A _Deployment_ is an Astro Runtime environment that is powered by the core components of Apache Airflow. In a Deployment, you can deploy and run DAGs, configure worker resources, and view metrics.
 
+You can choose to use an existing Deployment, or create a new one. But you must have at least one Deployment to complete your migration.
+
 Before you create your Deployment, copy the following information from your source Airflow environment:
 
 - Environment name

--- a/astro/migration-partials/workspaces.mdx
+++ b/astro/migration-partials/workspaces.mdx
@@ -1,6 +1,6 @@
 In your Astro Organization, you can create _Workspaces_, which are a collection of users that have access to the same Deployments. Workspaces are typically owned by a single team.
 
-You can choose to use an existing Workspace, or create a new one. But you must have at least one Workspace to complete your migration.
+You can choose to use an existing Workspace, or create a new one. However, you must have at least one Workspace to complete your migration.
 
 1. Follow the steps in [Manage Workspaces](manage-workspaces.md) to create a Workspace in the Cloud UI for your migrated Airflow environments. Astronomer recommends naming your first Workspace after your data team or initial business use case with Airflow. You can update these names in the Cloud UI after you finish the migration.
 

--- a/astro/migration-partials/workspaces.mdx
+++ b/astro/migration-partials/workspaces.mdx
@@ -1,4 +1,6 @@
-In your Astro Organization, you can create _Workspaces_, which are a collection of users that have access to the same Deployments. Workspaces are typically owned by a single team. 
+In your Astro Organization, you can create _Workspaces_, which are a collection of users that have access to the same Deployments. Workspaces are typically owned by a single team.
+
+You can choose to use an existing Workspace, or create a new one. But you must have at least one Workspace to complete your migration.
 
 1. Follow the steps in [Manage Workspaces](manage-workspaces.md) to create a Workspace in the Cloud UI for your migrated Airflow environments. Astronomer recommends naming your first Workspace after your data team or initial business use case with Airflow. You can update these names in the Cloud UI after you finish the migration.
 


### PR DESCRIPTION
marking those steps as optional because customers may already have a workspace and deployment