### PR TITLE
Rename Azure Active Directory to Microsoft Entra ID

### DIFF
--- a/archived_software_docs/version-0.16/integrate-auth-system.md
+++ b/archived_software_docs/version-0.16/integrate-auth-system.md
@@ -15,7 +15,7 @@ Astronomer Software by default allows users to create an account with and authen
 
 Authentication methods are entirely customizable. In addition to the 3 defaults above, we provide the option to integrate any provider that follows the [Open Id Connect (OIDC)](https://openid.net/connect/) protocol via [Implicit Flow](https://auth0.com/docs/authorization/mitigate-replay-attacks-when-using-the-implicit-flow). This includes (but is not limited to):
 
-- [Microsoft Azure Active Directory (AD)](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc)
+- [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc)
 - [Okta](https://www.okta.com)
 - [Auth0](https://auth0.com/)
 

--- a/astro/cli/authenticate-to-clouds.md
+++ b/astro/cli/authenticate-to-clouds.md
@@ -268,7 +268,7 @@ Run the following command to obtain your user credentials locally:
 az login
 ```
 
-The CLI provides you with a link to a webpage where you authenticate to your Azure account. Once you complete the login, the CLI stores your user credentials in your local Azure configuration folder. The developer account credentials are used in place of the credentials associated with the Registered Application (Service Principal) in Azure AD.
+The CLI provides you with a link to a webpage where you authenticate to your Azure account. Once you complete the login, the CLI stores your user credentials in your local Azure configuration folder. The developer account credentials are used in place of the credentials associated with the Registered Application (Service Principal) in Microsoft Entra ID.
     
 The default location of the Azure configuration folder depends on your operating system:
 

--- a/astro/configure-idp.md
+++ b/astro/configure-idp.md
@@ -56,7 +56,7 @@ At a high level, to configure an SSO identity provider (IdP) you will:
     groupId= "configure-your-identity-provider"
     values={[
         {label: 'Okta', value: 'Okta'},
-        {label: 'Azure AD', value: 'Azure AD'},
+        {label: 'Microsoft Entra ID', value: ME-ID'},
         {label: 'OneLogin', value: 'OneLogin'},
         {label: 'Ping Identity', value: 'Ping Identity'},
     ]}>
@@ -150,29 +150,29 @@ SCIM provisioning allows you to manage Astro users from your identity provider p
 
 </TabItem>
 
-<TabItem value="Azure AD">
+<TabItem value="ME-ID">
 
-This section provides setup steps for setting up Azure AD as your IdP on Astro. After completing this setup, your organization's users can use Azure AD to log in to Astro.
+This section provides setup steps for setting up Microsoft Entra ID as your IdP on Astro. After completing this setup, your organization's users can use Microsoft Entra ID to log in to Astro.
 
 #### Prerequisites
 
 To integrate Azure as your IdP for Astro you must have:
 
 - An Azure subscription.
-- An [Azure AD tenant](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-create-new-tenant) with `Global Administrator` privileges.
+- An [Microsoft Entra ID tenant](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-create-new-tenant) with `Global Administrator` privileges.
 - [Organization Owner](user-permissions.md) privileges in the Organization you're configuring.
 - At least one [verified domain](manage-domains.md).
 
 #### Step 1: Register Astro as an application on Azure
 
-Follow [Microsoft Documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app) to register a new app. When configuring the application, set the following values:
+Follow [Microsoft Documentation](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app) to register a new app. When configuring the application, set the following values:
 
 - **Name** and **Supported account types**: Set these according to your organization's needs.
 - **Redirect URI**: Select **Web** and specify `https://auth.astronomer.io/login/callback`.
 
 #### Step 2: Create a client secret
 
-Follow [Microsoft documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-credentials) to create a client secret for your new application. Make note of the client ID and secret value for Step 4.
+Follow [Microsoft documentation](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app#add-credentials) to create a client secret for your new application. Make note of the client ID and secret value for Step 4.
 
 :::caution
 
@@ -182,7 +182,7 @@ If you configure an expiring secret, make sure to record the expiration date and
 
 #### Step 3: Configure API permissions
 
-Follow [Microsoft's documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-access-web-apis#add-permissions-to-access-web-apis) to add the following **Delegated** permissions to **Microsoft Graph**:
+Follow [Microsoft's documentation](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-access-web-apis#add-permissions-to-access-web-apis) to add the following **Delegated** permissions to **Microsoft Graph**:
 
 - `OpenId.email`
 - `OpenId.openid`
@@ -191,27 +191,27 @@ Follow [Microsoft's documentation](https://docs.microsoft.com/en-us/azure/active
 
 :::info
 
-If your Azure Active Directory is configured to require admin approval on API permissions, make sure to also click the **Grant admin consent** button at the top of your permissions list.
+If your Microsoft Entra ID is configured to require admin approval on API permissions, make sure to also click the **Grant admin consent** button at the top of your permissions list.
 
 :::
 
-#### Step 4: Create an SSO connection to Azure AD
+#### Step 4: Create an SSO connection to Microsoft Entra ID
 
-1. Assign yourself to Astro from Azure AD. See [Assign users and groups to an Application](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/assign-user-or-group-access-portal?pivots=portal).
+1. Assign yourself to Astro from Microsoft Entra ID. See [Assign users and groups to an Application](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/assign-user-or-group-access-portal?pivots=portal).
 2. In the Cloud UI, click your Workspace name in the upper left corner, click **Organization Settings**, then click **Authentication**.
 3. In the **SSO Configuration** menu, click **Configure SSO**.
 4. Configure the following values for your connection:
 
-    - **Connection type**: Select **Azure AD**.
-    - **SSO Domain(s)**: Enter the verified domain(s) that you want to map to Azure AD.
-    - **Automatic Membership**: Set the default role for users who join your Organization through Azure AD and without an explicit invite from Astro.
-    - **Microsoft Azure AD Domain**: Retrieve this value from your Azure AD directory's overview page in the Microsoft Azure portal.
-    - **Application (client) ID**: Retrieve this from the **Overview** page of your Azure AD application.
+    - **Connection type**: Select **Microsoft Entra ID**.
+    - **SSO Domain(s)**: Enter the verified domain(s) that you want to map to Microsoft Entra ID.
+    - **Automatic Membership**: Set the default role for users who join your Organization through Microsoft Entra ID and without an explicit invite from Astro.
+    - **Microsoft Entra ID Domain**: Retrieve this value from your Microsoft Entra ID directory's overview page in the Microsoft Azure portal.
+    - **Application (client) ID**: Retrieve this from the **Overview** page of your Microsoft Entra ID application.
     - **Client ID and Client secret**: Enter the values you coped from [Step 2: Create a client secret](#step-2-create-a-client-secret)
 
 5. If you already completed [Step 1: Register Astro as an application on Azure](#step-1-register-astro-as-an-application-on-azure), skip the Cloud UI instructions to configure a Redirect URI.
-6. Click **Create**. Your Azure AD integration appears as an entry in **SSO Configuration**.
-7. In **SSO Configuration**, click **Activate**. You are redirected to Azure AD to test your configuration. After you have successfully authenticated, you are redirected to Astro.
+6. Click **Create**. Your Microsoft Entra ID integration appears as an entry in **SSO Configuration**.
+7. In **SSO Configuration**, click **Activate**. You are redirected to Microsoft Entra ID to test your configuration. After you have successfully authenticated, you are redirected to Astro.
 8. Click **Activate SSO**.
 
 #### Step 5: Copy your SSO bypass link
@@ -231,11 +231,11 @@ An SSO bypass link allows you to authenticate to your Organization without using
 If you don't want to maintain an SSO bypass link, click **Delete**. You can always regenerate a link if you need one in the future. 
 
 
-#### Step 6: Assign users to your Azure AD application
+#### Step 6: Assign users to your Microsoft Entra ID application
 
-Follow [Microsoft documentation](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/assign-user-or-group-access-portal) to assign users from your organization to your new application.
+Follow [Microsoft documentation](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/assign-user-or-group-access-portal?pivots=portal) to assign users from your organization to your new application.
 
-When a user assigned to the application accesses Astro, they will be brought automatically to Azure AD after entering their email in the Cloud UI.
+When a user assigned to the application accesses Astro, they will be brought automatically to Microsoft Entra ID after entering their email in the Cloud UI.
 
 </TabItem>
 

--- a/astro/configure-idp.md
+++ b/astro/configure-idp.md
@@ -56,7 +56,7 @@ At a high level, to configure an SSO identity provider (IdP) you will:
     groupId= "configure-your-identity-provider"
     values={[
         {label: 'Okta', value: 'Okta'},
-        {label: 'Microsoft Entra ID', value: ME-ID'},
+        {label: 'Microsoft Entra ID', value: 'ME-ID'},
         {label: 'OneLogin', value: 'OneLogin'},
         {label: 'Ping Identity', value: 'Ping Identity'},
     ]}>

--- a/astro/configure-idp.md
+++ b/astro/configure-idp.md
@@ -32,7 +32,7 @@ To limit users to only a subset of these options, see [Restrict authentication o
 
 Single Sign On (SSO) authorization allows users to log in using their company credentials, managed through an IdP. This provides a streamlined login experience for your Astro users, as they are able to leverage the same credentials across multiple applications. In addition, this provides improved security and control for organizations to manage access from a single source. Astro supports integrations with the following IdPs:
 
-- [Azure Active Directory (AD)](https://azure.microsoft.com/en-us/services/active-directory/)
+- [Microsoft Entra ID)](https://www.microsoft.com/en-us/security/business/microsoft-entra-pricing)
 - [Okta](https://www.okta.com/)
 - [OneLogin](https://www.onelogin.com/)
 - [Ping Identity](https://www.pingidentity.com/en.html)

--- a/astro/configure-idp.md
+++ b/astro/configure-idp.md
@@ -159,7 +159,7 @@ This section provides setup steps for setting up Microsoft Entra ID as your IdP 
 To integrate Azure as your IdP for Astro you must have:
 
 - An Azure subscription.
-- An [Microsoft Entra ID tenant](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-create-new-tenant) with `Global Administrator` privileges.
+- A [Microsoft Entra ID tenant](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-create-new-tenant) with `Global Administrator` privileges.
 - [Organization Owner](user-permissions.md) privileges in the Organization you're configuring.
 - At least one [verified domain](manage-domains.md).
 

--- a/astro/install-azure-hybrid.md
+++ b/astro/install-azure-hybrid.md
@@ -35,7 +35,7 @@ Astronomer support will create infrastructure within your AWS account to host th
 
 - An Microsoft Entra ID user with the following role assignments:
 
-    - `Application Administrator`. See [Understand roles in Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/roles/concept-understand-roles).
+    - `Application Administrator`. See [Understand roles in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/concept-understand-roles).
 
     - `Owner` with permission to create and manage subscription resources of all types. See [Azure built-in roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles).
 

--- a/astro/install-azure-hybrid.md
+++ b/astro/install-azure-hybrid.md
@@ -25,7 +25,7 @@ To complete the installation, you'll:
 
 - Create an Astronomer account.
 - Create a new Azure subscription with the required Azure resources.
-- Add the IAM service principal to Azure AD that'll be used by Astro.
+- Add the IAM service principal to Microsoft Entra ID that'll be used by Astro.
 
 Astronomer support will create infrastructure within your AWS account to host the resources and Apache Airflow components necessary to deploy DAGs and execute tasks. If you need more than one Astro cluster, contact [Astronomer support](https://cloud.astronomer.io/open-support-request).
 
@@ -33,13 +33,13 @@ Astronomer support will create infrastructure within your AWS account to host th
 
 - A new [Azure subscription](https://learn.microsoft.com/en-us/dynamics-nav/how-to--sign-up-for-a-microsoft-azure-subscription). For security reasons, Azure subscriptions with existing infrastructure aren't supported. Also, no [Azure policy](https://learn.microsoft.com/en-us/azure/governance/policy/overview) should be applicable to the subscription's [Azure management group](https://docs.microsoft.com/en-us/azure/governance/management-groups/overview).
 
-- An Azure AD user with the following role assignments:
+- An Microsoft Entra ID user with the following role assignments:
 
     - `Application Administrator`. See [Understand roles in Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/roles/concept-understand-roles).
 
     - `Owner` with permission to create and manage subscription resources of all types. See [Azure built-in roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles).
 
-    This Azure AD user is required for data plane activation. You can remove the user or modify their role assignments after the cluster is created.
+    This Microsoft Entra ID user is required for data plane activation. You can remove the user or modify their role assignments after the cluster is created.
 
 - [Microsoft Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) or [Azure Az PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps).
 
@@ -86,7 +86,7 @@ To create a VNet peering connection, contact [Astronomer Support](https://suppor
 - A CIDR block (RFC 1918 IP Space) no smaller than a `/19` range. This CIDR block can't overlap with any Azure VNet(s) that you will peer with later. The default CIDR range is `172.20.0.0/19`.
 - ResourceID, for example: `/subscriptions/<Subscription Id>/resourceGroups/myResourceGroupA/providers/Microsoft.Network/virtualNetworks/myVnetA`. You can find the resource ID in the Azure portal by following step 7 in [Create peering - Azure portal](https://docs.microsoft.com/en-us/azure/virtual-network/create-peering-different-subscriptions#portal).
 
-Additionally, ensure that your Azure AD user has at least one of the following role assignments: 
+Additionally, ensure that your Microsoft Entra ID user has at least one of the following role assignments: 
 
 -  Network Contributor: This permission is required for any VNet deployed through Resource Manager.
 -  Classic Network Contributor: This permission is required for any VNet deployed through the classic deployment model.
@@ -131,7 +131,7 @@ The data plane is a collection of Astro infrastructure components that run in yo
     ```sh
     az account set -s <subscription-id>
     ```
-3. Run the following command to add the Astronomer Service Principal to Azure AD:
+3. Run the following command to add the Astronomer Service Principal to Microsoft Entra ID:
 
     ```sh
     az ad sp create --id a67e6057-7138-4f78-bbaf-fd9db7b8aab0

--- a/astro/install-azure-hybrid.md
+++ b/astro/install-azure-hybrid.md
@@ -33,7 +33,7 @@ Astronomer support will create infrastructure within your AWS account to host th
 
 - A new [Azure subscription](https://learn.microsoft.com/en-us/dynamics-nav/how-to--sign-up-for-a-microsoft-azure-subscription). For security reasons, Azure subscriptions with existing infrastructure aren't supported. Also, no [Azure policy](https://learn.microsoft.com/en-us/azure/governance/policy/overview) should be applicable to the subscription's [Azure management group](https://docs.microsoft.com/en-us/azure/governance/management-groups/overview).
 
-- An Microsoft Entra ID user with the following role assignments:
+- A Microsoft Entra ID user with the following role assignments:
 
     - `Application Administrator`. See [Understand roles in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/concept-understand-roles).
 

--- a/astro/set-up-scim-provisioning.md
+++ b/astro/set-up-scim-provisioning.md
@@ -58,7 +58,7 @@ Okta's Astro integration supports the following SCIM actions:
     values={[
         {label: 'Okta - Astro integration (Recommended)', value: 'Okta'},
         {label: 'Okta - Manual', value: 'OktaManual'},
-        {label: 'Azure AD', value: 'Azure'},
+        {label: 'Microsoft Entra ID', value: 'ME-ID'},
     ]}>
 <TabItem value= "Okta">
 
@@ -118,18 +118,18 @@ Complete the manual setup if you configured your existing Astro app without usin
 7. Create user groups and push them to Astro. User groups pushed to Astro appear as [Teams](manage-teams.md) in the Cloud UI. See [Okta documentation](https://help.okta.com/en-us/Content/Topics/users-groups-profiles/usgp-enable-group-push.htm) for setup steps.
 
 </TabItem>
-<TabItem value="Azure">
+<TabItem value="ME-ID">
 
 1. Create an Organization API token with Organization Owner permissions. See [Organization API tokens](organization-api-tokens.md). Copy the token to use later in this setup.
 2. In the Cloud UI, click your Workspace name in the upper left corner, click **Organization Settings**, then click **Authentication**.
 3. In the **Advanced Settings** menu, click **Edit Settings**, then click the **SCIM integration** toggle to on.
 4. Copy the **SCIM Integration URL** that appears.
-5. Append the [Azure AD feature flag parameter](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/application-provisioning-config-problem-scim-compatibility#flags-to-alter-the-scim-behavior) `?aadOptscim062020` to your **SCIM Integration URL** and recopy it. For example, if your SCIM Integration URL is `https://api.astronomer.io/scim/v2/cknaqyipv05731evsry6cj4n0`, your final URL would be `https://api.astronomer.io/scim/v2/cknaqyipv05731evsry6cj4n0?aadOptscim062020`. The feature flag is required for fully compliant SCIM behavior in Azure AD.
-6. In the Azure AD management dashboard, [create a new enterprise application](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/add-application-portal#add-an-enterprise-application) with the third option, **Integrate any other application you don't find in the gallery**.
+5. Append the [Microsoft Entra ID feature flag parameter](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/application-provisioning-config-problem-scim-compatibility#flags-to-alter-the-scim-behavior) `?aadOptscim062020` to your **SCIM Integration URL** and recopy it. For example, if your SCIM Integration URL is `https://api.astronomer.io/scim/v2/cknaqyipv05731evsry6cj4n0`, your final URL would be `https://api.astronomer.io/scim/v2/cknaqyipv05731evsry6cj4n0?aadOptscim062020`. The feature flag is required for fully compliant SCIM behavior in Microsoft Entra ID.
+6. In the Microsoft Entra ID management dashboard, [create a new enterprise application](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/add-application-portal#add-an-enterprise-application) with the third option, **Integrate any other application you don't find in the gallery**.
 7. In the menu for your new application, click **Provisioning** and configure the following values:
 
     - **Provisioning mode**: Set to **Automatic**.
-    - **Admin Credentials** > **Tenant URL**: Enter the **SCIM integration URL** including the Azure AD feature flag parameter.
+    - **Admin Credentials** > **Tenant URL**: Enter the **SCIM integration URL** including the Microsoft Entra ID feature flag parameter.
     - **Secret Token**: Enter your Organization API token. 
 
   :::info Only provision users
@@ -171,7 +171,7 @@ Complete the manual setup if you configured your existing Astro app without usin
 
     ![Azure user mappings with only the correct 3 attributes listed](/img/docs/azure-mappings.png)
 
-1.  Click **Test connection** in the Azure AD application management menu to confirm your connection to the SCIM endpoint.
+1.  Click **Test connection** in the Microsoft Entra ID application management menu to confirm your connection to the SCIM endpoint.
 
 </TabItem>
 </Tabs>

--- a/astro/set-up-scim-provisioning.md
+++ b/astro/set-up-scim-provisioning.md
@@ -34,7 +34,7 @@ Some user management features on Astro behave differently after you set up SCIM 
 
 Astro supports SCIM provisioning with the following IdPs:
 
-- [Azure Active Directory (AD)](https://azure.microsoft.com/en-us/services/active-directory/)
+- [Microsoft Entra ID](https://www.microsoft.com/en-us/security/business/microsoft-entra)
 - [Okta](https://www.okta.com/)
 
 ### Supported Okta features
@@ -142,7 +142,7 @@ Complete the manual setup if you configured your existing Astro app without usin
 9. In **Target Object Actions**, tick the checkboxes for **Create**, **Update**, and **Delete**.
 10. In the **Attribute Mappings** table, add the following mappings:
 
-    | Azure Active Directory Attribute | Astro Attribute |
+    | Microsoft Entra ID Attribute | Astro Attribute |
     | -------------------------------- | --------------- |
     | displayName                      | displayName     |
     | members                          | members         |
@@ -155,7 +155,7 @@ Complete the manual setup if you configured your existing Astro app without usin
 12. In **Target Object Actions**, tick the checkboxes for **Create**, **Update**, and **Delete**.
 13. In the **Attribute Mappings** table, add the following mappings:
 
-    | Azure Active Directory Attribute                            | Astro Attribute |
+    | Microsoft Entra ID Attribute                            | Astro Attribute |
     | ----------------------------------------------------------- | --------------- |
     | userPrincipalName                                           | userName        |
     | Switch([IsSoftDeleted], , "False", "True", "True", "False") | active          |

--- a/learn/airflow-azure-container-instances.md
+++ b/learn/airflow-azure-container-instances.md
@@ -36,7 +36,7 @@ To complete this tutorial, you need:
 
 ## Step 1: Create an Azure service principal
 
-An Azure service principal is required for external tools like Airflow to connect to your Azure resources. Identify the Azure resource group you want to create your ACI in (or create a new one), then create service principal with write access over that resource group. For more information, see [Use the portal to create an Azure AD application and service principal that can access resources](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal).
+An Azure service principal is required for external tools like Airflow to connect to your Azure resources. Identify the Azure resource group you want to create your ACI in (or create a new one), then create service principal with write access over that resource group. For more information, see [Use the portal to create an Microsoft Entra ID application and service principal that can access resources](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal).
 
 ## Step 2: Configure your Astro project
 

--- a/learn/airflow-azure-container-instances.md
+++ b/learn/airflow-azure-container-instances.md
@@ -36,7 +36,7 @@ To complete this tutorial, you need:
 
 ## Step 1: Create an Azure service principal
 
-An Azure service principal is required for external tools like Airflow to connect to your Azure resources. Identify the Azure resource group you want to create your ACI in (or create a new one), then create service principal with write access over that resource group. For more information, see [Use the portal to create an Microsoft Entra ID application and service principal that can access resources](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal).
+An Azure service principal is required for external tools like Airflow to connect to your Azure resources. Identify the Azure resource group you want to create your ACI in (or create a new one), then create service principal with write access over that resource group. For more information, see [Use the portal to create a Microsoft Entra ID application and service principal that can access resources](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal).
 
 ## Step 2: Configure your Astro project
 

--- a/learn/airflow-azure-data-explorer.md
+++ b/learn/airflow-azure-data-explorer.md
@@ -38,7 +38,7 @@ To complete this tutorial, you need:
 
 ## Step 1: Configure your ADX cluster to work with Airflow
 
-To allow Airflow to communicate with your ADX database, you need to configure service principal authentication. To do this, create and register an Microsoft Entra ID service principal, then give that principal permission to access your ADX database. See [Create an Azure Active Directory application registration in Azure Data Explorer](https://docs.microsoft.com/en-us/azure/data-explorer/provision-azure-ad-app) for more details.
+To allow Airflow to communicate with your ADX database, you need to configure service principal authentication. To do this, create and register an Microsoft Entra ID service principal, then give that principal permission to access your ADX database. See [Create an Microsoft Entra ID application registration in Azure Data Explorer](https://learn.microsoft.com/en-us/azure/data-explorer/provision-entra-id-app) for more details.
 
 ## Step 2: Populate your ADX database
 

--- a/learn/airflow-azure-data-explorer.md
+++ b/learn/airflow-azure-data-explorer.md
@@ -38,7 +38,7 @@ To complete this tutorial, you need:
 
 ## Step 1: Configure your ADX cluster to work with Airflow
 
-To allow Airflow to communicate with your ADX database, you need to configure service principal authentication. To do this, create and register an Azure AD service principal, then give that principal permission to access your ADX database. See [Create an Azure Active Directory application registration in Azure Data Explorer](https://docs.microsoft.com/en-us/azure/data-explorer/provision-azure-ad-app) for more details.
+To allow Airflow to communicate with your ADX database, you need to configure service principal authentication. To do this, create and register an Microsoft Entra ID service principal, then give that principal permission to access your ADX database. See [Create an Azure Active Directory application registration in Azure Data Explorer](https://docs.microsoft.com/en-us/azure/data-explorer/provision-azure-ad-app) for more details.
 
 ## Step 2: Populate your ADX database
 

--- a/learn/airflow-azure-data-explorer.md
+++ b/learn/airflow-azure-data-explorer.md
@@ -38,7 +38,7 @@ To complete this tutorial, you need:
 
 ## Step 1: Configure your ADX cluster to work with Airflow
 
-To allow Airflow to communicate with your ADX database, you need to configure service principal authentication. To do this, create and register an Microsoft Entra ID service principal, then give that principal permission to access your ADX database. See [Create an Microsoft Entra ID application registration in Azure Data Explorer](https://learn.microsoft.com/en-us/azure/data-explorer/provision-entra-id-app) for more details.
+To allow Airflow to communicate with your ADX database, you need to configure service principal authentication. To do this, create and register a Microsoft Entra ID service principal, then give that principal permission to access your ADX database. See [Create a Microsoft Entra ID application registration in Azure Data Explorer](https://learn.microsoft.com/en-us/azure/data-explorer/provision-entra-id-app) for more details.
 
 ## Step 2: Populate your ADX database
 

--- a/learn/airflow-azure-data-factory-integration.md
+++ b/learn/airflow-azure-data-factory-integration.md
@@ -36,9 +36,9 @@ To complete this tutorial, you need:
 
 ## Step 1: Make your ADF pipelines runnable
 
-Before you can orchestrate your ADF pipelines with Airflow, you have to make the pipelines runnable by an external service. There are multiple ways to do this depending on how you manage authentication within your Azure account. This tutorial shows how to register an App with Azure Active Directory to get a **Client ID** and **Client Secret** (API Key) for your Data Factory.
+Before you can orchestrate your ADF pipelines with Airflow, you have to make the pipelines runnable by an external service. There are multiple ways to do this depending on how you manage authentication within your Azure account. This tutorial shows how to register an App with Microsoft Entra to get a **Client ID** and **Client Secret** (API Key) for your Data Factory.
 
-1. Go to Azure Active Directory and click **App registrations** to see a list of registered apps. If you created a Resource group, you should already have an app registered with the same name. Otherwise you can create a new one.
+1. Go to Microsoft Entra ID and click **App registrations** to see a list of registered apps. If you created a Resource group, you should already have an app registered with the same name. Otherwise you can create a new one.
 
     ![ADF App Registration](/img/integrations/airflow_azure_data_factory_integration_app_registration.png)
 
@@ -59,7 +59,7 @@ Before you can orchestrate your ADF pipelines with Airflow, you have to make the
 
 :::info
 
-Additional detail on requirements for interacting with Azure Data Factory using the REST API can be found [here](https://docs.microsoft.com/en-us/azure/data-factory/quickstart-create-data-factory-rest-api). You can also see [this link](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#register-an-application-with-azure-ad-and-create-a-service-principal) for more information on creating a registered application in Azure Active Directory.
+Find additional detail on requirements for interacting with Azure Data Factory using the REST API in the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/quickstart-create-data-factory-rest-api). You can also reference [the documentation](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#register-an-application-with-azure-ad-and-create-a-service-principal) for more information on creating a registered application in Microsoft Entra ID.
 
 :::
 

--- a/learn/connections/azure-blob-storage.md
+++ b/learn/connections/azure-blob-storage.md
@@ -100,9 +100,9 @@ Complete the following steps to retrieve these values:
 
 1. In your Azure portal, open your storage account.
 2. Follow [Azure documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-get-info?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json&tabs=portal#get-service-endpoints-for-the-storage-account) to copy your **Blob Service URL**. It should be in the format `https://mystorageaccount.blob.core.windows.net/`.
-3. Open your Azure AD application. Then, from the **Overview** tab, copy the **Application (client) ID** and **Directory (tenant) ID**.
-4. [Create a new client secret](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#option-3-create-a-new-application-secret) for your application to be used in the Airflow connection. Copy the **VALUE** of the client secret that appears.
-5. [Assign](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#assign-a-role-to-the-application) the [Storage Blob Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor) role to your app so that Airflow can access blob objects in your storage account.
+3. Open your Microsoft Entra ID application. Then, from the **Overview** tab, copy the **Application (client) ID** and **Directory (tenant) ID**.
+4. [Create a new client secret](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#option-3-create-a-new-application-secret) for your application to be used in the Airflow connection. Copy the **VALUE** of the client secret that appears.
+5. [Assign](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#assign-a-role-to-the-application) the [Storage Blob Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor) role to your app so that Airflow can access blob objects in your storage account.
 
 </TabItem>
 </Tabs>

--- a/learn/connections/azure-data-factory.md
+++ b/learn/connections/azure-data-factory.md
@@ -15,7 +15,7 @@ This guide provides the basic setup for creating an ADF connection. For a comple
 - The [Astro CLI](https://docs.astronomer.io/astro/cli/overview)
 - A locally running [Astro project](https://docs.astronomer.io/astro/cli/get-started-cli)
 - Permissions to [access your data factory](https://learn.microsoft.com/en-us/azure/data-factory/concepts-roles-permissions#roles-and-requirements)
-- An [Azure AD application](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal)
+- A [Microsoft Entra ID application](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal)
 
 ## Get connection details
 
@@ -33,9 +33,9 @@ Complete the following steps to retrieve all of these values:
 1. In your Azure portal, open your [data factory](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.DataFactory%2FdataFactories) service and select the subscription that contains your data factory.
 2. Copy the **Name** of your data factory and the **Resource group**.
 3. Click on the subscription for your data factory, then copy the **Subscription ID** from the subscription window.
-4. Open your Azure AD application. Then, from the **Overview** tab, copy the **Application (client) ID** and **Directory (tenant) ID**.
-5. [Create a new client secret](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#option-3-create-a-new-application-secret) for your application to be used in the Airflow connection. Copy the **VALUE** of the client secret that appears.
-6. [Assign](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal#assign-a-role-to-the-application) the [Data Factory Contributor](https://learn.microsoft.com/en-us/azure/data-factory/concepts-roles-permissions#set-up-permissions) role to your app so that Airflow can access the data factory.
+4. Open your Microsoft Entra ID application. Then, from the **Overview** tab, copy the **Application (client) ID** and **Directory (tenant) ID**.
+5. [Create a new client secret](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#option-3-create-a-new-application-secret) for your application to be used in the Airflow connection. Copy the **VALUE** of the client secret that appears.
+6. [Assign](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#assign-a-role-to-the-application) the [Data Factory Contributor](https://learn.microsoft.com/en-us/azure/data-factory/concepts-roles-permissions#set-up-permissions) role to your app so that Airflow can access the data factory.
 
 ## Create your connection
 

--- a/software/integrate-auth-system.md
+++ b/software/integrate-auth-system.md
@@ -62,7 +62,7 @@ astronomer:
             authUrlParams: # Additional required params set on case-by-case basis
 ```
 
-Replace the values above with those of the provider of your choice. If you want to configure Azure AD, Okta or Auth0 read below for specific guidelines.
+Replace the values above with those of the provider of your choice. If you want to configure Microsoft Entra ID, Okta, or Auth0 read below for specific guidelines.
 
 ### AWS Cognito
 
@@ -103,9 +103,9 @@ Your Cognito pool ID can be found in the `General settings` tab of the Cognito p
 
 Once you've saved your `config.yaml` file with these values, push it to your platform. See [Apply a config change](apply-platform-config.md).
 
-### Azure AD
+### Microsoft Entra ID
 
-Follow these steps to configure Azure AD as your OIDC provider. 
+Follow these steps to configure Microsoft Entra ID as your OIDC provider. 
 
 #### Register the Application using `App Registrations` on Azure
 
@@ -133,9 +133,9 @@ Follow these steps to configure Azure AD as your OIDC provider.
 
 #### Create a client secret (Optional)
 
-Complete this setup only if you want to import Azure AD groups to Astronomer Software as [Teams](import-idp-groups.md).
+Complete this setup only if you want to import Microsoft Entra ID groups to Astronomer Software as [Teams](import-idp-groups.md).
 
-1. In your Azure AD application management left menu, click **Certificates & secrets**.
+1. In your Microsoft Entra ID application management left menu, click **Certificates & secrets**.
 2. Click **New client secret**.
 3. Enter a description in the **Description** field and then select an expiry period in the **Expires** list. 
 4. Click **Add**.
@@ -163,7 +163,7 @@ Complete this setup only if you want to import Azure AD groups to Astronomer Sof
 10. Click **Add**.
 11. Encrypt the secret value you copied as a Kubernetes Secret on your Astronomer installation. See [Store and encrypt identity provider secrets](#store-and-encrypt-identity-provider-secrets).
 
-#### Enable Azure AD in your config.yaml file
+#### Enable Microsoft Entra ID in your config.yaml file
 
 Add the following values to the `config.yaml` file in your `astronomer` directory:
 
@@ -180,7 +180,7 @@ astronomer:
             enabled: true
             clientId: <your-client-id>
             discoveryUrl: https://login.microsoftonline.com/<tenant-id>/v2.0/.well-known/openid-configuration
-            # Configure a secret only if you're importing Azure AD user groups as Teams
+            # Configure a secret only if you're importing Microsoft Entra ID user groups as Teams
             clientSecret: <your-client-secret>
             baseDomain: login.microsoftonline.com
             authUrlParams:
@@ -419,7 +419,7 @@ SCIM works because the IdP pushes updates about users and teams to Astronomer So
     groupId="scim"
     defaultValue="okta"
     values={[
-        {label: 'Azure AD', value: 'azuread'},
+        {label: 'Microsoft Entra ID', value: 'ME-ID'},
         {label: 'Okta', value: 'okta'},
     ]}>
 <TabItem value="okta">
@@ -482,7 +482,7 @@ See [Add SCIM provisioning to app integrations](https://help.okta.com/en-us/Cont
 
 </TabItem>
 
-<TabItem value="azuread">
+<TabItem value="ME-ID">
 
 1. Generate a random string to use as an authentication secret. See [random.org](https://www.random.org/strings/) for accessible randomization tools.
 2. Follow the steps in [Store and encrypt identity provider secrets](#store-and-encrypt-identity-provider-secrets) to store your string as a Kubernetes secret. Your secret configuration should look similar to the following:
@@ -517,13 +517,13 @@ See [Add SCIM provisioning to app integrations](https://help.okta.com/en-us/Cont
 
 3. Push the configuration change. See [Apply a config change](https://docs.astronomer.io/software/apply-platform-config).
 
-4. Log in to the [Azure AD portal](https://aad.portal.azure.com/). 
+4. Log in to the [Microsoft Entra ID portal](https://aad.portal.azure.com/). 
    
 5. In the left menu, select **Enterprise applications**, then click **New application** > **Create your own application**.
    
 6. Enter a name for your application and select **Integrate any other application you don't find in the gallery**.
   
-7. Click **Create** to create an app object. Azure AD opens the application management menu for your new application.
+7. Click **Create** to create an app object. Microsoft Entra ID opens the application management menu for your new application.
   
 8. In the application management menu for your new application, go to **Manage** > **Provisioning** and click **Get Started**.
 
@@ -533,9 +533,9 @@ See [Add SCIM provisioning to app integrations](https://help.okta.com/en-us/Cont
 
 11. Paste the `scimAuthCode` that you generated in Step 1 into the **Secret Token** field.
 
-12. Click **Test connection** in the Azure AD application management menu to confirm your connection to the SCIM endpoint.
+12. Click **Test connection** in the Microsoft Entra ID application management menu to confirm your connection to the SCIM endpoint.
 
-13. Create mappings for your Astronomer users and roles. See [Tutorial - Customize user provisioning attribute-mappings for SaaS applications in Azure Active Directory](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/customize-application-attributes).
+13. Create mappings for your Astronomer users and roles. See [Tutorial - Customize user provisioning attribute-mappings for SaaS applications in Azure Active Directory](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/customize-application-attributes).
 
 14. Click **Manage** > **Provisioning** > **Settings**.
 

--- a/software/integrate-auth-system.md
+++ b/software/integrate-auth-system.md
@@ -16,7 +16,7 @@ Astronomer Software by default allows users to create an account with and authen
 
 Authentication methods are entirely customizable. In addition to the default methods, Astronomer provides the option to integrate any provider that follows the [Open Id Connect (OIDC)](https://openid.net/connect/) protocol. This includes (but is not limited to):
 
-- [Microsoft Azure Active Directory (AD)](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc)
+- [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc)
 - [Okta](https://www.okta.com)
 - [Auth0](https://auth0.com/)
 
@@ -109,7 +109,7 @@ Follow these steps to configure Microsoft Entra ID as your OIDC provider.
 
 #### Register the Application using `App Registrations` on Azure
 
-1. In Azure Active Directory, click **App registrations** > **New registration**. 
+1. In Microsoft Entra ID, click **App registrations** > **New registration**. 
 2. Complete the following sections:
   
     - **Name**: Any
@@ -535,7 +535,7 @@ See [Add SCIM provisioning to app integrations](https://help.okta.com/en-us/Cont
 
 12. Click **Test connection** in the Microsoft Entra ID application management menu to confirm your connection to the SCIM endpoint.
 
-13. Create mappings for your Astronomer users and roles. See [Tutorial - Customize user provisioning attribute-mappings for SaaS applications in Azure Active Directory](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/customize-application-attributes).
+13. Create mappings for your Astronomer users and roles. See [Tutorial - Customize user provisioning attribute-mappings for SaaS applications in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/customize-application-attributes).
 
 14. Click **Manage** > **Provisioning** > **Settings**.
 

--- a/software_versioned_docs/version-0.30/integrate-auth-system.md
+++ b/software_versioned_docs/version-0.30/integrate-auth-system.md
@@ -61,7 +61,7 @@ astronomer:
             authUrlParams: # Additional required params set on case-by-case basis
 ```
 
-Replace the values above with those of the provider of your choice. If you want to configure Azure AD, Okta or Auth0 read below for specific guidelines.
+Replace the values above with those of the provider of your choice. If you want to configure Microsoft Entra ID, Okta or Auth0 read below for specific guidelines.
 
 ## AWS Cognito
 
@@ -104,7 +104,7 @@ Your Cognito pool ID can be found in the `General settings` tab of the Cognito p
 
 Once you've saved your `config.yaml` file with these values, push it to your platform as described in [Apply a config change](apply-platform-config.md).
 
-## Azure AD
+## Microsoft Entra ID
 
 ### Register the Application using `App Registrations` on Azure
 
@@ -125,7 +125,7 @@ Example:
 
 ![authentication.png](/img/software/azure-authentication.png)
 
-### Enable Azure AD in your config.yaml file
+### Enable Microsoft Entra ID in your config.yaml file
 
 Make sure the `config.yaml` file in your `astronomer` directory is updated with the proper values:
 

--- a/software_versioned_docs/version-0.30/integrate-auth-system.md
+++ b/software_versioned_docs/version-0.30/integrate-auth-system.md
@@ -13,7 +13,7 @@ Astronomer Software by default allows users to create an account with and authen
 
 Authentication methods are entirely customizable. In addition to the 3 defaults above, we provide the option to integrate any provider that follows the [Open Id Connect (OIDC)](https://openid.net/connect/) protocol. This includes (but is not limited to):
 
-- [Microsoft Azure Active Directory (AD)](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc)
+- [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc)
 - [Okta](https://www.okta.com)
 - [Auth0](https://auth0.com/)
 

--- a/software_versioned_docs/version-0.32/integrate-auth-system.md
+++ b/software_versioned_docs/version-0.32/integrate-auth-system.md
@@ -16,7 +16,7 @@ Astronomer Software by default allows users to create an account with and authen
 
 Authentication methods are entirely customizable. In addition to the default methods, Astronomer provides the option to integrate any provider that follows the [Open Id Connect (OIDC)](https://openid.net/connect/) protocol. This includes (but is not limited to):
 
-- [Microsoft Azure Active Directory (AD)](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc)
+- [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc)
 - [Okta](https://www.okta.com)
 - [Auth0](https://auth0.com/)
 

--- a/software_versioned_docs/version-0.32/integrate-auth-system.md
+++ b/software_versioned_docs/version-0.32/integrate-auth-system.md
@@ -61,8 +61,9 @@ astronomer:
             clientId: <provider-client-id>
             authUrlParams: # Additional required params set on case-by-case basis
 ```
+### Microsoft Entra ID
 
-Replace the values above with those of the provider of your choice. If you want to configure Azure AD, Okta or Auth0 read below for specific guidelines.
+Replace the values above with those of the provider of your choice. If you want to configure Microsoft Entra ID, Okta or Auth0 read below for specific guidelines.
 
 ### AWS Cognito
 
@@ -103,13 +104,13 @@ Your Cognito pool ID can be found in the `General settings` tab of the Cognito p
 
 Once you've saved your `config.yaml` file with these values, push it to your platform. See [Apply a config change](apply-platform-config.md).
 
-### Azure AD
+### Microsoft Entra ID
 
-Follow these steps to configure Azure AD as your OIDC provider. 
+Follow these steps to configure Microsoft Entra ID as your OIDC provider. 
 
 #### Register the Application using `App Registrations` on Azure
 
-1. In Azure Active Directory, click **App registrations** > **New registration**. 
+1. In Microsoft Entra ID, click **App registrations** > **New registration**. 
 2. Complete the following sections:
   
     - **Name**: Any
@@ -133,9 +134,9 @@ Follow these steps to configure Azure AD as your OIDC provider.
 
 #### Create a client secret (Optional)
 
-Complete this setup only if you want to import Azure AD groups to Astronomer Software as [Teams](import-idp-groups.md).
+Complete this setup only if you want to import Microsoft Entra ID groups to Astronomer Software as [Teams](import-idp-groups.md).
 
-1. In your Azure AD application management left menu, click **Certificates & secrets**.
+1. In your Microsoft Entra ID application management left menu, click **Certificates & secrets**.
 2. Click **New client secret**.
 3. Enter a description in the **Description** field and then select an expiry period in the **Expires** list. 
 4. Click **Add**.
@@ -163,7 +164,7 @@ Complete this setup only if you want to import Azure AD groups to Astronomer Sof
 10. Click **Add**.
 11. Encrypt the secret value you copied as a Kubernetes Secret on your Astronomer installation. See [Store and encrypt identity provider secrets](#store-and-encrypt-identity-provider-secrets).
 
-#### Enable Azure AD in your config.yaml file
+#### Enable Microsoft Entra ID in your config.yaml file
 
 Add the following values to the `config.yaml` file in your `astronomer` directory:
 
@@ -180,7 +181,7 @@ astronomer:
             enabled: true
             clientId: <your-client-id>
             discoveryUrl: https://login.microsoftonline.com/<tenant-id>/v2.0/.well-known/openid-configuration
-            # Configure a secret only if you're importing Azure AD user groups as Teams
+            # Configure a secret only if you're importing Microsoft Entra ID user groups as Teams
             clientSecret: <your-client-secret>
             baseDomain: login.microsoftonline.com
             authUrlParams:
@@ -415,7 +416,7 @@ Astronomer Software supports integration with the open standard System for Cross
     groupId="scim"
     defaultValue="okta"
     values={[
-        {label: 'Azure AD', value: 'azuread'},
+        {label: 'Microsoft Entra ID', value: 'ME-ID'},
         {label: 'Okta', value: 'okta'},
     ]}>
 <TabItem value="okta">
@@ -461,7 +462,7 @@ See [Add SCIM provisioning to app integrations](https://help.okta.com/en-us/Cont
 
 </TabItem>
 
-<TabItem value="azuread">
+<TabItem value="ME-ID">
 
 1. In your `config.yaml` file, add the following configuration. Replace `<your-generated-secret-code>` with a randomly generated string. 
 
@@ -475,17 +476,17 @@ See [Add SCIM provisioning to app integrations](https://help.okta.com/en-us/Cont
                 scimAuthCode: <your-generated-secret-code>
     ```
    
-    **Note**: If you have already configured Open ID Connect with Azure AD, the `scimAuthCode` key should be on the same level as `clientId` and `discoveryUrl`
+    **Note**: If you have already configured Open ID Connect with Microsoft Entra ID, the `scimAuthCode` key should be on the same level as `clientId` and `discoveryUrl`
 
 2. Push the configuration change. See [Apply a config change](https://docs.astronomer.io/software/apply-platform-config).
 
-3. Sign in to the [Azure AD portal](https://aad.portal.azure.com/). 
+3. Sign in to the [Microsoft Entra ID portal](https://aad.portal.azure.com/). 
    
 4. In the left menu, select **Enterprise applications**, and then click **New application** > **Create your own application**.
    
 5. Enter a name for your application and select **Integrate any other application you don't find in the gallery**.
   
-6. Click **Create** to create an app object. Azure AD opens the application management menu for your new application.
+6. Click **Create** to create an app object. Microsoft Entra ID opens the application management menu for your new application.
   
 7. In the application management menu for your new application, go to **Manage** > **Provisioning** and click **Get Started**.
 
@@ -495,9 +496,9 @@ See [Add SCIM provisioning to app integrations](https://help.okta.com/en-us/Cont
 
 10. Paste the `scimAuthCode` generated at step 1 above into the **Secret Token** field.
 
-11. Click **Test connection** in the Azure AD application management menu to confirm your connection to the SCIM endpoint.
+11. Click **Test connection** in the Microsoft Entra ID application management menu to confirm your connection to the SCIM endpoint.
 
-12. Create mappings for your Astronomer users and roles. See [Tutorial - Customize user provisioning attribute-mappings for SaaS applications in Azure Active Directory](https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/customize-application-attributes).
+12. Create mappings for your Astronomer users and roles. See [Tutorial - Customize user provisioning attribute-mappings for SaaS applications in Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/customize-application-attributes).
 
 13. Click **Manage** > **Provisioning** > **Settings**.
 


### PR DESCRIPTION
Resolves #3009 

- Searched docs for `Azure Active Directory` and `Azure AD` and replaced with new name.
- Updated any related links.
- Did not make changes to archived software docs or historical release notes