### PR TITLE
`(Optional)` instead of `Optional.` in Learn guides

### DIFF
--- a/learn/astro-python-sdk-etl.md
+++ b/learn/astro-python-sdk-etl.md
@@ -60,7 +60,7 @@ For a full list of functions, see the [Astro Python SDK README in GitHub](https:
     AIRFLOW__CORE__XCOM_BACKEND='astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend'
     ```
 
-3. Optional. Create an [Airflow connection](connections.md) to the database where you want to store the temporary tables created by the Astro SDK. Set the following environment variables to configure your database as an Astro SDK storage backend. If you're using the Astro CLI, add these environment variables to the `.env` file of your Astro project:
+3. (Optional) Create an [Airflow connection](connections.md) to the database where you want to store the temporary tables created by the Astro SDK. Set the following environment variables to configure your database as an Astro SDK storage backend. If you're using the Astro CLI, add these environment variables to the `.env` file of your Astro project:
 
     ```text
     AIRFLOW__ASTRO_SDK__XCOM_STORAGE_CONN_ID='<your-database-connection-id>'

--- a/learn/cloud-ide-tutorial.md
+++ b/learn/cloud-ide-tutorial.md
@@ -165,7 +165,7 @@ Navigate back to your Astro Cloud IDE on Astro.
     WEIGHT_HIGH_LBS, REPS_UPPER, REPS_LOWER) IS NOT NULL
     ```
 
-5. Optional. If you want to use your external database, add your connection to the cell as shown in the following screenshot. If you are using the in memory database, you can skip this step.
+5. (Optional) If you want to use your external database, add your connection to the cell as shown in the following screenshot. If you are using the in memory database, you can skip this step.
 
     ![Cloud IDE screenshot showing the dialogue that opens when one clicks on the connection field of a cell, which by default says In-memory SQL. The option is shown to select the snowflake_conn that was defined in Step 3.](/img/tutorials/cloud-ide-tutorial_snowflake_conn.png)
 

--- a/learn/get-started-with-airflow.md
+++ b/learn/get-started-with-airflow.md
@@ -34,7 +34,7 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - [Docker Desktop](https://docs.docker.com/get-docker/) (v18.09 or higher).
 - The [Astro CLI](https://docs.astronomer.io/astro/cli/install-cli).
 - An integrated development environment (IDE) for Python development, such as [VSCode](https://code.visualstudio.com/).
-- Optional. A local installation of [Python 3](https://www.python.org/downloads/) to improve your Python developer experience.
+- (Optional) A local installation of [Python 3](https://www.python.org/downloads/) to improve your Python developer experience.
 
 ## Step 1: Create an Astro project
 

--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -140,8 +140,8 @@ The latest versions of Docker for Windows and Mac let you run a single node Kube
 
 2. Update the `<certificate-authority-data>`, `<client-authority-data>`, and `<client-key-data>` values in the `config` file with the values for your organization.
 3. Under cluster, change `server: https://localhost:6445` to `server: https://kubernetes.docker.internal:6443` to identify the localhost running Kubernetes Pods. If this doesn't work, try `server: https://host.docker.internal:6445`.
-4. Optional. Add the `.kube` folder to `.gitignore` if your Astro project is hosted in a GitHub repository and you want to prevent the file from being tracked by your version control tool.
-5. Optional. Add the `.kube` folder to `.dockerignore` to exclude it from the Docker image.
+4. (Optional) Add the `.kube` folder to `.gitignore` if your Astro project is hosted in a GitHub repository and you want to prevent the file from being tracked by your version control tool.
+5. (Optional) Add the `.kube` folder to `.dockerignore` to exclude it from the Docker image.
 
 </TabItem>
 <TabItem value="linux">
@@ -166,7 +166,7 @@ Once you've updated the definition of KubernetesPodOperator tasks in your Astro 
 
 #### Step 4: View Kubernetes logs
 
-Optional. Use the `kubectl` command line tool to review the logs for any Pods that were created by the operator for issues and help with troubleshooting. If you haven't installed the `kubectl` command line tool, see [Install Tools](https://kubernetes.io/docs/tasks/tools/#kubectl).
+(Optional) Use the `kubectl` command line tool to review the logs for any Pods that were created by the operator for issues and help with troubleshooting. If you haven't installed the `kubectl` command line tool, see [Install Tools](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
 <Tabs
     defaultValue="windows and mac"


### PR DESCRIPTION
To get parity with the Docs convention. Thanks @lzdanski for flagging this. 
The GX tutorial is not in this PR because there is already a PR for a new version of that, don't want to create a merge conflict there for something soon replaced anyways. :)