### PR TITLE
Connection Management - quick fixes and security update

### DIFF
--- a/astro/create-and-link-connections.md
+++ b/astro/create-and-link-connections.md
@@ -20,11 +20,10 @@ Compared to creating a connection in the Airflow UI, when you create a connectio
 
 ![Example of the Connections tab in the Astro Environment Manager page](/img/docs/connections-env-mgmt.png)
 
-## Requirements
+## Prerequisites
 
 - `WORKSPACE_OPERATOR` or `WORKSPACE_OWNER` [user permissions](user-permissions.md)
 - A Deployment on Astro. See [Create a Deployment](create-deployment.md)
-- Celery executors
 - Astro Runtime 9.3.0 or greater
 
 ## Create a connection

--- a/astro/create-and-link-connections.md
+++ b/astro/create-and-link-connections.md
@@ -18,6 +18,8 @@ Compared to creating a connection in the Airflow UI, when you create a connectio
 - Share connections with local Airflow environments using the Astro CLI. See [Import and export connections and variables](import-export-connections-variables.md#from-the-astro-cloud-ui).
 - Use connections in branch-based deploys and PR previews.
 
+Additionally, while creating connections requires Workspace Owner or Workspace Operator permissions, Workspace Authors can view and import/export Connections to a local development environment. When the Organization Owner enables **Environment Secrets fetching** in the **Organization Settings**, this includes the ability to view, import, and export Connections with secret values. See [Import and export connections and variables](import-export-connections-variables.md#from-the-astro-cloud-ui) for more details about using connections locally or [user permissions](user-permissions.md) to understand different Workspace user access levels.
+
 ![Example of the Connections tab in the Astro Environment Manager page](/img/docs/connections-env-mgmt.png)
 
 ## Prerequisites

--- a/astro/create-and-link-connections.md
+++ b/astro/create-and-link-connections.md
@@ -15,16 +15,16 @@ Compared to creating a connection in the Airflow UI, when you create a connectio
 
 - Share the connection with multiple Deployments within the Workspace.
 - Override fields in the connection for individual Deployments.
-- Share connections with local Airflow environments using the Astro CLI. See [Import and export connections and variables](import-export-connections-variables.md#from-the-astro-cloud-ui).
+- Use configured connections in local Airflow environments. See [Import and export connections and variables](import-export-connections-variables.md#from-the-astro-cloud-ui).
 - Use connections in branch-based deploys and PR previews.
 
-Additionally, while creating connections requires Workspace Owner or Workspace Operator permissions, Workspace Authors can view and import/export Connections to a local development environment. When the Organization Owner enables **Environment Secrets fetching** in the **Organization Settings**, this includes the ability to view, import, and export Connections with secret values. See [Import and export connections and variables](import-export-connections-variables.md#from-the-astro-cloud-ui) for more details about using connections locally or [user permissions](user-permissions.md) to understand different Workspace user access levels.
+Workspace Owners and Operators can create and assign connections, while Workspace Authors can view configured connections and use them in Deployments. If your Organization has **Environment Secrets Fetching** enabled, you can additionally use configured connections, including ones that contain secrets, in local development environments. See [Import and export connections and variables](import-export-connections-variables.md#from-the-astro-cloud-ui).
 
 ![Example of the Connections tab in the Astro Environment Manager page](/img/docs/connections-env-mgmt.png)
 
 ## Prerequisites
 
-- `WORKSPACE_OPERATOR` or `WORKSPACE_OWNER` [user permissions](user-permissions.md)
+- Workspace Operator or Workspace Owner [user permissions](user-permissions.md)
 - A Deployment on Astro. See [Create a Deployment](create-deployment.md)
 - Astro Runtime 9.3.0 or greater
 

--- a/astro/import-export-connections-variables.md
+++ b/astro/import-export-connections-variables.md
@@ -15,12 +15,6 @@ Based on the [management strategy for your connections and variables](manage-con
 
 ## From the Cloud UI
 
-:::caution
-
-This feature is in [Public Preview](feature-previews.md).
-
-:::
-
 You can share Airflow connections created through the [Environment Manager in the Cloud UI](create-and-link-connections.md) with local Airflow projects. These connections are not visible from the Airflow UI when you run your project locally.
 
 When you start a local project using `astro dev start`, you specify either the Workspace or Deployment that you want to import connections from. When you start your project with these settings, the Astro CLI fetches the necessary connections from Astro. Then, after the local Airflow containers start, the Astro CLI populates the metadata database with the connections. This ensures that the connections are encrypted in the metadata database and not easily accessible by an end user.

--- a/astro/manage-connections-variables.md
+++ b/astro/manage-connections-variables.md
@@ -13,7 +13,7 @@ Airflow supports several different methods for managing connections and variable
 
 For in-depth information on managing connections and variables, see [Connection Basics](https://docs.astronomer.io/learn/connections) and [Variable Basics](https://docs.astronomer.io/learn/airflow-variables).
 
-## Requirements
+## Prerequisites
 
 - A locally hosted Astro project created with the Astro CLI. See [Create a project](cli/get-started-cli.md).
 - A Deployment on Astro. See [Create a Deployment](create-deployment.md).

--- a/astro/user-permissions.md
+++ b/astro/user-permissions.md
@@ -68,7 +68,7 @@ The following table lists the specific permissions that each Workspace role has:
 | Push code to Deployments or Astro Cloud IDE projects                                            |                      | ✔️                   | ✔️                     | ✔️                  |
 | Create, update, and delete Astro Cloud IDE projects                                             |                      | ✔️                   | ✔️                     | ✔️                  |
 | Create, update, and delete Astro alerts                                                         |                      | ✔️                   | ✔️                     | ✔️                  |
-| View Airflow connections, variables, plugins, providers, pools, and XComs                       |                      | ✔️                   | ✔️                     | ✔️                  |
+| View Airflow connections, variables, plugins, providers, pools, and XComs that were created in the Airflow UI                       |                      | ✔️                   | ✔️                     | ✔️                  |
 | Create, update, and delete Airflow connections, variables, plugins, providers, pools, and XComs |                      |                      | ✔️                     | ✔️                  |
 | Create, update, delete, and assign connections to Deployments in the Astro Environment Manager  |                      |                      | ✔️                     | ✔️                  |
 | Update Deployment configurations                                                                |                      |                      | ✔️                     | ✔️                  |

--- a/astro/user-permissions.md
+++ b/astro/user-permissions.md
@@ -26,7 +26,7 @@ An Organization role grants a user or API token some level of access to an Astro
 | ---------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------------------------------ | ---------------------- |
 | View Organization details and user membership                                                                          | ✔️                      | ✔️                             | ✔️                     |
 | View lineage metadata in the **Lineage** tab                                                                           | ✔️                      | ✔️                             | ✔️                     |
-| View clusters                                                                           | ✔️                      | ✔️                             | ✔️                     |
+| View clusters                                                                                                          | ✔️                      | ✔️                             | ✔️                     |
 | Update Organization billing information and settings                                                                   |                         | ✔️                             | ✔️                     |
 | View usage for all Workspaces in the **Usage** tab                                                                     |                         | ✔️                             | ✔️                     |
 | Create, update, and delete clusters                                                                                    |                         |                                | ✔️                     |
@@ -70,6 +70,7 @@ The following table lists the specific permissions that each Workspace role has:
 | Create, update, and delete Astro alerts                                                         |                      | ✔️                   | ✔️                     | ✔️                  |
 | View Airflow connections, variables, plugins, providers, pools, and XComs                       |                      | ✔️                   | ✔️                     | ✔️                  |
 | Create, update, and delete Airflow connections, variables, plugins, providers, pools, and XComs |                      |                      | ✔️                     | ✔️                  |
+| Create, update, delete, and assign connections to Deployments in the Astro Environment Manager  |                      |                      | ✔️                     | ✔️                  |
 | Update Deployment configurations                                                                |                      |                      | ✔️                     | ✔️                  |
 | Create and delete Deployments                                                                   |                      |                      | ✔️                     | ✔️                  |
 | Create, update, and delete Deployment environment variables                                     |                      |                      | ✔️                     | ✔️                  |

--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -44,7 +44,7 @@ To get the most out of this guide, you should have an understanding of:
 - Airflow operators. See [Operators 101](what-is-an-operator.md).
 - Kubernetes basics. See the [Kubernetes Documentation](https://kubernetes.io/docs/home/).
 
-## Requirements
+## Prerequisites
 
 To use the KubernetesPodOperator you need to install the Kubernetes provider package. To install it with pip, run:
 

--- a/sidebarsAstro.js
+++ b/sidebarsAstro.js
@@ -51,7 +51,7 @@ module.exports = {
         "kubernetespodoperator",
         {
           type: "category",
-          label: "Airflow connections and variables",
+          label: "Connections and variables",
           items: [
             "manage-connections-variables",
             "create-and-link-connections",
@@ -236,8 +236,8 @@ module.exports = {
           label: "Networking",
           items: [
             "networking-overview",
-            "connect-aws", 
-            "connect-azure", 
+            "connect-aws",
+            "connect-azure",
             "connect-gcp"
         ],
         },


### PR DESCRIPTION
Address part of #3165 

Includes:
- Adding info about workspace author abilities for conn management
- Added Env Manager/Conn management to User Permissions reference
- Address general typos/inconsistency in doc

Does not yet include:

- Adding details about the "under the hood" connection management processes similar to what we have in the [Env Vars doc](https://docs.astronomer.io/astro/environment-variables#how-environment-variables-are-stored-in-the-cloud-ui)
- Environment secrets fetching information added to a new *Organization Settings* section.