### PR TITLE
Document DAG trigger payload + example code

### DIFF
--- a/astro/alerts.md
+++ b/astro/alerts.md
@@ -103,7 +103,7 @@ This feature is in [Private Preview](https://docs.astronomer.io/astro/feature-pr
 
 The **DAG Trigger** communication channel works differently from other communication channel types. Instead of sending a pre-formatted alert message, Astro makes a generic request through the Airflow REST API to trigger a DAG on Astro. You can configure the triggered DAG to complete any action, such as sending a message to your own incident management system or writing data about an incident to a table.
 
-1. Create the DAG that you want to trigger on an alert. Here's an example of the payload and DAG implementation:
+1. Create a DAG that you want to run when the alert is triggered. For example, you can use the following DAG to run arbitrary Python code when the alert is triggered:
 
   ```python
   import datetime
@@ -135,8 +135,8 @@ The **DAG Trigger** communication channel works differently from other communica
 
   ```
 
-2. Deploy the DAG to any Deployment in the same Workspace as the alert will be triggered it. The DAG to alert on, and the DAG to be triggered by the alert, can be deployed in different Deployments, but must be deployed within the same Workspace.
-3. Create a [Deployment API token](deployment-api-tokens.md) for the Deployment where you deployed the DAG that will be triggered. Copy the token to use in the next step.
+2. Deploy the DAG to any Deployment in the Workspace where you want to create the alert. The DAG that triggers the alert and the DAG that the alert runs can be in different Deployments, but they must be deployed in the same Workspace.
+3. Create a [Deployment API token](deployment-api-tokens.md) for the Deployment where you deployed the DAG that the alert will run. Copy the token to use in the next step.
 
 </TabItem>
 </Tabs>

--- a/astro/alerts.md
+++ b/astro/alerts.md
@@ -97,7 +97,7 @@ No external configuration is required for the email integration. Astronomer reco
 
 :::caution
 
-This feature is in [Private Preview](https://docs.astronomer.io/astro/feature-previews).
+This feature is in [Private Preview](https://docs.astronomer.io/astro/feature-previews). Please reach out to your customer success manager to enable this feature.
 
 :::
 

--- a/astro/alerts.md
+++ b/astro/alerts.md
@@ -38,7 +38,7 @@ To configure Airflow notifications, see [Airflow email notifications](airflow-em
         {label: 'Slack', value: 'Slack'},
         {label: 'PagerDuty', value: 'PagerDuty'},
         {label: 'Email', value: 'Email'},
-        {label: 'With DAG trigger', value: 'DAG'}
+        {label: 'DAG Trigger', value: 'DAG'}
     ]}>
 <TabItem value="Slack">
 
@@ -95,10 +95,41 @@ No external configuration is required for the email integration. Astronomer reco
 </TabItem>
 <TabItem value="DAG">
 
-**With DAG trigger** works differently from other communication channel types. Instead of sending a pre-formatted alert message, Astro sends a generic request through the Airflow REST API to trigger a DAG on Astro. You can configure the triggered DAG to complete any action, such as sending a message through a custom communication channel or writing data about an incident to a table.
+The **DAG Trigger** communication channel works differently from other communication channel types. Instead of sending a pre-formatted alert message, Astro makes a generic request through the Airflow REST API to trigger a DAG on Astro. You can configure the triggered DAG to complete any action, such as sending a message to your own incident management system or writing data about an incident to a table.
 
-1. In the Workspace where you want to configure the communication channel, create and deploy the DAG that you want to trigger. You can deploy the DAG to any Deployment in the Workspace even if the alert is not applied to that Deployment.
-2. Create a [Deployment API token](deployment-api-tokens.md) for the Deployment where you deployed the DAG. Copy the token to use in the next step.
+1. Create the DAG that you want to trigger on an alert. Here's an example of the payload and DAG implementation:
+
+  ```python
+  import datetime
+
+  from airflow import DAG
+  from airflow.models import DagRun
+  from airflow.operators.python import PythonOperator
+  
+  with DAG(
+      dag_id="register_incident",
+      start_date=datetime.datetime(2023, 1, 1),
+      schedule=None,
+  ):
+  
+      def _register_incident(dag_run: DagRun):
+          # Here you can run arbitrary Python code. Example DAG run conf payload:
+          # {
+          #     "dagName": "fail_dag",
+          #     "alertType": "PIPELINE_FAILURE",
+          #     "alertId": "d75e7517-88cc-4bab-b40f-660dd79df216",
+          #     "message": "[Astro Alerts] Pipeline failure detected on DAG fail_dag. \\nStart time: 2023-11-17 17:32:54 UTC. \\nFailed at: 2023-11-17 17:40:10 UTC. \\nAlert notification time: 2023-11-17 17:40:10 UTC. \\nClick link to investigate in Astro UI: https://cloud.astronomer.io/clkya6zgv000401k8zafabcde/dags/clncyz42l6957401bvfuxn8zyxw/fail_dag/c6fbe201-a3f1-39ad-9c5c-817cbf99d123?utm_source=alert\"\\n"
+          # }
+  
+          # Example:
+          failed_dag = dag_run.conf["dagName"]
+          print(f"Register an incident in my system for DAG {failed_dag}.")
+  
+      PythonOperator(task_id="register_incident", python_callable=_register_incident)
+  ```
+
+2. Deploy the DAG to any Deployment in the same Workspace as the alert will be triggered it. The DAG to alert on, and the DAG to be triggered by the alert, can be deployed in different Deployments, but must be deployed within the same Workspace.
+3. Create a [Deployment API token](deployment-api-tokens.md) for the Deployment where you deployed the DAG that will be triggered. Copy the token to use in the next step.
 
 </TabItem>
 </Tabs>
@@ -124,7 +155,7 @@ In the Cloud UI, you can enable alerts from the **Workspace Settings** page.
             {label: 'Slack', value: 'Slack'},
             {label: 'PagerDuty', value: 'PagerDuty'},
             {label: 'Email', value: 'Email'},
-            {label: 'With DAG trigger', value: 'DAG'}
+            {label: 'DAG Trigger', value: 'DAG'}
         ]}>
     <TabItem value="Slack">
     

--- a/astro/alerts.md
+++ b/astro/alerts.md
@@ -101,9 +101,9 @@ The **DAG Trigger** communication channel works differently from other communica
 
   ```python
   import datetime
+  from typing import Any
 
   from airflow import DAG
-  from airflow.models import DagRun
   from airflow.operators.python import PythonOperator
   
   with DAG(
@@ -112,7 +112,7 @@ The **DAG Trigger** communication channel works differently from other communica
       schedule=None,
   ):
   
-      def _register_incident(dag_run: DagRun):
+      def _register_incident(params: dict[str, Any]):
           # Here you can run arbitrary Python code. Example DAG run conf payload:
           # {
           #     "dagName": "fail_dag",
@@ -122,10 +122,11 @@ The **DAG Trigger** communication channel works differently from other communica
           # }
   
           # Example:
-          failed_dag = dag_run.conf["dagName"]
+          failed_dag = params["dagName"]
           print(f"Register an incident in my system for DAG {failed_dag}.")
   
       PythonOperator(task_id="register_incident", python_callable=_register_incident)
+
   ```
 
 2. Deploy the DAG to any Deployment in the same Workspace as the alert will be triggered it. The DAG to alert on, and the DAG to be triggered by the alert, can be deployed in different Deployments, but must be deployed within the same Workspace.

--- a/astro/alerts.md
+++ b/astro/alerts.md
@@ -95,6 +95,12 @@ No external configuration is required for the email integration. Astronomer reco
 </TabItem>
 <TabItem value="DAG">
 
+:::caution
+
+This feature is in [Private Preview](https://docs.astronomer.io/astro/feature-previews).
+
+:::
+
 The **DAG Trigger** communication channel works differently from other communication channel types. Instead of sending a pre-formatted alert message, Astro makes a generic request through the Airflow REST API to trigger a DAG on Astro. You can configure the triggered DAG to complete any action, such as sending a message to your own incident management system or writing data about an incident to a table.
 
 1. Create the DAG that you want to trigger on an alert. Here's an example of the payload and DAG implementation:


### PR DESCRIPTION
The DAG trigger feature is still in private preview, so this PR adds a warning to the docs.

This PR also changes some details about the new DAG trigger channel to align with how it's displayed in the Astro UI. Additionally, it documents the payload structure and shows an example DAG implementation.