### PR TITLE
Hotfix - alphabetize help ref

### DIFF
--- a/astro/cli/astro-run.md
+++ b/astro/cli/astro-run.md
@@ -22,8 +22,8 @@ astro run <dag-id>
 | Option                  | Description                                                                                                                                 | Possible Values                            |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
 | `-d`, `--dag-file` | The location of your DAG file. When you specify this flag, only the specified DAG is parsed by the Astro CLI. All other DAGs in the project are ignored.| Any valid DAG file in your `dags` directory. |
-| `--execution-date`            | The execution date for the DAG run.                                      | An execution date formatted as either `YYYY-MM-DD`, `YYYY-MM-DDTHH:MM:SS`. or `YYYY-MM-DD HH:MM:SS`.                        |
 | `-e`,`--env`            | Path to an alternative environment variable file. The default is `.env` in your current Astro project.                                      | Any valid filepath.                         |
+| `--execution-date`            | The execution date for the DAG run.                                      | An execution date formatted as either `YYYY-MM-DD`, `YYYY-MM-DDTHH:MM:SS`. or `YYYY-MM-DD HH:MM:SS`.                        |
 | `--no-cache`            | Build your Astro project into a Docker image without using cache.                                                                           | None.                                       |
 | `-s`, `--settings-file` | An alternative settings file from which Airflow objects are imported. The default is `airflow_settings.yaml` in your current Astro project. | Any valid filepath. |
 


### PR DESCRIPTION
Received feedback that help text for `astro run` was out of sync. Identified that help text is alphabetized while the command ref is not. 