### PR TITLE
Explain usage of deployment API tokens

### DIFF
--- a/astro/cli/astro-deployment-airflow-variable-copy.md
+++ b/astro/cli/astro-deployment-airflow-variable-copy.md
@@ -19,13 +19,13 @@ This command only copies Airflow variables that were configured through the Airf
 
 :::tip
 
-This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate a Deployment or Workspace API Token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
+This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate an API token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
 
 ```bash
 export ASTRO_API_TOKEN=<your-token>
 ```
 
-See [Deployment API Tokens](deployment-api-tokens.md) and [Workspace API Tokens](workspace-api-tokens.md) for more details about ways to use tokens.
+See [Organization](organization-api-tokens.md), [Workspace](workspace-api-tokens.md), and [Deployment](deployment-api-tokens.md) API token documentation for more details about ways to use API tokens.
 
 :::
 

--- a/astro/cli/astro-deployment-airflow-variable-copy.md
+++ b/astro/cli/astro-deployment-airflow-variable-copy.md
@@ -4,10 +4,10 @@ title: "astro deployment airflow-variable copy"
 id: astro-deployment-airflow-variable-copy
 description: Copy an Airflow variable from a Deployment.
 hide_table_of_contents: true
-sidebar_custom_props: { icon: 'img/term-icon.png' } 
+sidebar_custom_props: { icon: 'img/term-icon.png' }
 ---
 
-Copy Airflow variables from one Astro Deployment to another. Airflow variables are stored in the target Deployment's metadata database and appear in the Airflow UI.  
+Copy Airflow variables from one Astro Deployment to another. Airflow variables are stored in the target Deployment's metadata database and appear in the Airflow UI.
 
 ## Usage
 
@@ -19,12 +19,13 @@ This command only copies Airflow variables that were configured through the Airf
 
 :::tip
 
-This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate a Deployment or Workspace API Token and set the following OS-level environment variable in a way that the Astro CLI can access them:
+This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate a Deployment or Workspace API Token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
 
-- `ASTRONOMER_KEY_ID`
-- `ASTRONOMER_KEY_SECRET`
+```bash
+export ASTRO_API_TOKEN=<your-token>
+```
 
-After setting the variables, this command works for a Deployment without you having to manually authenticate to Astronomer. Astronomer recommends storing `ASTRONOMER_KEY_SECRET` as a secret before using it to programmatically update production-level Deployments.
+See [Deployment API Tokens](deployment-api-tokens.md) and [Workspace API Tokens](workspace-api-tokens.md) for more details about ways to use tokens.
 
 :::
 

--- a/astro/cli/astro-deployment-airflow-variable-create.md
+++ b/astro/cli/astro-deployment-airflow-variable-create.md
@@ -17,13 +17,13 @@ astro deployment airflow-variable create
 
 :::tip
 
-This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate a Deployment or Workspace API Token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
+This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate an API token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
 
 ```bash
 export ASTRO_API_TOKEN=<your-token>
 ```
 
-See [Deployment API Tokens](deployment-api-tokens.md) and [Workspace API Tokens](workspace-api-tokens.md) for more details about ways to use tokens.
+See [Organization](organization-api-tokens.md), [Workspace](workspace-api-tokens.md), and [Deployment](deployment-api-tokens.md) API token documentation for more details about ways to use API tokens.
 
 :::
 

--- a/astro/cli/astro-deployment-airflow-variable-create.md
+++ b/astro/cli/astro-deployment-airflow-variable-create.md
@@ -4,25 +4,26 @@ title: "astro deployment airflow-variable create"
 id: astro-deployment-airflow-variable-create
 description: Create an Airflow variable in a Deployment.
 hide_table_of_contents: true
-sidebar_custom_props: { icon: 'img/term-icon.png' } 
+sidebar_custom_props: { icon: 'img/term-icon.png' }
 ---
 
-Create Airflow variables on a Deployment. Airflow variables are stored in the Deployment's metadata database and appear in the Airflow UI.  
+Create Airflow variables on a Deployment. Airflow variables are stored in the Deployment's metadata database and appear in the Airflow UI.
 
 ## Usage
 
-```sh
+```bash
 astro deployment airflow-variable create
 ```
 
 :::tip
 
-This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), set the following OS-level environment variables in a way that the Astro CLI can access them:
+This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate a Deployment or Workspace API Token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
 
-- `ASTRONOMER_KEY_ID`
-- `ASTRONOMER_KEY_SECRET`
+```bash
+export ASTRO_API_TOKEN=<your-token>
+```
 
-After setting the variables, this command works for a Deployment without you having to manually authenticate to Astronomer. Astronomer recommends storing `ASTRONOMER_KEY_SECRET` as a secret before using it to programmatically update production-level Deployments.
+See [Deployment API Tokens](deployment-api-tokens.md) and [Workspace API Tokens](workspace-api-tokens.md) for more details about ways to use tokens.
 
 :::
 

--- a/astro/cli/astro-deployment-connection-copy.md
+++ b/astro/cli/astro-deployment-connection-copy.md
@@ -19,13 +19,13 @@ This command only copies Airflow connections that were configured through the Ai
 
 :::tip
 
-This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate a Deployment or Workspace API Token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
+This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate an API token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
 
 ```bash
 export ASTRO_API_TOKEN=<your-token>
 ```
 
-See [Deployment API Tokens](deployment-api-tokens.md) and [Workspace API Tokens](workspace-api-tokens.md) for more details about ways to use tokens.
+See [Organization](organization-api-tokens.md), [Workspace](workspace-api-tokens.md), and [Deployment](deployment-api-tokens.md) API token documentation for more details about ways to use API tokens.
 
 :::
 

--- a/astro/cli/astro-deployment-connection-copy.md
+++ b/astro/cli/astro-deployment-connection-copy.md
@@ -4,10 +4,10 @@ title: "astro deployment connection copy"
 id: astro-deployment-connection-copy
 description: Copy an Airflow connection from a Deployment.
 hide_table_of_contents: true
-sidebar_custom_props: { icon: 'img/term-icon.png' } 
+sidebar_custom_props: { icon: 'img/term-icon.png' }
 ---
 
-Copy Airflow connections from one Astro Deployment to another. Airflow connections are stored in the target Deployment's metadata database and appear in the Airflow UI.  
+Copy Airflow connections from one Astro Deployment to another. Airflow connections are stored in the target Deployment's metadata database and appear in the Airflow UI.
 
 ## Usage
 
@@ -15,16 +15,17 @@ Copy Airflow connections from one Astro Deployment to another. Airflow connectio
 astro deployment connection copy
 ```
 
-This command only copies Airflow connections that were configured through the Airflow UI or otherwise stored in the Airflow metadata database. 
+This command only copies Airflow connections that were configured through the Airflow UI or otherwise stored in the Airflow metadata database.
 
 :::tip
 
-This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), set the following OS-level environment connections in a way that the Astro CLI can access them:
+This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate a Deployment or Workspace API Token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
 
-- `ASTRONOMER_KEY_ID`
-- `ASTRONOMER_KEY_SECRET`
+```bash
+export ASTRO_API_TOKEN=<your-token>
+```
 
-After setting the connections, this command works for a Deployment without you having to manually authenticate to Astronomer. Astronomer recommends storing `ASTRONOMER_KEY_SECRET` as a secret before using it to programmatically update production-level Deployments.
+See [Deployment API Tokens](deployment-api-tokens.md) and [Workspace API Tokens](workspace-api-tokens.md) for more details about ways to use tokens.
 
 :::
 

--- a/astro/cli/astro-deployment-connection-update.md
+++ b/astro/cli/astro-deployment-connection-update.md
@@ -17,13 +17,13 @@ astro deployment connection update
 
 :::tip
 
-This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate a Deployment or Workspace API Token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
+This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate an API token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
 
 ```bash
 export ASTRO_API_TOKEN=<your-token>
 ```
 
-See [Deployment API Tokens](deployment-api-tokens.md) and [Workspace API Tokens](workspace-api-tokens.md) for more details about ways to use tokens.
+See [Organization](organization-api-tokens.md), [Workspace](workspace-api-tokens.md), and [Deployment](deployment-api-tokens.md) API token documentation for more details about ways to use API tokens.
 
 :::
 

--- a/astro/cli/astro-deployment-connection-update.md
+++ b/astro/cli/astro-deployment-connection-update.md
@@ -4,10 +4,10 @@ title: "astro deployment connection update"
 id: astro-deployment-connection-update
 description: Update an Airflow connection in a Deployment.
 hide_table_of_contents: true
-sidebar_custom_props: { icon: 'img/term-icon.png' } 
+sidebar_custom_props: { icon: 'img/term-icon.png' }
 ---
 
-Update the value for a Deployment's Airflow variable. 
+Update the value for a Deployment's Airflow variable.
 
 ## Usage
 
@@ -17,12 +17,13 @@ astro deployment connection update
 
 :::tip
 
-This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), set the following OS-level environment variables in a way that the Astro CLI can access them:
+This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate a Deployment or Workspace API Token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
 
-- `ASTRONOMER_KEY_ID`
-- `ASTRONOMER_KEY_SECRET`
+```bash
+export ASTRO_API_TOKEN=<your-token>
+```
 
-After setting the variables, this command works for a Deployment without you having to manually authenticate to Astronomer. Astronomer recommends storing `ASTRONOMER_KEY_SECRET` as a secret before using it to programmatically update production-level Deployments.
+See [Deployment API Tokens](deployment-api-tokens.md) and [Workspace API Tokens](workspace-api-tokens.md) for more details about ways to use tokens.
 
 :::
 

--- a/astro/cli/astro-deployment-pool-copy.md
+++ b/astro/cli/astro-deployment-pool-copy.md
@@ -20,13 +20,13 @@ This command only copies Airflow pools that were configured through the Airflow 
 
 :::tip
 
-This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate a Deployment or Workspace API Token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
+This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate an API token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
 
 ```bash
 export ASTRO_API_TOKEN=<your-token>
 ```
 
-See [Deployment API Tokens](deployment-api-tokens.md) and [Workspace API Tokens](workspace-api-tokens.md) for more details about ways to use tokens.
+See [Organization](organization-api-tokens.md), [Workspace](workspace-api-tokens.md), and [Deployment](deployment-api-tokens.md) API token documentation for more details about ways to use API tokens.
 
 :::
 

--- a/astro/cli/astro-deployment-pool-copy.md
+++ b/astro/cli/astro-deployment-pool-copy.md
@@ -4,11 +4,11 @@ title: "astro deployment pool copy"
 id: astro-deployment-pool-copy
 description: Copy an Airflow pool from a Deployment.
 hide_table_of_contents: true
-sidebar_custom_props: { icon: 'img/term-icon.png' } 
+sidebar_custom_props: { icon: 'img/term-icon.png' }
 ---
 
 
-Copy Airflow pools from one Astro Deployment to another. Airflow pools are stored in the target Deployment's metadata database and appear in the Airflow UI.  
+Copy Airflow pools from one Astro Deployment to another. Airflow pools are stored in the target Deployment's metadata database and appear in the Airflow UI.
 
 ## Usage
 
@@ -16,16 +16,17 @@ Copy Airflow pools from one Astro Deployment to another. Airflow pools are store
 astro deployment pool copy
 ```
 
-This command only copies Airflow pools that were configured through the Airflow UI or otherwise stored in the Airflow metadata database. 
+This command only copies Airflow pools that were configured through the Airflow UI or otherwise stored in the Airflow metadata database.
 
 :::tip
 
-This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), set the following OS-level environment pools in a way that the Astro CLI can access them:
+This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate a Deployment or Workspace API Token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
 
-- `ASTRONOMER_KEY_ID`
-- `ASTRONOMER_KEY_SECRET`
+```bash
+export ASTRO_API_TOKEN=<your-token>
+```
 
-After setting the pools, this command works for a Deployment without you having to manually authenticate to Astronomer. Astronomer recommends storing `ASTRONOMER_KEY_SECRET` as a secret before using it to programmatically update production-level Deployments.
+See [Deployment API Tokens](deployment-api-tokens.md) and [Workspace API Tokens](workspace-api-tokens.md) for more details about ways to use tokens.
 
 :::
 

--- a/astro/cli/astro-deployment-pool-create.md
+++ b/astro/cli/astro-deployment-pool-create.md
@@ -4,10 +4,10 @@ title: "astro deployment pool create"
 id: astro-deployment-pool-create
 description: Create Airflow pools in a Deployment.
 hide_table_of_contents: true
-sidebar_custom_props: { icon: 'img/term-icon.png' } 
+sidebar_custom_props: { icon: 'img/term-icon.png' }
 ---
 
-Create Airflow pools in a Deployment. Airflow pools are stored in the Deployment's metadata database and appear in the Airflow UI.  
+Create Airflow pools in a Deployment. Airflow pools are stored in the Deployment's metadata database and appear in the Airflow UI.
 
 ## Usage
 
@@ -17,12 +17,13 @@ astro deployment pool create
 
 :::tip
 
-This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), set the following OS-level environment pools in a way that the Astro CLI can access them:
+This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate a Deployment or Workspace API Token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
 
-- `ASTRONOMER_KEY_ID`
-- `ASTRONOMER_KEY_SECRET`
+```bash
+export ASTRO_API_TOKEN=<your-token>
+```
 
-After setting the pools, this command works for a Deployment without you having to manually authenticate to Astronomer. Astronomer recommends storing `ASTRONOMER_KEY_SECRET` as a secret before using it to programmatically update production-level Deployments.
+See [Deployment API Tokens](deployment-api-tokens.md) and [Workspace API Tokens](workspace-api-tokens.md) for more details about ways to use tokens.
 
 :::
 

--- a/astro/cli/astro-deployment-pool-create.md
+++ b/astro/cli/astro-deployment-pool-create.md
@@ -17,13 +17,13 @@ astro deployment pool create
 
 :::tip
 
-This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate a Deployment or Workspace API Token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
+This command is recommended for automated workflows. To run this command in an automated process such as a [CI/CD pipeline](set-up-ci-cd.md), you can generate an API token, then specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
 
 ```bash
 export ASTRO_API_TOKEN=<your-token>
 ```
 
-See [Deployment API Tokens](deployment-api-tokens.md) and [Workspace API Tokens](workspace-api-tokens.md) for more details about ways to use tokens.
+See [Organization](organization-api-tokens.md), [Workspace](workspace-api-tokens.md), and [Deployment](deployment-api-tokens.md) API token documentation for more details about ways to use API tokens.
 
 :::
 

--- a/astro/deployment-api-tokens.md
+++ b/astro/deployment-api-tokens.md
@@ -76,7 +76,7 @@ After you configure the `ASTRO_API_TOKEN` environment variable, you can run Astr
 
 :::info
 
-If you have configured both a Deployment API token using `ASTRO_API_TOKEN` and Deployment API keys (deprecated) with `ASTRONOMER_KEY_ID`/`ASTRONOMER_KEY_SECRET`, the Deployment API token takes precedence.
+If you have configured both a Deployment API token using `ASTRO_API_TOKEN` and Deployment API keys (deprecated) with `ASTRONOMER_KEY_ID` or `ASTRONOMER_KEY_SECRET`, the Deployment API token takes precedence.
 
 :::
 

--- a/astro/deployment-api-tokens.md
+++ b/astro/deployment-api-tokens.md
@@ -72,11 +72,11 @@ To use a Deployment API token with Astro CLI, specify the `ASTRO_API_TOKEN` envi
 export ASTRO_API_TOKEN=<your-token>
 ```
 
-After you configure the `ASTRO_API_TOKEN` environment variable, you can run Astro CLI commands related to the deployment for which the Deployment API token was created. For example, `astro deployment inspect` or `astro deployment logs`.
+After you configure the `ASTRO_API_TOKEN` environment variable, you can run Astro CLI commands related to the Deployment for which the Deployment API token was created. For example, `astro deployment inspect` or `astro deployment logs`.
 
 :::info
 
-If you have configured both a Deployment API token via `ASTRO_API_TOKEN` and Deployment API keys (deprecated) via `ASTRONOMER_KEY_ID`/`ASTRONOMER_KEY_SECRET`, the Deployment API token takes precedence. 
+If you have configured both a Deployment API token using `ASTRO_API_TOKEN` and Deployment API keys (deprecated) with `ASTRONOMER_KEY_ID`/`ASTRONOMER_KEY_SECRET`, the Deployment API token takes precedence. 
 
 :::
 

--- a/astro/deployment-api-tokens.md
+++ b/astro/deployment-api-tokens.md
@@ -21,11 +21,11 @@ Unlike Workspace API tokens and Organization API tokens, Deployment API tokens a
 ## Create a Deployment API token
 
 1. In the Cloud UI, open your Workspace, then open the Deployment you want to create an API token for.
-   
+
 2. Click **API Tokens**.
-   
+
 3. Click **+ API Token**.
-   
+
 4. Configure the new Deployment API token:
 
     - **Name**: The name for the API token.
@@ -33,34 +33,34 @@ Unlike Workspace API tokens and Organization API tokens, Deployment API tokens a
     - **Expiration**: The number of days that the API token can be used before it expires.
 
 5. Click **Create API token**. A confirmation screen showing the token appears.
-   
-6. Copy the token and store it in a safe place. You will not be able to retrieve this value from Astro again. 
+
+6. Copy the token and store it in a safe place. You will not be able to retrieve this value from Astro again.
 
 ## Update or delete a Deployment API token
 
 If you delete a Deployment API token, make sure that no existing CI/CD workflows are using it. After it's deleted, an API token cannot be recovered. If you unintentionally delete an API token, create a new one and update any CI/CD workflows that used the deleted API token.
 
 1. In the Cloud UI, open your Workspace, then open the Deployment that the API token belongs to.
-   
+
 2. Click **Edit** next to your API token.
 
 3. Update the name or description of your token, then click **Save Changes**.
-   
+
 4. Optional. To delete a Deployment API token, click **Delete API Token**, enter `Delete`, and then click **Yes, Continue**.
 
 ## Rotate a Deployment API token
 
-Rotating a Deployment API token lets you renew a token without needing to reconfigure its name, description, and permissions. You can also rotate a token if you lose your current token value and need it for additional workflows. 
+Rotating a Deployment API token lets you renew a token without needing to reconfigure its name, description, and permissions. You can also rotate a token if you lose your current token value and need it for additional workflows.
 
-When you rotate a Deployment API token, you receive a new valid token from Astro that can be used in your existing workflows. The previous token value becomes invalid and any workflows using those previous values stop working. 
+When you rotate a Deployment API token, you receive a new valid token from Astro that can be used in your existing workflows. The previous token value becomes invalid and any workflows using those previous values stop working.
 
 1. In the Cloud UI, open your Workspace, then open the Deployment that the API token belongs to.
-   
+
 2. Click **Edit** next to your API token.
 
-3. Click **Rotate token**. The Cloud UI rotates the token and shows the new token value. 
+3. Click **Rotate token**. The Cloud UI rotates the token and shows the new token value.
 
-4. Copy the new token value and store it in a safe place. You will not be able to retrieve this value from Astro again. 
+4. Copy the new token value and store it in a safe place. You will not be able to retrieve this value from Astro again.
 
 5. In any workflows using the token, replace the old token value with the new value you copied.
 
@@ -72,11 +72,11 @@ To use a Deployment API token with Astro CLI, specify the `ASTRO_API_TOKEN` envi
 export ASTRO_API_TOKEN=<your-token>
 ```
 
-After you configure the `ASTRO_API_TOKEN` environment variable, you can run Astro CLI commands related to the Deployment for which the Deployment API token was created. For example, `astro deployment inspect` or `astro deployment logs`.
+After you configure the `ASTRO_API_TOKEN` environment variable, you can run Astro CLI commands related to the Deployment for which the Deployment API token was created. For example, [`astro deployment inspect`](cli/astro-deployment-inspect.md) or [`astro deployment logs`](cli/astro-deployment-logs.md).
 
 :::info
 
-If you have configured both a Deployment API token using `ASTRO_API_TOKEN` and Deployment API keys (deprecated) with `ASTRONOMER_KEY_ID`/`ASTRONOMER_KEY_SECRET`, the Deployment API token takes precedence. 
+If you have configured both a Deployment API token using `ASTRO_API_TOKEN` and Deployment API keys (deprecated) with `ASTRONOMER_KEY_ID`/`ASTRONOMER_KEY_SECRET`, the Deployment API token takes precedence.
 
 :::
 
@@ -84,7 +84,7 @@ When using a Deployment API token for automation, Astronomer recommends storing 
 
 ### Use a Deployment API token for CI/CD
 
-You can use Deployment API tokens and the Astro CLI to automate various Deployment management actions in CI/CD. 
+You can use Deployment API tokens and the Astro CLI to automate various Deployment management actions in CI/CD.
 
 For all use cases, you must make the following environment variable available to your CI/CD environment:
 

--- a/astro/deployment-api-tokens.md
+++ b/astro/deployment-api-tokens.md
@@ -62,4 +62,34 @@ When you rotate a Deployment API token, you receive a new valid token from Astro
 
 4. Copy the new token value and store it in a safe place. You will not be able to retrieve this value from Astro again. 
 
-5. In any workflows using the token, replace the old token value with the new value you copied. 
+5. In any workflows using the token, replace the old token value with the new value you copied.
+
+## Use a Deployment API token with the Astro CLI
+
+To use a Deployment API token with Astro CLI, specify the `ASTRO_API_TOKEN` environment variable in the system running the Astro CLI:
+
+```sh
+export ASTRO_API_TOKEN=<your-token>
+```
+
+After you configure the `ASTRO_API_TOKEN` environment variable, you can run Astro CLI commands related to the deployment for which the Deployment API token was created. For example, `astro deployment inspect` or `astro deployment logs`.
+
+:::info
+
+If you have configured both a Deployment API token via `ASTRO_API_TOKEN` and Deployment API keys (deprecated) via `ASTRONOMER_KEY_ID`/`ASTRONOMER_KEY_SECRET`, the Deployment API token takes precedence. 
+
+:::
+
+When using a Deployment API token for automation, Astronomer recommends storing `ASTRO_API_TOKEN` as a secret.
+
+### Use a Deployment API token for CI/CD
+
+You can use Deployment API tokens and the Astro CLI to automate various Deployment management actions in CI/CD. 
+
+For all use cases, you must make the following environment variable available to your CI/CD environment:
+
+```text
+ASTRO_API_TOKEN=<your-token>
+```
+
+After you set this environment variable, you can run Astro CLI commands from CI/CD pipelines without needing to manually authenticate to Astro. For more information and examples, see [Automate code deploys with CI/CD](set-up-ci-cd.md).


### PR DESCRIPTION
We have a page on deployment API tokens but that only shows how to create one. I've added a paragraph explaining how to use deployment API tokens, similar to the explanation of how workspace & organisation API tokens are used.