### PR TITLE
Update permissions to say workspace operators can create, update, get and delete deployment API keys and deployment API tokens

### DIFF
--- a/astro/user-permissions.md
+++ b/astro/user-permissions.md
@@ -70,11 +70,11 @@ The following table lists the specific permissions that each Workspace role has:
 | Update Deployment configurations                                            |                      |                      | ✔️                      | ✔️                   |
 | Create and Delete Deployments                                               |                      |                      | ✔️                      | ✔️                   |
 | Create, Update and Delete Deployment environment variables                  |                      |                      | ✔️                      | ✔️                   |
+| Create, update, and delete Deployment and Workspace API keys and tokens      |                      |                      | ✔️                      | ✔️                   |
 | View the **Cluster Activity** tab in the Airflow UI                         |                      |                      |                        | ✔️                   |
 | Update user roles and permissions                                           |                      |                      |                        | ✔️                   |
 | Invite users to a Workspace                                                 |                      |                      |                        | ✔️                   |
 | Assign Teams to or remove from Workspaces                                   |                      |                      |                        | ✔️                   |
-| Create, update, and delete Deployment and Workspace API keys and tokens      |                      |                      |                        | ✔️                   |
 
 To manage a user's Workspace permissions, see [Manage Worksapce users](manage-workspace-users.md#add-a-user-to-a-workspace).
 


### PR DESCRIPTION
Workspace operators can now do CRUD operations on deployment API tokens and deployment API keys for deployments belonging to that workspace so we should update these docs.

[#17154](https://github.com/astronomer/astro/issues/17154)
Affiliated code PR [#astro/17197](https://github.com/astronomer/astro/pull/17197)