### PR TITLE
Suggestion from the content sync to rename the trial button from "Try Astro" to "Get Started Free"

### DIFF
--- a/src/theme/Navbar/Content/index.js
+++ b/src/theme/Navbar/Content/index.js
@@ -62,7 +62,7 @@ export default function NavbarContent() {
               <NavbarItems items={rightItems} />
               <NavbarColorModeToggle className={styles.colorModeToggle} />
               <a className={cn(styles.button, styles.button__outline)} href="https://www.astronomer.io/?referral=docs-nav-button" target="_blank">Learn About Astronomer</a>
-              <a className={styles.button} href="https://www.astronomer.io/try-astro/?referral=docs-nav-button" target="_blank">Try Astro</a>
+              <a className={styles.button} href="https://www.astronomer.io/try-astro/?referral=docs-nav-button" target="_blank">Get Started Free</a>
             </>
           }
         />


### PR DESCRIPTION
this is a running A/B test on the main website and Get Started Free is winning according to the marketing team. This PR is just to put the suggestion on the table and see what it looks like, obv your decision @astronomer/docs  🙂 

cc: @juliana-astro and @katiebrady-astro 