### PR TITLE
Add note about model matchup in LLM use case

### DIFF
--- a/learn/use-case-airflow-llm-rag-finance.md
+++ b/learn/use-case-airflow-llm-rag-finance.md
@@ -430,6 +430,7 @@ def import_data_local_embed(
 :::info
 
 Local embedding is much slower than embedding via a cloud based vectorizer. Astronomer recommends using a [cloud based vectorizer](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules) for production use cases.
+Note that if you use local embeddings you will also need to set `EMBEDD_LOCALLY` to `True` at the start of the [streamlit app](https://github.com/astronomer/use-case-airflow-llm-rag-finance/blob/main/include/streamlit/streamlit_app.py) file in match the models used for embedding between the news articles and the user input in the app.
 
 :::
 


### PR DESCRIPTION
Noticed a potential pitfall in the use case when users switch between using a local and cloud based model with one being used in the pipeline but the other in the app, in that case the vector lengths don't match up and the app will not be able to retrieve any articles. 

I changed the use case to be cloud based first and added a note that if a user switches to local embeddings they will also need to toggle that variable in the streamlit app :). 