### PR TITLE
[Tiny PR] Add another note about CLI upgrading to the Create your first DAG doc

### DIFF
--- a/astro/create-first-dag.md
+++ b/astro/create-first-dag.md
@@ -127,7 +127,7 @@ DAG-only deploys are an Astro feature that you can use to quickly update your As
     astro deploy --dags
     ```
 
-    This command returns a list of Deployments available in your Workspace and prompts you to confirm where you want to deploy your DAG code. After you select a Deployment, the CLI parses your DAGs to ensure that they don't contain basic syntax and import errors. If your code passes the parse, the Astro CLI deploys your DAGs to Astro.
+    This command returns a list of Deployments available in your Workspace and prompts you to confirm where you want to deploy your DAG code. After you select a Deployment, the CLI parses your DAGs to ensure that they don't contain basic syntax and import errors. If your code passes the parse, the Astro CLI deploys your DAGs to Astro. If you run into issues deploying your DAGs, check to make sure that you have the latest version of the Astro CLI. See [Upgrade the CLI](cli/install-cli.md#upgrade-the-cli).
 
 ## Step 4: Trigger your DAG on Astro
 


### PR DESCRIPTION
There was another user running into dag-only deploy not working because they had an old CLI version (they reached out over intercom). This is just a proposal, maybe it makes more sense to have a note at the end of Step 3 that covers the deployment step generally? 