### PR TITLE
Update K8s executor secret env var section

### DIFF
--- a/astro/environment-variables.md
+++ b/astro/environment-variables.md
@@ -66,13 +66,12 @@ After you set an environment variable key, only the environment variable value c
 
 ### How environment variables are stored on Astro
 
-Non-secret environment variables set in the Cloud UI are stored in a database that is managed by Astronomer and hosted in the Astro control plane. When you configure a secret environment variable in the Cloud UI, the following methodology is used:
+Non-secret environment variables set in the Cloud UI are stored in a Hashicorp Vault secrets manager hosted in Astro control plane. These environment variables are available to your Astro Deployment’s Kubernetes namespace as a Kubernetes secret.
 
-- Astro generates a manifest that defines a Kubernetes secret, named `env-secrets`, that contains your variable's key and value.
-- Astro applies this manifest to your Deployment's namespace.
-- After the manifest is applied, the key and value of your environment variable are stored in a managed [etcd cluster](https://etcd.io/) at rest within Astro.
-
-This process occurs every time you update the environment variable's key or value. To use a secret environment variable value in a KubernetesPodOperator, you need to mount the value from the Astro kubernetes secret to your Kubernetes Pod. See [Use secret environment variables with the KuberernetesPodOperator](kubernetespodoperator.md#use-secret-environment-variables-with-the-kubernetespodoperator).
+To use these environment variables in an Astro Deployment:
+- In a regular PythonOperator or Python code, you can use `os.environ` method.
+- If you can’t use Python or are using a pre-defined code that expects specific keys for environment variables, you need to mount the secret environment variables using BaseOperator’s `executor_config` by providing a `pod_override`. See [Use secret environment variables in worker Pods](kubernetes-executor.md#use-secret-environment-variables-in-worker-pods).
+- If you need to use these secret environment variables in a KubernetesPodOperator, see [Use secret environment variables with KubernetesPodOperator](kubernetespodoperator.md#use-secret-environment-variables-with-the-kubernetespodoperator).
 
 :::caution
 

--- a/astro/environment-variables.md
+++ b/astro/environment-variables.md
@@ -72,10 +72,7 @@ Non-secret environment variables set in the Cloud UI are stored in a database th
 - Astro applies this manifest to your Deployment's namespace.
 - After the manifest is applied, the key and value of your environment variable are stored in a managed [etcd cluster](https://etcd.io/) at rest within Astro.
 
-This process occurs every time you update the environment variable's key or value. To use a secret environment variable value in a task running on the Kubernetes executor or the KubernetesPodOperator, you need to mount the value from the Astro kubernetes secret to your Kubernetes Pod. See:
-
-- [Mount secret environment variables to worker pods](kubernetes-executor.md#mount-secret-environment-variables-to-worker-pods)
-- [Use secret environment variables with the KubernetesPodOperator](kubernetespodoperator.md#use-secret-environment-variables-with-the-kubernetespodoperator)
+This process occurs every time you update the environment variable's key or value. To use a secret environment variable value in a KubernetesPodOperator, you need to mount the value from the Astro kubernetes secret to your Kubernetes Pod. See [Use secret environment variables with the KuberernetesPodOperator](kubernetespodoperator.md#use-secret-environment-variables-with-the-kubernetespodoperator).
 
 :::caution
 

--- a/astro/kubernetes-executor.md
+++ b/astro/kubernetes-executor.md
@@ -94,9 +94,89 @@ When this DAG runs, it launches a Kubernetes Pod with exactly 0.5m of CPU and 10
 
 ## Use secret environment variables in worker Pods
 
-In Astro, [environment variables](environment-variables.md) marked as secrets are stored in a Kubernetes secret called `env-secrets`. These environment variables are already available to your worker Pods and can be accessed in your tasks just like any other environment variable, `os.environ[<your-secret-env-var>]` or `os.getenv(<your-secret-env-var>, None)`. 
+In Astro, [environment variables](environment-variables.md) marked as secrets are stored in a Kubernetes secret called `env-secrets`. These environment variables are already available to your worker Pods and can be accessed in your tasks just like any other environment variable. For example, you can use `os.environ[<your-secret-env-var>]` or `os.getenv(<your-secret-env-var>, None)` in your Python code. 
 
-However, in KubernetesPodOperator, you need to read the value from `env-secrets` as described in [Run the KubernetesPodOperator on Astro](kubernetespodoperator.md#use-secret-environment-variables-with-the-kubernetespodoperator).
+However, if you can’t use Python or are using a pre-defined code that expects specific keys for environment variables, you need to mount the secret environment variables by pulling the value from `env-secrets` and mount it to the Pod running your task as a new Kubernetes Secret.
+
+1. Add the following import to your DAG file:
+   
+    ```python
+    from airflow.kubernetes.secret import Secret
+    ```
+
+2. Define a Kubernetes `Secret` in your DAG instantiation using the following format:
+
+    ```python
+    secret_env = Secret(deploy_type="env", deploy_target="<VARIABLE_KEY>", secret="env-secrets", key="<VARIABLE_KEY>")
+    namespace = conf.get("kubernetes", "NAMESPACE")
+    ```
+
+3. Specify the `Secret` in the `secret_key_ref` section of your `pod_override` configuration.
+
+4. In the task where you want to use the secret value, add the following task-level argument:
+
+    ```python
+    op_kwargs={
+            "env_name": secret_env.deploy_target
+    },
+    ```
+
+5. In the executable for the task, call the secret value using `os.environ[env_name]`.
+
+In the following example, a secret named `MY_SECRET` is pulled from `env-secrets` and printed to logs.
+ 
+```python
+import pendulum
+from kubernetes.client import models as k8s
+
+from airflow.configuration import conf
+from airflow.kubernetes.secret import Secret
+from airflow.models import DAG
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.operators.python import PythonOperator
+
+
+def print_env(env_name):
+    import os
+    print(os.environ[env_name])
+
+with DAG(
+        dag_id='test-secret',
+        start_date=pendulum.datetime(2022, 1, 1, tz="UTC"),
+        end_date=pendulum.datetime(2022, 1, 5, tz="UTC"),
+        schedule="@once",
+) as dag:
+    secret_env = Secret(deploy_type="env", deploy_target="MY_SECRET", secret="env-secrets", key="MY_SECRET")
+    namespace = conf.get("kubernetes", "NAMESPACE")
+
+    p = PythonOperator(
+        python_callable=print_env,
+        op_kwargs={
+            "env_name": secret_env.deploy_target
+        },
+        task_id='test-py-env',
+        executor_config={
+            "pod_override": k8s.V1Pod(
+                spec=k8s.V1PodSpec(
+                    containers=[
+                        k8s.V1Container(
+                            name="base",
+                            env=[
+                                k8s.V1EnvVar(
+                                    name=secret_env.deploy_target,
+                                    value_from=k8s.V1EnvVarSource(
+                                        secret_key_ref=k8s.V1SecretKeySelector(name=secret_env.secret,
+                                                                               key=secret_env.key)
+                                    ),
+                                )
+                            ],
+                        )
+                    ]
+                )
+            ),
+        }
+    )
+```
 
 ## (Astro Hybrid only) Change the Kubernetes executor's worker node type
 

--- a/astro/kubernetes-executor.md
+++ b/astro/kubernetes-executor.md
@@ -92,11 +92,17 @@ with DAG(
 
 When this DAG runs, it launches a Kubernetes Pod with exactly 0.5m of CPU and 1024Mi of memory, as long as that infrastructure is available in your Deployment. After the task finishes, the Pod terminates gracefully.
 
+## Use secret environment variables in worker Pods
+
+In Astro, [environment variables](environment-variables.md) marked as secrets are stored in a Kubernetes secret called `env-secrets`. These environment variables are already available to your worker Pods and can be accessed in your tasks just like any other environment variable, `os.environ[<your-secret-env-var>]` or `os.getenv(<your-secret-env-var>, None)`. 
+
+However, in KubernetesPodOperator, you need to read the value from `env-secrets` as described in [Run the KubernetesPodOperator on Astro](kubernetespodoperator.md#use-secret-environment-variables-with-the-kubernetespodoperator).
+
 ## (Astro Hybrid only) Change the Kubernetes executor's worker node type
 
 :::info
 
-This section applies only to [Astro Hybrid](hybrid-overview.md) users. To see whether you're an Astro Hybrid user, open go to the Cloud UI, click on your Workspace name and go to **Organization Settings** > **General**. Your Astro product type is listed under **Product Type**.
+This section applies only to [Astro Hybrid](hybrid-overview.md) users. To see whether you're an Astro Hybrid user, open your Organization in the Cloud UI and go to **Settings** > **General**. Your Astro product type is listed under **Product Type**.
 
 :::
 


### PR DESCRIPTION
Resolves #2770 

Add a simple method to access env variables in addition to the complex method that requires `pod_override` in only special cases. Also change how env vars are stored on astro. 