### PR TITLE
Update Code samples to preferred `DAG` import path

### DIFF
--- a/astro/airflow-api.md
+++ b/astro/airflow-api.md
@@ -250,7 +250,7 @@ This topic has guidelines on how to trigger a DAG run, but you can modify the ex
 
     ```python
     from datetime import datetime
-    from airflow import DAG
+    from airflow.models.dag import DAG
     from airflow.providers.http.operators.http import SimpleHttpOperator
 
     with DAG(dag_id="triggering_dag", schedule=None, start_date=datetime(2023, 1, 1)):

--- a/astro/alerts.md
+++ b/astro/alerts.md
@@ -113,7 +113,7 @@ The **DAG Trigger** communication channel works differently from other communica
   import datetime
   from typing import Any
 
-  from airflow import DAG
+  from airflow.models.dag import DAG
   from airflow.operators.python import PythonOperator
   
   with DAG(

--- a/astro/cli/authenticate-to-clouds.md
+++ b/astro/cli/authenticate-to-clouds.md
@@ -412,7 +412,7 @@ Now that Airflow has access to your user credentials, you can use them to connec
 5. Add a DAG  which uses the secrets backend to your Astro project `dags` directory. You can use the following example DAG to retrieve `<my_variable_name>` and `<my_connection_id> from the secrets backend and print it to the terminal:
 
     ```python
-    from airflow import DAG
+    from airflow.models.dag import DAG
     from airflow.hooks.base import BaseHook
     from airflow.models import Variable
     from airflow.decorators import task
@@ -468,7 +468,7 @@ Now that Airflow has access to your user credentials, you can use them to connec
 5. Add a DAG  which uses the secrets backend to your Astro project `dags` directory. You can use the following example DAG to retrieve `<my_variable_name>` and `<my_connection_id>` from the secrets backend and print it to the terminal:
 
     ```python
-    from airflow import DAG
+    from airflow.models.dag import DAG
     from airflow.hooks.base import BaseHook
     from airflow.models import Variable
     from airflow.decorators import task
@@ -535,7 +535,7 @@ Now that Airflow has access to your user credentials, you can use them to connec
 6. Add a DAG  which uses the secrets backend to your Astro project `dags` directory. You can use the following example DAG to retrieve a value from `airflow/variables` and print it to the terminal:
 
     ```python
-    from airflow import DAG
+    from airflow.models.dag import DAG
     from airflow.hooks.base import BaseHook
     from airflow.models import Variable
     from airflow.decorators import task

--- a/astro/kubernetes-executor.md
+++ b/astro/kubernetes-executor.md
@@ -46,7 +46,7 @@ The following example shows how you can use a `pod_override` configuration in yo
 import pendulum
 import time
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.decorators import task
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator

--- a/astro/migration-partials/starship-usage.mdx
+++ b/astro/migration-partials/starship-usage.mdx
@@ -42,7 +42,7 @@ Refer to the [Configuration](https://github.com/astronomer/starship/tree/master/
 1. Add the following DAG to your source Airflow environment:
 
     ```python
-    from airflow import DAG
+    from airflow.models.dag import DAG
     from astronomer.starship.operators import AstroMigrationOperator
     from datetime import datetime
 

--- a/learn/airflow-azure-container-instances.md
+++ b/learn/airflow-azure-container-instances.md
@@ -82,7 +82,7 @@ Choose a Docker image that you want to run. The `AzureContainerInstancesOperator
 In your Astro project `dags/` folder, create a new file called `aci-pipeline.py`. Paste the following code into the file:
 
 ```python
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.microsoft.azure.operators.container_instances import AzureContainerInstancesOperator
 from datetime import datetime, timedelta
 

--- a/learn/airflow-azure-data-explorer.md
+++ b/learn/airflow-azure-data-explorer.md
@@ -91,7 +91,7 @@ Your connection should look similar to this:
 In your Astro project `dags/` folder, create a new file called `adx-pipeline.py`. Paste the following code into the file:
 
 ```python
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.microsoft.azure.operators.adx import AzureDataExplorerQueryOperator
 from datetime import datetime, timedelta
 

--- a/learn/airflow-branch-operator.md
+++ b/learn/airflow-branch-operator.md
@@ -156,7 +156,7 @@ branch_python_operator_decorator_example()
 ```python
 """Example DAG demonstrating the usage of the BranchPythonOperator."""
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator
 from airflow.utils.edgemodifier import Label
@@ -280,7 +280,7 @@ short_circuit_operator_decorator_example()
 ```python
 """Example DAG demonstrating the usage of the ShortCircuitOperator."""
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.models.baseoperator import chain
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import ShortCircuitOperator

--- a/learn/airflow-sagemaker.md
+++ b/learn/airflow-sagemaker.md
@@ -160,7 +160,7 @@ predictions on the Iris dataset. To use the DAG, add Airflow variables for `role
 then fill in the information directly below with the target AWS S3 locations, and model and training job names.
 """
 import textwrap
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.decorators import task
 from airflow.providers.amazon.aws.operators.sagemaker import SageMakerModelOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook

--- a/learn/airflow-talend-integration.md
+++ b/learn/airflow-talend-integration.md
@@ -93,7 +93,7 @@ Next create and run the example DAG.
 import json
 from datetime import datetime, timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.http.operators.http import SimpleHttpOperator
 
 default_args = {
@@ -181,7 +181,7 @@ This example DAG executes two Talend jobs, one of which is dependent on the othe
 ```python
 from datetime import datetime, timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow import configuration as conf
 from airflow.operators.email import EmailOperator
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator

--- a/learn/custom-airflow-ui-docs-tutorial.md
+++ b/learn/custom-airflow-ui-docs-tutorial.md
@@ -69,7 +69,7 @@ To run Airflow locally, you first need to create an Astro project.
 <TabItem value="TaskFlowAPI">
 
 ```python
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.decorators import task, dag
 from pendulum import datetime
 import requests
@@ -96,7 +96,7 @@ docs_example_dag()
 <TabItem value="traditional">
 
 ```python
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.python import PythonOperator
 from pendulum import datetime
 import requests

--- a/learn/dynamically-generating-dags.md
+++ b/learn/dynamically-generating-dags.md
@@ -100,7 +100,7 @@ def create_dag(dag_id, schedule, dag_number, default_args):
 <TabItem value="traditional">
 
 ```python
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.operators.python import PythonOperator
 
 

--- a/learn/execute-notebooks.md
+++ b/learn/execute-notebooks.md
@@ -85,7 +85,7 @@ Create your DAG with the `PapermillOperator` to execute your notebook. Use your 
 ```python
 from datetime import datetime, timedelta
 
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.providers.papermill.operators.papermill import PapermillOperator
 
 

--- a/learn/get-started-with-airflow.md
+++ b/learn/get-started-with-airflow.md
@@ -163,7 +163,7 @@ Now that we can run DAGs and navigate the UI, let's write our own DAG and run it
 2. Open `my-dag.py` in your IDE. Add the required imports for Python packages:
 
     ```python
-    from airflow import DAG
+    from airflow.models.dag import DAG
     from airflow.operators.python import PythonOperator
     from airflow.operators.bash import BashOperator
 

--- a/learn/marquez.md
+++ b/learn/marquez.md
@@ -145,7 +145,7 @@ For this tutorial you will create two DAGs to generate and interpret lineage met
     ```python
     from datetime import datetime, timedelta
 
-    from airflow import DAG
+    from airflow.models.dag import DAG
     from airflow.providers.postgres.operators.postgres import PostgresOperator
 
     create_table_query= '''
@@ -198,7 +198,7 @@ For this tutorial you will create two DAGs to generate and interpret lineage met
     ```python
     from datetime import datetime, timedelta
 
-    from airflow import DAG
+    from airflow.models.dag import DAG
     from airflow.providers.postgres.operators.postgres import PostgresOperator
 
     aggregate_reporting_query = '''

--- a/learn/operator-extra-link-tutorial.md
+++ b/learn/operator-extra-link-tutorial.md
@@ -55,7 +55,7 @@ You'll first add a static link to the SimpleHttpOperator which goes to the [Mozi
 2. Copy and paste the following DAG code into your file:
 
     ```python
-    from airflow import DAG
+    from airflow.models.dag import DAG
     from airflow.providers.http.operators.http import SimpleHttpOperator
     from pendulum import datetime
 

--- a/learn/soda-data-quality.md
+++ b/learn/soda-data-quality.md
@@ -128,7 +128,7 @@ Save the YAML instructions in a file named `checks.yml` and place the file in th
 In your Astro project `dags/` folder, create a new file called `soda-pipeline.py`. Paste the following code into the file:
 
 ```python
-from airflow import DAG
+from airflow.models.dag import DAG
 from datetime import datetime
 
 from airflow.operators.bash import BashOperator

--- a/learn/testing-airflow.md
+++ b/learn/testing-airflow.md
@@ -231,7 +231,7 @@ To use `dag.test()`, you only need to add a few lines of code to the end of your
 <TabItem value="traditional">
 
 ```python {14-15}
-from airflow import DAG
+from airflow.models.dag import DAG
 from pendulum import datetime
 from airflow.operators.empty import EmptyOperator
 
@@ -368,7 +368,7 @@ You then write a `test_evencheckoperator.py` file with unit tests similar to the
 ```python
 import unittest
 from datetime import datetime
-from airflow import DAG
+from airflow.models.dag import DAG
 from airflow.models import TaskInstance
 
 DEFAULT_DATE = datetime(2021, 1, 1)


### PR DESCRIPTION
Noticed that there are plans to deprecate importing from `airflow` directly when going through release notes. For 2.8 it looks like only [Dataset](https://github.com/apache/airflow/pull/34586) and [AirflowException](https://github.com/apache/airflow/pull/34512) direct import is deprecated [but this PR](https://github.com/apache/airflow/pull/34600) says there are plans to include `DAG`, so I switched over to the preferred import statement because why not :) 