### PR TITLE
Update alerts.md -- make email configuration steps more obvious

### DIFF
--- a/astro/alerts.md
+++ b/astro/alerts.md
@@ -19,8 +19,6 @@ Astro alerts requires OpenLineage. By default, every Astro Deployment has OpenLi
 
 :::
 
-To configure Airflow notifications, see [Airflow email notifications](airflow-email-notifications.md) and [Manage Airflow DAG notifications](https://docs.astronomer.io/learn/error-notifications-in-airflow).
-
 ## Prerequisites
 
 - An [Astro project](cli/develop-project.md).
@@ -30,6 +28,12 @@ To configure Airflow notifications, see [Airflow email notifications](airflow-em
 <!-- Sensitive header used in product - do not change without a redirect-->
 
 ## Step 1: Configure your communication channel
+
+:::info
+
+To configure Airflow notifications, see [Airflow email notifications](airflow-email-notifications.md) and [Manage Airflow DAG notifications](https://docs.astronomer.io/learn/error-notifications-in-airflow).
+
+:::
 
 <Tabs
     defaultValue="Slack"

--- a/astro/alerts.md
+++ b/astro/alerts.md
@@ -15,7 +15,7 @@ Unlike Airflow callbacks and SLAs, Astro alerts require no changes to DAG code. 
 
 :::info
 
-Astro alerts requires OpenLineage. By default, every Astro Deployment has OpenLineage enabled. If you disabled OpenLineage in your Deployment, you need to enable it to use Astro alerts. See [Enable/Disable OpenLineage](set-up-data-lineage.md#enabledisable-openlineage).
+To configure Airflow notifications, see [Airflow email notifications](airflow-email-notifications.md) and [Manage Airflow DAG notifications](https://docs.astronomer.io/learn/error-notifications-in-airflow).
 
 :::
 
@@ -25,15 +25,15 @@ Astro alerts requires OpenLineage. By default, every Astro Deployment has OpenLi
 - An [Astro Deployment](create-deployment.md). Your Deployment must run Astro Runtime 7.1.0 or later to configure Astro alerts, and it must also have [OpenLineage enabled](set-up-data-lineage.md#enabledisable-openlineage).
 - A Slack workspace, PagerDuty service, or email address.
 
+:::info
+
+Astro alerts requires OpenLineage. By default, every Astro Deployment has OpenLineage enabled. If you disabled OpenLineage in your Deployment, you need to enable it to use Astro alerts. See [Enable/Disable OpenLineage](set-up-data-lineage.md#enabledisable-openlineage).
+
+:::
+
 <!-- Sensitive header used in product - do not change without a redirect-->
 
 ## Step 1: Configure your communication channel
-
-:::info
-
-To configure Airflow notifications, see [Airflow email notifications](airflow-email-notifications.md) and [Manage Airflow DAG notifications](https://docs.astronomer.io/learn/error-notifications-in-airflow).
-
-:::
 
 <Tabs
     defaultValue="Slack"


### PR DESCRIPTION
The current links to set up email notifications for Astro are sort of hidden under a different info block. This change makes it a lot more obvious that users need to configure email notifications to leverage Astro Alerts for email.