### PR TITLE
Simplify KubernetesPodOperator Local Instructions - `docker-desktop` kubeconfig

### DIFF
--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -152,7 +152,7 @@ The latest versions of Docker for Windows and Mac let you run a single node Kube
     client-key-data: <client-key-data>
     ```
 
-2. If facing issues connecting, check the server configuration in the `kubeconfig` file. If `server: https://localhost:6445` is present, change to `server: https://kubernetes.docker.internal:6443` to identify the localhost running Kubernetes Pods. If this doesn't work, try `server: https://host.docker.internal:6445`.
+2. If you have issues connecting, check the server configuration in the `kubeconfig` file. If `server: https://localhost:6445` is present, change to `server: https://kubernetes.docker.internal:6443` to identify the localhost running Kubernetes Pods. If this doesn't work, try `server: https://host.docker.internal:6445`.
 3. (Optional) Add the `.kube` folder to `.gitignore` if your Astro project is hosted in a GitHub repository and you want to prevent the file from being tracked by your version control tool.
 4. (Optional) Add the `.kube` folder to `.dockerignore` to exclude it from the Docker image.
 

--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -152,10 +152,9 @@ The latest versions of Docker for Windows and Mac let you run a single node Kube
     client-key-data: <client-key-data>
     ```
 
-2. Update the `<certificate-authority-data>`, `<client-authority-data>`, and `<client-key-data>` values in the `config` file with the values for your organization.
-3. Under cluster, change `server: https://localhost:6445` to `server: https://kubernetes.docker.internal:6443` to identify the localhost running Kubernetes Pods. If this doesn't work, try `server: https://host.docker.internal:6445`.
-4. (Optional) Add the `.kube` folder to `.gitignore` if your Astro project is hosted in a GitHub repository and you want to prevent the file from being tracked by your version control tool.
-5. (Optional) Add the `.kube` folder to `.dockerignore` to exclude it from the Docker image.
+2. If facing issues connecting, check the server configuration in the `kubeconfig` file. If `server: https://localhost:6445` is present, change to `server: https://kubernetes.docker.internal:6443` to identify the localhost running Kubernetes Pods. If this doesn't work, try `server: https://host.docker.internal:6445`.
+3. (Optional) Add the `.kube` folder to `.gitignore` if your Astro project is hosted in a GitHub repository and you want to prevent the file from being tracked by your version control tool.
+4. (Optional) Add the `.kube` folder to `.dockerignore` to exclude it from the Docker image.
 
 </TabItem>
 <TabItem value="linux">

--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -122,31 +122,12 @@ The latest versions of Docker for Windows and Mac let you run a single node Kube
     ]}>
 <TabItem value="windows and mac">
 
-1. Go to the `$HOME/.kube` directory that was created when you enabled Kubernetes in Docker and copy the `config` file into the `/include/.kube/` folder in your Astro project. The `config` file contains all the information the KubernetesPodOperator uses to connect to your cluster. For example:
+1. Copy the `docker-desktop` context from the Kubernetes configuration file and save it as a separate file in the `/include/.kube/` folder in your Astro project. The `config` file contains all the information the KubernetesPodOperator uses to connect to your cluster.
 
-     ```apiVersion: v1
-    clusters:
-    - cluster:
-        certificate-authority-data: <certificate-authority-data>
-        server: https://kubernetes.docker.internal:6443/
-        name: docker-desktop
-    contexts:
-    - context:
-        cluster: docker-desktop
-        user: docker-desktop
-        name: docker-desktop
-    current-context: docker-desktop
-    kind: Config
-    preferences: {}
-    users:
-    - name: docker-desktop
-        user:
-        client-certificate-data: <client-certificate-data>
-        client-key-data: <client-key-data>
-     ```
-    
-    The cluster `name` should be searchable as `docker-desktop` in your local `$HOME/.kube/config` file. Do not add any additional data to the `config` file.
-
+    ```bash
+    kubectl set-config docker-desktop
+    kubectl config view -- minify --raw > <Astro project directory>/include/.kube
+    ```
 2. Update the `<certificate-authority-data>`, `<client-authority-data>`, and `<client-key-data>` values in the `config` file with the values for your organization.
 3. Under cluster, change `server: https://localhost:6445` to `server: https://kubernetes.docker.internal:6443` to identify the localhost running Kubernetes Pods. If this doesn't work, try `server: https://host.docker.internal:6445`.
 4. (Optional) Add the `.kube` folder to `.gitignore` if your Astro project is hosted in a GitHub repository and you want to prevent the file from being tracked by your version control tool.

--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -128,6 +128,30 @@ The latest versions of Docker for Windows and Mac let you run a single node Kube
     kubectl set-config docker-desktop
     kubectl config view -- minify --raw > <Astro project directory>/include/.kube
     ```
+
+    After running these commands, you will find a `config` file in the `/include/.kube/` folder of your Astro project which resembles this example:
+
+    ```
+    clusters:
+    - cluster:
+    certificate-authority-data: <certificate-authority-data>
+    server: https://kubernetes.docker.internal:6443/
+    name: docker-desktop
+    contexts:
+    - context:
+    cluster: docker-desktop
+    user: docker-desktop
+    name: docker-desktop
+    current-context: docker-desktop
+    kind: Config
+    preferences: {}
+    users:
+    - name: docker-desktop
+    user:
+    client-certificate-data: <client-certificate-data>
+    client-key-data: <client-key-data>
+    ```
+
 2. Update the `<certificate-authority-data>`, `<client-authority-data>`, and `<client-key-data>` values in the `config` file with the values for your organization.
 3. Under cluster, change `server: https://localhost:6445` to `server: https://kubernetes.docker.internal:6443` to identify the localhost running Kubernetes Pods. If this doesn't work, try `server: https://host.docker.internal:6445`.
 4. (Optional) Add the `.kube` folder to `.gitignore` if your Astro project is hosted in a GitHub repository and you want to prevent the file from being tracked by your version control tool.


### PR DESCRIPTION
Instead of manually copying part of the contents of the `kubeconfig` file, we can run `kubectl` commands which will accomplish this automatically without having to manually copy parts of files into another.