### PR TITLE
Updated airflow_dbt_simple.py

### DIFF
--- a/code-samples/dags/airflow-dbt-cloud/airflow_dbt_simple.py
+++ b/code-samples/dags/airflow-dbt-cloud/airflow_dbt_simple.py
@@ -21,9 +21,11 @@ def check_before_running_dbt_cloud_job():
         """
         hook = DbtCloudHook(DBT_CLOUD_CONN_ID)
         runs = hook.list_job_runs(job_definition_id=job_id, order_by="-id")
-        latest_run = runs[0].json()["data"][0]
-
-        return DbtCloudJobRunStatus.is_terminal(latest_run["status"])
+        if not runs[0].json().get("data"):
+            return True
+        else:
+            latest_run = runs[0].json()["data"][0]
+            return DbtCloudJobRunStatus.is_terminal(latest_run["status"])
 
     trigger_job = DbtCloudRunJobOperator(
         task_id="trigger_dbt_cloud_job",


### PR DESCRIPTION
In dbt cloud, we get empty data if the job hasn't run at least once and added the edge case to ignore the empty data set. So it returns true. 

To recreate the error:
1. Create a job in dbt cloud - (Do not run it from dbt cloud)
2. Use the airflow_dbt_simple to trigger from Airflow
3. It will throw an error, Index not found.