### PR TITLE
Related content notes

### DIFF
--- a/learn/airflow-branch-operator.md
+++ b/learn/airflow-branch-operator.md
@@ -16,7 +16,7 @@ When designing your data pipelines, you may encounter use cases that require mor
 
 In this guide, you'll learn how you can use `@task.branch` (BranchPythonOperator) and `@task.short_circuit` (ShortCircuitOperator), other available branching operators, and additional resources to implement conditional logic in your Airflow DAGs.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-branch-operator.md
+++ b/learn/airflow-branch-operator.md
@@ -16,7 +16,7 @@ When designing your data pipelines, you may encounter use cases that require mor
 
 In this guide, you'll learn how you can use `@task.branch` (BranchPythonOperator) and `@task.short_circuit` (ShortCircuitOperator), other available branching operators, and additional resources to implement conditional logic in your Airflow DAGs.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-branch-operator.md
+++ b/learn/airflow-branch-operator.md
@@ -16,9 +16,9 @@ When designing your data pipelines, you may encounter use cases that require mor
 
 In this guide, you'll learn how you can use `@task.branch` (BranchPythonOperator) and `@task.short_circuit` (ShortCircuitOperator), other available branching operators, and additional resources to implement conditional logic in your Airflow DAGs.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: Branching](https://academy.astronomer.io/astro-runtime-branching) module.
 

--- a/learn/airflow-branch-operator.md
+++ b/learn/airflow-branch-operator.md
@@ -18,6 +18,8 @@ In this guide, you'll learn how you can use `@task.branch` (BranchPythonOperator
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: Branching](https://academy.astronomer.io/astro-runtime-branching) module.
 
 :::

--- a/learn/airflow-branch-operator.md
+++ b/learn/airflow-branch-operator.md
@@ -24,6 +24,12 @@ To get the most out of this guide, you should have an understanding of:
 - Dependencies in Airflow. See [Managing Dependencies in Apache Airflow](managing-dependencies.md).
 - Using Airflow decorators. See [Introduction to Airflow decorators](airflow-decorators.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Branching](https://academy.astronomer.io/astro-runtime-branching) module.
+
+:::
+
 ## `@task.branch` (BranchPythonOperator)
 
 One of the simplest ways to implement branching in Airflow is to use the `@task.branch` decorator, which is a decorated version of the [BranchPythonOperator](https://registry.astronomer.io/providers/apache-airflow/modules/branchpythonoperator). `@task.branch` accepts any Python function as an input as long as the function returns a list of valid IDs for Airflow tasks that the DAG should run after the function completes. 

--- a/learn/airflow-branch-operator.md
+++ b/learn/airflow-branch-operator.md
@@ -16,6 +16,12 @@ When designing your data pipelines, you may encounter use cases that require mor
 
 In this guide, you'll learn how you can use `@task.branch` (BranchPythonOperator) and `@task.short_circuit` (ShortCircuitOperator), other available branching operators, and additional resources to implement conditional logic in your Airflow DAGs.
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Branching](https://academy.astronomer.io/astro-runtime-branching) module.
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
@@ -23,12 +29,6 @@ To get the most out of this guide, you should have an understanding of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Dependencies in Airflow. See [Managing Dependencies in Apache Airflow](managing-dependencies.md).
 - Using Airflow decorators. See [Introduction to Airflow decorators](airflow-decorators.md).
-
-:::tip Related Content
-
-- Astronomer Academy: [Airflow: Branching](https://academy.astronomer.io/astro-runtime-branching) module.
-
-:::
 
 ## `@task.branch` (BranchPythonOperator)
 

--- a/learn/airflow-branch-operator.md
+++ b/learn/airflow-branch-operator.md
@@ -18,7 +18,7 @@ In this guide, you'll learn how you can use `@task.branch` (BranchPythonOperator
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: Branching](https://academy.astronomer.io/astro-runtime-branching) module.
 

--- a/learn/airflow-databricks.md
+++ b/learn/airflow-databricks.md
@@ -46,7 +46,7 @@ This tutorial shows how to use the Astro Databricks provider to run two Databric
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [How to Orchestrate Databricks Jobs Using Airflow](https://www.astronomer.io/events/webinars/how-to-orchestrate-databricks-jobs-using-airflow/).
 - Use case: [ELT with Airflow and Databricks](use-case-airflow-databricks.md) including a ready-to-use [example project repository](https://github.com/astronomer/astro-provider-databricks/blob/main/quickstart/astro-cli.md).

--- a/learn/airflow-databricks.md
+++ b/learn/airflow-databricks.md
@@ -44,7 +44,7 @@ with task_group:
 
 This tutorial shows how to use the Astro Databricks provider to run two Databricks notebooks as a Databricks Workflow. If you don't use Databricks Workflows, see [Alternative ways to run Databricks with Airflow](#alternative-ways-to-run-databricks-with-airflow).
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-databricks.md
+++ b/learn/airflow-databricks.md
@@ -44,7 +44,7 @@ with task_group:
 
 This tutorial shows how to use the Astro Databricks provider to run two Databricks notebooks as a Databricks Workflow. If you don't use Databricks Workflows, see [Alternative ways to run Databricks with Airflow](#alternative-ways-to-run-databricks-with-airflow).
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-databricks.md
+++ b/learn/airflow-databricks.md
@@ -46,6 +46,8 @@ This tutorial shows how to use the Astro Databricks provider to run two Databric
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [How to Orchestrate Databricks Jobs Using Airflow](https://www.astronomer.io/events/webinars/how-to-orchestrate-databricks-jobs-using-airflow/).
 - Use case: [ELT with Airflow and Databricks](use-case-airflow-databricks.md) including a ready-to-use [example project repository](https://github.com/astronomer/astro-provider-databricks/blob/main/quickstart/astro-cli.md).
 

--- a/learn/airflow-databricks.md
+++ b/learn/airflow-databricks.md
@@ -44,9 +44,9 @@ with task_group:
 
 This tutorial shows how to use the Astro Databricks provider to run two Databricks notebooks as a Databricks Workflow. If you don't use Databricks Workflows, see [Alternative ways to run Databricks with Airflow](#alternative-ways-to-run-databricks-with-airflow).
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [How to Orchestrate Databricks Jobs Using Airflow](https://www.astronomer.io/events/webinars/how-to-orchestrate-databricks-jobs-using-airflow/).
 - Use case: [ELT with Airflow and Databricks](use-case-airflow-databricks.md) including a ready-to-use [example project repository](https://github.com/astronomer/astro-provider-databricks/blob/main/quickstart/astro-cli.md).

--- a/learn/airflow-databricks.md
+++ b/learn/airflow-databricks.md
@@ -74,6 +74,14 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Airflow connections. See [Managing your Connections in Apache Airflow](connections.md).
 
+:::tip Related Content
+
+- Webinar: [How to Orchestrate Databricks Jobs Using Airflow](https://www.astronomer.io/events/webinars/how-to-orchestrate-databricks-jobs-using-airflow/).
+- Blog post: [Comparing Data Orchestration: Databricks Workflows vs. Apache Airflow, Part 1](https://www.astronomer.io/blog/comparing-data-orchestration-databricks-workflows-vs-apache-airflow-part-1/).
+- Use case: [ELT with Airflow and Databricks](use-case-airflow-databricks.md).
+
+:::
+
 ## Prerequisites
 
 - The [Astro CLI](https://docs.astronomer.io/astro/cli/overview).

--- a/learn/airflow-databricks.md
+++ b/learn/airflow-databricks.md
@@ -44,9 +44,10 @@ with task_group:
 
 This tutorial shows how to use the Astro Databricks provider to run two Databricks notebooks as a Databricks Workflow. If you don't use Databricks Workflows, see [Alternative ways to run Databricks with Airflow](#alternative-ways-to-run-databricks-with-airflow).
 
-:::info 
+:::tip Related Content
 
-If you are already familiar with Airflow and Databricks and just want to get a project running, clone the [example project repository](https://github.com/astronomer/astro-provider-databricks/blob/main/quickstart/astro-cli.md) and run it locally using the Astro CLI.
+- Webinar: [How to Orchestrate Databricks Jobs Using Airflow](https://www.astronomer.io/events/webinars/how-to-orchestrate-databricks-jobs-using-airflow/).
+- Use case: [ELT with Airflow and Databricks](use-case-airflow-databricks.md) including a ready-to-use [example project repository](https://github.com/astronomer/astro-provider-databricks/blob/main/quickstart/astro-cli.md).
 
 :::
 
@@ -73,14 +74,6 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow fundamentals, such as writing DAGs and defining tasks. See [Get started with Apache Airflow](get-started-with-airflow.md).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Airflow connections. See [Managing your Connections in Apache Airflow](connections.md).
-
-:::tip Related Content
-
-- Webinar: [How to Orchestrate Databricks Jobs Using Airflow](https://www.astronomer.io/events/webinars/how-to-orchestrate-databricks-jobs-using-airflow/).
-- Blog post: [Comparing Data Orchestration: Databricks Workflows vs. Apache Airflow, Part 1](https://www.astronomer.io/blog/comparing-data-orchestration-databricks-workflows-vs-apache-airflow-part-1/).
-- Use case: [ELT with Airflow and Databricks](use-case-airflow-databricks.md).
-
-:::
 
 ## Prerequisites
 

--- a/learn/airflow-datasets.md
+++ b/learn/airflow-datasets.md
@@ -28,6 +28,14 @@ To get the most out of this guide, you should have an existing knowledge of:
 - Creating dependencies between DAGs. See [Cross-DAG Dependencies](cross-dag-dependencies.md).
 - The Astro Python SDK. See [Using the Astro Python SDK](https://docs.astronomer.io/tutorials/astro-python-sdk).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Datasets](https://academy.astronomer.io/astro-runtime-datasets) module.
+- Webinar: [Data Driven Scheduling](https://www.astronomer.io/events/webinars/data-driven-scheduling/).
+- Use case: [Orchestrate machine learning pipelines with Airflow datasets](use-case-airflow-datasets-multi-team-ml.md).
+
+:::
+
 ## Why use datasets?
 
 Datasets allow you to define explicit dependencies between DAGs and updates to your data. This helps you to:

--- a/learn/airflow-datasets.md
+++ b/learn/airflow-datasets.md
@@ -22,7 +22,7 @@ In this guide, you'll learn about datasets in Airflow and how to use them to imp
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: Datasets](https://academy.astronomer.io/astro-runtime-datasets) module.
 - Webinar: [Data Driven Scheduling](https://www.astronomer.io/events/webinars/data-driven-scheduling/).

--- a/learn/airflow-datasets.md
+++ b/learn/airflow-datasets.md
@@ -20,9 +20,9 @@ Datasets can help resolve common issues. For example, consider a data engineerin
 
 In this guide, you'll learn about datasets in Airflow and how to use them to implement triggering of DAGs based on dataset updates. You'll also learn how datasets work with the Astro Python SDK.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: Datasets](https://academy.astronomer.io/astro-runtime-datasets) module.
 - Webinar: [Data Driven Scheduling](https://www.astronomer.io/events/webinars/data-driven-scheduling/).

--- a/learn/airflow-datasets.md
+++ b/learn/airflow-datasets.md
@@ -20,14 +20,6 @@ Datasets can help resolve common issues. For example, consider a data engineerin
 
 In this guide, you'll learn about datasets in Airflow and how to use them to implement triggering of DAGs based on dataset updates. You'll also learn how datasets work with the Astro Python SDK.
 
-## Assumed knowledge
-
-To get the most out of this guide, you should have an existing knowledge of:
-
-- Airflow scheduling concepts. See [Scheduling and Timetables in Airflow](scheduling-in-airflow.md).
-- Creating dependencies between DAGs. See [Cross-DAG Dependencies](cross-dag-dependencies.md).
-- The Astro Python SDK. See [Using the Astro Python SDK](https://docs.astronomer.io/tutorials/astro-python-sdk).
-
 :::tip Related Content
 
 - Astronomer Academy: [Airflow: Datasets](https://academy.astronomer.io/astro-runtime-datasets) module.
@@ -35,6 +27,14 @@ To get the most out of this guide, you should have an existing knowledge of:
 - Use case: [Orchestrate machine learning pipelines with Airflow datasets](use-case-airflow-datasets-multi-team-ml.md).
 
 :::
+
+## Assumed knowledge
+
+To get the most out of this guide, you should have an existing knowledge of:
+
+- Airflow scheduling concepts. See [Scheduling and Timetables in Airflow](scheduling-in-airflow.md).
+- Creating dependencies between DAGs. See [Cross-DAG Dependencies](cross-dag-dependencies.md).
+- The Astro Python SDK. See [Using the Astro Python SDK](https://docs.astronomer.io/tutorials/astro-python-sdk).
 
 ## Why use datasets?
 

--- a/learn/airflow-datasets.md
+++ b/learn/airflow-datasets.md
@@ -22,6 +22,8 @@ In this guide, you'll learn about datasets in Airflow and how to use them to imp
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: Datasets](https://academy.astronomer.io/astro-runtime-datasets) module.
 - Webinar: [Data Driven Scheduling](https://www.astronomer.io/events/webinars/data-driven-scheduling/).
 - Use case: [Orchestrate machine learning pipelines with Airflow datasets](use-case-airflow-datasets-multi-team-ml.md).

--- a/learn/airflow-datasets.md
+++ b/learn/airflow-datasets.md
@@ -20,7 +20,7 @@ Datasets can help resolve common issues. For example, consider a data engineerin
 
 In this guide, you'll learn about datasets in Airflow and how to use them to implement triggering of DAGs based on dataset updates. You'll also learn how datasets work with the Astro Python SDK.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-datasets.md
+++ b/learn/airflow-datasets.md
@@ -20,7 +20,7 @@ Datasets can help resolve common issues. For example, consider a data engineerin
 
 In this guide, you'll learn about datasets in Airflow and how to use them to implement triggering of DAGs based on dataset updates. You'll also learn how datasets work with the Astro Python SDK.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -38,13 +38,14 @@ DbtTaskGroup(
 )
 ```
 
-:::info
+:::tip Related Content
 
-If you are already familiar with Airflow and dbt Core and just want to get a project running, clone [this Cosmos use case example repository](https://github.com/astronomer/cosmos-use-case) and run it locally using the Astro CLI.
-
-:::
+- Webinar: [Introducing Cosmos: The Easy Way to Run dbt Models in Airflow](https://www.astronomer.io/events/webinars/introducing-cosmos-the-east-way-to-run-dbt-models-in-airflow/).
+- Use case: [ELT with Airflow and dbt Core](use-case-airflow-dbt.md) including a a ready-to-use [example Cosmos project repository](https://github.com/astronomer/cosmos-use-case).
 
 For a tutorial on how to use dbt Cloud with Airflow, see [Orchestrate dbt Cloud with Airflow](airflow-dbt-cloud.md).
+
+:::
 
 ## Why use Airflow with dbt Core?
 
@@ -72,14 +73,6 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Airflow task groups. See [Airflow task groups](task-groups.md).
 - Airflow connections. See [Manage connections in Apache Airflow](connections.md).
-
-:::tip Related Content
-
-- Webinar: [Introducing Cosmos: The Easy Way to Run dbt Models in Airflow](https://www.astronomer.io/events/webinars/introducing-cosmos-the-east-way-to-run-dbt-models-in-airflow/).
-- Blog post: [Introducing Cosmos 1.0: the best way to run dbt Core in Airflow](https://www.astronomer.io/blog/introducing-cosmos-1-0/).
-- Use case: [ELT with Airflow and dbt Core](use-case-airflow-dbt.md).
-
-:::
 
 ## Prerequisites
 

--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -38,9 +38,9 @@ DbtTaskGroup(
 )
 ```
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [Introducing Cosmos: The Easy Way to Run dbt Models in Airflow](https://www.astronomer.io/events/webinars/introducing-cosmos-the-east-way-to-run-dbt-models-in-airflow/).
 - Use case: [ELT with Airflow and dbt Core](use-case-airflow-dbt.md) including a a ready-to-use [example Cosmos project repository](https://github.com/astronomer/cosmos-use-case).

--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -73,6 +73,14 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow task groups. See [Airflow task groups](task-groups.md).
 - Airflow connections. See [Manage connections in Apache Airflow](connections.md).
 
+:::tip Related Content
+
+- Webinar: [Introducing Cosmos: The Easy Way to Run dbt Models in Airflow](https://www.astronomer.io/events/webinars/introducing-cosmos-the-east-way-to-run-dbt-models-in-airflow/).
+- Blog post: [Introducing Cosmos 1.0: the best way to run dbt Core in Airflow](https://www.astronomer.io/blog/introducing-cosmos-1-0/).
+- Use case: [ELT with Airflow and dbt Core](use-case-airflow-dbt.md).
+
+:::
+
 ## Prerequisites
 
 - The [Astro CLI](https://docs.astronomer.io/astro/cli/overview).

--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -38,7 +38,7 @@ DbtTaskGroup(
 )
 ```
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -40,6 +40,8 @@ DbtTaskGroup(
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [Introducing Cosmos: The Easy Way to Run dbt Models in Airflow](https://www.astronomer.io/events/webinars/introducing-cosmos-the-east-way-to-run-dbt-models-in-airflow/).
 - Use case: [ELT with Airflow and dbt Core](use-case-airflow-dbt.md) including a a ready-to-use [example Cosmos project repository](https://github.com/astronomer/cosmos-use-case).
 

--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -38,7 +38,7 @@ DbtTaskGroup(
 )
 ```
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -40,7 +40,7 @@ DbtTaskGroup(
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [Introducing Cosmos: The Easy Way to Run dbt Models in Airflow](https://www.astronomer.io/events/webinars/introducing-cosmos-the-east-way-to-run-dbt-models-in-airflow/).
 - Use case: [ELT with Airflow and dbt Core](use-case-airflow-dbt.md) including a a ready-to-use [example Cosmos project repository](https://github.com/astronomer/cosmos-use-case).

--- a/learn/airflow-decorators.md
+++ b/learn/airflow-decorators.md
@@ -18,9 +18,9 @@ The _TaskFlow API_ is a functional API for using decorators to define DAGs and t
 
 In this guide, you'll learn about the benefits of decorators and the decorators available in Airflow. You'll also review an example DAG and learn when you should use decorators and how you can combine them with traditional operators in a DAG.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: Taskflow API](https://academy.astronomer.io/astro-runtime-taskflow) module.
 - Webinar: [Writing Functional DAGs with Decorators](https://www.astronomer.io/events/webinars/writing-functional-dags-with-decorators/).

--- a/learn/airflow-decorators.md
+++ b/learn/airflow-decorators.md
@@ -18,19 +18,19 @@ The _TaskFlow API_ is a functional API for using decorators to define DAGs and t
 
 In this guide, you'll learn about the benefits of decorators and the decorators available in Airflow. You'll also review an example DAG and learn when you should use decorators and how you can combine them with traditional operators in a DAG.
 
-## Assumed knowledge
-
-To get the most out of this guide, you should have an understanding of:
-
-- Basic Python. See the [Python Documentation](https://docs.python.org/3/tutorial/index.html).
-- Airflow operators. See [Operators 101](what-is-an-operator.md).
-
 :::tip Related Content
 
 - Astronomer Academy: [Airflow: Taskflow API](https://academy.astronomer.io/astro-runtime-taskflow) module.
 - Webinar: [Writing Functional DAGs with Decorators](https://www.astronomer.io/events/webinars/writing-functional-dags-with-decorators/).
 
 :::
+
+## Assumed knowledge
+
+To get the most out of this guide, you should have an understanding of:
+
+- Basic Python. See the [Python Documentation](https://docs.python.org/3/tutorial/index.html).
+- Airflow operators. See [Operators 101](what-is-an-operator.md).
 
 ## What is a decorator?
 

--- a/learn/airflow-decorators.md
+++ b/learn/airflow-decorators.md
@@ -20,7 +20,7 @@ In this guide, you'll learn about the benefits of decorators and the decorators 
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: Taskflow API](https://academy.astronomer.io/astro-runtime-taskflow) module.
 - Webinar: [Writing Functional DAGs with Decorators](https://www.astronomer.io/events/webinars/writing-functional-dags-with-decorators/).

--- a/learn/airflow-decorators.md
+++ b/learn/airflow-decorators.md
@@ -25,6 +25,13 @@ To get the most out of this guide, you should have an understanding of:
 - Basic Python. See the [Python Documentation](https://docs.python.org/3/tutorial/index.html).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Taskflow API](https://academy.astronomer.io/astro-runtime-taskflow) module.
+- Webinar: [Writing Functional DAGs with Decorators](https://www.astronomer.io/events/webinars/writing-functional-dags-with-decorators/).
+
+:::
+
 ## What is a decorator?
 
 In Python, [decorators](https://realpython.com/primer-on-python-decorators/) are functions that take another function as an argument and extend the behavior of that function. For example, the `@multiply_by_100_decorator` takes any function as the `decorated_function` argument and returns the result of that function multiplied by 100. 

--- a/learn/airflow-decorators.md
+++ b/learn/airflow-decorators.md
@@ -18,7 +18,7 @@ The _TaskFlow API_ is a functional API for using decorators to define DAGs and t
 
 In this guide, you'll learn about the benefits of decorators and the decorators available in Airflow. You'll also review an example DAG and learn when you should use decorators and how you can combine them with traditional operators in a DAG.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-decorators.md
+++ b/learn/airflow-decorators.md
@@ -20,6 +20,8 @@ In this guide, you'll learn about the benefits of decorators and the decorators 
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: Taskflow API](https://academy.astronomer.io/astro-runtime-taskflow) module.
 - Webinar: [Writing Functional DAGs with Decorators](https://www.astronomer.io/events/webinars/writing-functional-dags-with-decorators/).
 

--- a/learn/airflow-decorators.md
+++ b/learn/airflow-decorators.md
@@ -18,7 +18,7 @@ The _TaskFlow API_ is a functional API for using decorators to define DAGs and t
 
 In this guide, you'll learn about the benefits of decorators and the decorators available in Airflow. You'll also review an example DAG and learn when you should use decorators and how you can combine them with traditional operators in a DAG.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-duckdb.md
+++ b/learn/airflow-duckdb.md
@@ -24,7 +24,7 @@ Airflow can interact with DuckDB in three key ways:
 
 In this tutorial we will cover the first two ways. To learn more about how to connect to DuckDB (and other data warehouses) with the Astro Python SDK, see [Write a DAG with the Astro Python SDK](astro-python-sdk.md).
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-duckdb.md
+++ b/learn/airflow-duckdb.md
@@ -43,6 +43,13 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow decorators. See [Introduction to Airflow decorators](airflow-decorators.md).
 - Airflow connections. See [Manage connections in Apache Airflow](connections.md).
 
+:::tip Related Content
+
+- Webinar: [How to use DuckDB with Airflow](https://www.astronomer.io/events/webinars/how-to-use-duckdb-with-airflow/).
+- Blog post: [Three ways to use Airflow with MotherDuck and DuckDB](https://www.astronomer.io/blog/three-ways-to-use-airflow-with-motherduck-and-duckdb/).
+
+:::
+
 ## Prerequisites
 
 - The [Astro CLI](https://docs.astronomer.io/astro/cli/overview).

--- a/learn/airflow-duckdb.md
+++ b/learn/airflow-duckdb.md
@@ -26,7 +26,7 @@ In this tutorial we will cover the first two ways. To learn more about how to co
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [How to use DuckDB with Airflow](https://www.astronomer.io/events/webinars/how-to-use-duckdb-with-airflow/).
 - Example repository: [Astronomer's DuckDB example repository](https://github.com/astronomer/airflow-duckdb-examples).

--- a/learn/airflow-duckdb.md
+++ b/learn/airflow-duckdb.md
@@ -24,7 +24,7 @@ Airflow can interact with DuckDB in three key ways:
 
 In this tutorial we will cover the first two ways. To learn more about how to connect to DuckDB (and other data warehouses) with the Astro Python SDK, see [Write a DAG with the Astro Python SDK](astro-python-sdk.md).
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-duckdb.md
+++ b/learn/airflow-duckdb.md
@@ -24,9 +24,9 @@ Airflow can interact with DuckDB in three key ways:
 
 In this tutorial we will cover the first two ways. To learn more about how to connect to DuckDB (and other data warehouses) with the Astro Python SDK, see [Write a DAG with the Astro Python SDK](astro-python-sdk.md).
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [How to use DuckDB with Airflow](https://www.astronomer.io/events/webinars/how-to-use-duckdb-with-airflow/).
 - Example repository: [Astronomer's DuckDB example repository](https://github.com/astronomer/airflow-duckdb-examples).

--- a/learn/airflow-duckdb.md
+++ b/learn/airflow-duckdb.md
@@ -26,6 +26,8 @@ In this tutorial we will cover the first two ways. To learn more about how to co
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [How to use DuckDB with Airflow](https://www.astronomer.io/events/webinars/how-to-use-duckdb-with-airflow/).
 - Example repository: [Astronomer's DuckDB example repository](https://github.com/astronomer/airflow-duckdb-examples).
 

--- a/learn/airflow-duckdb.md
+++ b/learn/airflow-duckdb.md
@@ -24,9 +24,10 @@ Airflow can interact with DuckDB in three key ways:
 
 In this tutorial we will cover the first two ways. To learn more about how to connect to DuckDB (and other data warehouses) with the Astro Python SDK, see [Write a DAG with the Astro Python SDK](astro-python-sdk.md).
 
-:::info
+:::tip Related Content
 
-If you are already familiar with DuckDB and Airflow, you can clone [Astronomer's DuckDB example repository](https://github.com/astronomer/airflow-duckdb-examples) and run it locally using the Astro CLI to explore different ways of using DuckDB with Airflow.
+- Webinar: [How to use DuckDB with Airflow](https://www.astronomer.io/events/webinars/how-to-use-duckdb-with-airflow/).
+- Example repository: [Astronomer's DuckDB example repository](https://github.com/astronomer/airflow-duckdb-examples).
 
 :::
 
@@ -42,13 +43,6 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow fundamentals, such as writing DAGs and defining tasks. See [Get started with Apache Airflow](get-started-with-airflow.md).
 - Airflow decorators. See [Introduction to Airflow decorators](airflow-decorators.md).
 - Airflow connections. See [Manage connections in Apache Airflow](connections.md).
-
-:::tip Related Content
-
-- Webinar: [How to use DuckDB with Airflow](https://www.astronomer.io/events/webinars/how-to-use-duckdb-with-airflow/).
-- Blog post: [Three ways to use Airflow with MotherDuck and DuckDB](https://www.astronomer.io/blog/three-ways-to-use-airflow-with-motherduck-and-duckdb/).
-
-:::
 
 ## Prerequisites
 

--- a/learn/airflow-fivetran.md
+++ b/learn/airflow-fivetran.md
@@ -16,7 +16,7 @@ In this tutorial, you'll learn how to install and use the Airflow Fivetran provi
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [Hands-on Workshop: automate your data ingestion with Fivetran and Astronomer](https://www.astronomer.io/events/webinars/workshop-automate-data-ingestion-fivetran-astronomer/).
 

--- a/learn/airflow-fivetran.md
+++ b/learn/airflow-fivetran.md
@@ -26,6 +26,12 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow fundamentals, such as writing DAGs and defining tasks. See [Get started with Apache Airflow](get-started-with-airflow.md).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 
+:::tip Related Content
+
+- Webinar: [Hands-on Workshop: automate your data ingestion with Fivetran and Astronomer](https://www.astronomer.io/events/webinars/workshop-automate-data-ingestion-fivetran-astronomer/).
+
+:::
+
 ## Prerequisites
 
 - A Fivetran account. Fivetran offers a [14-day free trial](https://fivetran.com/signup) for new customers.

--- a/learn/airflow-fivetran.md
+++ b/learn/airflow-fivetran.md
@@ -14,7 +14,7 @@ Using Airflow with Fivetran allows you to schedule your Fivetran syncs based on 
 
 In this tutorial, you'll learn how to install and use the Airflow Fivetran provider to submit and monitor Fivetran syncs.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-fivetran.md
+++ b/learn/airflow-fivetran.md
@@ -14,9 +14,9 @@ Using Airflow with Fivetran allows you to schedule your Fivetran syncs based on 
 
 In this tutorial, you'll learn how to install and use the Airflow Fivetran provider to submit and monitor Fivetran syncs.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [Hands-on Workshop: automate your data ingestion with Fivetran and Astronomer](https://www.astronomer.io/events/webinars/workshop-automate-data-ingestion-fivetran-astronomer/).
 

--- a/learn/airflow-fivetran.md
+++ b/learn/airflow-fivetran.md
@@ -14,7 +14,7 @@ Using Airflow with Fivetran allows you to schedule your Fivetran syncs based on 
 
 In this tutorial, you'll learn how to install and use the Airflow Fivetran provider to submit and monitor Fivetran syncs.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-fivetran.md
+++ b/learn/airflow-fivetran.md
@@ -16,6 +16,8 @@ In this tutorial, you'll learn how to install and use the Airflow Fivetran provi
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [Hands-on Workshop: automate your data ingestion with Fivetran and Astronomer](https://www.astronomer.io/events/webinars/workshop-automate-data-ingestion-fivetran-astronomer/).
 
 :::

--- a/learn/airflow-fivetran.md
+++ b/learn/airflow-fivetran.md
@@ -14,6 +14,12 @@ Using Airflow with Fivetran allows you to schedule your Fivetran syncs based on 
 
 In this tutorial, you'll learn how to install and use the Airflow Fivetran provider to submit and monitor Fivetran syncs.
 
+:::tip Related Content
+
+- Webinar: [Hands-on Workshop: automate your data ingestion with Fivetran and Astronomer](https://www.astronomer.io/events/webinars/workshop-automate-data-ingestion-fivetran-astronomer/).
+
+:::
+
 ## Time to complete
 
 This tutorial takes approximately 1 hour to complete.
@@ -25,12 +31,6 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - The basics of Fivetran. See Fivetran's [Getting started](https://fivetran.com/docs/getting-started) documentation.
 - Airflow fundamentals, such as writing DAGs and defining tasks. See [Get started with Apache Airflow](get-started-with-airflow.md).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
-
-:::tip Related Content
-
-- Webinar: [Hands-on Workshop: automate your data ingestion with Fivetran and Astronomer](https://www.astronomer.io/events/webinars/workshop-automate-data-ingestion-fivetran-astronomer/).
-
-:::
 
 ## Prerequisites
 

--- a/learn/airflow-great-expectations.md
+++ b/learn/airflow-great-expectations.md
@@ -15,7 +15,7 @@ This tutorial shows how to use the [`GreatExpectationsOperator`](https://registr
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [How to Improve Data Quality with Airflow's Great Expectations Operator](https://www.astronomer.io/events/webinars/how-to-improve-data-quality-with-airflows-great-expectations-operator/).
 

--- a/learn/airflow-great-expectations.md
+++ b/learn/airflow-great-expectations.md
@@ -13,6 +13,13 @@ import gx_dag from '!!raw-loader!../code-samples/dags/airflow-great-expectations
 
 This tutorial shows how to use the [`GreatExpectationsOperator`](https://registry.astronomer.io/providers/airflow-provider-great-expectations/versions/latest/modules/GreatExpectationsOperator) in an Airflow DAG, leveraging automatic creation of a default [Checkpoint](https://docs.greatexpectations.io/docs/terms/checkpoint) and connecting via an [Airflow connection](connections.md).
 
+:::tip Related Content
+
+- Webinar: [How to Improve Data Quality with Airflow's Great Expectations Operator](https://www.astronomer.io/events/webinars/how-to-improve-data-quality-with-airflows-great-expectations-operator/).
+- Blog post: [Get Improved Data Quality Checks in Airflow with the Updated Great Expectations Operator](https://www.astronomer.io/blog/improved-data-quality-checks-in-airflow-with-great-expectations-operator/).
+
+:::
+
 ## Time to complete
 
 This tutorial takes approximately 20 minutes to complete.
@@ -25,13 +32,6 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow fundamentals, such as writing DAGs and defining tasks. See [Get started with Apache Airflow](get-started-with-airflow.md).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Airflow connections. See [Managing your Connections in Apache Airflow](connections.md).
-
-:::tip Related Content
-
-- Webinar: [How to Improve Data Quality with Airflow's Great Expectations Operator](https://www.astronomer.io/events/webinars/how-to-improve-data-quality-with-airflows-great-expectations-operator/).
-- Blog post: [Get Improved Data Quality Checks in Airflow with the Updated Great Expectations Operator](https://www.astronomer.io/blog/improved-data-quality-checks-in-airflow-with-great-expectations-operator/).
-
-:::
 
 ## Prerequisites
 

--- a/learn/airflow-great-expectations.md
+++ b/learn/airflow-great-expectations.md
@@ -13,9 +13,9 @@ import gx_dag from '!!raw-loader!../code-samples/dags/airflow-great-expectations
 
 This tutorial shows how to use the [`GreatExpectationsOperator`](https://registry.astronomer.io/providers/airflow-provider-great-expectations/versions/latest/modules/GreatExpectationsOperator) in an Airflow DAG, leveraging automatic creation of a default [Checkpoint](https://docs.greatexpectations.io/docs/terms/checkpoint) and connecting via an [Airflow connection](connections.md).
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [How to Improve Data Quality with Airflow's Great Expectations Operator](https://www.astronomer.io/events/webinars/how-to-improve-data-quality-with-airflows-great-expectations-operator/).
 

--- a/learn/airflow-great-expectations.md
+++ b/learn/airflow-great-expectations.md
@@ -13,7 +13,7 @@ import gx_dag from '!!raw-loader!../code-samples/dags/airflow-great-expectations
 
 This tutorial shows how to use the [`GreatExpectationsOperator`](https://registry.astronomer.io/providers/airflow-provider-great-expectations/versions/latest/modules/GreatExpectationsOperator) in an Airflow DAG, leveraging automatic creation of a default [Checkpoint](https://docs.greatexpectations.io/docs/terms/checkpoint) and connecting via an [Airflow connection](connections.md).
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-great-expectations.md
+++ b/learn/airflow-great-expectations.md
@@ -16,7 +16,6 @@ This tutorial shows how to use the [`GreatExpectationsOperator`](https://registr
 :::tip Related Content
 
 - Webinar: [How to Improve Data Quality with Airflow's Great Expectations Operator](https://www.astronomer.io/events/webinars/how-to-improve-data-quality-with-airflows-great-expectations-operator/).
-- Blog post: [Get Improved Data Quality Checks in Airflow with the Updated Great Expectations Operator](https://www.astronomer.io/blog/improved-data-quality-checks-in-airflow-with-great-expectations-operator/).
 
 :::
 

--- a/learn/airflow-great-expectations.md
+++ b/learn/airflow-great-expectations.md
@@ -26,6 +26,13 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Airflow connections. See [Managing your Connections in Apache Airflow](connections.md).
 
+:::tip Related Content
+
+- Webinar: [How to Improve Data Quality with Airflow's Great Expectations Operator](https://www.astronomer.io/events/webinars/how-to-improve-data-quality-with-airflows-great-expectations-operator/).
+- Blog post: [Get Improved Data Quality Checks in Airflow with the Updated Great Expectations Operator](https://www.astronomer.io/blog/improved-data-quality-checks-in-airflow-with-great-expectations-operator/).
+
+:::
+
 ## Prerequisites
 
 - The [Astro CLI](https://docs.astronomer.io/astro/cli/overview).

--- a/learn/airflow-great-expectations.md
+++ b/learn/airflow-great-expectations.md
@@ -13,7 +13,7 @@ import gx_dag from '!!raw-loader!../code-samples/dags/airflow-great-expectations
 
 This tutorial shows how to use the [`GreatExpectationsOperator`](https://registry.astronomer.io/providers/airflow-provider-great-expectations/versions/latest/modules/GreatExpectationsOperator) in an Airflow DAG, leveraging automatic creation of a default [Checkpoint](https://docs.greatexpectations.io/docs/terms/checkpoint) and connecting via an [Airflow connection](connections.md).
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-great-expectations.md
+++ b/learn/airflow-great-expectations.md
@@ -15,6 +15,8 @@ This tutorial shows how to use the [`GreatExpectationsOperator`](https://registr
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [How to Improve Data Quality with Airflow's Great Expectations Operator](https://www.astronomer.io/events/webinars/how-to-improve-data-quality-with-airflows-great-expectations-operator/).
 
 :::

--- a/learn/airflow-mlflow.md
+++ b/learn/airflow-mlflow.md
@@ -13,6 +13,8 @@ import mlflow_tutorial_dag from '!!raw-loader!../code-samples/dags/airflow-mlflo
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Use case: [Predict possum tail length using MLflow, Airflow, and linear regression](use-case-airflow-mlflow.md) including a ready-to-use [example repository](https://github.com/astronomer/use-case-mlflow). 
 
 :::

--- a/learn/airflow-mlflow.md
+++ b/learn/airflow-mlflow.md
@@ -11,7 +11,7 @@ import mlflow_tutorial_dag from '!!raw-loader!../code-samples/dags/airflow-mlflo
 
 [MLflow](https://mlflow.org/) is a popular tool for tracking and managing machine learning models. It can be used together with Airflow for ML orchestration (MLOx), leveraging both tools for what they do best. In this tutorial, you’ll learn about three different ways you can use MLflow with Airflow.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-mlflow.md
+++ b/learn/airflow-mlflow.md
@@ -11,9 +11,9 @@ import mlflow_tutorial_dag from '!!raw-loader!../code-samples/dags/airflow-mlflo
 
 [MLflow](https://mlflow.org/) is a popular tool for tracking and managing machine learning models. It can be used together with Airflow for ML orchestration (MLOx), leveraging both tools for what they do best. In this tutorial, you’ll learn about three different ways you can use MLflow with Airflow.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Use case: [Predict possum tail length using MLflow, Airflow, and linear regression](use-case-airflow-mlflow.md) including a ready-to-use [example repository](https://github.com/astronomer/use-case-mlflow). 
 

--- a/learn/airflow-mlflow.md
+++ b/learn/airflow-mlflow.md
@@ -13,7 +13,7 @@ import mlflow_tutorial_dag from '!!raw-loader!../code-samples/dags/airflow-mlflo
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Use case: [Predict possum tail length using MLflow, Airflow, and linear regression](use-case-airflow-mlflow.md) including a ready-to-use [example repository](https://github.com/astronomer/use-case-mlflow). 
 

--- a/learn/airflow-mlflow.md
+++ b/learn/airflow-mlflow.md
@@ -11,7 +11,7 @@ import mlflow_tutorial_dag from '!!raw-loader!../code-samples/dags/airflow-mlflo
 
 [MLflow](https://mlflow.org/) is a popular tool for tracking and managing machine learning models. It can be used together with Airflow for ML orchestration (MLOx), leveraging both tools for what they do best. In this tutorial, you’ll learn about three different ways you can use MLflow with Airflow.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-mlflow.md
+++ b/learn/airflow-mlflow.md
@@ -11,9 +11,9 @@ import mlflow_tutorial_dag from '!!raw-loader!../code-samples/dags/airflow-mlflo
 
 [MLflow](https://mlflow.org/) is a popular tool for tracking and managing machine learning models. It can be used together with Airflow for ML orchestration (MLOx), leveraging both tools for what they do best. In this tutorial, you’ll learn about three different ways you can use MLflow with Airflow.
 
-:::info
+:::tip Related Content
 
-If you're already familiar with MLflow and Airflow and want to get a use case up and running, clone the [quickstart repository](https://github.com/astronomer/use-case-mlflow) to automatically start up Airflow and local MLflow and MinIO instances. After you clone the repository, configure the local MLflow connection as shown in [Step 2](#step-2-configure-your-airflow-connection) of this tutorial, and run the three example DAGs.
+- Use case: [Predict possum tail length using MLflow, Airflow, and linear regression](use-case-airflow-mlflow.md) including a ready-to-use [example repository](https://github.com/astronomer/use-case-mlflow). 
 
 :::
 
@@ -38,12 +38,6 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Airflow hooks. See [Hooks 101](what-is-a-hook.md).
 - Airflow connections. See [Managing your Connections in Apache Airflow](connections.md).
-
-:::tip Related Content
-
-- Use case: [Predict possum tail length using MLflow, Airflow, and linear regression](use-case-airflow-mlflow.md).
-
-:::
 
 ## Prerequisites
 

--- a/learn/airflow-mlflow.md
+++ b/learn/airflow-mlflow.md
@@ -39,6 +39,12 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow hooks. See [Hooks 101](what-is-a-hook.md).
 - Airflow connections. See [Managing your Connections in Apache Airflow](connections.md).
 
+:::tip Related Content
+
+- Use case: [Predict possum tail length using MLflow, Airflow, and linear regression](use-case-airflow-mlflow.md).
+
+:::
+
 ## Prerequisites
 
 - The [Astro CLI](https://docs.astronomer.io/astro/cli/get-started).

--- a/learn/airflow-openlineage.md
+++ b/learn/airflow-openlineage.md
@@ -21,6 +21,12 @@ To get the most out of this guide, make sure you have an understanding of:
 - Airflow fundamentals, such as writing DAGs and defining tasks. See [Get started with Apache Airflow](get-started-with-airflow.md).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 
+:::tip Related Content
+
+- Webinar: [OpenLineage and Airflow: A Deeper Dive](https://www.astronomer.io/events/webinars/openlineage-and-airflow-deeper-dive/).
+
+:::
+
 ## What is data lineage
 
 Data lineage is a way of tracing the complex set of relationships that exist among datasets within an ecosystem.  The concept of data lineage encompasses:

--- a/learn/airflow-openlineage.md
+++ b/learn/airflow-openlineage.md
@@ -16,6 +16,8 @@ Astro offers robust support for extracting and visualizing data lineage. To lear
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [OpenLineage and Airflow: A Deeper Dive](https://www.astronomer.io/events/webinars/openlineage-and-airflow-deeper-dive/).
 
 :::

--- a/learn/airflow-openlineage.md
+++ b/learn/airflow-openlineage.md
@@ -14,7 +14,7 @@ In this guide, you’ll learn about core data lineage concepts and understand ho
 
 Astro offers robust support for extracting and visualizing data lineage. To learn more, see [Data lineage on Astro](https://docs.astronomer.io/astro/data-lineage).
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-openlineage.md
+++ b/learn/airflow-openlineage.md
@@ -14,9 +14,9 @@ In this guide, you’ll learn about core data lineage concepts and understand ho
 
 Astro offers robust support for extracting and visualizing data lineage. To learn more, see [Data lineage on Astro](https://docs.astronomer.io/astro/data-lineage).
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [OpenLineage and Airflow: A Deeper Dive](https://www.astronomer.io/events/webinars/openlineage-and-airflow-deeper-dive/).
 

--- a/learn/airflow-openlineage.md
+++ b/learn/airflow-openlineage.md
@@ -16,7 +16,7 @@ Astro offers robust support for extracting and visualizing data lineage. To lear
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [OpenLineage and Airflow: A Deeper Dive](https://www.astronomer.io/events/webinars/openlineage-and-airflow-deeper-dive/).
 

--- a/learn/airflow-openlineage.md
+++ b/learn/airflow-openlineage.md
@@ -14,7 +14,7 @@ In this guide, you’ll learn about core data lineage concepts and understand ho
 
 Astro offers robust support for extracting and visualizing data lineage. To learn more, see [Data lineage on Astro](https://docs.astronomer.io/astro/data-lineage).
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-openlineage.md
+++ b/learn/airflow-openlineage.md
@@ -14,18 +14,18 @@ In this guide, you’ll learn about core data lineage concepts and understand ho
 
 Astro offers robust support for extracting and visualizing data lineage. To learn more, see [Data lineage on Astro](https://docs.astronomer.io/astro/data-lineage).
 
+:::tip Related Content
+
+- Webinar: [OpenLineage and Airflow: A Deeper Dive](https://www.astronomer.io/events/webinars/openlineage-and-airflow-deeper-dive/).
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, make sure you have an understanding of:
 
 - Airflow fundamentals, such as writing DAGs and defining tasks. See [Get started with Apache Airflow](get-started-with-airflow.md).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
-
-:::tip Related Content
-
-- Webinar: [OpenLineage and Airflow: A Deeper Dive](https://www.astronomer.io/events/webinars/openlineage-and-airflow-deeper-dive/).
-
-:::
 
 ## What is data lineage
 

--- a/learn/airflow-passing-data-between-tasks.md
+++ b/learn/airflow-passing-data-between-tasks.md
@@ -22,9 +22,9 @@ Sharing data between tasks is a very common use case in Airflow. If you've been 
 
 There are a few methods you can use to implement data sharing between your Airflow tasks. In this guide, you'll walk through the two most commonly used methods, learn when to use them, and use some example DAGs to understand how they can be implemented.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: XComs 101](https://academy.astronomer.io/astro-runtime-xcoms-101) module.
 - Webinar: [How to pass data between your Airflow tasks](https://www.astronomer.io/events/webinars/how-to-pass-data-between-your-airflow-tasks/).

--- a/learn/airflow-passing-data-between-tasks.md
+++ b/learn/airflow-passing-data-between-tasks.md
@@ -22,9 +22,10 @@ Sharing data between tasks is a very common use case in Airflow. If you've been 
 
 There are a few methods you can use to implement data sharing between your Airflow tasks. In this guide, you'll walk through the two most commonly used methods, learn when to use them, and use some example DAGs to understand how they can be implemented.
 
-:::info
+:::tip Related Content
 
-All code in this guide can be found in [the Github repo](https://github.com/astronomer/airflow-guide-passing-data-between-tasks).
+- Astronomer Academy: [Airflow: XComs 101](https://academy.astronomer.io/astro-runtime-xcoms-101) module.
+- Webinar: [How to pass data between your Airflow tasks](https://www.astronomer.io/events/webinars/how-to-pass-data-between-your-airflow-tasks/).
 
 :::
 
@@ -34,13 +35,6 @@ To get the most out of this guide, you should have an understanding of:
 
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - DAG writing best practices. See [DAG writing best practices in Apache Airflow](dag-best-practices.md).
-
-:::tip Related Content
-
-- Astronomer Academy: [Airflow: XComs 101](https://academy.astronomer.io/astro-runtime-xcoms-101) module.
-- Webinar: [How to pass data between your Airflow tasks](https://www.astronomer.io/events/webinars/how-to-pass-data-between-your-airflow-tasks/).
-
-:::
 
 ## Best practices
 

--- a/learn/airflow-passing-data-between-tasks.md
+++ b/learn/airflow-passing-data-between-tasks.md
@@ -22,7 +22,7 @@ Sharing data between tasks is a very common use case in Airflow. If you've been 
 
 There are a few methods you can use to implement data sharing between your Airflow tasks. In this guide, you'll walk through the two most commonly used methods, learn when to use them, and use some example DAGs to understand how they can be implemented.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-passing-data-between-tasks.md
+++ b/learn/airflow-passing-data-between-tasks.md
@@ -24,6 +24,8 @@ There are a few methods you can use to implement data sharing between your Airfl
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: XComs 101](https://academy.astronomer.io/astro-runtime-xcoms-101) module.
 - Webinar: [How to pass data between your Airflow tasks](https://www.astronomer.io/events/webinars/how-to-pass-data-between-your-airflow-tasks/).
 

--- a/learn/airflow-passing-data-between-tasks.md
+++ b/learn/airflow-passing-data-between-tasks.md
@@ -35,6 +35,13 @@ To get the most out of this guide, you should have an understanding of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - DAG writing best practices. See [DAG writing best practices in Apache Airflow](dag-best-practices.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: XComs 101](https://academy.astronomer.io/astro-runtime-xcoms-101) module.
+- Webinar: [How to pass data between your Airflow tasks](https://www.astronomer.io/events/webinars/how-to-pass-data-between-your-airflow-tasks/).
+
+:::
+
 ## Best practices
 
 Before you dive into the specifics, there are a couple of important concepts to understand before you write DAGs that pass data between tasks.

--- a/learn/airflow-passing-data-between-tasks.md
+++ b/learn/airflow-passing-data-between-tasks.md
@@ -22,7 +22,7 @@ Sharing data between tasks is a very common use case in Airflow. If you've been 
 
 There are a few methods you can use to implement data sharing between your Airflow tasks. In this guide, you'll walk through the two most commonly used methods, learn when to use them, and use some example DAGs to understand how they can be implemented.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-passing-data-between-tasks.md
+++ b/learn/airflow-passing-data-between-tasks.md
@@ -24,7 +24,7 @@ There are a few methods you can use to implement data sharing between your Airfl
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: XComs 101](https://academy.astronomer.io/astro-runtime-xcoms-101) module.
 - Webinar: [How to pass data between your Airflow tasks](https://www.astronomer.io/events/webinars/how-to-pass-data-between-your-airflow-tasks/).

--- a/learn/airflow-pools.md
+++ b/learn/airflow-pools.md
@@ -19,7 +19,7 @@ Pools allow you to limit parallelism for an arbitrary set of tasks, allowing you
 
 In this guide, you'll learn basic Airflow pool concepts, how to create and assign pools, and what you can and can't do with pools. You'll also implement some sample DAGs that use pools to fulfill simple requirements. 
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-pools.md
+++ b/learn/airflow-pools.md
@@ -19,7 +19,7 @@ Pools allow you to limit parallelism for an arbitrary set of tasks, allowing you
 
 In this guide, you'll learn basic Airflow pool concepts, how to create and assign pools, and what you can and can't do with pools. You'll also implement some sample DAGs that use pools to fulfill simple requirements. 
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-pools.md
+++ b/learn/airflow-pools.md
@@ -19,18 +19,18 @@ Pools allow you to limit parallelism for an arbitrary set of tasks, allowing you
 
 In this guide, you'll learn basic Airflow pool concepts, how to create and assign pools, and what you can and can't do with pools. You'll also implement some sample DAGs that use pools to fulfill simple requirements. 
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Pools](https://academy.astronomer.io/astro-runtime-pools) module.
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
 
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - The basics of scaling Airflow. See [Scaling out Airflow](airflow-scaling-workers.md).
-
-:::tip Related Content
-
-- Astronomer Academy: [Airflow: Pools](https://academy.astronomer.io/astro-runtime-pools) module.
-
-:::
 
 ## Create a pool
 

--- a/learn/airflow-pools.md
+++ b/learn/airflow-pools.md
@@ -21,6 +21,8 @@ In this guide, you'll learn basic Airflow pool concepts, how to create and assig
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: Pools](https://academy.astronomer.io/astro-runtime-pools) module.
 
 :::

--- a/learn/airflow-pools.md
+++ b/learn/airflow-pools.md
@@ -19,9 +19,9 @@ Pools allow you to limit parallelism for an arbitrary set of tasks, allowing you
 
 In this guide, you'll learn basic Airflow pool concepts, how to create and assign pools, and what you can and can't do with pools. You'll also implement some sample DAGs that use pools to fulfill simple requirements. 
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: Pools](https://academy.astronomer.io/astro-runtime-pools) module.
 

--- a/learn/airflow-pools.md
+++ b/learn/airflow-pools.md
@@ -26,6 +26,12 @@ To get the most out of this guide, you should have an understanding of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - The basics of scaling Airflow. See [Scaling out Airflow](airflow-scaling-workers.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Pools](https://academy.astronomer.io/astro-runtime-pools) module.
+
+:::
+
 ## Create a pool
 
 There are three ways you can create and manage pools in Airflow:

--- a/learn/airflow-pools.md
+++ b/learn/airflow-pools.md
@@ -21,7 +21,7 @@ In this guide, you'll learn basic Airflow pool concepts, how to create and assig
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: Pools](https://academy.astronomer.io/astro-runtime-pools) module.
 

--- a/learn/airflow-sagemaker.md
+++ b/learn/airflow-sagemaker.md
@@ -23,6 +23,12 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Airflow connections. See [Managing your Connections in Apache Airflow](connections.md).
 
+:::tip Related Content
+
+- Webinar: [Batch Inference with Airflow and SageMaker](https://www.astronomer.io/events/webinars/batch-inference-with-airflow-and-sagemaker/).
+
+:::
+
 ## Prerequisites
 
 To complete this tutorial, you need:

--- a/learn/airflow-sagemaker.md
+++ b/learn/airflow-sagemaker.md
@@ -10,9 +10,9 @@ sidebar_custom_props: { icon: 'img/integrations/sagemaker.png' }
 
 This tutorial demonstrates how to orchestrate a full ML pipeline including creating, training, and testing a new SageMaker model. This use case is relevant if you want to automate the model training, testing, and deployment components of your ML pipeline.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [Batch Inference with Airflow and SageMaker](https://www.astronomer.io/events/webinars/batch-inference-with-airflow-and-sagemaker/).
 

--- a/learn/airflow-sagemaker.md
+++ b/learn/airflow-sagemaker.md
@@ -10,6 +10,12 @@ sidebar_custom_props: { icon: 'img/integrations/sagemaker.png' }
 
 This tutorial demonstrates how to orchestrate a full ML pipeline including creating, training, and testing a new SageMaker model. This use case is relevant if you want to automate the model training, testing, and deployment components of your ML pipeline.
 
+:::tip Related Content
+
+- Webinar: [Batch Inference with Airflow and SageMaker](https://www.astronomer.io/events/webinars/batch-inference-with-airflow-and-sagemaker/).
+
+:::
+
 ## Time to complete
 
 This tutorial takes approximately 60 minutes to complete.
@@ -22,12 +28,6 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow fundamentals, such as writing DAGs and defining tasks. See [Get started with Apache Airflow](get-started-with-airflow.md).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Airflow connections. See [Managing your Connections in Apache Airflow](connections.md).
-
-:::tip Related Content
-
-- Webinar: [Batch Inference with Airflow and SageMaker](https://www.astronomer.io/events/webinars/batch-inference-with-airflow-and-sagemaker/).
-
-:::
 
 ## Prerequisites
 

--- a/learn/airflow-sagemaker.md
+++ b/learn/airflow-sagemaker.md
@@ -12,6 +12,8 @@ This tutorial demonstrates how to orchestrate a full ML pipeline including creat
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [Batch Inference with Airflow and SageMaker](https://www.astronomer.io/events/webinars/batch-inference-with-airflow-and-sagemaker/).
 
 :::

--- a/learn/airflow-sagemaker.md
+++ b/learn/airflow-sagemaker.md
@@ -10,7 +10,7 @@ sidebar_custom_props: { icon: 'img/integrations/sagemaker.png' }
 
 This tutorial demonstrates how to orchestrate a full ML pipeline including creating, training, and testing a new SageMaker model. This use case is relevant if you want to automate the model training, testing, and deployment components of your ML pipeline.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-sagemaker.md
+++ b/learn/airflow-sagemaker.md
@@ -10,7 +10,7 @@ sidebar_custom_props: { icon: 'img/integrations/sagemaker.png' }
 
 This tutorial demonstrates how to orchestrate a full ML pipeline including creating, training, and testing a new SageMaker model. This use case is relevant if you want to automate the model training, testing, and deployment components of your ML pipeline.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-sagemaker.md
+++ b/learn/airflow-sagemaker.md
@@ -12,7 +12,7 @@ This tutorial demonstrates how to orchestrate a full ML pipeline including creat
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [Batch Inference with Airflow and SageMaker](https://www.astronomer.io/events/webinars/batch-inference-with-airflow-and-sagemaker/).
 

--- a/learn/airflow-scaling-workers.md
+++ b/learn/airflow-scaling-workers.md
@@ -26,7 +26,7 @@ This guide references the parameters available in Airflow version 2.0 and later.
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [Scaling Out Airflow](https://www.astronomer.io/events/webinars/scaling-out-airflow/).
 

--- a/learn/airflow-scaling-workers.md
+++ b/learn/airflow-scaling-workers.md
@@ -31,6 +31,12 @@ To get the most out of this guide, you should have an understanding of:
 - Airflow core components. See [Airflow's components](airflow-components.md).
 - Airflow executors. See [Airflow executors explained](airflow-executors-explained.md).
 
+:::tip Related Content
+
+- Webinar: [Scaling Out Airflow](https://www.astronomer.io/events/webinars/scaling-out-airflow/).
+
+:::
+
 ## Parameter tuning
 
 Airflow has many parameters that impact its performance. Tuning these settings can impact DAG parsing and task scheduling performance, parallelism in your Airflow environment, and more. 

--- a/learn/airflow-scaling-workers.md
+++ b/learn/airflow-scaling-workers.md
@@ -24,18 +24,18 @@ In this guide, you'll learn about the key parameters that you can use to modify 
 
 This guide references the parameters available in Airflow version 2.0 and later. If you're using an earlier version of Airflow, some of the parameter names might be different.
 
+:::tip Related Content
+
+- Webinar: [Scaling Out Airflow](https://www.astronomer.io/events/webinars/scaling-out-airflow/).
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
 
 - Airflow core components. See [Airflow's components](airflow-components.md).
 - Airflow executors. See [Airflow executors explained](airflow-executors-explained.md).
-
-:::tip Related Content
-
-- Webinar: [Scaling Out Airflow](https://www.astronomer.io/events/webinars/scaling-out-airflow/).
-
-:::
 
 ## Parameter tuning
 

--- a/learn/airflow-scaling-workers.md
+++ b/learn/airflow-scaling-workers.md
@@ -24,9 +24,9 @@ In this guide, you'll learn about the key parameters that you can use to modify 
 
 This guide references the parameters available in Airflow version 2.0 and later. If you're using an earlier version of Airflow, some of the parameter names might be different.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [Scaling Out Airflow](https://www.astronomer.io/events/webinars/scaling-out-airflow/).
 

--- a/learn/airflow-scaling-workers.md
+++ b/learn/airflow-scaling-workers.md
@@ -24,7 +24,7 @@ In this guide, you'll learn about the key parameters that you can use to modify 
 
 This guide references the parameters available in Airflow version 2.0 and later. If you're using an earlier version of Airflow, some of the parameter names might be different.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-scaling-workers.md
+++ b/learn/airflow-scaling-workers.md
@@ -24,7 +24,7 @@ In this guide, you'll learn about the key parameters that you can use to modify 
 
 This guide references the parameters available in Airflow version 2.0 and later. If you're using an earlier version of Airflow, some of the parameter names might be different.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-scaling-workers.md
+++ b/learn/airflow-scaling-workers.md
@@ -26,6 +26,8 @@ This guide references the parameters available in Airflow version 2.0 and later.
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [Scaling Out Airflow](https://www.astronomer.io/events/webinars/scaling-out-airflow/).
 
 :::

--- a/learn/airflow-setup-teardown.md
+++ b/learn/airflow-setup-teardown.md
@@ -17,7 +17,7 @@ Starting in Airflow 2.7, you can use a special type of task to create and delete
 
 ![DAG with setup/ teardown - all successful](/img/guides/airflow-setup-teardown_intro_dag.png)
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-setup-teardown.md
+++ b/learn/airflow-setup-teardown.md
@@ -17,9 +17,9 @@ Starting in Airflow 2.7, you can use a special type of task to create and delete
 
 ![DAG with setup/ teardown - all successful](/img/guides/airflow-setup-teardown_intro_dag.png)
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [What’s New in Airflow 2.7](https://www.astronomer.io/events/webinars/whats-new-in-airflow-2-7/).
 - Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).

--- a/learn/airflow-setup-teardown.md
+++ b/learn/airflow-setup-teardown.md
@@ -19,7 +19,7 @@ Starting in Airflow 2.7, you can use a special type of task to create and delete
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [What’s New in Airflow 2.7](https://www.astronomer.io/events/webinars/whats-new-in-airflow-2-7/).
 - Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).

--- a/learn/airflow-setup-teardown.md
+++ b/learn/airflow-setup-teardown.md
@@ -24,6 +24,14 @@ To get the most out of this guide, you should have an understanding of:
 - Airflow decorators. See [Introduction to the TaskFlow API and Airflow decorators](airflow-decorators).
 - Managing dependencies in Airflow. See [Manage task and task group dependencies in Airflow](managing-dependencies.md).
 
+:::tip Related Content
+
+- Webinar: [What’s New in Airflow 2.7](https://www.astronomer.io/events/webinars/whats-new-in-airflow-2-7/).
+- Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).
+- Use case: [Use Airflow setup/ teardown to run data quality checks in an MLOps pipeline](use-case-setup-teardown-data-quality.md).
+
+:::
+
 ## When to use setup/ teardown tasks
 
 Setup/ teardown tasks ensure that the necessary resources to run an Airflow task are set up before a task is executed and that those resources are torn down after the task has completed, regardless of any task failures.

--- a/learn/airflow-setup-teardown.md
+++ b/learn/airflow-setup-teardown.md
@@ -19,6 +19,8 @@ Starting in Airflow 2.7, you can use a special type of task to create and delete
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [What’s New in Airflow 2.7](https://www.astronomer.io/events/webinars/whats-new-in-airflow-2-7/).
 - Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).
 - Use case: [Use Airflow setup/ teardown to run data quality checks in an MLOps pipeline](use-case-setup-teardown-data-quality.md).

--- a/learn/airflow-setup-teardown.md
+++ b/learn/airflow-setup-teardown.md
@@ -17,7 +17,7 @@ Starting in Airflow 2.7, you can use a special type of task to create and delete
 
 ![DAG with setup/ teardown - all successful](/img/guides/airflow-setup-teardown_intro_dag.png)
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-setup-teardown.md
+++ b/learn/airflow-setup-teardown.md
@@ -17,13 +17,6 @@ Starting in Airflow 2.7, you can use a special type of task to create and delete
 
 ![DAG with setup/ teardown - all successful](/img/guides/airflow-setup-teardown_intro_dag.png)
 
-## Assumed knowledge
-
-To get the most out of this guide, you should have an understanding of:
-
-- Airflow decorators. See [Introduction to the TaskFlow API and Airflow decorators](airflow-decorators).
-- Managing dependencies in Airflow. See [Manage task and task group dependencies in Airflow](managing-dependencies.md).
-
 :::tip Related Content
 
 - Webinar: [What’s New in Airflow 2.7](https://www.astronomer.io/events/webinars/whats-new-in-airflow-2-7/).
@@ -31,6 +24,13 @@ To get the most out of this guide, you should have an understanding of:
 - Use case: [Use Airflow setup/ teardown to run data quality checks in an MLOps pipeline](use-case-setup-teardown-data-quality.md).
 
 :::
+
+## Assumed knowledge
+
+To get the most out of this guide, you should have an understanding of:
+
+- Airflow decorators. See [Introduction to the TaskFlow API and Airflow decorators](airflow-decorators).
+- Managing dependencies in Airflow. See [Manage task and task group dependencies in Airflow](managing-dependencies.md).
 
 ## When to use setup/ teardown tasks
 

--- a/learn/airflow-sql-data-quality.md
+++ b/learn/airflow-sql-data-quality.md
@@ -14,9 +14,9 @@ The SQL check operators in the [Common SQL provider](https://registry.astronomer
 
 This tutorial shows how to use three SQL check operators (SQLColumnCheckOperator, SQLTableCheckOperator, and SQLCheckOperator) to build a robust data quality suite for your DAGs.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [Implementing Data Quality Checks in Airflow](https://www.astronomer.io/events/webinars/implementing-data-quality-checks-in-airflow/).
 - Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).

--- a/learn/airflow-sql-data-quality.md
+++ b/learn/airflow-sql-data-quality.md
@@ -14,7 +14,7 @@ The SQL check operators in the [Common SQL provider](https://registry.astronomer
 
 This tutorial shows how to use three SQL check operators (SQLColumnCheckOperator, SQLTableCheckOperator, and SQLCheckOperator) to build a robust data quality suite for your DAGs.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-sql-data-quality.md
+++ b/learn/airflow-sql-data-quality.md
@@ -16,6 +16,8 @@ This tutorial shows how to use three SQL check operators (SQLColumnCheckOperator
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [Implementing Data Quality Checks in Airflow](https://www.astronomer.io/events/webinars/implementing-data-quality-checks-in-airflow/).
 - Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).
 - Use case: [Use Airflow setup/ teardown to run data quality checks in an MLOps pipeline](use-case-setup-teardown-data-quality.md).

--- a/learn/airflow-sql-data-quality.md
+++ b/learn/airflow-sql-data-quality.md
@@ -31,6 +31,14 @@ To get the most out of this tutorial, you should have an understanding of:
 - How to design a data quality process. See [Data quality and Airflow](data-quality.md).
 - Running SQL from Airflow. See [Using Airflow to execute SQL](airflow-sql.md).
 
+:::tip Related Content
+
+- Webinar: [Implementing Data Quality Checks in Airflow](https://www.astronomer.io/events/webinars/implementing-data-quality-checks-in-airflow/).
+- Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).
+- Use case: [Use Airflow setup/ teardown to run data quality checks in an MLOps pipeline](use-case-setup-teardown-data-quality.md).
+
+:::
+
 ## Prerequisites
 
 - The [Astro CLI](https://docs.astronomer.io/astro/cli/overview).

--- a/learn/airflow-sql-data-quality.md
+++ b/learn/airflow-sql-data-quality.md
@@ -14,9 +14,12 @@ The SQL check operators in the [Common SQL provider](https://registry.astronomer
 
 This tutorial shows how to use three SQL check operators (SQLColumnCheckOperator, SQLTableCheckOperator, and SQLCheckOperator) to build a robust data quality suite for your DAGs.
 
-:::info
+:::tip Related Content
 
-You can find more examples of data quality checks in pipelines in the [data quality demo repository](https://github.com/astronomer/airflow-data-quality-demo/).
+- Webinar: [Implementing Data Quality Checks in Airflow](https://www.astronomer.io/events/webinars/implementing-data-quality-checks-in-airflow/).
+- Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).
+- Use case: [Use Airflow setup/ teardown to run data quality checks in an MLOps pipeline](use-case-setup-teardown-data-quality.md).
+- Example repository: [data quality demo](https://github.com/astronomer/airflow-data-quality-demo/).
 
 :::
 
@@ -30,14 +33,6 @@ To get the most out of this tutorial, you should have an understanding of:
 
 - How to design a data quality process. See [Data quality and Airflow](data-quality.md).
 - Running SQL from Airflow. See [Using Airflow to execute SQL](airflow-sql.md).
-
-:::tip Related Content
-
-- Webinar: [Implementing Data Quality Checks in Airflow](https://www.astronomer.io/events/webinars/implementing-data-quality-checks-in-airflow/).
-- Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).
-- Use case: [Use Airflow setup/ teardown to run data quality checks in an MLOps pipeline](use-case-setup-teardown-data-quality.md).
-
-:::
 
 ## Prerequisites
 

--- a/learn/airflow-sql-data-quality.md
+++ b/learn/airflow-sql-data-quality.md
@@ -14,7 +14,7 @@ The SQL check operators in the [Common SQL provider](https://registry.astronomer
 
 This tutorial shows how to use three SQL check operators (SQLColumnCheckOperator, SQLTableCheckOperator, and SQLCheckOperator) to build a robust data quality suite for your DAGs.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-sql-data-quality.md
+++ b/learn/airflow-sql-data-quality.md
@@ -16,7 +16,7 @@ This tutorial shows how to use three SQL check operators (SQLColumnCheckOperator
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [Implementing Data Quality Checks in Airflow](https://www.astronomer.io/events/webinars/implementing-data-quality-checks-in-airflow/).
 - Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).

--- a/learn/airflow-ui.md
+++ b/learn/airflow-ui.md
@@ -16,19 +16,20 @@ This guide is an overview of some of the most useful features and visualizations
 
 All images in this guide were taken from an [Astronomer Runtime](https://docs.astronomer.io/astro/runtime-release-notes) Airflow image. Other than some modified colors and an additional **Astronomer** tab, the UI is the same as when using OSS Airflow. The images in this guide are from Airflow version 2.7, if you are using an older version of Airflow, some UI elements might be slightly different or missing.
 
-## Assumed knowledge
-
-To get the most out of this guide, you should have an understanding of:
-
-- Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md).
-- Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
-
 :::tip Related Content
 
 - Astronomer Academy: [Airflow: UI](https://academy.astronomer.io/astro-runtime-airflow-ui) module.
 - Webinar: [A Deep Dive into the Airflow UI](https://www.astronomer.io/events/webinars/a-deep-dive-into-the-airflow-ui/).
 
 :::
+
+
+## Assumed knowledge
+
+To get the most out of this guide, you should have an understanding of:
+
+- Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md).
+- Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
 
 ## DAGs
 

--- a/learn/airflow-ui.md
+++ b/learn/airflow-ui.md
@@ -16,7 +16,7 @@ This guide is an overview of some of the most useful features and visualizations
 
 All images in this guide were taken from an [Astronomer Runtime](https://docs.astronomer.io/astro/runtime-release-notes) Airflow image. Other than some modified colors and an additional **Astronomer** tab, the UI is the same as when using OSS Airflow. The images in this guide are from Airflow version 2.7, if you are using an older version of Airflow, some UI elements might be slightly different or missing.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-ui.md
+++ b/learn/airflow-ui.md
@@ -23,6 +23,13 @@ To get the most out of this guide, you should have an understanding of:
 - Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md).
 - Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow UI](https://academy.astronomer.io/astro-runtime-airflow-ui) module.
+- Webinar: [A Deep Dive into the Airflow UI](https://www.astronomer.io/events/webinars/a-deep-dive-into-the-airflow-ui/).
+
+:::
+
 ## DAGs
 
 The **DAGs** view is the landing page when you sign in to Airflow. It shows a list of all your DAGs, the status of recent DAG runs and tasks, the time of the last DAG run, and basic metadata about the DAG like the owner and the schedule. To see the status of the DAGs update in real time, toggle **Auto-refresh**.

--- a/learn/airflow-ui.md
+++ b/learn/airflow-ui.md
@@ -23,7 +23,6 @@ All images in this guide were taken from an [Astronomer Runtime](https://docs.as
 
 :::
 
-
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:

--- a/learn/airflow-ui.md
+++ b/learn/airflow-ui.md
@@ -18,6 +18,8 @@ All images in this guide were taken from an [Astronomer Runtime](https://docs.as
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: UI](https://academy.astronomer.io/astro-runtime-airflow-ui) module.
 - Webinar: [A Deep Dive into the Airflow UI](https://www.astronomer.io/events/webinars/a-deep-dive-into-the-airflow-ui/).
 

--- a/learn/airflow-ui.md
+++ b/learn/airflow-ui.md
@@ -16,9 +16,9 @@ This guide is an overview of some of the most useful features and visualizations
 
 All images in this guide were taken from an [Astronomer Runtime](https://docs.astronomer.io/astro/runtime-release-notes) Airflow image. Other than some modified colors and an additional **Astronomer** tab, the UI is the same as when using OSS Airflow. The images in this guide are from Airflow version 2.7, if you are using an older version of Airflow, some UI elements might be slightly different or missing.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: UI](https://academy.astronomer.io/astro-runtime-airflow-ui) module.
 - Webinar: [A Deep Dive into the Airflow UI](https://www.astronomer.io/events/webinars/a-deep-dive-into-the-airflow-ui/).

--- a/learn/airflow-ui.md
+++ b/learn/airflow-ui.md
@@ -16,7 +16,7 @@ This guide is an overview of some of the most useful features and visualizations
 
 All images in this guide were taken from an [Astronomer Runtime](https://docs.astronomer.io/astro/runtime-release-notes) Airflow image. Other than some modified colors and an additional **Astronomer** tab, the UI is the same as when using OSS Airflow. The images in this guide are from Airflow version 2.7, if you are using an older version of Airflow, some UI elements might be slightly different or missing.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-ui.md
+++ b/learn/airflow-ui.md
@@ -25,7 +25,7 @@ To get the most out of this guide, you should have an understanding of:
 
 :::tip Related Content
 
-- Astronomer Academy: [Airflow UI](https://academy.astronomer.io/astro-runtime-airflow-ui) module.
+- Astronomer Academy: [Airflow: UI](https://academy.astronomer.io/astro-runtime-airflow-ui) module.
 - Webinar: [A Deep Dive into the Airflow UI](https://www.astronomer.io/events/webinars/a-deep-dive-into-the-airflow-ui/).
 
 :::

--- a/learn/airflow-ui.md
+++ b/learn/airflow-ui.md
@@ -18,7 +18,7 @@ All images in this guide were taken from an [Astronomer Runtime](https://docs.as
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: UI](https://academy.astronomer.io/astro-runtime-airflow-ui) module.
 - Webinar: [A Deep Dive into the Airflow UI](https://www.astronomer.io/events/webinars/a-deep-dive-into-the-airflow-ui/).

--- a/learn/airflow-variables.md
+++ b/learn/airflow-variables.md
@@ -16,7 +16,7 @@ There are two distinct types of Airflow variables: regular values and JSON seria
 
 This concept guide covers how to create Airflow variables and access them programmatically.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-variables.md
+++ b/learn/airflow-variables.md
@@ -18,6 +18,8 @@ This concept guide covers how to create Airflow variables and access them progra
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: Variables 101](https://academy.astronomer.io/astro-runtime-variables-101) module.
 
 :::

--- a/learn/airflow-variables.md
+++ b/learn/airflow-variables.md
@@ -23,6 +23,12 @@ To get the most out of this guide, you should have an understanding of:
 - Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Variables 101](https://academy.astronomer.io/astro-runtime-variables-101) module.
+
+:::
+
 ## Best practices for storing information in Airflow
 
 [Airflow variables](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/variables.html#variables) store key-value pairs or short JSON objects that need to be accessible in your whole Airflow instance. They are Airflow’s runtime configuration concept and defined using the [`airflow.model.variable`](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/variable/index.html#module-airflow.models.variable) object. 

--- a/learn/airflow-variables.md
+++ b/learn/airflow-variables.md
@@ -16,18 +16,18 @@ There are two distinct types of Airflow variables: regular values and JSON seria
 
 This concept guide covers how to create Airflow variables and access them programmatically.
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Variables 101](https://academy.astronomer.io/astro-runtime-variables-101) module.
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
 
 - Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
-
-:::tip Related Content
-
-- Astronomer Academy: [Airflow: Variables 101](https://academy.astronomer.io/astro-runtime-variables-101) module.
-
-:::
 
 ## Best practices for storing information in Airflow
 

--- a/learn/airflow-variables.md
+++ b/learn/airflow-variables.md
@@ -16,9 +16,9 @@ There are two distinct types of Airflow variables: regular values and JSON seria
 
 This concept guide covers how to create Airflow variables and access them programmatically.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: Variables 101](https://academy.astronomer.io/astro-runtime-variables-101) module.
 

--- a/learn/airflow-variables.md
+++ b/learn/airflow-variables.md
@@ -18,7 +18,7 @@ This concept guide covers how to create Airflow variables and access them progra
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: Variables 101](https://academy.astronomer.io/astro-runtime-variables-101) module.
 

--- a/learn/airflow-variables.md
+++ b/learn/airflow-variables.md
@@ -16,7 +16,7 @@ There are two distinct types of Airflow variables: regular values and JSON seria
 
 This concept guide covers how to create Airflow variables and access them programmatically.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-weaviate.md
+++ b/learn/airflow-weaviate.md
@@ -21,6 +21,8 @@ The provider used in this tutorial is currently in beta and subject to change. A
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [Power your LLMOps with Airflow’s Weaviate Provider](https://www.astronomer.io/events/webinars/power-your-llmops-with-airflows-weaviate-provider/).
 
 :::

--- a/learn/airflow-weaviate.md
+++ b/learn/airflow-weaviate.md
@@ -19,9 +19,9 @@ The provider used in this tutorial is currently in beta and subject to change. A
 
 :::
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [Power your LLMOps with Airflow’s Weaviate Provider](https://www.astronomer.io/events/webinars/power-your-llmops-with-airflows-weaviate-provider/).
 

--- a/learn/airflow-weaviate.md
+++ b/learn/airflow-weaviate.md
@@ -19,7 +19,7 @@ The provider used in this tutorial is currently in beta and subject to change. A
 
 :::
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/airflow-weaviate.md
+++ b/learn/airflow-weaviate.md
@@ -19,6 +19,12 @@ The provider used in this tutorial is currently in beta and subject to change. A
 
 :::
 
+:::tip Related Content
+
+- Webinar: [Power your LLMOps with Airflow’s Weaviate Provider](https://www.astronomer.io/events/webinars/power-your-llmops-with-airflows-weaviate-provider/).
+
+:::
+
 ## Why use Airflow with Weaviate?
 
 Weaviate allows you to store objects alongside their vector embeddings and to query these objects based on their similarity. Vector embeddings are key components of many modern machine learning models such as [LLMs](https://en.wikipedia.org/wiki/Large_language_model) or [ResNet](https://arxiv.org/abs/1512.03385).
@@ -42,12 +48,6 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow decorators. [Introduction to the TaskFlow API and Airflow decorators](airflow-decorators.md).
 - Airflow hooks. See [Hooks 101](what-is-a-hook.md).
 - Airflow connections. See [Managing your Connections in Apache Airflow](connections.md).
-
-:::tip Related Content
-
-- Webinar: [Power your LLMOps with Airflow’s Weaviate Provider](https://www.astronomer.io/events/webinars/power-your-llmops-with-airflows-weaviate-provider/).
-
-:::
 
 ## Prerequisites
 

--- a/learn/airflow-weaviate.md
+++ b/learn/airflow-weaviate.md
@@ -43,6 +43,12 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Airflow hooks. See [Hooks 101](what-is-a-hook.md).
 - Airflow connections. See [Managing your Connections in Apache Airflow](connections.md).
 
+:::tip Related Content
+
+- Webinar: [Power your LLMOps with Airflow’s Weaviate Provider](https://www.astronomer.io/events/webinars/power-your-llmops-with-airflows-weaviate-provider/).
+
+:::
+
 ## Prerequisites
 
 - The [Astro CLI](https://docs.astronomer.io/astro/cli/get-started).

--- a/learn/airflow-weaviate.md
+++ b/learn/airflow-weaviate.md
@@ -21,7 +21,7 @@ The provider used in this tutorial is currently in beta and subject to change. A
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [Power your LLMOps with Airflow’s Weaviate Provider](https://www.astronomer.io/events/webinars/power-your-llmops-with-airflows-weaviate-provider/).
 

--- a/learn/airflow-weaviate.md
+++ b/learn/airflow-weaviate.md
@@ -19,7 +19,7 @@ The provider used in this tutorial is currently in beta and subject to change. A
 
 :::
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/astro-python-sdk-etl.md
+++ b/learn/astro-python-sdk-etl.md
@@ -24,7 +24,7 @@ This guide is based on the latest version of the Astro SDK. If you're using an e
 
 :::
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/astro-python-sdk-etl.md
+++ b/learn/astro-python-sdk-etl.md
@@ -24,16 +24,16 @@ This guide is based on the latest version of the Astro SDK. If you're using an e
 
 :::
 
-## Assumed knowledge
-
-To get the most out of this guide, you should have an understanding of Airflow decorators. See [Introduction to Airflow Decorators guide](airflow-decorators.md).
-
 :::tip Related Content
 
 - Astronomer Academy: [Astro: SDK](https://academy.astronomer.io/astro-runtime-sdk) module.
 - Webinar: [Simplified DAG authoring with the Astro SDK](https://www.astronomer.io/events/webinars/simplified-dag-authoring-with-the-astro-sdk/).
 
 :::
+
+## Assumed knowledge
+
+To get the most out of this guide, you should have an understanding of Airflow decorators. See [Introduction to Airflow Decorators guide](airflow-decorators.md).
 
 ## Python SDK functions
 

--- a/learn/astro-python-sdk-etl.md
+++ b/learn/astro-python-sdk-etl.md
@@ -24,9 +24,9 @@ This guide is based on the latest version of the Astro SDK. If you're using an e
 
 :::
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Astro: SDK](https://academy.astronomer.io/astro-runtime-sdk) module.
 - Webinar: [Simplified DAG authoring with the Astro SDK](https://www.astronomer.io/events/webinars/simplified-dag-authoring-with-the-astro-sdk/).

--- a/learn/astro-python-sdk-etl.md
+++ b/learn/astro-python-sdk-etl.md
@@ -26,7 +26,7 @@ This guide is based on the latest version of the Astro SDK. If you're using an e
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Astro: SDK](https://academy.astronomer.io/astro-runtime-sdk) module.
 - Webinar: [Simplified DAG authoring with the Astro SDK](https://www.astronomer.io/events/webinars/simplified-dag-authoring-with-the-astro-sdk/).

--- a/learn/astro-python-sdk-etl.md
+++ b/learn/astro-python-sdk-etl.md
@@ -24,7 +24,7 @@ This guide is based on the latest version of the Astro SDK. If you're using an e
 
 :::
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/astro-python-sdk-etl.md
+++ b/learn/astro-python-sdk-etl.md
@@ -26,6 +26,8 @@ This guide is based on the latest version of the Astro SDK. If you're using an e
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Astro: SDK](https://academy.astronomer.io/astro-runtime-sdk) module.
 - Webinar: [Simplified DAG authoring with the Astro SDK](https://www.astronomer.io/events/webinars/simplified-dag-authoring-with-the-astro-sdk/).
 

--- a/learn/astro-python-sdk-etl.md
+++ b/learn/astro-python-sdk-etl.md
@@ -28,6 +28,13 @@ This guide is based on the latest version of the Astro SDK. If you're using an e
 
 To get the most out of this guide, you should have an understanding of Airflow decorators. See [Introduction to Airflow Decorators guide](airflow-decorators.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Astro: SDK](https://academy.astronomer.io/astro-runtime-sdk) module.
+- Webinar: [Simplified DAG authoring with the Astro SDK](https://www.astronomer.io/events/webinars/simplified-dag-authoring-with-the-astro-sdk/).
+
+:::
+
 ## Python SDK functions
 
 The Astro Python SDK makes implementing ELT use cases easier by allowing you to seamlessly transition between Python and SQL for each step in your process. Details like creating dataframes, storing intermediate results, passing context and data between tasks, and creating task dependencies are all managed automatically.

--- a/learn/astro-python-sdk.md
+++ b/learn/astro-python-sdk.md
@@ -24,7 +24,7 @@ This guide is based on the latest version of the Astro SDK. If you're using an e
 
 :::
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/astro-python-sdk.md
+++ b/learn/astro-python-sdk.md
@@ -24,6 +24,12 @@ This guide is based on the latest version of the Astro SDK. If you're using an e
 
 :::
 
+:::tip Related Content
+
+- Astronomer Academy: [Astro: SDK](https://academy.astronomer.io/astro-runtime-sdk) module.
+- Webinar: [Simplified DAG authoring with the Astro SDK](https://www.astronomer.io/events/webinars/simplified-dag-authoring-with-the-astro-sdk/).
+
+:::
 
 ## Assumed knowledge
 
@@ -32,13 +38,6 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Basic Python and SQL.
 - Basic knowledge of [Amazon S3](https://aws.amazon.com/s3/getting-started/) and [Snowflake](https://docs.snowflake.com/en/user-guide-getting-started.html).
 - Airflow fundamentals, such as writing DAGs and defining tasks. See [Get started with Apache Airflow](get-started-with-airflow.md).
-
-:::tip Related Content
-
-- Astronomer Academy: [Astro: SDK](https://academy.astronomer.io/astro-runtime-sdk) module.
-- Webinar: [Simplified DAG authoring with the Astro SDK](https://www.astronomer.io/events/webinars/simplified-dag-authoring-with-the-astro-sdk/).
-
-:::
 
 ## Prerequisites
 

--- a/learn/astro-python-sdk.md
+++ b/learn/astro-python-sdk.md
@@ -33,6 +33,13 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Basic knowledge of [Amazon S3](https://aws.amazon.com/s3/getting-started/) and [Snowflake](https://docs.snowflake.com/en/user-guide-getting-started.html).
 - Airflow fundamentals, such as writing DAGs and defining tasks. See [Get started with Apache Airflow](get-started-with-airflow.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Astro: SDK](https://academy.astronomer.io/astro-runtime-sdk) module.
+- Webinar: [Simplified DAG authoring with the Astro SDK](https://www.astronomer.io/events/webinars/simplified-dag-authoring-with-the-astro-sdk/).
+
+:::
+
 ## Prerequisites
 
 To complete this tutorial, you need:

--- a/learn/astro-python-sdk.md
+++ b/learn/astro-python-sdk.md
@@ -24,9 +24,9 @@ This guide is based on the latest version of the Astro SDK. If you're using an e
 
 :::
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Astro: SDK](https://academy.astronomer.io/astro-runtime-sdk) module.
 - Webinar: [Simplified DAG authoring with the Astro SDK](https://www.astronomer.io/events/webinars/simplified-dag-authoring-with-the-astro-sdk/).

--- a/learn/astro-python-sdk.md
+++ b/learn/astro-python-sdk.md
@@ -26,7 +26,7 @@ This guide is based on the latest version of the Astro SDK. If you're using an e
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Astro: SDK](https://academy.astronomer.io/astro-runtime-sdk) module.
 - Webinar: [Simplified DAG authoring with the Astro SDK](https://www.astronomer.io/events/webinars/simplified-dag-authoring-with-the-astro-sdk/).

--- a/learn/astro-python-sdk.md
+++ b/learn/astro-python-sdk.md
@@ -24,7 +24,7 @@ This guide is based on the latest version of the Astro SDK. If you're using an e
 
 :::
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/astro-python-sdk.md
+++ b/learn/astro-python-sdk.md
@@ -26,6 +26,8 @@ This guide is based on the latest version of the Astro SDK. If you're using an e
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Astro: SDK](https://academy.astronomer.io/astro-runtime-sdk) module.
 - Webinar: [Simplified DAG authoring with the Astro SDK](https://www.astronomer.io/events/webinars/simplified-dag-authoring-with-the-astro-sdk/).
 

--- a/learn/cloud-ide-tutorial.md
+++ b/learn/cloud-ide-tutorial.md
@@ -23,6 +23,8 @@ After you complete this tutorial, you'll be able to:
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Astro: Cloud IDE](https://academy.astronomer.io/astro-runtime-cloud-ide) module.
 - Webinar: [Develop ML Pipelines with the Astro Cloud IDE](https://www.astronomer.io/events/webinars/develop-ml-pipelines-with-the-astro-cloud-ide/).
 

--- a/learn/cloud-ide-tutorial.md
+++ b/learn/cloud-ide-tutorial.md
@@ -34,6 +34,13 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Basic SQL. See the [W3 Schools SQL tutorial](https://www.w3schools.com/sql/).
 - The Astro Cloud IDE. See [Astro Cloud IDE](https://docs.astronomer.io/astro/cloud-ide).
 
+:::tip Related Content
+
+- Astronomer Academy: [Astro: Cloud IDE](https://academy.astronomer.io/astro-runtime-cloud-ide) module.
+- Webinar: [Develop ML Pipelines with the Astro Cloud IDE](https://www.astronomer.io/events/webinars/develop-ml-pipelines-with-the-astro-cloud-ide/).
+
+:::
+
 ## Prerequisites
 
 - An Astro account. If you do not already have an Astro account, [sign up for a free trial](https://www.astronomer.io/try-astro/) and follow the onboarding flow to create your first Organization and Workspace.

--- a/learn/cloud-ide-tutorial.md
+++ b/learn/cloud-ide-tutorial.md
@@ -21,9 +21,9 @@ After you complete this tutorial, you'll be able to:
 - Export a DAG from the Astro Cloud IDE to GitHub.
 - Configure GitHub Secrets to deploy your DAG to Astro.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Astro: Cloud IDE](https://academy.astronomer.io/astro-runtime-cloud-ide) module.
 - Webinar: [Develop ML Pipelines with the Astro Cloud IDE](https://www.astronomer.io/events/webinars/develop-ml-pipelines-with-the-astro-cloud-ide/).

--- a/learn/cloud-ide-tutorial.md
+++ b/learn/cloud-ide-tutorial.md
@@ -21,7 +21,7 @@ After you complete this tutorial, you'll be able to:
 - Export a DAG from the Astro Cloud IDE to GitHub.
 - Configure GitHub Secrets to deploy your DAG to Astro.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/cloud-ide-tutorial.md
+++ b/learn/cloud-ide-tutorial.md
@@ -21,6 +21,13 @@ After you complete this tutorial, you'll be able to:
 - Export a DAG from the Astro Cloud IDE to GitHub.
 - Configure GitHub Secrets to deploy your DAG to Astro.
 
+:::tip Related Content
+
+- Astronomer Academy: [Astro: Cloud IDE](https://academy.astronomer.io/astro-runtime-cloud-ide) module.
+- Webinar: [Develop ML Pipelines with the Astro Cloud IDE](https://www.astronomer.io/events/webinars/develop-ml-pipelines-with-the-astro-cloud-ide/).
+
+:::
+
 ## Time to complete
 
 This tutorial takes approximately 1 hour to complete.
@@ -33,13 +40,6 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Basic Python. See the [Python Documentation](https://docs.python.org/3/tutorial/index.html).
 - Basic SQL. See the [W3 Schools SQL tutorial](https://www.w3schools.com/sql/).
 - The Astro Cloud IDE. See [Astro Cloud IDE](https://docs.astronomer.io/astro/cloud-ide).
-
-:::tip Related Content
-
-- Astronomer Academy: [Astro: Cloud IDE](https://academy.astronomer.io/astro-runtime-cloud-ide) module.
-- Webinar: [Develop ML Pipelines with the Astro Cloud IDE](https://www.astronomer.io/events/webinars/develop-ml-pipelines-with-the-astro-cloud-ide/).
-
-:::
 
 ## Prerequisites
 

--- a/learn/cloud-ide-tutorial.md
+++ b/learn/cloud-ide-tutorial.md
@@ -21,7 +21,7 @@ After you complete this tutorial, you'll be able to:
 - Export a DAG from the Astro Cloud IDE to GitHub.
 - Configure GitHub Secrets to deploy your DAG to Astro.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/cloud-ide-tutorial.md
+++ b/learn/cloud-ide-tutorial.md
@@ -23,7 +23,7 @@ After you complete this tutorial, you'll be able to:
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Astro: Cloud IDE](https://academy.astronomer.io/astro-runtime-cloud-ide) module.
 - Webinar: [Develop ML Pipelines with the Astro Cloud IDE](https://www.astronomer.io/events/webinars/develop-ml-pipelines-with-the-astro-cloud-ide/).

--- a/learn/connections.md
+++ b/learn/connections.md
@@ -21,7 +21,7 @@ In this guide you'll:
 - Learn how to define connections using environment variables.
 - Add sample Snowflake and Slack Webhook connections to a DAG.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/connections.md
+++ b/learn/connections.md
@@ -21,7 +21,7 @@ In this guide you'll:
 - Learn how to define connections using environment variables.
 - Add sample Snowflake and Slack Webhook connections to a DAG.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/connections.md
+++ b/learn/connections.md
@@ -23,7 +23,7 @@ In this guide you'll:
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: Connections 101](https://academy.astronomer.io/connections-101) module.
 

--- a/learn/connections.md
+++ b/learn/connections.md
@@ -21,9 +21,9 @@ In this guide you'll:
 - Learn how to define connections using environment variables.
 - Add sample Snowflake and Slack Webhook connections to a DAG.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: Connections 101](https://academy.astronomer.io/connections-101) module.
 

--- a/learn/connections.md
+++ b/learn/connections.md
@@ -23,6 +23,8 @@ In this guide you'll:
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: Connections 101](https://academy.astronomer.io/connections-101) module.
 
 :::

--- a/learn/connections.md
+++ b/learn/connections.md
@@ -29,6 +29,12 @@ To get the most out of this guide, you should have an understanding of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Airflow hooks. See [Hooks 101](what-is-a-hook.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Connections 101](https://academy.astronomer.io/connections-101) module.
+
+:::
+
 ## Airflow connection basics
 
 An Airflow connection is a set of configurations that send requests to the API of an external tool. In most cases, a connection requires login credentials or a private key to authenticate Airflow to the external tool.

--- a/learn/connections.md
+++ b/learn/connections.md
@@ -21,6 +21,12 @@ In this guide you'll:
 - Learn how to define connections using environment variables.
 - Add sample Snowflake and Slack Webhook connections to a DAG.
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Connections 101](https://academy.astronomer.io/connections-101) module.
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
@@ -28,12 +34,6 @@ To get the most out of this guide, you should have an understanding of:
 - Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md/).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Airflow hooks. See [Hooks 101](what-is-a-hook.md).
-
-:::tip Related Content
-
-- Astronomer Academy: [Airflow: Connections 101](https://academy.astronomer.io/connections-101) module.
-
-:::
 
 ## Airflow connection basics
 

--- a/learn/dags.md
+++ b/learn/dags.md
@@ -24,7 +24,7 @@ In this guide, you'll learn DAG basics and about DAG parameters and how to defin
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: DAGs 101](https://academy.astronomer.io/dag-101-1) module.
 

--- a/learn/dags.md
+++ b/learn/dags.md
@@ -29,6 +29,12 @@ To get the most out of this guide, you should have an understanding of:
 - Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: DAGs 101](https://academy.astronomer.io/dag-101-1) module.
+
+:::
+
 ## What is a DAG?
 
 In Airflow, a directed acyclic graph (DAG) is a data pipeline defined in Python code. Each DAG represents a collection of tasks you want to run and is organized to show relationships between tasks in the Airflow UI. The mathematical properties of DAGs make them useful for building data pipelines:

--- a/learn/dags.md
+++ b/learn/dags.md
@@ -24,6 +24,8 @@ In this guide, you'll learn DAG basics and about DAG parameters and how to defin
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: DAGs 101](https://academy.astronomer.io/dag-101-1) module.
 
 :::

--- a/learn/dags.md
+++ b/learn/dags.md
@@ -22,7 +22,7 @@ In Airflow, data pipelines are defined in Python code as directed acyclic graphs
 
 In this guide, you'll learn DAG basics and about DAG parameters and how to define a DAG in Python.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/dags.md
+++ b/learn/dags.md
@@ -22,7 +22,7 @@ In Airflow, data pipelines are defined in Python code as directed acyclic graphs
 
 In this guide, you'll learn DAG basics and about DAG parameters and how to define a DAG in Python.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/dags.md
+++ b/learn/dags.md
@@ -22,9 +22,9 @@ In Airflow, data pipelines are defined in Python code as directed acyclic graphs
 
 In this guide, you'll learn DAG basics and about DAG parameters and how to define a DAG in Python.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: DAGs 101](https://academy.astronomer.io/dag-101-1) module.
 

--- a/learn/dags.md
+++ b/learn/dags.md
@@ -22,18 +22,18 @@ In Airflow, data pipelines are defined in Python code as directed acyclic graphs
 
 In this guide, you'll learn DAG basics and about DAG parameters and how to define a DAG in Python.
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: DAGs 101](https://academy.astronomer.io/dag-101-1) module.
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
 
 - Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md).
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
-
-:::tip Related Content
-
-- Astronomer Academy: [Airflow: DAGs 101](https://academy.astronomer.io/dag-101-1) module.
-
-:::
 
 ## What is a DAG?
 

--- a/learn/data-quality.md
+++ b/learn/data-quality.md
@@ -22,7 +22,7 @@ This guide covers:
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).
 - Use case: [Use Airflow setup/ teardown to run data quality checks in an MLOps pipeline](use-case-setup-teardown-data-quality.md).

--- a/learn/data-quality.md
+++ b/learn/data-quality.md
@@ -31,6 +31,13 @@ To get the most out of this guide, you should have knowledge of:
 - Airflow connections. See [Managing your Connections in Apache Airflow](connections.md).
 - Relational databases. See [Relational database on Wikipedia](https://en.wikipedia.org/wiki/Relational_database).
 
+:::tip Related Content
+
+- Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).
+- Use case: [Use Airflow setup/ teardown to run data quality checks in an MLOps pipeline](use-case-setup-teardown-data-quality.md).
+
+:::
+
 ## Data quality essentials
 
 What is considered good quality data is determined by the needs of your organization. Defining quality criteria for a given collection of datasets is often a task requiring collaboration with all data professionals involved in each step of the pipeline.

--- a/learn/data-quality.md
+++ b/learn/data-quality.md
@@ -20,7 +20,7 @@ This guide covers:
 - An in-depth look at two commonly used data quality check tools: [SQL check operators](#sql-check-operators) and [Great Expectations](#great-expectations).
 - An example comparing implementations of data quality checks using each of these tools.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/data-quality.md
+++ b/learn/data-quality.md
@@ -9,8 +9,6 @@ import CodeBlock from '@theme/CodeBlock';
 import example_dag_sql_check_operators from '!!raw-loader!../code-samples/dags/data-quality/example_dag_sql_check_operators.py';
 import gx_example_dag from '!!raw-loader!../code-samples/dags/data-quality/gx_example_dag.py';
 
-## Overview
-
 Checking the quality of your data is essential to getting actionable insights from your data pipelines. Airflow offers many ways to orchestrate data quality checks directly from your DAGs.
 
 This guide covers:
@@ -22,6 +20,13 @@ This guide covers:
 - An in-depth look at two commonly used data quality check tools: [SQL check operators](#sql-check-operators) and [Great Expectations](#great-expectations).
 - An example comparing implementations of data quality checks using each of these tools.
 
+:::tip Related Content
+
+- Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).
+- Use case: [Use Airflow setup/ teardown to run data quality checks in an MLOps pipeline](use-case-setup-teardown-data-quality.md).
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have knowledge of:
@@ -30,13 +35,6 @@ To get the most out of this guide, you should have knowledge of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Airflow connections. See [Managing your Connections in Apache Airflow](connections.md).
 - Relational databases. See [Relational database on Wikipedia](https://en.wikipedia.org/wiki/Relational_database).
-
-:::tip Related Content
-
-- Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).
-- Use case: [Use Airflow setup/ teardown to run data quality checks in an MLOps pipeline](use-case-setup-teardown-data-quality.md).
-
-:::
 
 ## Data quality essentials
 

--- a/learn/data-quality.md
+++ b/learn/data-quality.md
@@ -20,7 +20,7 @@ This guide covers:
 - An in-depth look at two commonly used data quality check tools: [SQL check operators](#sql-check-operators) and [Great Expectations](#great-expectations).
 - An example comparing implementations of data quality checks using each of these tools.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/data-quality.md
+++ b/learn/data-quality.md
@@ -20,9 +20,9 @@ This guide covers:
 - An in-depth look at two commonly used data quality check tools: [SQL check operators](#sql-check-operators) and [Great Expectations](#great-expectations).
 - An example comparing implementations of data quality checks using each of these tools.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).
 - Use case: [Use Airflow setup/ teardown to run data quality checks in an MLOps pipeline](use-case-setup-teardown-data-quality.md).

--- a/learn/data-quality.md
+++ b/learn/data-quality.md
@@ -22,6 +22,8 @@ This guide covers:
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [Efficient data quality checks with Airflow 2.7](https://www.astronomer.io/events/webinars/efficient-data-quality-checks-with-airflow-2-7/).
 - Use case: [Use Airflow setup/ teardown to run data quality checks in an MLOps pipeline](use-case-setup-teardown-data-quality.md).
 

--- a/learn/debugging-dags.md
+++ b/learn/debugging-dags.md
@@ -16,6 +16,8 @@ Consider implementing systematic testing of your DAGs to prevent common issues. 
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [Debugging your Airflow DAGs](https://www.astronomer.io/events/webinars/debugging-your-airflow-dags/).
 
 :::

--- a/learn/debugging-dags.md
+++ b/learn/debugging-dags.md
@@ -16,7 +16,7 @@ Consider implementing systematic testing of your DAGs to prevent common issues. 
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [Debugging your Airflow DAGs](https://www.astronomer.io/events/webinars/debugging-your-airflow-dags/).
 

--- a/learn/debugging-dags.md
+++ b/learn/debugging-dags.md
@@ -14,9 +14,9 @@ Consider implementing systematic testing of your DAGs to prevent common issues. 
 
 :::
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [Debugging your Airflow DAGs](https://www.astronomer.io/events/webinars/debugging-your-airflow-dags/).
 

--- a/learn/debugging-dags.md
+++ b/learn/debugging-dags.md
@@ -14,7 +14,7 @@ Consider implementing systematic testing of your DAGs to prevent common issues. 
 
 :::
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/debugging-dags.md
+++ b/learn/debugging-dags.md
@@ -21,6 +21,12 @@ To get the most out of this guide, you should have an understanding of:
 - Basic Airflow concepts. See [Get started with Airflow tutorial](get-started-with-airflow.md).
 - Basic knowledge of Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
 
+:::tip Related Content
+
+- Webinar: [Debugging your Airflow DAGs](https://www.astronomer.io/events/webinars/debugging-your-airflow-dags/).
+
+:::
+
 ## General Airflow debugging approach
 
 To give yourself the best possible chance of fixing a bug in Airflow, contextualize the issue by asking yourself the following questions:

--- a/learn/debugging-dags.md
+++ b/learn/debugging-dags.md
@@ -14,7 +14,7 @@ Consider implementing systematic testing of your DAGs to prevent common issues. 
 
 :::
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/debugging-dags.md
+++ b/learn/debugging-dags.md
@@ -14,18 +14,18 @@ Consider implementing systematic testing of your DAGs to prevent common issues. 
 
 :::
 
+:::tip Related Content
+
+- Webinar: [Debugging your Airflow DAGs](https://www.astronomer.io/events/webinars/debugging-your-airflow-dags/).
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
 
 - Basic Airflow concepts. See [Get started with Airflow tutorial](get-started-with-airflow.md).
 - Basic knowledge of Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
-
-:::tip Related Content
-
-- Webinar: [Debugging your Airflow DAGs](https://www.astronomer.io/events/webinars/debugging-your-airflow-dags/).
-
-:::
 
 ## General Airflow debugging approach
 

--- a/learn/deferrable-operators.md
+++ b/learn/deferrable-operators.md
@@ -16,6 +16,8 @@ With Airflow 2.2 and later, you can use deferrable operators to run tasks in you
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: Deferrable Operators](https://academy.astronomer.io/astro-runtime-deferrable-operators) module.
 - Webinar: [Astronomer Providers](https://www.astronomer.io/events/webinars/astronomer-providers/).
 

--- a/learn/deferrable-operators.md
+++ b/learn/deferrable-operators.md
@@ -14,7 +14,7 @@ import async_dag from '!!raw-loader!../code-samples/dags/deferrable-operators/as
 
 With Airflow 2.2 and later, you can use deferrable operators to run tasks in your Airflow environment. These operators leverage the Python [asyncio](https://docs.python.org/3/library/asyncio.html) library to efficiently run tasks waiting for an external resource to finish. This frees up your workers and allows you to utilize resources more effectively. In this guide, you'll review deferrable operator concepts and learn how to use deferrable operators in your DAGs.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/deferrable-operators.md
+++ b/learn/deferrable-operators.md
@@ -21,6 +21,13 @@ To get the most out of this guide, you should have an understanding of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Airflow sensors. See [Sensors 101](what-is-a-sensor.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Deferrable Operators](https://academy.astronomer.io/astro-runtime-deferrable-operators).
+- Webinar: [Astronomer Providers](https://www.astronomer.io/events/webinars/astronomer-providers/).
+
+:::
+
 ## Terms and concepts
 
 Review the following terms and concepts to gain a better understanding of deferrable operator functionality:

--- a/learn/deferrable-operators.md
+++ b/learn/deferrable-operators.md
@@ -23,7 +23,7 @@ To get the most out of this guide, you should have an understanding of:
 
 :::tip Related Content
 
-- Astronomer Academy: [Airflow: Deferrable Operators](https://academy.astronomer.io/astro-runtime-deferrable-operators).
+- Astronomer Academy: [Airflow: Deferrable Operators](https://academy.astronomer.io/astro-runtime-deferrable-operators) module.
 - Webinar: [Astronomer Providers](https://www.astronomer.io/events/webinars/astronomer-providers/).
 
 :::

--- a/learn/deferrable-operators.md
+++ b/learn/deferrable-operators.md
@@ -16,7 +16,7 @@ With Airflow 2.2 and later, you can use deferrable operators to run tasks in you
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: Deferrable Operators](https://academy.astronomer.io/astro-runtime-deferrable-operators) module.
 - Webinar: [Astronomer Providers](https://www.astronomer.io/events/webinars/astronomer-providers/).

--- a/learn/deferrable-operators.md
+++ b/learn/deferrable-operators.md
@@ -14,7 +14,7 @@ import async_dag from '!!raw-loader!../code-samples/dags/deferrable-operators/as
 
 With Airflow 2.2 and later, you can use deferrable operators to run tasks in your Airflow environment. These operators leverage the Python [asyncio](https://docs.python.org/3/library/asyncio.html) library to efficiently run tasks waiting for an external resource to finish. This frees up your workers and allows you to utilize resources more effectively. In this guide, you'll review deferrable operator concepts and learn how to use deferrable operators in your DAGs.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/deferrable-operators.md
+++ b/learn/deferrable-operators.md
@@ -14,19 +14,19 @@ import async_dag from '!!raw-loader!../code-samples/dags/deferrable-operators/as
 
 With Airflow 2.2 and later, you can use deferrable operators to run tasks in your Airflow environment. These operators leverage the Python [asyncio](https://docs.python.org/3/library/asyncio.html) library to efficiently run tasks waiting for an external resource to finish. This frees up your workers and allows you to utilize resources more effectively. In this guide, you'll review deferrable operator concepts and learn how to use deferrable operators in your DAGs.
 
-## Assumed knowledge
-
-To get the most out of this guide, you should have an understanding of:
-
-- Airflow operators. See [Operators 101](what-is-an-operator.md).
-- Airflow sensors. See [Sensors 101](what-is-a-sensor.md).
-
 :::tip Related Content
 
 - Astronomer Academy: [Airflow: Deferrable Operators](https://academy.astronomer.io/astro-runtime-deferrable-operators) module.
 - Webinar: [Astronomer Providers](https://www.astronomer.io/events/webinars/astronomer-providers/).
 
 :::
+
+## Assumed knowledge
+
+To get the most out of this guide, you should have an understanding of:
+
+- Airflow operators. See [Operators 101](what-is-an-operator.md).
+- Airflow sensors. See [Sensors 101](what-is-a-sensor.md).
 
 ## Terms and concepts
 

--- a/learn/deferrable-operators.md
+++ b/learn/deferrable-operators.md
@@ -14,9 +14,9 @@ import async_dag from '!!raw-loader!../code-samples/dags/deferrable-operators/as
 
 With Airflow 2.2 and later, you can use deferrable operators to run tasks in your Airflow environment. These operators leverage the Python [asyncio](https://docs.python.org/3/library/asyncio.html) library to efficiently run tasks waiting for an external resource to finish. This frees up your workers and allows you to utilize resources more effectively. In this guide, you'll review deferrable operator concepts and learn how to use deferrable operators in your DAGs.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: Deferrable Operators](https://academy.astronomer.io/astro-runtime-deferrable-operators) module.
 - Webinar: [Astronomer Providers](https://www.astronomer.io/events/webinars/astronomer-providers/).

--- a/learn/dynamic-tasks.md
+++ b/learn/dynamic-tasks.md
@@ -26,6 +26,13 @@ To get the most out of this guide, you should have an understanding of:
 - How to use Airflow decorators to define tasks. See [Introduction to Airflow Decorators](airflow-decorators.md).
 - XComs in Airflow. See [Passing Data Between Airflow Tasks](airflow-passing-data-between-tasks.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Dynamic Task Mapping](https://academy.astronomer.io/astro-runtime-dynamic-task-mapping).
+- Webinar: [Dynamic Tasks in Airflow](https://www.astronomer.io/events/webinars/dynamic-tasks-in-airflow/).
+
+:::
+
 ## Dynamic task concepts
 
 The Airflow dynamic task mapping feature is based on the [MapReduce](https://en.wikipedia.org/wiki/MapReduce) programming model. Dynamic task mapping creates a single task for each input. The reduce procedure, which is optional, allows a task to operate on the collected output of a mapped task. In practice, this means that your DAG can create an arbitrary number of parallel tasks at runtime based on some input parameter (the map), and then if needed, have a single task downstream of your parallel mapped tasks that depends on their output (the reduce).

--- a/learn/dynamic-tasks.md
+++ b/learn/dynamic-tasks.md
@@ -18,9 +18,9 @@ Prior to Airflow 2.3, tasks could only be generated dynamically at the time that
 
 In this guide, you'll learn about dynamic task mapping and complete an example implementation for a common use case.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: Dynamic Task Mapping](https://academy.astronomer.io/astro-runtime-dynamic-task-mapping) module.
 - Webinar: [Dynamic Tasks in Airflow](https://www.astronomer.io/events/webinars/dynamic-tasks-in-airflow/).

--- a/learn/dynamic-tasks.md
+++ b/learn/dynamic-tasks.md
@@ -20,6 +20,8 @@ In this guide, you'll learn about dynamic task mapping and complete an example i
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: Dynamic Task Mapping](https://academy.astronomer.io/astro-runtime-dynamic-task-mapping) module.
 - Webinar: [Dynamic Tasks in Airflow](https://www.astronomer.io/events/webinars/dynamic-tasks-in-airflow/).
 

--- a/learn/dynamic-tasks.md
+++ b/learn/dynamic-tasks.md
@@ -18,7 +18,7 @@ Prior to Airflow 2.3, tasks could only be generated dynamically at the time that
 
 In this guide, you'll learn about dynamic task mapping and complete an example implementation for a common use case.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/dynamic-tasks.md
+++ b/learn/dynamic-tasks.md
@@ -18,6 +18,13 @@ Prior to Airflow 2.3, tasks could only be generated dynamically at the time that
 
 In this guide, you'll learn about dynamic task mapping and complete an example implementation for a common use case.
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Dynamic Task Mapping](https://academy.astronomer.io/astro-runtime-dynamic-task-mapping).
+- Webinar: [Dynamic Tasks in Airflow](https://www.astronomer.io/events/webinars/dynamic-tasks-in-airflow/).
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
@@ -25,13 +32,6 @@ To get the most out of this guide, you should have an understanding of:
 - Airflow Operators. See [Operators 101](what-is-an-operator.md).
 - How to use Airflow decorators to define tasks. See [Introduction to Airflow Decorators](airflow-decorators.md).
 - XComs in Airflow. See [Passing Data Between Airflow Tasks](airflow-passing-data-between-tasks.md).
-
-:::tip Related Content
-
-- Astronomer Academy: [Airflow: Dynamic Task Mapping](https://academy.astronomer.io/astro-runtime-dynamic-task-mapping).
-- Webinar: [Dynamic Tasks in Airflow](https://www.astronomer.io/events/webinars/dynamic-tasks-in-airflow/).
-
-:::
 
 ## Dynamic task concepts
 

--- a/learn/dynamic-tasks.md
+++ b/learn/dynamic-tasks.md
@@ -20,7 +20,7 @@ In this guide, you'll learn about dynamic task mapping and complete an example i
 
 :::tip Related Content
 
-- Astronomer Academy: [Airflow: Dynamic Task Mapping](https://academy.astronomer.io/astro-runtime-dynamic-task-mapping).
+- Astronomer Academy: [Airflow: Dynamic Task Mapping](https://academy.astronomer.io/astro-runtime-dynamic-task-mapping) module.
 - Webinar: [Dynamic Tasks in Airflow](https://www.astronomer.io/events/webinars/dynamic-tasks-in-airflow/).
 
 :::

--- a/learn/dynamic-tasks.md
+++ b/learn/dynamic-tasks.md
@@ -18,7 +18,7 @@ Prior to Airflow 2.3, tasks could only be generated dynamically at the time that
 
 In this guide, you'll learn about dynamic task mapping and complete an example implementation for a common use case.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/dynamic-tasks.md
+++ b/learn/dynamic-tasks.md
@@ -20,7 +20,7 @@ In this guide, you'll learn about dynamic task mapping and complete an example i
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: Dynamic Task Mapping](https://academy.astronomer.io/astro-runtime-dynamic-task-mapping) module.
 - Webinar: [Dynamic Tasks in Airflow](https://www.astronomer.io/events/webinars/dynamic-tasks-in-airflow/).

--- a/learn/dynamically-generating-dags.md
+++ b/learn/dynamically-generating-dags.md
@@ -36,7 +36,7 @@ As of Airflow 2.3, you can use [dynamic task mapping](dynamic-tasks.md) to write
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: Dynamic DAGs](https://academy.astronomer.io/astro-runtime-dynamic-dags).
 

--- a/learn/dynamically-generating-dags.md
+++ b/learn/dynamically-generating-dags.md
@@ -34,9 +34,9 @@ As of Airflow 2.3, you can use [dynamic task mapping](dynamic-tasks.md) to write
 
 :::
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: Dynamic DAGs](https://academy.astronomer.io/astro-runtime-dynamic-dags).
 

--- a/learn/dynamically-generating-dags.md
+++ b/learn/dynamically-generating-dags.md
@@ -40,6 +40,12 @@ To get the most out of this guide, you should have an understanding of:
 
 - Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Dynamic DAGs](https://academy.astronomer.io/astro-runtime-dynamic-dags).
+
+:::
+
 ## Single-file methods
 
 One method for dynamically generating DAGs is to have a single Python file which generates DAGs based on some input parameter(s). For example, a list of APIs or tables. A common use case for this is an ETL or ELT-type pipeline where there are many data sources or destinations. This requires creating many DAGs that all follow a similar pattern.

--- a/learn/dynamically-generating-dags.md
+++ b/learn/dynamically-generating-dags.md
@@ -34,17 +34,17 @@ As of Airflow 2.3, you can use [dynamic task mapping](dynamic-tasks.md) to write
 
 :::
 
-## Assumed knowledge
-
-To get the most out of this guide, you should have an understanding of:
-
-- Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
-
 :::tip Related Content
 
 - Astronomer Academy: [Airflow: Dynamic DAGs](https://academy.astronomer.io/astro-runtime-dynamic-dags).
 
 :::
+
+## Assumed knowledge
+
+To get the most out of this guide, you should have an understanding of:
+
+- Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
 
 ## Single-file methods
 

--- a/learn/dynamically-generating-dags.md
+++ b/learn/dynamically-generating-dags.md
@@ -34,7 +34,7 @@ As of Airflow 2.3, you can use [dynamic task mapping](dynamic-tasks.md) to write
 
 :::
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/dynamically-generating-dags.md
+++ b/learn/dynamically-generating-dags.md
@@ -36,6 +36,8 @@ As of Airflow 2.3, you can use [dynamic task mapping](dynamic-tasks.md) to write
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: Dynamic DAGs](https://academy.astronomer.io/astro-runtime-dynamic-dags).
 
 :::

--- a/learn/dynamically-generating-dags.md
+++ b/learn/dynamically-generating-dags.md
@@ -34,7 +34,7 @@ As of Airflow 2.3, you can use [dynamic task mapping](dynamic-tasks.md) to write
 
 :::
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/error-notifications-in-airflow.md
+++ b/learn/error-notifications-in-airflow.md
@@ -25,7 +25,7 @@ When you're using a data orchestration tool, how do you know when something has 
 
 In this guide, you'll learn the basics of Airflow notifications and how to set up common notification mechanisms including email, pre-built and custom notifiers, and SLAs. You'll also learn how to leverage Airflow alerting when using Astro.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/error-notifications-in-airflow.md
+++ b/learn/error-notifications-in-airflow.md
@@ -27,6 +27,8 @@ In this guide, you'll learn the basics of Airflow notifications and how to set u
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [How to monitor your pipelines with Airflow and Astro alerts](https://www.astronomer.io/events/webinars/how-to-monitor-your-pipelines-with-airflow-and-astro-alerts/).
 
 :::

--- a/learn/error-notifications-in-airflow.md
+++ b/learn/error-notifications-in-airflow.md
@@ -25,18 +25,18 @@ When you're using a data orchestration tool, how do you know when something has 
 
 In this guide, you'll learn the basics of Airflow notifications and how to set up common notification mechanisms including email, pre-built and custom notifiers, and SLAs. You'll also learn how to leverage Airflow alerting when using Astro.
 
+:::tip Related Content
+
+- Webinar: [How to monitor your pipelines with Airflow and Astro alerts](https://www.astronomer.io/events/webinars/how-to-monitor-your-pipelines-with-airflow-and-astro-alerts/).
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
 
 - Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
 - Task dependencies. See [Managing dependencies in Apache Airflow](managing-dependencies.md).
-
-:::tip Related Content
-
-- Webinar: [How to monitor your pipelines with Airflow and Astro alerts](https://www.astronomer.io/events/webinars/how-to-monitor-your-pipelines-with-airflow-and-astro-alerts/).
-
-:::
 
 ## Airflow notification types
 

--- a/learn/error-notifications-in-airflow.md
+++ b/learn/error-notifications-in-airflow.md
@@ -32,6 +32,12 @@ To get the most out of this guide, you should have an understanding of:
 - Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
 - Task dependencies. See [Managing dependencies in Apache Airflow](managing-dependencies.md).
 
+:::tip Related Content
+
+- Webinar: [How to monitor your pipelines with Airflow and Astro alerts](https://www.astronomer.io/events/webinars/how-to-monitor-your-pipelines-with-airflow-and-astro-alerts/).
+
+:::
+
 ## Airflow notification types
 
 Airflow has a few options for notifying you on the status of your DAGs and tasks:

--- a/learn/error-notifications-in-airflow.md
+++ b/learn/error-notifications-in-airflow.md
@@ -27,7 +27,7 @@ In this guide, you'll learn the basics of Airflow notifications and how to set u
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [How to monitor your pipelines with Airflow and Astro alerts](https://www.astronomer.io/events/webinars/how-to-monitor-your-pipelines-with-airflow-and-astro-alerts/).
 

--- a/learn/error-notifications-in-airflow.md
+++ b/learn/error-notifications-in-airflow.md
@@ -25,7 +25,7 @@ When you're using a data orchestration tool, how do you know when something has 
 
 In this guide, you'll learn the basics of Airflow notifications and how to set up common notification mechanisms including email, pre-built and custom notifiers, and SLAs. You'll also learn how to leverage Airflow alerting when using Astro.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/error-notifications-in-airflow.md
+++ b/learn/error-notifications-in-airflow.md
@@ -25,9 +25,9 @@ When you're using a data orchestration tool, how do you know when something has 
 
 In this guide, you'll learn the basics of Airflow notifications and how to set up common notification mechanisms including email, pre-built and custom notifiers, and SLAs. You'll also learn how to leverage Airflow alerting when using Astro.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [How to monitor your pipelines with Airflow and Astro alerts](https://www.astronomer.io/events/webinars/how-to-monitor-your-pipelines-with-airflow-and-astro-alerts/).
 

--- a/learn/external-python-operator.md
+++ b/learn/external-python-operator.md
@@ -28,6 +28,13 @@ To get the most out of this tutorial, you should be familiar with:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Python virtual environments. See [Python Virtual Environments: A Primer](https://realpython.com/python-virtual-environments-a-primer/).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: The ExternalPythonOperator](https://academy.astronomer.io/astro-runtime-the-externalpythonoperator) module.
+- Webinar: [Running Airflow Tasks in Isolated Environments](https://www.astronomer.io/events/webinars/running-airflow-tasks-in-isolated-environments/).
+
+:::
+
 ## Prerequisites
 
 - The [Astro CLI](https://docs.astronomer.io/astro/cli/overview).

--- a/learn/external-python-operator.md
+++ b/learn/external-python-operator.md
@@ -17,9 +17,9 @@ In this tutorial, you'll learn how to use the [ExternalPythonOperator](https://a
 
 Snowpark requires Python 3.8, while the [Astro Runtime](https://docs.astronomer.io/astro/runtime-image-architecture) uses Python 3.9. The ExternalPythonOperator can run your Snowpark query in a Python 3.8 virtual environment, allowing you to use a different Python version for your task than in the Airflow environment. You can use these same general steps for any use case for running a task in a reusable Python virtual environment.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: The ExternalPythonOperator](https://academy.astronomer.io/astro-runtime-the-externalpythonoperator) module.
 - Webinar: [Running Airflow Tasks in Isolated Environments](https://www.astronomer.io/events/webinars/running-airflow-tasks-in-isolated-environments/).

--- a/learn/external-python-operator.md
+++ b/learn/external-python-operator.md
@@ -19,6 +19,8 @@ Snowpark requires Python 3.8, while the [Astro Runtime](https://docs.astronomer.
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: The ExternalPythonOperator](https://academy.astronomer.io/astro-runtime-the-externalpythonoperator) module.
 - Webinar: [Running Airflow Tasks in Isolated Environments](https://www.astronomer.io/events/webinars/running-airflow-tasks-in-isolated-environments/).
 

--- a/learn/external-python-operator.md
+++ b/learn/external-python-operator.md
@@ -19,7 +19,7 @@ Snowpark requires Python 3.8, while the [Astro Runtime](https://docs.astronomer.
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: The ExternalPythonOperator](https://academy.astronomer.io/astro-runtime-the-externalpythonoperator) module.
 - Webinar: [Running Airflow Tasks in Isolated Environments](https://www.astronomer.io/events/webinars/running-airflow-tasks-in-isolated-environments/).

--- a/learn/external-python-operator.md
+++ b/learn/external-python-operator.md
@@ -17,7 +17,7 @@ In this tutorial, you'll learn how to use the [ExternalPythonOperator](https://a
 
 Snowpark requires Python 3.8, while the [Astro Runtime](https://docs.astronomer.io/astro/runtime-image-architecture) uses Python 3.9. The ExternalPythonOperator can run your Snowpark query in a Python 3.8 virtual environment, allowing you to use a different Python version for your task than in the Airflow environment. You can use these same general steps for any use case for running a task in a reusable Python virtual environment.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/external-python-operator.md
+++ b/learn/external-python-operator.md
@@ -17,6 +17,13 @@ In this tutorial, you'll learn how to use the [ExternalPythonOperator](https://a
 
 Snowpark requires Python 3.8, while the [Astro Runtime](https://docs.astronomer.io/astro/runtime-image-architecture) uses Python 3.9. The ExternalPythonOperator can run your Snowpark query in a Python 3.8 virtual environment, allowing you to use a different Python version for your task than in the Airflow environment. You can use these same general steps for any use case for running a task in a reusable Python virtual environment.
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: The ExternalPythonOperator](https://academy.astronomer.io/astro-runtime-the-externalpythonoperator) module.
+- Webinar: [Running Airflow Tasks in Isolated Environments](https://www.astronomer.io/events/webinars/running-airflow-tasks-in-isolated-environments/).
+
+:::
+
 ## Time to complete
 
 This tutorial takes approximately one hour to complete.
@@ -27,13 +34,6 @@ To get the most out of this tutorial, you should be familiar with:
 
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Python virtual environments. See [Python Virtual Environments: A Primer](https://realpython.com/python-virtual-environments-a-primer/).
-
-:::tip Related Content
-
-- Astronomer Academy: [Airflow: The ExternalPythonOperator](https://academy.astronomer.io/astro-runtime-the-externalpythonoperator) module.
-- Webinar: [Running Airflow Tasks in Isolated Environments](https://www.astronomer.io/events/webinars/running-airflow-tasks-in-isolated-environments/).
-
-:::
 
 ## Prerequisites
 

--- a/learn/external-python-operator.md
+++ b/learn/external-python-operator.md
@@ -17,7 +17,7 @@ In this tutorial, you'll learn how to use the [ExternalPythonOperator](https://a
 
 Snowpark requires Python 3.8, while the [Astro Runtime](https://docs.astronomer.io/astro/runtime-image-architecture) uses Python 3.9. The ExternalPythonOperator can run your Snowpark query in a Python 3.8 virtual environment, allowing you to use a different Python version for your task than in the Airflow environment. You can use these same general steps for any use case for running a task in a reusable Python virtual environment.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/get-started-with-airflow.md
+++ b/learn/get-started-with-airflow.md
@@ -17,7 +17,7 @@ After you complete this tutorial, you'll be able to:
 - Navigate the Airflow UI.
 - Use code from the Astronomer Registry.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/get-started-with-airflow.md
+++ b/learn/get-started-with-airflow.md
@@ -17,7 +17,7 @@ After you complete this tutorial, you'll be able to:
 - Navigate the Airflow UI.
 - Use code from the Astronomer Registry.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/get-started-with-airflow.md
+++ b/learn/get-started-with-airflow.md
@@ -17,6 +17,13 @@ After you complete this tutorial, you'll be able to:
 - Navigate the Airflow UI.
 - Use code from the Astronomer Registry.
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow 101 Learning Path](https://academy.astronomer.io/path/airflow-101).
+- Webinar: [Airflow 101: How to get started writing data pipelines with Apache Airflow](https://www.astronomer.io/events/webinars/airflow-101-how-to-get-started-writing-data-pipelines-with-apache-airflow/).
+
+:::
+
 ## Time to complete
 
 This tutorial takes approximately 1 hour to complete.
@@ -27,13 +34,6 @@ To get the most out of this tutorial, make sure you have an understanding of:
 
 - Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md).
 - Basic Python. See the [Python Documentation](https://docs.python.org/3/tutorial/index.html).
-
-:::tip Related Content
-
-- Astronomer Academy: [Airflow 101 Learning Path](https://academy.astronomer.io/path/airflow-101).
-- Webinar: [Airflow 101: How to get started writing data pipelines with Apache Airflow](https://www.astronomer.io/events/webinars/airflow-101-how-to-get-started-writing-data-pipelines-with-apache-airflow/).
-
-:::
 
 ## Prerequisites
 

--- a/learn/get-started-with-airflow.md
+++ b/learn/get-started-with-airflow.md
@@ -19,7 +19,7 @@ After you complete this tutorial, you'll be able to:
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow 101 Learning Path](https://academy.astronomer.io/path/airflow-101).
 - Webinar: [Airflow 101: How to get started writing data pipelines with Apache Airflow](https://www.astronomer.io/events/webinars/airflow-101-how-to-get-started-writing-data-pipelines-with-apache-airflow/).

--- a/learn/get-started-with-airflow.md
+++ b/learn/get-started-with-airflow.md
@@ -28,6 +28,13 @@ To get the most out of this tutorial, make sure you have an understanding of:
 - Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md).
 - Basic Python. See the [Python Documentation](https://docs.python.org/3/tutorial/index.html).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow 101 Learning Path](https://academy.astronomer.io/path/airflow-101).
+- Webinar: [Airflow 101: How to get started writing data pipelines with Apache Airflow](https://www.astronomer.io/events/webinars/airflow-101-how-to-get-started-writing-data-pipelines-with-apache-airflow/).
+
+:::
+
 ## Prerequisites
 
 - A terminal that accepts bash commands. This is pre-installed on most operating systems.

--- a/learn/get-started-with-airflow.md
+++ b/learn/get-started-with-airflow.md
@@ -17,9 +17,9 @@ After you complete this tutorial, you'll be able to:
 - Navigate the Airflow UI.
 - Use code from the Astronomer Registry.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow 101 Learning Path](https://academy.astronomer.io/path/airflow-101).
 - Webinar: [Airflow 101: How to get started writing data pipelines with Apache Airflow](https://www.astronomer.io/events/webinars/airflow-101-how-to-get-started-writing-data-pipelines-with-apache-airflow/).

--- a/learn/get-started-with-airflow.md
+++ b/learn/get-started-with-airflow.md
@@ -19,6 +19,8 @@ After you complete this tutorial, you'll be able to:
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow 101 Learning Path](https://academy.astronomer.io/path/airflow-101).
 - Webinar: [Airflow 101: How to get started writing data pipelines with Apache Airflow](https://www.astronomer.io/events/webinars/airflow-101-how-to-get-started-writing-data-pipelines-with-apache-airflow/).
 

--- a/learn/intro-to-airflow.md
+++ b/learn/intro-to-airflow.md
@@ -19,8 +19,6 @@ This guide offers an introduction to Apache Airflow and its core concepts. You'l
 - When you should use Airflow.
 - Core Airflow concepts.
 
-For a hands-on introduction to Airflow using the Astro CLI, see [Get started with Apache Airflow](get-started-with-airflow.md).
-
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
@@ -29,6 +27,7 @@ To get the most out of this guide, you should have an understanding of:
 
 :::tip Related Content
 
+- Hands-on tutorial: [Get started with Apache Airflow](get-started-with-airflow.md).
 - Astronomer Academy: [Airflow 101 Learning Path](https://academy.astronomer.io/path/airflow-101).
 - Webinar: [Airflow 101: How to get started writing data pipelines with Apache Airflow](https://www.astronomer.io/events/webinars/airflow-101-how-to-get-started-writing-data-pipelines-with-apache-airflow/).
 

--- a/learn/intro-to-airflow.md
+++ b/learn/intro-to-airflow.md
@@ -21,6 +21,8 @@ This guide offers an introduction to Apache Airflow and its core concepts. You'l
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Hands-on tutorial: [Get started with Apache Airflow](get-started-with-airflow.md).
 - Astronomer Academy: [Airflow 101 Learning Path](https://academy.astronomer.io/path/airflow-101).
 - Webinar: [Airflow 101: How to get started writing data pipelines with Apache Airflow](https://www.astronomer.io/events/webinars/airflow-101-how-to-get-started-writing-data-pipelines-with-apache-airflow/).

--- a/learn/intro-to-airflow.md
+++ b/learn/intro-to-airflow.md
@@ -19,12 +19,6 @@ This guide offers an introduction to Apache Airflow and its core concepts. You'l
 - When you should use Airflow.
 - Core Airflow concepts.
 
-## Assumed knowledge
-
-To get the most out of this guide, you should have an understanding of:
-
-- Basic Python. See the [Python Documentation](https://docs.python.org/3/tutorial/index.html).
-
 :::tip Related Content
 
 - Hands-on tutorial: [Get started with Apache Airflow](get-started-with-airflow.md).
@@ -32,6 +26,12 @@ To get the most out of this guide, you should have an understanding of:
 - Webinar: [Airflow 101: How to get started writing data pipelines with Apache Airflow](https://www.astronomer.io/events/webinars/airflow-101-how-to-get-started-writing-data-pipelines-with-apache-airflow/).
 
 :::
+
+## Assumed knowledge
+
+To get the most out of this guide, you should have an understanding of:
+
+- Basic Python. See the [Python Documentation](https://docs.python.org/3/tutorial/index.html).
 
 ## History
 

--- a/learn/intro-to-airflow.md
+++ b/learn/intro-to-airflow.md
@@ -21,7 +21,7 @@ This guide offers an introduction to Apache Airflow and its core concepts. You'l
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Hands-on tutorial: [Get started with Apache Airflow](get-started-with-airflow.md).
 - Astronomer Academy: [Airflow 101 Learning Path](https://academy.astronomer.io/path/airflow-101).

--- a/learn/intro-to-airflow.md
+++ b/learn/intro-to-airflow.md
@@ -27,6 +27,13 @@ To get the most out of this guide, you should have an understanding of:
 
 - Basic Python. See the [Python Documentation](https://docs.python.org/3/tutorial/index.html).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow 101 Learning Path](https://academy.astronomer.io/path/airflow-101).
+- Webinar: [Airflow 101: How to get started writing data pipelines with Apache Airflow](https://www.astronomer.io/events/webinars/airflow-101-how-to-get-started-writing-data-pipelines-with-apache-airflow/).
+
+:::
+
 ## History
 
 Airflow started as an open source project at Airbnb. In 2015, Airbnb was growing rapidly and struggling to manage the vast quantities of internal data it generated every day. Airbnb data engineers, data scientists, and analysts had to regularly write scheduled batch jobs to automate processes. To satisfy the need for a robust scheduling tool, [Maxime Beauchemin](https://maximebeauchemin.medium.com/) created Airflow to allow Airbnb to quickly author, iterate, and monitor batch data pipelines.

--- a/learn/intro-to-airflow.md
+++ b/learn/intro-to-airflow.md
@@ -19,9 +19,9 @@ This guide offers an introduction to Apache Airflow and its core concepts. You'l
 - When you should use Airflow.
 - Core Airflow concepts.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Hands-on tutorial: [Get started with Apache Airflow](get-started-with-airflow.md).
 - Astronomer Academy: [Airflow 101 Learning Path](https://academy.astronomer.io/path/airflow-101).

--- a/learn/intro-to-airflow.md
+++ b/learn/intro-to-airflow.md
@@ -19,7 +19,7 @@ This guide offers an introduction to Apache Airflow and its core concepts. You'l
 - When you should use Airflow.
 - Core Airflow concepts.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/intro-to-airflow.md
+++ b/learn/intro-to-airflow.md
@@ -19,7 +19,7 @@ This guide offers an introduction to Apache Airflow and its core concepts. You'l
 - When you should use Airflow.
 - Core Airflow concepts.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -28,19 +28,19 @@ You'll also learn how to use the KubernetesPodOperator to run a task in a langua
 
 For more information about running the KubernetesPodOperator on a hosted cloud, see [Run the KubernetesPodOperator on Astro](https://docs.astronomer.io/astro/kubernetespodoperator).
 
-## Assumed knowledge
-
-To get the most out of this guide, you should have an understanding of:
-
-- Airflow operators. See [Operators 101](what-is-an-operator.md).
-- Kubernetes basics. See the [Kubernetes Documentation](https://kubernetes.io/docs/home/).  
-
 :::tip Related Content
 
 - Astronomer Academy: [Airflow: The KubernetesPodOperator](https://academy.astronomer.io/astro-runtime-the-kubernetespodoperator-1) module.
 - Webinar: [Running Airflow Tasks in Isolated Environments](https://www.astronomer.io/events/webinars/running-airflow-tasks-in-isolated-environments/).
 
 :::
+
+## Assumed knowledge
+
+To get the most out of this guide, you should have an understanding of:
+
+- Airflow operators. See [Operators 101](what-is-an-operator.md).
+- Kubernetes basics. See the [Kubernetes Documentation](https://kubernetes.io/docs/home/).  
 
 ## Requirements
 

--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -26,7 +26,7 @@ In this guide, you'll learn:
 
 You'll also learn how to use the KubernetesPodOperator to run a task in a language other than Python, how to use the KubernetesPodOperator with XComs, and how to launch a Pod in a remote AWS EKS Cluster.
 
-For more information about running the KubernetesPodOperator on a hosted cloud, see [Run the KubernetesPodOperator on Astro](https://docs.astronomer.io/astro/kubernetespodoperator)
+For more information about running the KubernetesPodOperator on a hosted cloud, see [Run the KubernetesPodOperator on Astro](https://docs.astronomer.io/astro/kubernetespodoperator).
 
 ## Assumed knowledge
 

--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -35,6 +35,13 @@ To get the most out of this guide, you should have an understanding of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Kubernetes basics. See the [Kubernetes Documentation](https://kubernetes.io/docs/home/).  
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: The KubernetesPodOperator](https://academy.astronomer.io/astro-runtime-the-kubernetespodoperator-1) module.
+- Webinar: [Running Airflow Tasks in Isolated Environments](https://www.astronomer.io/events/webinars/running-airflow-tasks-in-isolated-environments/).
+
+:::
+
 ## Requirements
 
 To use the KubernetesPodOperator you need to install the Kubernetes provider package. To install it with pip, run:

--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -30,6 +30,8 @@ For more information about running the KubernetesPodOperator on a hosted cloud, 
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: The KubernetesPodOperator](https://academy.astronomer.io/astro-runtime-the-kubernetespodoperator-1) module.
 - Webinar: [Running Airflow Tasks in Isolated Environments](https://www.astronomer.io/events/webinars/running-airflow-tasks-in-isolated-environments/).
 

--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -28,9 +28,9 @@ You'll also learn how to use the KubernetesPodOperator to run a task in a langua
 
 For more information about running the KubernetesPodOperator on a hosted cloud, see [Run the KubernetesPodOperator on Astro](https://docs.astronomer.io/astro/kubernetespodoperator).
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: The KubernetesPodOperator](https://academy.astronomer.io/astro-runtime-the-kubernetespodoperator-1) module.
 - Webinar: [Running Airflow Tasks in Isolated Environments](https://www.astronomer.io/events/webinars/running-airflow-tasks-in-isolated-environments/).

--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -30,7 +30,7 @@ For more information about running the KubernetesPodOperator on a hosted cloud, 
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: The KubernetesPodOperator](https://academy.astronomer.io/astro-runtime-the-kubernetespodoperator-1) module.
 - Webinar: [Running Airflow Tasks in Isolated Environments](https://www.astronomer.io/events/webinars/running-airflow-tasks-in-isolated-environments/).

--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -28,7 +28,7 @@ You'll also learn how to use the KubernetesPodOperator to run a task in a langua
 
 For more information about running the KubernetesPodOperator on a hosted cloud, see [Run the KubernetesPodOperator on Astro](https://docs.astronomer.io/astro/kubernetespodoperator).
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -28,7 +28,7 @@ You'll also learn how to use the KubernetesPodOperator to run a task in a langua
 
 For more information about running the KubernetesPodOperator on a hosted cloud, see [Run the KubernetesPodOperator on Astro](https://docs.astronomer.io/astro/kubernetespodoperator).
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -15,6 +15,8 @@ In this guide, you'll learn Airflow scheduling concepts and the different ways y
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: DAG Scheduling](https://academy.astronomer.io/astro-runtime-scheduling) module.
 - Webinar: [Scheduling in Airflow: A Comprehensive Introduction](https://www.astronomer.io/events/webinars/scheduling-in-airflow-comprehensive-intro/).
 

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -11,9 +11,7 @@ id: scheduling-in-airflow
 
 One of the fundamental features of Apache Airflow is the ability to schedule jobs. Historically, Airflow users scheduled their DAGs by specifying a `schedule` with a cron expression, a timedelta object, or a preset Airflow schedule. Timetables, released in Airflow 2.2, allow users to create their own custom schedules using Python, effectively eliminating the limitations of cron. With timetables, you can now schedule DAGs to run at any time. Datasets, introduced in Airflow 2.4, let you schedule your DAGs on updates to a dataset rather than a time-based schedule. For more information about datasets, see [Datasets and Data-Aware Scheduling in Airflow](airflow-datasets.md).
 
-In this guide, you'll learn Airflow scheduling concepts and the different ways you can schedule a DAG with a focus on timetables. For a video overview of these concepts, see [Scheduling in Airflow webinar](https://www.astronomer.io/events/webinars/trigger-dags-any-schedule).  
-
-All code used in this guide is available in the [airflow-scheduling-tutorial repository](https://github.com/astronomer/airflow-scheduling-tutorial).
+In this guide, you'll learn Airflow scheduling concepts and the different ways you can schedule a DAG with a focus on timetables. All code used in this guide is available in the [airflow-scheduling-tutorial repository](https://github.com/astronomer/airflow-scheduling-tutorial).
 
 ## Assumed knowledge
 

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -13,9 +13,9 @@ One of the fundamental features of Apache Airflow is the ability to schedule job
 
 In this guide, you'll learn Airflow scheduling concepts and the different ways you can schedule a DAG with a focus on timetables. All code used in this guide is available in the [airflow-scheduling-tutorial repository](https://github.com/astronomer/airflow-scheduling-tutorial).
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: DAG Scheduling](https://academy.astronomer.io/astro-runtime-scheduling) module.
 - Webinar: [Scheduling in Airflow: A Comprehensive Introduction](https://www.astronomer.io/events/webinars/scheduling-in-airflow-comprehensive-intro/).

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -13,7 +13,7 @@ One of the fundamental features of Apache Airflow is the ability to schedule job
 
 In this guide, you'll learn Airflow scheduling concepts and the different ways you can schedule a DAG with a focus on timetables. All code used in this guide is available in the [airflow-scheduling-tutorial repository](https://github.com/astronomer/airflow-scheduling-tutorial).
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -13,6 +13,13 @@ One of the fundamental features of Apache Airflow is the ability to schedule job
 
 In this guide, you'll learn Airflow scheduling concepts and the different ways you can schedule a DAG with a focus on timetables. All code used in this guide is available in the [airflow-scheduling-tutorial repository](https://github.com/astronomer/airflow-scheduling-tutorial).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: DAG Scheduling](https://academy.astronomer.io/astro-runtime-scheduling) module.
+- Webinar: [Scheduling in Airflow: A Comprehensive Introduction](https://www.astronomer.io/events/webinars/scheduling-in-airflow-comprehensive-intro/).
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an existing knowledge of:
@@ -20,13 +27,6 @@ To get the most out of this guide, you should have an existing knowledge of:
 - Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md).
 - Configuring Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
 - Date and time modules in Python3. See the [Python documentation on the `datetime` package](https://docs.python.org/3/library/datetime.html).
-
-:::tip Related Content
-
-- Astronomer Academy: [Airflow: DAG Scheduling](https://academy.astronomer.io/astro-runtime-scheduling) module.
-- Webinar: [Scheduling in Airflow: A Comprehensive Introduction](https://www.astronomer.io/events/webinars/scheduling-in-airflow-comprehensive-intro/).
-
-:::
 
 ## Scheduling concepts
 

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -23,6 +23,13 @@ To get the most out of this guide, you should have an existing knowledge of:
 - Configuring Airflow DAGs. See [Introduction to Airflow DAGs](dags.md).
 - Date and time modules in Python3. See the [Python documentation on the `datetime` package](https://docs.python.org/3/library/datetime.html).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: DAG Scheduling](https://academy.astronomer.io/astro-runtime-scheduling) module.
+- Webinar: [Scheduling in Airflow: A Comprehensive Introduction](https://www.astronomer.io/events/webinars/scheduling-in-airflow-comprehensive-intro/).
+
+:::
+
 ## Scheduling concepts
 
 To gain a better understanding of DAG scheduling, it's important that you become familiar with the following terms and parameters:

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -15,7 +15,7 @@ In this guide, you'll learn Airflow scheduling concepts and the different ways y
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: DAG Scheduling](https://academy.astronomer.io/astro-runtime-scheduling) module.
 - Webinar: [Scheduling in Airflow: A Comprehensive Introduction](https://www.astronomer.io/events/webinars/scheduling-in-airflow-comprehensive-intro/).

--- a/learn/scheduling-in-airflow.md
+++ b/learn/scheduling-in-airflow.md
@@ -13,7 +13,7 @@ One of the fundamental features of Apache Airflow is the ability to schedule job
 
 In this guide, you'll learn Airflow scheduling concepts and the different ways you can schedule a DAG with a focus on timetables. All code used in this guide is available in the [airflow-scheduling-tutorial repository](https://github.com/astronomer/airflow-scheduling-tutorial).
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/task-groups.md
+++ b/learn/task-groups.md
@@ -31,7 +31,7 @@ In this guide, you'll learn how to create and use task groups in your DAGs. You 
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: Task Groups](https://academy.astronomer.io/astro-runtime-task-groups) module.
 - Webinar: [How to expertly organize your DAGs with task groups](https://www.astronomer.io/events/webinars/how-to-expertly-organize-your-dags-with-task-groups/).

--- a/learn/task-groups.md
+++ b/learn/task-groups.md
@@ -29,18 +29,18 @@ In this guide, you'll learn how to create and use task groups in your DAGs. You 
 
 ![Task group intro gif](/img/guides/task-groups_intro_task_group_gif.gif)
 
-## Assumed knowledge
-
-To get the most out of this guide, you should have an understanding of:
-
-- Airflow operators. See [Operators 101](what-is-an-operator.md).
-
 :::tip Related Content
 
 - Astronomer Academy: [Airflow: Task Groups](https://academy.astronomer.io/astro-runtime-task-groups) module.
 - Webinar: [How to expertly organize your DAGs with task groups](https://www.astronomer.io/events/webinars/how-to-expertly-organize-your-dags-with-task-groups/).
 
 :::
+
+## Assumed knowledge
+
+To get the most out of this guide, you should have an understanding of:
+
+- Airflow operators. See [Operators 101](what-is-an-operator.md).
 
 ## When to use task groups
 

--- a/learn/task-groups.md
+++ b/learn/task-groups.md
@@ -35,6 +35,13 @@ To get the most out of this guide, you should have an understanding of:
 
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Task Groups](https://academy.astronomer.io/astro-runtime-task-groups) module.
+- Webinar: [How to expertly organize your DAGs with task groups](https://www.astronomer.io/events/webinars/how-to-expertly-organize-your-dags-with-task-groups/).
+
+:::
+
 ## When to use task groups
 
 Task groups are most often used to visually organize complicated DAGs. For example, you might use task groups:

--- a/learn/task-groups.md
+++ b/learn/task-groups.md
@@ -29,9 +29,9 @@ In this guide, you'll learn how to create and use task groups in your DAGs. You 
 
 ![Task group intro gif](/img/guides/task-groups_intro_task_group_gif.gif)
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: Task Groups](https://academy.astronomer.io/astro-runtime-task-groups) module.
 - Webinar: [How to expertly organize your DAGs with task groups](https://www.astronomer.io/events/webinars/how-to-expertly-organize-your-dags-with-task-groups/).

--- a/learn/task-groups.md
+++ b/learn/task-groups.md
@@ -31,6 +31,8 @@ In this guide, you'll learn how to create and use task groups in your DAGs. You 
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: Task Groups](https://academy.astronomer.io/astro-runtime-task-groups) module.
 - Webinar: [How to expertly organize your DAGs with task groups](https://www.astronomer.io/events/webinars/how-to-expertly-organize-your-dags-with-task-groups/).
 

--- a/learn/task-groups.md
+++ b/learn/task-groups.md
@@ -29,7 +29,7 @@ In this guide, you'll learn how to create and use task groups in your DAGs. You 
 
 ![Task group intro gif](/img/guides/task-groups_intro_task_group_gif.gif)
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/task-groups.md
+++ b/learn/task-groups.md
@@ -29,7 +29,7 @@ In this guide, you'll learn how to create and use task groups in your DAGs. You 
 
 ![Task group intro gif](/img/guides/task-groups_intro_task_group_gif.gif)
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/templating.md
+++ b/learn/templating.md
@@ -34,7 +34,7 @@ Airflow leverages [Jinja](https://jinja.palletsprojects.com), a Python templatin
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: Templating](https://academy.astronomer.io/astro-runtime-templating) module.
 

--- a/learn/templating.md
+++ b/learn/templating.md
@@ -32,7 +32,7 @@ Airflow leverages [Jinja](https://jinja.palletsprojects.com), a Python templatin
 - How to apply custom variables and functions when templating.
 - How to render templates to strings and native Python code.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/templating.md
+++ b/learn/templating.md
@@ -32,7 +32,7 @@ Airflow leverages [Jinja](https://jinja.palletsprojects.com), a Python templatin
 - How to apply custom variables and functions when templating.
 - How to render templates to strings and native Python code.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/templating.md
+++ b/learn/templating.md
@@ -34,6 +34,8 @@ Airflow leverages [Jinja](https://jinja.palletsprojects.com), a Python templatin
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: Templating](https://academy.astronomer.io/astro-runtime-templating) module.
 
 :::

--- a/learn/templating.md
+++ b/learn/templating.md
@@ -39,6 +39,12 @@ To get the most out of this guide, you should have an understanding of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Jinja templating. See [Jinja basics](https://jinja.palletsprojects.com/en/3.1.x/api/#basics). 
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Templating](https://academy.astronomer.io/astro-runtime-templating) module.
+
+:::
+
 ## Templating variables in Airflow
 
 Templating in Airflow works the same as Jinja templating in Python. You enclose the code you want evaluated between double curly braces, and the expression is evaluated at runtime. 

--- a/learn/templating.md
+++ b/learn/templating.md
@@ -32,18 +32,18 @@ Airflow leverages [Jinja](https://jinja.palletsprojects.com), a Python templatin
 - How to apply custom variables and functions when templating.
 - How to render templates to strings and native Python code.
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Templating](https://academy.astronomer.io/astro-runtime-templating) module.
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
 
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Jinja templating. See [Jinja basics](https://jinja.palletsprojects.com/en/3.1.x/api/#basics). 
-
-:::tip Related Content
-
-- Astronomer Academy: [Airflow: Templating](https://academy.astronomer.io/astro-runtime-templating) module.
-
-:::
 
 ## Templating variables in Airflow
 

--- a/learn/templating.md
+++ b/learn/templating.md
@@ -32,9 +32,9 @@ Airflow leverages [Jinja](https://jinja.palletsprojects.com), a Python templatin
 - How to apply custom variables and functions when templating.
 - How to render templates to strings and native Python code.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: Templating](https://academy.astronomer.io/astro-runtime-templating) module.
 

--- a/learn/testing-airflow.md
+++ b/learn/testing-airflow.md
@@ -14,9 +14,9 @@ import TabItem from '@theme/TabItem';
 
 Effectively testing DAGs requires an understanding of their structure and their relationship to other code and data in your environment. In this guide, you'll learn about various types of DAG validation testing, unit testing, and where to find further information on data quality checks.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Webinar: [How to easily test your Airflow DAGs with the new dag.test() function](https://www.astronomer.io/events/webinars/how-to-easily-test-your-airflow-dags-with-the-new-dag-test-function/).
 

--- a/learn/testing-airflow.md
+++ b/learn/testing-airflow.md
@@ -14,6 +14,12 @@ import TabItem from '@theme/TabItem';
 
 Effectively testing DAGs requires an understanding of their structure and their relationship to other code and data in your environment. In this guide, you'll learn about various types of DAG validation testing, unit testing, and where to find further information on data quality checks.
 
+:::tip Related Content
+
+- Webinar: [How to easily test your Airflow DAGs with the new dag.test() function](https://www.astronomer.io/events/webinars/how-to-easily-test-your-airflow-dags-with-the-new-dag-test-function/).
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
@@ -22,12 +28,6 @@ To get the most out of this guide, you should have an understanding of:
 - At least one Python test runner. This guide mostly uses [`pytest`](https://docs.pytest.org/en/stable/index.html), but you can use others including [`nose2`](https://docs.nose2.io/en/latest/getting_started.html) and [`unittest`](https://docs.python.org/3/library/unittest.html).
 - CI/CD for Python scripts. See [Continuous Integration with Python: An Introduction](https://realpython.com/python-continuous-integration/).
 - Basic Airflow and [Astro CLI](https://docs.astronomer.io/astro/cli/install-cli) concepts. See [Get started with Airflow](get-started-with-airflow.md).
-
-:::tip Related Content
-
-- Webinar: [How to easily test your Airflow DAGs with the new dag.test() function](https://www.astronomer.io/events/webinars/how-to-easily-test-your-airflow-dags-with-the-new-dag-test-function/).
-
-:::
 
 ## Write DAG validation tests
 

--- a/learn/testing-airflow.md
+++ b/learn/testing-airflow.md
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 
 Effectively testing DAGs requires an understanding of their structure and their relationship to other code and data in your environment. In this guide, you'll learn about various types of DAG validation testing, unit testing, and where to find further information on data quality checks.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/testing-airflow.md
+++ b/learn/testing-airflow.md
@@ -16,6 +16,8 @@ Effectively testing DAGs requires an understanding of their structure and their 
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Webinar: [How to easily test your Airflow DAGs with the new dag.test() function](https://www.astronomer.io/events/webinars/how-to-easily-test-your-airflow-dags-with-the-new-dag-test-function/).
 
 :::

--- a/learn/testing-airflow.md
+++ b/learn/testing-airflow.md
@@ -23,6 +23,12 @@ To get the most out of this guide, you should have an understanding of:
 - CI/CD for Python scripts. See [Continuous Integration with Python: An Introduction](https://realpython.com/python-continuous-integration/).
 - Basic Airflow and [Astro CLI](https://docs.astronomer.io/astro/cli/install-cli) concepts. See [Get started with Airflow](get-started-with-airflow.md).
 
+:::tip Related Content
+
+- Webinar: [How to easily test your Airflow DAGs with the new dag.test() function](https://www.astronomer.io/events/webinars/how-to-easily-test-your-airflow-dags-with-the-new-dag-test-function/).
+
+:::
+
 ## Write DAG validation tests
 
 DAG validation tests ensure that your DAGs fulfill a list of criteria. Using validation tests can help you:

--- a/learn/testing-airflow.md
+++ b/learn/testing-airflow.md
@@ -16,7 +16,7 @@ Effectively testing DAGs requires an understanding of their structure and their 
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Webinar: [How to easily test your Airflow DAGs with the new dag.test() function](https://www.astronomer.io/events/webinars/how-to-easily-test-your-airflow-dags-with-the-new-dag-test-function/).
 

--- a/learn/testing-airflow.md
+++ b/learn/testing-airflow.md
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 
 Effectively testing DAGs requires an understanding of their structure and their relationship to other code and data in your environment. In this guide, you'll learn about various types of DAG validation testing, unit testing, and where to find further information on data quality checks.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/what-is-a-hook.md
+++ b/learn/what-is-a-hook.md
@@ -29,6 +29,12 @@ To get the most out of this guide, you should have an understanding of:
 - Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md).
 - Basic Python. See the [Python Documentation](https://docs.python.org/3/tutorial/index.html).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Sensors](https://academy.astronomer.io/sensors-course) module.
+
+:::
+
 ## Hook basics
 
 Hooks wrap around APIs and provide methods to interact with different external systems. Hooks standardize how Astronomer interacts with external systems and using them makes your DAG code cleaner, easier to read, and less prone to errors.

--- a/learn/what-is-a-hook.md
+++ b/learn/what-is-a-hook.md
@@ -29,12 +29,6 @@ To get the most out of this guide, you should have an understanding of:
 - Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md).
 - Basic Python. See the [Python Documentation](https://docs.python.org/3/tutorial/index.html).
 
-:::tip Related Content
-
-- Astronomer Academy: [Airflow: Sensors](https://academy.astronomer.io/sensors-course) module.
-
-:::
-
 ## Hook basics
 
 Hooks wrap around APIs and provide methods to interact with different external systems. Hooks standardize how Astronomer interacts with external systems and using them makes your DAG code cleaner, easier to read, and less prone to errors.

--- a/learn/what-is-a-sensor.md
+++ b/learn/what-is-a-sensor.md
@@ -22,12 +22,6 @@ import sql_sensor_example_traditional from '!!raw-loader!../code-samples/dags/wh
 
 In this guide, you'll learn how sensors are used in Airflow, best practices for implementing sensors in production, and how to use deferrable versions of sensors.
 
-:::info
-
-For a video course on Airflow sensors, check out the [Astronomer Academy](https://academy.astronomer.io/sensors-course).
-
-:::
-
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:

--- a/learn/what-is-a-sensor.md
+++ b/learn/what-is-a-sensor.md
@@ -22,7 +22,7 @@ import sql_sensor_example_traditional from '!!raw-loader!../code-samples/dags/wh
 
 In this guide, you'll learn how sensors are used in Airflow, best practices for implementing sensors in production, and how to use deferrable versions of sensors.
 
-:::tip Other ways to learn:
+:::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/what-is-a-sensor.md
+++ b/learn/what-is-a-sensor.md
@@ -22,18 +22,18 @@ import sql_sensor_example_traditional from '!!raw-loader!../code-samples/dags/wh
 
 In this guide, you'll learn how sensors are used in Airflow, best practices for implementing sensors in production, and how to use deferrable versions of sensors.
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Sensors](https://academy.astronomer.io/sensors-course) module.
+
+:::
+
 ## Assumed knowledge
 
 To get the most out of this guide, you should have an understanding of:
 
 - Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md).
 - Basic Python. See the [Python Documentation](https://docs.python.org/3/tutorial/index.html).
-
-:::tip Related Content
-
-- Astronomer Academy: [Airflow: Sensors](https://academy.astronomer.io/sensors-course) module.
-
-:::
 
 ## Sensor basics
 

--- a/learn/what-is-a-sensor.md
+++ b/learn/what-is-a-sensor.md
@@ -24,7 +24,7 @@ In this guide, you'll learn how sensors are used in Airflow, best practices for 
 
 :::tip Related content
 
-There are multiple resources for learning about this topic. See also:
+Other ways to learn:
 
 - Astronomer Academy: [Airflow: Sensors](https://academy.astronomer.io/sensors-course) module.
 

--- a/learn/what-is-a-sensor.md
+++ b/learn/what-is-a-sensor.md
@@ -24,6 +24,8 @@ In this guide, you'll learn how sensors are used in Airflow, best practices for 
 
 :::tip Related Content
 
+There are multiple resources for learning about this topic. See also:
+
 - Astronomer Academy: [Airflow: Sensors](https://academy.astronomer.io/sensors-course) module.
 
 :::

--- a/learn/what-is-a-sensor.md
+++ b/learn/what-is-a-sensor.md
@@ -22,9 +22,9 @@ import sql_sensor_example_traditional from '!!raw-loader!../code-samples/dags/wh
 
 In this guide, you'll learn how sensors are used in Airflow, best practices for implementing sensors in production, and how to use deferrable versions of sensors.
 
-:::tip Related content
+:::tip Other ways to learn:
 
-Other ways to learn:
+There are multiple resources for learning about this topic. See also:
 
 - Astronomer Academy: [Airflow: Sensors](https://academy.astronomer.io/sensors-course) module.
 

--- a/learn/what-is-a-sensor.md
+++ b/learn/what-is-a-sensor.md
@@ -22,7 +22,7 @@ import sql_sensor_example_traditional from '!!raw-loader!../code-samples/dags/wh
 
 In this guide, you'll learn how sensors are used in Airflow, best practices for implementing sensors in production, and how to use deferrable versions of sensors.
 
-:::tip Related Content
+:::tip Related content
 
 There are multiple resources for learning about this topic. See also:
 

--- a/learn/what-is-a-sensor.md
+++ b/learn/what-is-a-sensor.md
@@ -35,6 +35,12 @@ To get the most out of this guide, you should have an understanding of:
 - Basic Airflow concepts. See [Introduction to Apache Airflow](intro-to-airflow.md).
 - Basic Python. See the [Python Documentation](https://docs.python.org/3/tutorial/index.html).
 
+:::tip Related Content
+
+- Astronomer Academy: [Airflow: Sensors](https://academy.astronomer.io/sensors-course) module.
+
+:::
+
 ## Sensor basics
 
 Sensors are a type of operator that checks if a condition is met at a specific interval. If the condition is met, the task is marked successful and the DAG can move to downstream tasks. If the condition isn't met, the sensor waits for another interval before checking again. 


### PR DESCRIPTION
Trying to interlink Academy modules, learn content and webinars more. :) 
I am not sure whether I picked the best spot for the note here, I think it could also go at the end of the intro, as long as it is in the same spot for all content.
Originally I wanted to make a custom admonition "Related Content" in purple but JS/CSS won. If you think it is something worth looking into I'll poke Katie for help 😅 .

Very open to discussing the best location and format for this :)

Aside from that I tried to get all relevant Academy modules and for webinars the newest relevant webinar or in a few cases Live (for example for DuckDB there is a live of webinar length 😄 ). I did add a couple of blog post when I knew there was a relevant technical blog post around, but very possible I missed some there. 