### PR TITLE
Runtime 9.4.0 release notes

### DIFF
--- a/astro/release-notes.md
+++ b/astro/release-notes.md
@@ -21,7 +21,7 @@ import HybridBadge from '@site/src/components/HybridBadge';
 
 Astronomer is committed to continuous delivery of both features and bug fixes to Astro. To keep your team up to date on what's new, this document will provide a regular summary of all changes released to Astro.
 
-**Latest Astro Runtime Version**: 9.3 ([Release notes](runtime-release-notes.md))
+**Latest Astro Runtime Version**: 9.4 ([Release notes](runtime-release-notes.md))
 
 **Latest CLI Version**: 1.19.3 ([Release notes](cli/release-notes.md))
 

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -24,6 +24,22 @@ Astro Runtime is a Docker image built and published by Astronomer that extends t
 
 To upgrade Astro Runtime, see [Upgrade Astro Runtime](upgrade-runtime.md). For general product release notes, see [Astro Release Notes](release-notes.md). If you have any questions or a bug to report, contact [Astronomer support](https://cloud.astronomer.io/support).
 
+## Astro Runtime 9.4.0
+
+- Release date: October 23, 2023
+- Airflow version: 2.7.2
+
+### Additional improvements
+
+- Upgraded `astronomer-providers-logging` to `1.4.1`. This upgrade adds the ability to export Airflow task logs to [AWS Cloudwatch](https://aws.amazon.com/cloudwatch/). 
+- Upgraded `google-cloud-aiplatform` to 1.35.0. 
+- Upgraded [Shapely](https://shapely.readthedocs.io/en/stable/manual.html) to 2.0.2.
+- Added a link for Astronomer Academy to the **Astronomer** menu in the Airflow UI.
+
+### Bug fixes 
+
+- Fixed an issue where the Airflow UI showed an incorrect count for the total number of DAGs.
+
 ## Astro Runtime 9.3.0
 
 - Release date: October 19, 2023

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,6 +1,6 @@
 export const siteVariables = {
   // version-specific
-  runtimeVersion: '9.3.0',
+  runtimeVersion: '9.4.0',
   cliVersion: '1.19.3',
   jenkinsenv: '${env.GIT_BRANCH}',
   jenkinsenv1: '${files[*]}',


### PR DESCRIPTION
Documentation for exporting logs to Cloudwatch is delayed, will arrive in a separate PR