### PR TITLE
[Tiny PR] Add default schedule to scheduling guide

### DIFF
--- a/learn/cross-dag-dependencies.md
+++ b/learn/cross-dag-dependencies.md
@@ -106,7 +106,7 @@ You can trigger a downstream DAG with the TriggerDagRunOperator from any point i
 
 A common use case for this implementation is when an upstream DAG fetches new testing data for a machine learning pipeline, runs and tests a model, and publishes the model's prediction. In case of the model underperforming, the TriggerDagRunOperator is used to start a separate DAG that retrains the model while the upstream DAG waits. Once the model is retrained and tested by the downstream DAG, the upstream DAG resumes and publishes the new model's results.
 
-The [schedule](scheduling-in-airflow.md) of the downstream DAG is independent of the runs triggered by the TriggerDagRunOperator. For a DAG to only run based on the TriggerDagRunOperator, set the `schedule` parameter to `None`. Note that the dependent DAG must be unpaused for it to be triggered by the TriggerDagRunOperator.
+The [schedule](scheduling-in-airflow.md) of the downstream DAG is independent of the runs triggered by the TriggerDagRunOperator. To run a DAG solely with the TriggerDagRunOperator, set the DAG's `schedule` parameter to `None`. Note that the dependent DAG must be unpaused to get triggered.
 
 The following example DAG implements the TriggerDagRunOperator to trigger a DAG with the `dag_id` `dependent_dag` between two other tasks. Since both the `wait_for_completion` and the `deferrable` parameters of the `trigger_dependent_dag` task in the `trigger_dagrun_dag` are set to `True`, the task is deferred until the `dependent_dag` has finished its run. Once the `trigger_dagrun_dag` task completes, the `end_task` will run.
 

--- a/learn/cross-dag-dependencies.md
+++ b/learn/cross-dag-dependencies.md
@@ -106,6 +106,8 @@ You can trigger a downstream DAG with the TriggerDagRunOperator from any point i
 
 A common use case for this implementation is when an upstream DAG fetches new testing data for a machine learning pipeline, runs and tests a model, and publishes the model's prediction. In case of the model underperforming, the TriggerDagRunOperator is used to start a separate DAG that retrains the model while the upstream DAG waits. Once the model is retrained and tested by the downstream DAG, the upstream DAG resumes and publishes the new model's results.
 
+The [schedule](scheduling-in-airflow.md) of the downstream DAG is independent of the runs triggered by the TriggerDagRunOperator. For a DAG to only run based on the TriggerDagRunOperator, set the `schedule` parameter to `None`. Note that the dependent DAG must be unpaused for it to be triggered by the TriggerDagRunOperator.
+
 The following example DAG implements the TriggerDagRunOperator to trigger a DAG with the `dag_id` `dependent_dag` between two other tasks. Since both the `wait_for_completion` and the `deferrable` parameters of the `trigger_dependent_dag` task in the `trigger_dagrun_dag` are set to `True`, the task is deferred until the `dependent_dag` has finished its run. Once the `trigger_dagrun_dag` task completes, the `end_task` will run.
 
 <Tabs

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -41,7 +41,7 @@ The following parameters ensure your DAGs run at the correct time:
 
 - **`data_interval_start`**: Defines the start date and time of the data interval. A DAG's timetable will return this parameter for each DAG run. This parameter is created automatically by Airflow, or is specified by the user when implementing a custom timetable.
 - **`data_interval_end`**: Defines the end date and time of the data interval. A DAG's timetable will return this parameter for each DAG run. This parameter is created automatically by Airflow, or is specified by the user when implementing a custom timetable.
-- **`schedule`**: Defines when a DAG will be run. This value is set at the DAG configuration level. It accepts cron expressions, timedelta objects, timetables, and lists of datasets.
+- **`schedule`**: Defines when a DAG will be run. This value is set at the DAG configuration level. It accepts cron expressions, timedelta objects, timetables, and lists of datasets. The default `schedule` is `timedelta(days=1)`.
 - **`start_date`**: The first date your DAG will be executed. This parameter is required for your DAG to be scheduled by Airflow.
 - **`end_date`**: The last date your DAG will be executed. This parameter is optional.
 

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -41,7 +41,7 @@ The following parameters ensure your DAGs run at the correct time:
 
 - **`data_interval_start`**: Defines the start date and time of the data interval. A DAG's timetable will return this parameter for each DAG run. This parameter is created automatically by Airflow, or is specified by the user when implementing a custom timetable.
 - **`data_interval_end`**: Defines the end date and time of the data interval. A DAG's timetable will return this parameter for each DAG run. This parameter is created automatically by Airflow, or is specified by the user when implementing a custom timetable.
-- **`schedule`**: Defines when a DAG will be run. This value is set at the DAG configuration level. It accepts cron expressions, timedelta objects, timetables, and lists of datasets. The default `schedule` is `timedelta(days=1)`.
+- **`schedule`**: Defines when a DAG will be run. This value is set at the DAG configuration level. It accepts cron expressions, timedelta objects, timetables, and lists of datasets. The default `schedule` is `timedelta(days=1)`, which runs the DAG once per day if no `schedule` is defined. If you [trigger your DAG externally](cross-dag-dependencies.md), set the `schedule` to `None`.
 - **`start_date`**: The first date your DAG will be executed. This parameter is required for your DAG to be scheduled by Airflow.
 - **`end_date`**: The last date your DAG will be executed. This parameter is optional.
 


### PR DESCRIPTION
TIL I learned `schedule` is not a mandatory parameter, or defaults to None, no, for backwards compatitbility reasons the default is `timedelta(days=1)`: https://github.com/apache/airflow/blob/eed2901e877b32a211e0e74bc9d69fc11e552f2a/airflow/models/dag.py#L164 😄 Added that and a note on how to handle the schedule with the TriggerDagRunOperator since that is the use case that led to this discussion in the #airflow channel. 

