### PR TITLE
Fix unclear instructions when using CloudFormation template for AWS VPC Peering

### DIFF
--- a/astro/connect-aws.md
+++ b/astro/connect-aws.md
@@ -80,7 +80,7 @@ To create a VPC peering connection between an Astro VPC and an AWS VPC, you must
     - **Stack name**: Enter a meaningful name for your stack.
     - **Peer Owner IDs**: Enter your cluster's AWS account ID. To retrieve your cluster's AWS account ID on Astro Hosted, contact [Astronomer support](https://cloud.astronomer.io/support). To retrieve your cluster's AWS account ID on Astro Hybrid, click the name of your Workspace in the upper left corner of the Cloud UI, click **Organization Settings**, then click **Clusters**. Open your cluster and copy its **Account ID**.
 
-3. After the stack is created, go to the **Stack info** tab and copy the AssumeRole ARN from the **Stack ID** field.
+3. After the stack is created, go to the **Outputs** tab and copy the Value from the **PeerRole ARN** field.
 
 4. In the Cloud UI, click your Workspace name in the upper left corner, then click **Organization Settings**. Click **Clusters**, select your cluster, and copy the **ID** of the cluster.
 
@@ -90,7 +90,7 @@ To create a VPC peering connection between an Astro VPC and an AWS VPC, you must
     - VPC ID of the external VPC from Step 1
     - AWS account ID of the external VPC from Step 1
     - CIDR block of the external VPC from Step 1
-    - **Stack ID** from Step 3
+    - **PeerRole ARN** from Step 3
     - Astro cluster **ID** from Step 4
     
     Astronomer support will initiate a peering request and create the routing table entries in the Astro VPC.


### PR DESCRIPTION
Fixing the instructions for using the CloudFormation template that creates an AWS Role for use in VPC Peering. The instructions currently refer to the wrong location in the CloudFormation UI and is causing customers to send us the wrong information