### PR TITLE
Add note to weaviate tutorial about class name capitalization

### DIFF
--- a/learn/airflow-weaviate.md
+++ b/learn/airflow-weaviate.md
@@ -256,6 +256,12 @@ In order to prepare Weaviate to ingest your data, you need to define a [schema](
     }
     ```
 
+:::tip
+
+It is best practice to capitalize the first letter of the `class` name in the schema definition. Weaviate will capitalize the first letter of the `class` name in the schema definition if it is not capitalized.
+
+:::
+
 ## Step 4: Create your DAG
 
 1. In your `dags` folder, create a file called `query_movie_vectors.py`.


### PR DESCRIPTION
This just took me half an hour to debug 😅 Weaviate capitalizes the first letter of the class name automatically. Added a note and also raised an issue in the provider repo if we can newbie proof the provider against that 

