### PR TITLE
Small fixes to Deployment API token permissions paragraph

### DIFF
--- a/astro/deployment-api-tokens.md
+++ b/astro/deployment-api-tokens.md
@@ -16,7 +16,7 @@ Use this document to learn how to create and manage API tokens. To use your API 
 
 ## Deployment API token permissions
 
-Unlike Workspace API tokens and Organization API tokens, Deployment API tokens are are not scoped to a specific [user role](user-permissions.md). Generally speaking, Deployment API tokens have the same permissions as the Workspace Operator role, but only for Deployment-level operations. For example, an API token can create a Deployment [environment variable](environment-variables.md) but, unlike a Workspace Operator, it can't create an [Astro alert](alerts.md) because alerts apply to the whole Workspace.
+Unlike Workspace API tokens and Organization API tokens, Deployment API tokens are not scoped to a specific [user role](user-permissions.md). Deployment API tokens have the same permissions as the [Workspace Operator](user-permissions.md#workspace-roles) role, but only for Deployment-level operations. For example, an API token can create a Deployment [environment variable](environment-variables.md) but, unlike a Workspace Operator, it can't create an [Astro alert](alerts.md) because alerts apply to the whole Workspace.
 
 ## Create a Deployment API token
 


### PR DESCRIPTION
This PR:
- Fixes a typo in https://docs.astronomer.io/astro/deployment-api-tokens#deployment-api-token-permissions
- Removes "generally speaking" for clarity
- Adds a link to the permissions overview for easy reference