### PR TITLE
Software SCIM fixes

### DIFF
--- a/software/integrate-auth-system.md
+++ b/software/integrate-auth-system.md
@@ -484,49 +484,66 @@ See [Add SCIM provisioning to app integrations](https://help.okta.com/en-us/Cont
 
 <TabItem value="azuread">
 
-1. In your `config.yaml` file, add the following configuration. Replace `<your-generated-secret-code>` with a randomly generated string. 
+1. Generate a random string to use as an authentication secret. See [random.org](https://www.random.org/strings/) for accessible randomization tools.
+2. Follow the steps in [Store and encrypt identity provider secrets](#store-and-encrypt-identity-provider-secrets) to store your string as a Kubernetes secret. Your secret configuration should look similar to the following:
+
+    ```yaml
+    # Required configuration for all secrets
+    kind: Secret
+    apiVersion: v1
+    metadata:
+         name: azure-provisioning-secret
+         labels:
+            release: {{ .Release.Name }}
+            chart: {{ .Chart.Name }}
+            heritage: {{ .Release.Service }}
+            component: {{ template "houston.backendSecret" . }}
+    type: Opaque
+    # Specify a key and value for the data you want to encrypt
+    data:
+        azure_provisioning_secret: {{ "<your-generated-string>" | b64enc | quote }}
+    ```
+
+2. In your `config.yaml` file, add the following configuration:
 
     ```yaml
     astronomer:
-      houston: 
-        config:
-          auth:
-            openidConnect:
-              microsoft:
-                scimAuthCode: <your-generated-secret-code>
+        houston:
+            secret:
+             - envName: "SCIM_AUTH_CODE_MICROSOFT"
+               secretName: "azure-provisioning-secret"
+               secretKey: "azure_provisioning_secret"
     ```
-   
-    **Note**: If you have already configured Open ID Connect with Azure AD, the `scimAuthCode` key should be on the same level as `clientId` and `discoveryUrl`
 
-2. Push the configuration change. See [Apply a config change](https://docs.astronomer.io/software/apply-platform-config).
+3. Push the configuration change. See [Apply a config change](https://docs.astronomer.io/software/apply-platform-config).
 
-3. Sign in to the [Azure AD portal](https://aad.portal.azure.com/). 
+4. Log in to the [Azure AD portal](https://aad.portal.azure.com/). 
    
-4. In the left menu, select **Enterprise applications**, and then click **New application** > **Create your own application**.
+5. In the left menu, select **Enterprise applications**, then click **New application** > **Create your own application**.
    
-5. Enter a name for your application and select **Integrate any other application you don't find in the gallery**.
+6. Enter a name for your application and select **Integrate any other application you don't find in the gallery**.
   
-6. Click **Create** to create an app object. Azure AD opens the application management menu for your new application.
+7. Click **Create** to create an app object. Azure AD opens the application management menu for your new application.
   
-7. In the application management menu for your new application, go to **Manage** > **Provisioning** and click **Get Started**.
+8. In the application management menu for your new application, go to **Manage** > **Provisioning** and click **Get Started**.
 
-8. Click **Provisioning Mode** > **Automatic**.
+9.  Click **Provisioning Mode** > **Automatic**.
 
-9. In the **Tenant URL** field, enter `https://houston.BASEDOMAIN/v1/scim/v2/microsoft`. This is the Astronomer SCIM endpoint URL.
+10. In the **Tenant URL** field, enter `https://BASEDOMAIN/v1/scim/v2/microsoft`. This is the Astronomer SCIM endpoint URL.
 
-10. Paste the `scimAuthCode` generated at step 1 above into the **Secret Token** field.
+11. Paste the `scimAuthCode` that you generated in Step 1 into the **Secret Token** field.
 
-11. Click **Test connection** in the Azure AD application management menu to confirm your connection to the SCIM endpoint.
+12. Click **Test connection** in the Azure AD application management menu to confirm your connection to the SCIM endpoint.
 
-12. Create mappings for your Astronomer users and roles. See [Tutorial - Customize user provisioning attribute-mappings for SaaS applications in Azure Active Directory](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/customize-application-attributes).
+13. Create mappings for your Astronomer users and roles. See [Tutorial - Customize user provisioning attribute-mappings for SaaS applications in Azure Active Directory](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/customize-application-attributes).
 
-13. Click **Manage** > **Provisioning** > **Settings**.
+14. Click **Manage** > **Provisioning** > **Settings**.
 
-14. In the **Scope** setting list, select **Sync only assigned users and groups**.
+15. In the **Scope** setting list, select **Sync only assigned users and groups**.
    
-15. Click the **Provisioning status** toggle to turn provisioning status on.
+16. Click the **Provisioning status** toggle to turn provisioning status on.
 
-16. Click **Save**.
+17. Click **Save**.
 
 </TabItem>
 </Tabs>

--- a/software/integrate-auth-system.md
+++ b/software/integrate-auth-system.md
@@ -429,23 +429,24 @@ SCIM works because the IdP pushes updates about users and teams to Astronomer So
 2. Click **Browse App catalog**
 
 3. Search for `SCIM 2.0`, then select the option that includes **Basic Auth**. The configuration page for the SCIM integration appears.
-
-4. Click **Provisioning**, then click **Configure API integration**.
-5. Tick the **Enable API integration** checkbox, then configure the following values.
+4. Complete the **General Settings** page, then click **Next**.
+5. Complete the **Sign-On Options** page and click **Done**.
+6. Return to the **Applications** menu and search for the integration you just created. Click the integration to open its settings.
+7. Click **Provisioning**, then click **Configure API integration**.
+8. Tick the **Enable API integration** checkbox, then configure the following values:
 
     - **SCIM connector base URL**: `https://astro-software-host/v1/scim/v2/okta`
     - **Authentication mode**: Basic Auth
         - Username: `<your-provisioning-account-username>`
         - Password: `<your-provisioning-account-password>`
-    - **To App**: Enable **Provisioning to App** for **Create Users**, **Update User Attributes**, and **Deactivate Users**.
 
-6. Click **General**, then click **Edit**. Give your application a name and configure any other required general settings. 
+9. Click **General**, then click **Edit**. Give your application a name and configure any other required general settings. 
 
-7. Go to **Push Groups** page and create a rule for Group Push. See [Group Push](https://help.okta.com/en-us/Content/Topics/users-groups-profiles/usgp-about-group-push.htm).
+10. Go to **Push Groups** page and create a rule for Group Push. See [Group Push](https://help.okta.com/en-us/Content/Topics/users-groups-profiles/usgp-about-group-push.htm).
 
-8.  On the **Assignments** tab, ensure that the right users and groups in your org are assigned to the app integration. See [Use the Assign Users to App action](https://help.okta.com/en-us/Content/Topics/Apps/apps-assign-applications.htm?cshid=ext_Apps_Apps_Page-assign).
+11. On the **Assignments** tab, ensure that the right users and groups in your org are assigned to the app integration. See [Use the Assign Users to App action](https://help.okta.com/en-us/Content/Topics/Apps/apps-assign-applications.htm?cshid=ext_Apps_Apps_Page-assign).
 
-9. Follow the steps in [Store and encrypt identity provider secrets](#store-and-encrypt-identity-provider-secrets) to store your provisioning account credentials as a Kubernetes secret. Your secret configuration should look similar to the following:
+12. Follow the steps in [Store and encrypt identity provider secrets](#store-and-encrypt-identity-provider-secrets) to store your provisioning account credentials as a Kubernetes secret. Your secret configuration should look similar to the following:
 
     ```yaml
     # Required configuration for all secrets
@@ -464,7 +465,7 @@ SCIM works because the IdP pushes updates about users and teams to Astronomer So
         okta_provisioning_account_secret: {{ "<your-provisioning-account-username>:<your-provisioning-account-password>" | b64enc | quote }}
     ```
 
-10. Add the following lines to your `config.yaml` file:
+13. Add the following lines to your `config.yaml` file:
 
     ```yaml
     astronomer:
@@ -475,7 +476,7 @@ SCIM works because the IdP pushes updates about users and teams to Astronomer So
                secretKey: "okta_provisioning_account_secret"
     ```
 
-11. Push the configuration change. See [Apply a config change](https://docs.astronomer.io/software/apply-platform-config).
+14. Push the configuration change. See [Apply a config change](https://docs.astronomer.io/software/apply-platform-config).
 
 See [Add SCIM provisioning to app integrations](https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SCIM.htm?cshid=ext_Apps_App_Integration_Wizard-scim) for more information about configuring SCIM within Okta.
 


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/2960

Rewrites the SCIM integration guide to no longer assume that a user has created an integration previously. Also updates recommendations to encrypt credentials as a secret within Helm.

I've only made the changes for Okta, but once we get some approvals I'll make similar changes to the Azure AD sections as well.

