### PR TITLE
0.32.4 Release Notes

### DIFF
--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -133,6 +133,10 @@ Release date: October 19, 2023
     - [CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
     - [CVE-2023-45133](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45133)
     - [CVE-2023-48174](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-48174)
+    - [CVE-2022-21698](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21698)
+    - [CVE-2021-33194](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33194)
+    - [CVE-2021-38561](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38561)
+    - [CVE-2023-40577](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-40577)
 
 ## 0.32.3
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -107,7 +107,6 @@ This feature is off by default. You can enable it by setting  `deployments.pgBou
     - [CVE-2023-39417](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-39417)
     - [CVE-2023-37920](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-37920)
     - [CVE-2023-35945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-35945)
-    - [CVE-2023-35945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-35945)
 
 ## 0.33.4
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -115,19 +115,25 @@ Release date: October 18, 2023
 
 ### Bug fixes
 
-- Fixed an issue where when `global.networkPolicy.enabled` is set to `false` and `blackbox-exporter`is enabled, it prevented components from communicating with Commander and other Software components because it set `blackbox-exporter` as the only network policy. Now, when `global.networkPolicy.enabled` is set to `false`, `blackbox-exporter` policies are removed. <!--https://github.com/astronomer/issues/issues/5843 -->
+- Fixed an issue where `ap-blackbox-exporter` did not respect global network policies.<!--https://github.com/astronomer/issues/issues/5843 -->
+
 - Fixed the following vulnerabilities:
-    - [CVE-2023-45133](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45133) <!--https://github.com/astronomer/issues/issues/5922-->
-    - [CVE-2023-4911](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4911)<!--https://github.com/astronomer/issues/issues/5917-->
-    - [CVE-2023-29491](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-29491)<!--https://github.com/astronomer/issues/issues/5917-->
-    - [CVE-2023-38039](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039)<!--https://github.com/astronomer/issues/issues/5916-->
-    - [CVE-2023-38545](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38545)<!--https://github.com/astronomer/issues/issues/5916-->
-    - [CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)<!--https://github.com/astronomer/issues/issues/5916-->
-    - [CVE-2023-4863](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4863)<!--https://github.com/astronomer/issues/issues/5877-->
-    - [CVE-2023-37920](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-37920)<!--https://github.com/astronomer/issues/issues/5777-->
-    - [CVE-2023-2253](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2253)<!--https://github.com/astronomer/issues/issues/5777-->
-    - [CVE-2023-39417](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-39417)<!--https://github.com/astronomer/issues/issues/5777-->
-    - ap-registry https://github.com/astronomer/issues/issues/5772
+    - [CVE-2023-2253](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2253)
+    - [CVE-2023-4863](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4863)
+    - [CVE-2023-4911](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4911)
+    - [CVE-2023-11468](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-11468)
+    - [CVE-2023-28840](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28840)
+    - [CVE-2023-29491](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-29491)
+    - [CVE-2023-37788](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-37788)
+    - [CVE-2023-37920](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-37920)
+    - [CVE-2023-38039](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039)
+    - [CVE-2023-38325](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38325)
+    - [CVE-2023-38545](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38545)
+    - [CVE-2023-39417](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-39417)
+    - [CVE-2023-41721](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-41721)
+    - [CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
+    - [CVE-2023-45133](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45133)
+    - [CVE-2023-48174](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-48174)
 
 ## 0.32.3
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -117,7 +117,6 @@ Release date: October 19, 2023
 - Fixed an issue where `ap-blackbox-exporter` did not respect global network policies.
 
 - Fixed the following vulnerabilities:
-    - [CVE-2023-2253](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2253)
     - [CVE-2023-4863](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4863)
     - [CVE-2023-4911](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4911)
     - [CVE-2023-11468](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-11468)
@@ -133,7 +132,6 @@ Release date: October 19, 2023
     - [CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
     - [CVE-2023-45133](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45133)
     - [CVE-2023-48174](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-48174)
-    - [CVE-2022-21698](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21698)
     - [CVE-2021-33194](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33194)
     - [CVE-2021-38561](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38561)
     - [CVE-2023-40577](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-40577)

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -110,11 +110,11 @@ This feature is off by default. You can enable it by setting  `deployments.pgBou
 
 ## 0.32.4
 
-Release date: October 18, 2023
+Release date: October 19, 2023
 
 ### Bug fixes
 
-- Fixed an issue where `ap-blackbox-exporter` did not respect global network policies.<!--https://github.com/astronomer/issues/issues/5843 -->
+- Fixed an issue where `ap-blackbox-exporter` did not respect global network policies.
 
 - Fixed the following vulnerabilities:
     - [CVE-2023-2253](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2253)

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -123,7 +123,11 @@ Release date: October 18, 2023
     - [CVE-2023-38039](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039)<!--https://github.com/astronomer/issues/issues/5916-->
     - [CVE-2023-38545](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38545)<!--https://github.com/astronomer/issues/issues/5916-->
     - [CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)<!--https://github.com/astronomer/issues/issues/5916-->
-    - https://github.com/astronomer/issues/issues/5772
+    - [CVE-2023-4863](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4863)<!--https://github.com/astronomer/issues/issues/5877-->
+    - [CVE-2023-37920](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-37920)<!--https://github.com/astronomer/issues/issues/5777-->
+    - [CVE-2023-2253](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2253)<!--https://github.com/astronomer/issues/issues/5777-->
+    - [CVE-2023-39417](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-39417)<!--https://github.com/astronomer/issues/issues/5777-->
+    - ap-registry https://github.com/astronomer/issues/issues/5772
 
 ## 0.32.3
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -109,6 +109,22 @@ This feature is off by default. You can enable it by setting  `deployments.pgBou
     - [CVE-2023-35945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-35945)
     - [CVE-2023-35945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-35945)
 
+## 0.33.4
+
+Release date: October 18, 2023
+
+### Bug fixes
+
+- Fixed an issue where when `global.networkPolicy.enabled` is set to `false` and `blackbox-exporter`is enabled, it prevented components from communicating with Commander and other Software components because it set `blackbox-exporter` as the only network policy. Now, when `global.networkPolicy.enabled` is set to `false`, `blackbox-exporter` policies are removed. <!--https://github.com/astronomer/issues/issues/5843 -->
+- Fixed the following vulnerabilities:
+    - [CVE-2023-45133](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45133) <!--https://github.com/astronomer/issues/issues/5922-->
+    - [CVE-2023-4911](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4911)<!--https://github.com/astronomer/issues/issues/5917-->
+    - [CVE-2023-29491](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-29491)<!--https://github.com/astronomer/issues/issues/5917-->
+    - [CVE-2023-38039](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039)<!--https://github.com/astronomer/issues/issues/5916-->
+    - [CVE-2023-38545](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38545)<!--https://github.com/astronomer/issues/issues/5916-->
+    - [CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)<!--https://github.com/astronomer/issues/issues/5916-->
+    - https://github.com/astronomer/issues/issues/5772
+
 ## 0.32.3
 
 Release date: August 31, 2023

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -112,6 +112,10 @@ This feature is off by default. You can enable it by setting  `deployments.pgBou
 
 Release date: October 19, 2023
 
+### Additional improvements
+
+You can now create a default Kibana index when installing Software. 
+
 ### Bug fixes
 
 - Fixed an issue where `ap-blackbox-exporter` did not respect global network policies.

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -108,7 +108,7 @@ This feature is off by default. You can enable it by setting  `deployments.pgBou
     - [CVE-2023-37920](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-37920)
     - [CVE-2023-35945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-35945)
 
-## 0.33.4
+## 0.32.4
 
 Release date: October 18, 2023
 

--- a/software_versioned_docs/version-0.30/release-notes.md
+++ b/software_versioned_docs/version-0.30/release-notes.md
@@ -129,6 +129,10 @@ Release date: October 19, 2023
     - [CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
     - [CVE-2023-45133](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45133)
     - [CVE-2023-48174](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-48174)
+    - [CVE-2022-21698](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21698)
+    - [CVE-2021-33194](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33194)
+    - [CVE-2021-38561](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38561)
+    - [CVE-2023-40577](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-40577)
 
 ## 0.32.3
 

--- a/software_versioned_docs/version-0.30/release-notes.md
+++ b/software_versioned_docs/version-0.30/release-notes.md
@@ -108,6 +108,10 @@ Astronomer Software now automatically scales the size of PGBouncer connection po
 
 Release date: October 19, 2023
 
+### Additional improvements
+
+You can now create a default Kibana index when installing Software. 
+
 ### Bug fixes
 
 - Fixed an issue where `ap-blackbox-exporter` did not respect global network policies.

--- a/software_versioned_docs/version-0.30/release-notes.md
+++ b/software_versioned_docs/version-0.30/release-notes.md
@@ -104,6 +104,32 @@ Astronomer Software now automatically scales the size of PGBouncer connection po
     - [CVE-2023-35945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-35945)
     - [CVE-2023-35945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-35945)
 
+## 0.32.4
+
+Release date: October 19, 2023
+
+### Bug fixes
+
+- Fixed an issue where `ap-blackbox-exporter` did not respect global network policies.
+
+- Fixed the following vulnerabilities:
+    - [CVE-2023-2253](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2253)
+    - [CVE-2023-4863](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4863)
+    - [CVE-2023-4911](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4911)
+    - [CVE-2023-11468](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-11468)
+    - [CVE-2023-28840](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28840)
+    - [CVE-2023-29491](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-29491)
+    - [CVE-2023-37788](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-37788)
+    - [CVE-2023-37920](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-37920)
+    - [CVE-2023-38039](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039)
+    - [CVE-2023-38325](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38325)
+    - [CVE-2023-38545](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38545)
+    - [CVE-2023-39417](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-39417)
+    - [CVE-2023-41721](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-41721)
+    - [CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
+    - [CVE-2023-45133](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45133)
+    - [CVE-2023-48174](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-48174)
+
 ## 0.32.3
 
 Release date: August 31, 2023

--- a/software_versioned_docs/version-0.30/release-notes.md
+++ b/software_versioned_docs/version-0.30/release-notes.md
@@ -113,7 +113,6 @@ Release date: October 19, 2023
 - Fixed an issue where `ap-blackbox-exporter` did not respect global network policies.
 
 - Fixed the following vulnerabilities:
-    - [CVE-2023-2253](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2253)
     - [CVE-2023-4863](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4863)
     - [CVE-2023-4911](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4911)
     - [CVE-2023-11468](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-11468)
@@ -129,7 +128,6 @@ Release date: October 19, 2023
     - [CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
     - [CVE-2023-45133](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45133)
     - [CVE-2023-48174](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-48174)
-    - [CVE-2022-21698](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21698)
     - [CVE-2021-33194](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33194)
     - [CVE-2021-38561](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38561)
     - [CVE-2023-40577](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-40577)

--- a/software_versioned_docs/version-0.32/release-notes.md
+++ b/software_versioned_docs/version-0.32/release-notes.md
@@ -131,6 +131,10 @@ Release date: October 19, 2023
     - [CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
     - [CVE-2023-45133](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45133)
     - [CVE-2023-48174](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-48174)
+    - [CVE-2022-21698](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21698)
+    - [CVE-2021-33194](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33194)
+    - [CVE-2021-38561](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38561)
+    - [CVE-2023-40577](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-40577)
 
 ## 0.32.3
 

--- a/software_versioned_docs/version-0.32/release-notes.md
+++ b/software_versioned_docs/version-0.32/release-notes.md
@@ -115,7 +115,6 @@ Release date: October 19, 2023
 - Fixed an issue where `ap-blackbox-exporter` did not respect global network policies.
 
 - Fixed the following vulnerabilities:
-    - [CVE-2023-2253](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2253)
     - [CVE-2023-4863](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4863)
     - [CVE-2023-4911](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4911)
     - [CVE-2023-11468](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-11468)
@@ -131,7 +130,6 @@ Release date: October 19, 2023
     - [CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
     - [CVE-2023-45133](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45133)
     - [CVE-2023-48174](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-48174)
-    - [CVE-2022-21698](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21698)
     - [CVE-2021-33194](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33194)
     - [CVE-2021-38561](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38561)
     - [CVE-2023-40577](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-40577)

--- a/software_versioned_docs/version-0.32/release-notes.md
+++ b/software_versioned_docs/version-0.32/release-notes.md
@@ -106,6 +106,32 @@ Astronomer Software now automatically scales the size of PGBouncer connection po
     - [CVE-2023-35945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-35945)
     - [CVE-2023-35945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-35945)
 
+## 0.32.4
+
+Release date: October 19, 2023
+
+### Bug fixes
+
+- Fixed an issue where `ap-blackbox-exporter` did not respect global network policies.
+
+- Fixed the following vulnerabilities:
+    - [CVE-2023-2253](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2253)
+    - [CVE-2023-4863](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4863)
+    - [CVE-2023-4911](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-4911)
+    - [CVE-2023-11468](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-11468)
+    - [CVE-2023-28840](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28840)
+    - [CVE-2023-29491](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-29491)
+    - [CVE-2023-37788](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-37788)
+    - [CVE-2023-37920](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-37920)
+    - [CVE-2023-38039](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38039)
+    - [CVE-2023-38325](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38325)
+    - [CVE-2023-38545](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-38545)
+    - [CVE-2023-39417](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-39417)
+    - [CVE-2023-41721](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-41721)
+    - [CVE-2023-44487](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-44487)
+    - [CVE-2023-45133](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-45133)
+    - [CVE-2023-48174](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-48174)
+
 ## 0.32.3
 
 Release date: August 31, 2023

--- a/software_versioned_docs/version-0.32/release-notes.md
+++ b/software_versioned_docs/version-0.32/release-notes.md
@@ -110,6 +110,10 @@ Astronomer Software now automatically scales the size of PGBouncer connection po
 
 Release date: October 19, 2023
 
+### Additional improvements
+
+You can now create a default Kibana index when installing Software. 
+
 ### Bug fixes
 
 - Fixed an issue where `ap-blackbox-exporter` did not respect global network policies.


### PR DESCRIPTION
Includes CVE's listed in: 

- https://github.com/astronomer/issues/issues?q=is%3Aissue+label%3A0.32.4

could access PR, but not identify details about CVEs included (I don't have all the same permissions as @jwitz) in the following PRs:

- ap-registry https://github.com/astronomer/issues/issues/5772
- ap base https://github.com/astronomer/issues/issues/5829
- ap-prometheus https://github.com/astronomer/issues/issues/5773

See conversation for more info: https://astronomer.slack.com/archives/C04JELRC6J3/p1697564937125329