### PR TITLE
Fix broken links

### DIFF
--- a/astro/secrets-backend.md
+++ b/astro/secrets-backend.md
@@ -405,7 +405,7 @@ For more information on creating secrets in Google Cloud Secret Manager, read th
 
 3. Optional. Remove the environment variables from your `.env` file or store your `.env` file in a safe location to protect your credentials in `AIRFLOW__SECRETS__BACKEND_KWARGS`.
 
-To ensure the security of secrets, the `.env` variable is only available in your local environment and not in the Cloud UI . See [Set Environment Variables Locally](https://docs.astronomer.io/cli/develop-project#set-environment-variables-locally).
+To ensure the security of secrets, the `.env` variable is only available in your local environment and not in the Cloud UI . See [Set Environment Variables Locally](https://docs.astronomer.io/astro/cli/develop-project#set-environment-variables-locally).
 
 #### Configure Secret Manager on Astro using a service account JSON key file
 

--- a/learn/airflow-database.md
+++ b/learn/airflow-database.md
@@ -107,7 +107,7 @@ There are additional tables in the metadata database storing data ranging from D
 
 The best method for retrieving data from the metadata database is using the Airflow UI or making a GET request to the [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html). 
 
-Between the UI and API, much of the metadata database can be viewed without the risk inherent in direct querying. In rare cases where neither the Airflow UI nor the REST API can provide sufficient data, it is possible to use SQLAlchemy with [Airflow models](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html) to access data from the metadata database. Direct querying of the metadata database is not recommended since direct manipulation can result in corruption of your Airflow instance.
+Between the UI and API, much of the metadata database can be viewed without the risk inherent in direct querying. In rare cases where neither the Airflow UI nor the REST API can provide sufficient data, it is possible to use SQLAlchemy with Airflow models to access data from the metadata database. Direct querying of the metadata database is not recommended since direct manipulation can result in corruption of your Airflow instance.
 
 This section shows three examples of how to use the Airflow REST API to interact with the Airflow metadata database.
 

--- a/learn/airflow-database.md
+++ b/learn/airflow-database.md
@@ -107,7 +107,7 @@ There are additional tables in the metadata database storing data ranging from D
 
 The best method for retrieving data from the metadata database is using the Airflow UI or making a GET request to the [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html). 
 
-Between the UI and API, much of the metadata database can be viewed without the risk inherent in direct querying. In rare cases where neither the Airflow UI nor the REST API can provide sufficient data, it is possible to use SQLAlchemy with [Airflow models](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/index.html) to access data from the metadata database. Direct querying of the metadata database is not recommended since direct manipulation can result in corruption of your Airflow instance.
+Between the UI and API, much of the metadata database can be viewed without the risk inherent in direct querying. In rare cases where neither the Airflow UI nor the REST API can provide sufficient data, it is possible to use SQLAlchemy with [Airflow models](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html) to access data from the metadata database. Direct querying of the metadata database is not recommended since direct manipulation can result in corruption of your Airflow instance.
 
 This section shows three examples of how to use the Airflow REST API to interact with the Airflow metadata database.
 

--- a/learn/debugging-dags.md
+++ b/learn/debugging-dags.md
@@ -55,7 +55,7 @@ The most common issues related to the Astro CLI are:
 
 To troubleshoot infrastructure issues when running Airflow on other platforms, for example in Docker, on Kubernetes using the [Helm Chart](https://airflow.apache.org/docs/helm-chart/stable/index.html) or on managed services, please refer to the relevant documentation and customer support.
 
-You can learn more about [testing and troubleshooting locally](https://docs.astronomer.io/astro/cli/test-your-astro-project-locally.md) with the Astro CLI in the Astro documentation.
+You can learn more about [testing and troubleshooting locally](https://docs.astronomer.io/astro/cli/test-your-astro-project-locally) with the Astro CLI in the Astro documentation.
 
 ## Common DAG issues
 

--- a/learn/get-started-with-airflow.md
+++ b/learn/get-started-with-airflow.md
@@ -316,5 +316,5 @@ Astronomer offers a variety of resources like this tutorial to learn more about 
 Don't know where to start? For beginners, the next resources we recommend are:
 
 - [Managing connections in Airflow](connections.md): Learn how to connect Airflow to third party products and services.
-- [Develop a project](https://docs.astronomer.io/cli/develop-project): Learn about all of the ways you can configure your Astro project and local Airflow environment.
+- [Develop a project](https://docs.astronomer.io/astro/cli/develop-project): Learn about all of the ways you can configure your Astro project and local Airflow environment.
 - [DAG Writing Best Practices](dag-best-practices.md): Learn how to write efficient, secure, and scalable DAGs.

--- a/learn/testing-airflow.md
+++ b/learn/testing-airflow.md
@@ -150,7 +150,7 @@ The Astro CLI includes two commands to run DAG validation tests. Airflow does no
 - [`astro dev parse`](https://docs.astronomer.io/astro/cli/astro-dev-parse): will quickly parse your DAGs to find any Python syntax or DAG import errors.
 - [`astro dev pytest`](https://docs.astronomer.io/astro/cli/astro-dev-pytest): will run all pytest test suites in the `test` directory of your current Airflow project.
 
-Every new Astro project will be initialized with a `test/dags` folder in your Astro project directory. This folder contains the `test_dag_integrity.py` script defining several examples of using `pytest` with Airflow. For more information on the Astro CLI's testing capabilities, see [Test your Astro project locally](https://docs.astronomer.io/astro/test-your-astro-project-locally).
+Every new Astro project will be initialized with a `test/dags` folder in your Astro project directory. This folder contains the `test_dag_integrity.py` script defining several examples of using `pytest` with Airflow. For more information on the Astro CLI's testing capabilities, see [Test your Astro project locally](https://docs.astronomer.io/astro/cli/test-your-astro-project-locally).
 
 ### Airflow CLI 
 

--- a/software/houston-api.md
+++ b/software/houston-api.md
@@ -28,7 +28,7 @@ If you're using the Astronomer Houston API and you're migrating from Astronomer 
 
 ## Getting started
 
-The Astronomer Houston API is available in a [GraphQL Playground](https://www.apollogplatformraphql.com/docs/apollo-server/testing/graphql-playground/), "a graphical, interactive, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphQL." [GraphQL](https://graphql.org/) itself is an open source query language for APIs that makes for an easy and simple way to manage data.
+The Astronomer Houston API is available in a [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/v2/testing/graphql-playground/), "a graphical, interactive, in-browser GraphQL IDE, created by [Prisma](https://www.prisma.io/) and based on GraphQL." [GraphQL](https://graphql.org/) itself is an open source query language for APIs that makes for an easy and simple way to manage data.
 
 In short, the Playground is a portal that allows you to write GraphQL queries directly against the API within your browser.
 


### PR DESCRIPTION
Resolves #2873 

@TJaniF + @kentdanas - swapped some links in the Learn docs because some Airflow content has been removed/changed (Airflow Databases). Do these new links look good to you?

