### PR TITLE
Remove errant underscore

### DIFF
--- a/astro/ci-cd-templates/azure-devops.md
+++ b/astro/ci-cd-templates/azure-devops.md
@@ -48,7 +48,7 @@ Complete the following setup in an Azure repository that hosts an Astro project:
             curl -sSL install.astronomer.io | sudo bash -s
             astro deploy ${ASTRO_DEPLOYMENT_ID} -f
           env:
-            ASTRO_API_TOKEN_: $(ASTRO_API_TOKEN)
+            ASTRO_API_TOKEN: $(ASTRO_API_TOKEN)
             ASTRO_DEPLOYMENT_ID: $(ASTRO_DEPLOYMENT_ID)
     ```
 


### PR DESCRIPTION
The variable was incorrectly named (with an extra trailing underscore), causing authentication failure. See [this doc for the correct variable name, without underscore](https://docs.astronomer.io/astro/ci-cd-templates/template-overview#image-deploy-templates).