### PR TITLE
add a note about log tags for datadog task logs 

### DIFF
--- a/astro/view-logs.md
+++ b/astro/view-logs.md
@@ -156,7 +156,7 @@ You can forward Airflow task logs from a Deployment to [Datadog](https://www.dat
     - **Key**: `ASTRO_DATADOG_TASK_LOGS_TAGS`
     - **Value**: `<tag-key-1>:<tag-value-1>,<tag-key-2>:<tag-value-2>`
 
-By default, the tags `source=astronomer` and `service=astronomer-task-logs` will be used.
+By default, Astro uses the tags `source=astronomer` and `service=astronomer-task-logs`.
 
 5. Click **Save variable**.
 

--- a/astro/view-logs.md
+++ b/astro/view-logs.md
@@ -146,11 +146,18 @@ You can forward Airflow task logs from a Deployment to [Datadog](https://www.dat
 
   :::
 
-3. (Optional) Set the following [environment variable](environment-variables.md) on your Deployment to send your metrics to a specific [Datadog site](https://docs.datadoghq.com/getting_started/site/):
+3. (Optional) Set the following [environment variable](environment-variables.md) on your Deployment to send your logs to a specific [Datadog site](https://docs.datadoghq.com/getting_started/site/):
 
     - **Key**: `DATADOG_SITE`
     - **Value**: Your Datadog site name. For example, `US3`.
    
+4. (Optional) Set the following [environment variable](environment-variables.md) on your Deployment to [add specific tags to your logs](https://docs.datadoghq.com/getting_started/tagging/):
+
+    - **Key**: `ASTRO_DATADOG_TASK_LOGS_TAGS`
+    - **Value**: `<tag-key-1>:<tag-value-1>,<tag-key-2>:<tag-value-2>`
+
+By default, the tags `source=astronomer` and `service=astronomer-task-logs` will be used.
+
 5. Click **Save variable**.
 
 Astro also supports exporting [Airflow metrics](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/metrics.html) to Datadog. See [Export Airflow metrics to Datadog](deployment-metrics.md#export-airflow-metrics-to-datadog).


### PR DESCRIPTION
without this note customers will not know what to search for when looking for their task logs in Datadog.