### PR TITLE
Try a layout for Connection and Example docs

### DIFF
--- a/learn/airflow-redshift.md
+++ b/learn/airflow-redshift.md
@@ -1,6 +1,6 @@
 ---
 title: "Orchestrate Redshift operations with Airflow"
-sidebar_label: "Amazon Redshift"
+sidebar_label: "Example"
 description: "Orchestrate Redshift queries from your Airflow DAGs."
 id: airflow-redshift
 tags: [Database, SQL, DAGs, Integrations, AWS]

--- a/learn/connections/redshift.md
+++ b/learn/connections/redshift.md
@@ -1,7 +1,7 @@
 ---
 title: "Create an Amazon Redshift Connection in Airflow"
 id: redshift
-sidebar_label: Redshift
+sidebar_label: Connection 
 description: Learn how to create an Amazon Redshift connection in Airflow.
 sidebar_custom_props: { icon: 'img/integrations/redshift.png' }
 ---

--- a/sidebarsLearn.js
+++ b/sidebarsLearn.js
@@ -151,7 +151,20 @@ module.exports = {
         description: 'Integrate Airflow with commonly used data engineering tools.',
       },
       items: [
-        'airflow-redshift',
+        {
+          type: 'category',
+          label: 'Redshift',
+          link: {
+              type: 'generated-index',
+              title: 'Redshift',
+              description: 'Orchestrate Redshift queries from your Airflow DAGs.',
+              image: '/img/integrations/redshift.png'
+          },
+          items: [
+            'airflow-redshift',
+            'connections/redshift'
+          ],
+        },
         'airflow-sagemaker',
         'airflow-kafka',
         'airflow-azure-container-instances',
@@ -201,7 +214,6 @@ module.exports = {
               'connections/dbt-cloud',
               'connections/ms-sqlserver',
               'connections/postgres',
-              'connections/redshift',
               'connections/snowflake'
             ],
           },


### PR DESCRIPTION
Had an idea for how to put together the integration docs. Currently the connection docs are semi-buried and hard to find.

<img width="1361" alt="image" src="https://github.com/astronomer/docs/assets/80706212/4d310935-bb5a-4488-b6c4-e7aaaf0b702d">
<img width="1361" alt="image" src="https://github.com/astronomer/docs/assets/80706212/d565850a-6d62-4dfd-b813-8ecebdf66608">
