### PR TITLE
10 17 release notes

### DIFF
--- a/astro/deploy-history.md
+++ b/astro/deploy-history.md
@@ -9,12 +9,6 @@ The **Deploy History** tab in the Cloud UI shows you a record of all code deploy
 
 ![View of the Deploy History tab in the Cloud UI, with one deploy entry](/img/docs/deploy-history.png)
 
-:::caution
-
-Deploy history is currently available only for image deploys and Astro Hosted users. DAG deploys do not appear in the **Deploy History** tab.
-
-:::
-
 ## View deploy history
 
 1. In the Cloud UI, select a Deployment.

--- a/astro/environment-variables.md
+++ b/astro/environment-variables.md
@@ -39,8 +39,8 @@ If you prefer to work with the Astro CLI, you can create and update environment 
 3. Click **Edit Variables**.
 
 4. Enter an environment variable key and value. 
-  - For sensitive credentials that should be treated with an additional layer of security, select the **Secret** checkbox. This will permanently hide the variable's value from all users in your Workspace.
-  - Each key-value pair must be unique.
+  - For sensitive credentials that should be treated with an additional layer of security, enable the **Secret** toggle. This will permanently hide the variable's value from all users in your Workspace.
+  - Each key must be unique.
 
 5. Click **Update Environment Variables** to save your changes. Your Airflow scheduler, webserver, and workers restart. After saving, it can take up to two minutes for new variables to be applied to your Deployment.
 

--- a/astro/environment-variables.md
+++ b/astro/environment-variables.md
@@ -38,7 +38,9 @@ If you prefer to work with the Astro CLI, you can create and update environment 
 
 3. Click **Edit Variables**.
 
-4. Enter an environment variable key and value. For sensitive credentials that should be treated with an additional layer of security, select the **Secret** checkbox. This will permanently hide the variable's value from all users in your Workspace.
+4. Enter an environment variable key and value. 
+  - For sensitive credentials that should be treated with an additional layer of security, select the **Secret** checkbox. This will permanently hide the variable's value from all users in your Workspace.
+  - Each key-value pair must be unique.
 
 5. Click **Update Environment Variables** to save your changes. Your Airflow scheduler, webserver, and workers restart. After saving, it can take up to two minutes for new variables to be applied to your Deployment.
 

--- a/astro/release-notes.md
+++ b/astro/release-notes.md
@@ -31,7 +31,7 @@ Astronomer is committed to continuous delivery of both features and bug fixes to
 
 ### Additional improvements
 
-- You can now view deploy history for both Hosted and Hybrid Astro Deployments in the Cloud UI. For more information, see [View deploy history](https://docs.astronomer.io/astro/deploy-history)
+- You can now view deploy history for both Hosted and Hybrid Astro Deployments in the Cloud UI. For more information, see [View deploy history](https://docs.astronomer.io/astro/deploy-history).
 
 ### Bug fixes
 

--- a/astro/release-notes.md
+++ b/astro/release-notes.md
@@ -27,6 +27,12 @@ Astronomer is committed to continuous delivery of both features and bug fixes to
 
 <!-- ALL LINKS TO INTERNAL DOCS MUST BE COMPLETE URLS INCLUDING HTTPS. Otherwise the links will break in RSS. -->
 
+## October 17, 2023
+
+### Bug fixes
+
+- Modified behavior for Astro Hosted so that KubernetesExecutor and KubernetesPodOperator pods running in-cluster have equivalent resource requests and limits. If you do not configure them to have equivalent resource requests and limits, Astro modifies them to the become the limits. Previously, the DAG deploy would fail if `resources` did not equal `limits`.
+
 ## October 10, 2023
 
 ### Deployment API tokens
@@ -45,13 +51,13 @@ After October 31, 2023, you will not be able to create new API keys. While you c
 
 ### New Edit Deployments in the Cloud UI
 
-Editing Deployments in the Cloud UI has a new, consolidated flow. All of the configuration options are now editable in a single form, similar to Deployment creation, instead of spread across multiple forms. See [Deployment Settings](deployment-settings.md) for a detailed description of how to create, update, and configure your Deployment options.
+Editing Deployments in the Cloud UI has a new, consolidated flow. All of the configuration options are now editable in a single form, similar to Deployment creation, instead of spread across multiple forms. See [Deployment Settings](https://docs.astronomer.io/astro/deployment-settings) for a detailed description of how to create, update, and configure your Deployment options.
 
 ## October 3, 2023
 
 ### Additional Improvements
 
-- Added a **DAG Success** alert so you can now set up an alert for successful completion events. See how to set up [Astro alerts](alerts.md). 
+- Added a **DAG Success** alert so you can now set up an alert for successful completion events. See how to set up [Astro alerts](https://docs.astronomer.io/astro/alerts). 
 
 ### Bug Fixes
 

--- a/astro/release-notes.md
+++ b/astro/release-notes.md
@@ -29,6 +29,10 @@ Astronomer is committed to continuous delivery of both features and bug fixes to
 
 ## October 17, 2023
 
+### Additional improvements
+
+- You can now view deploy history for both Hosted and Hybrid Astro Deployments in the Cloud UI. For more information, see [View deploy history](https://docs.astronomer.io/astro/deploy-history)
+
 ### Bug fixes
 
 - Modified behavior for Astro Hosted so that KubernetesExecutor and KubernetesPodOperator pods running in-cluster have equivalent resource requests and limits. If you do not configure them to have equivalent resource requests and limits, Astro modifies them to the become the limits. Previously, the DAG deploy would fail if `resources` did not equal `limits`.


### PR DESCRIPTION
@ryanahamilton - looks like UI changes are driving the docs updates/release notes this week. Should be a quick review. 

Sign-off needed:
- [x] Behavior change for KE/KPO resource requests and limits (https://github.com/astronomer/astro/pull/16807)
- [x] Deploy history now available for hybrid (https://github.com/astronomer/astro/pull/16962)
- [x] Key-value pairs must be unique to set env vars in the UI (No release note needed, but small docs update)(https://github.com/astronomer/astro/pull/16943)