### PR TITLE
Follow up on use case formats

### DIFF
--- a/astro/manage-connections-variables.md
+++ b/astro/manage-connections-variables.md
@@ -77,7 +77,7 @@ Astro includes connection management system that behaves like you are using an A
 
 :::info
 
-To see how you can use connections set in the Astro Cloud UI Environment Manager in a best practice branch-based Deployment set up, see the [Manage Astro connections in branch-based deploy workflows](astro-use-case/use-case-astro-connections) use case.
+To see how you can use connections set in the Astro Cloud UI Environment Manager in a best practice branch-based Deployment set up, see the [Manage Astro connections in branch-based deploy workflows](use-cases/connections-branch-deploys.md) use case.
 
 :::
 

--- a/astro/manage-connections-variables.md
+++ b/astro/manage-connections-variables.md
@@ -77,7 +77,7 @@ Astro includes connection management system that behaves like you are using an A
 
 :::info
 
-To see how you can use connections set in the Astro Cloud UI Environment Manager in a best practice branch-based Deployment set up, see the [Manage Astro connections in branch-based deploy workflows](use-cases/connections-branch-deploys.md) use case.
+To see how you can use connections set in the Astro Cloud UI Environment Manager in a best practice, branch-based Deployment setup, see the [Manage Astro connections in branch-based deploy workflows](use-cases/connections-branch-deploys.md) use case.
 
 :::
 

--- a/astro/use-cases/connections-branch-deploys.md
+++ b/astro/use-cases/connections-branch-deploys.md
@@ -27,7 +27,7 @@ This use case assumes you have:
 
 - At least two Astro Deployments, one for development and one for production.
 - A Git-based repository where you manage an Astro project.
-- A configured multi-branch CI/CD pipeline. See [CI/CD templates](ci-cd-templates.md)
+- A configured multi-branch CI/CD pipeline. See [CI/CD templates](ci-cd-templates/overview.md)
 
 However, you can extend this use case to encompass multiple development or production environments.
 

--- a/astro/use-cases/connections-branch-deploys.md
+++ b/astro/use-cases/connections-branch-deploys.md
@@ -4,9 +4,9 @@ sidebar_label: 'Connections + branch-based deploys'
 id: connections-branch-deploys
 ---
 
-Airflow DAGs often interact with a multitude of external systems, such as data warehouses and APIs. DAGs access these systems using [Airflow connections](https://docs.astronomer.io/astro/manage-connections-variables). A common logistical consideration when running Airflow at scale is deciding how to manage connections between development and production environments. Different environment types require different levels access to external resources. 
+Airflow DAGs often interact with a multitude of external systems, such as data warehouses and APIs. DAGs access these systems using [Airflow connections](manage-connections-variables.md). A common logistical consideration when running Airflow at scale is deciding how to manage connections between development and production environments. Different environment types require different levels access to external resources. 
 
-Astro's [branch-based development](https://docs.astronomer.io/astro/automation-overview) and [connection management](https://docs.astronomer.io/astro/manage-connections-variables) features allow you to automatically share specific Airflow connections with Astro Deployments based on their development context. 
+Astro's [branch-based development](automation-overview.md) and [connection management](manage-connections-variables.md) features allow you to automatically share specific Airflow connections with Astro Deployments based on their development context. 
 
 When you combine branch-based deploys and connection management, you can:
 
@@ -18,8 +18,8 @@ When you combine branch-based deploys and connection management, you can:
 
 This use case depends on three key Astro features to create a fully integrated CI/CD pipeline:
 
-- Configuring Airflow connections in the [Astro Environment Manager](https://docs.astronomer.io/astro/manage-connections-variables).
-- Branch-based, or multi-branch Deployments using [CI/CD](https://docs.astronomer.io/astro/set-up-ci-cd.md#multiple-environments).
+- Configuring Airflow connections in the [Astro Environment Manager](manage-connections-variables.md).
+- Branch-based, or multi-branch Deployments using [CI/CD](set-up-ci-cd.md#multiple-environments).
 
 ## Prerequisites
 
@@ -27,7 +27,7 @@ This use case assumes you have:
 
 - At least two Astro Deployments, one for development and one for production.
 - A Git-based repository where you manage an Astro project.
-- A configured multi-branch CI/CD pipeline. See [CI/CD templates](ci-cd-templates/overview.md)
+- A configured multi-branch CI/CD pipeline. See [CI/CD templates](ci-cd-templates/template-overview.md)
 
 However, you can extend this use case to encompass multiple development or production environments.
 
@@ -38,7 +38,7 @@ To implement this use case:
 1. As a Workspace Operator or Admin, create connections in the Astro Environment manager to your development-level resources. See [Create a connection](create-and-link-connections.md#create-a-connection).
 2. Set these connections to be available to all Deployments in the Workspace by default. See [Configure connection sharing for a Workspace](create-and-link-connections.md#configure-connection-sharing-for-a-workspace). Your DAG authors can now access external development and testing resources across all Deployments.
 3. Choose a Deployment in your Workspace that you want to run your production workflows. In the Deployment, override the connections you configured to instead connect to your production resources. See [Override connection fields](create-and-link-connections.md#override-connection-fields).
-4. In the Git repository for your Astro project, define a multi-branch CI/CD pipeline for deploying to Astro. For an example of how to do this in GitHub, see [CI/CD templates](/ci-cd-temploates/github-actions.md?tab=multibranch#deploy-action-templates).
+4. In the Git repository for your Astro project, define a multi-branch CI/CD pipeline for deploying to Astro. For an example of how to do this in GitHub, see [CI/CD templates](/ci-cd-templates/github-actions.md?tab=multibranch#deploy-action-templates).
 
 Now, when a DAG author deploys to either a production or development Deployment through CI/CD, they can run their DAGs in Astro without needing to configure connections. Additionally, because your override production connection shares the same connection ID as your default development connection, DAG authors don't have to update their code to point towards different connections when promoting their code to production.
 
@@ -46,13 +46,13 @@ Now, when a DAG author deploys to either a production or development Deployment 
 
 Using branch-based Deployments with the Astro Environment Manager allows your team to focus on the parts of Astro that matter most for their roles. For example, using the Astro Environment Manager means that you only need one administrative user to manage connections across multiple Deployments:  
 
-- A Workspace Owner [creates an Airflow connection](https://docs.astronomer.io/astro/create-and-link-connections#create-a-connection) in the Astro Environment Manager that connects to external development resources. They share this connection to all Deployments by default by turning on the [**Linked to all Deployments** setting](https://docs.astronomer.io/astro/create-and-link-connections#configure-connection-sharing-for-a-workspace).
-- In the production Deployment, the Workspace Owner [overrides the linked connection](https://docs.astronomer.io/astro/create-and-link-connections#override-connection-fields) to instead connect to production resources on the same external system. Because the connection ID and code are the same, this override requires no updates at the DAG level. 
+- A Workspace Owner [creates an Airflow connection](create-and-link-connections.md#create-a-connection) in the Astro Environment Manager that connects to external development resources. They share this connection to all Deployments by default by turning on the [**Linked to all Deployments** setting](https://docs.astronomer.io/astro/create-and-link-connections#configure-connection-sharing-for-a-workspace).
+- In the production Deployment, the Workspace Owner [overrides the linked connection](create-and-link-connections.md#override-connection-fields) to instead connect to production resources on the same external system. Because the connection ID and code are the same, this override requires no updates at the DAG level. 
 
 After a Workspace Owner creates connections, DAG authors can develop DAGs without needing to reconfigure connections between development and production:
 
-- A DAG author creates a new development branch of an Astro project. The CI/CD pipeline for the repository deploys their branch to the development Deployment on Astro. This is known as a [multi-branch CI/CD pipeline](https://docs.astronomer.io/astro/set-up-ci-cd#multiple-environments).
-- While the DAG author is testing in Astro, they have access to the development resources because the Workspace Author configured a default Airflow connection for the Deployment. The author can [pull this connection onto their local machine](https://docs.astronomer.io/astro/import-export-connections-variables.md#from-the-cloud-ui) for testing purposes, or test by deploying to the development Deployment on Astro.
+- A DAG author creates a new development branch of an Astro project. The CI/CD pipeline for the repository deploys their branch to the development Deployment on Astro. This is known as a [multi-branch CI/CD pipeline](set-up-ci-cd.md#multiple-environments).
+- While the DAG author is testing in Astro, they have access to the development resources because the Workspace Author configured a default Airflow connection for the Deployment. The author can [pull this connection onto their local machine](import-export-connections-variables.md#from-the-cloud-ui) for testing purposes, or test by deploying to the development Deployment on Astro.
 - When the DAG author finishes development, they merge their development branch into production. The CI/CD pipeline deploys this change to the production Deployment.
 - When the DAG author's code runs in the production Deployment, it now accesses production resources based on the overrides configured by the Workspace Owner. 
 
@@ -64,5 +64,5 @@ This use case provides several benefits for both Workspace managers and DAG auth
 
 ## See also
 
-- [Manage Airflow connections and variables](https://docs.astronomer.io/astro/manage-connections-variables)
-- [Automate actions on Astro](https://docs.astronomer.io/astro/automation-overview)
+- [Manage Airflow connections and variables](manage-connections-variables.md)
+- [Automate actions on Astro](automation-overview.md)

--- a/astro/use-cases/connections-branch-deploys.md
+++ b/astro/use-cases/connections-branch-deploys.md
@@ -13,9 +13,7 @@ When you combine branch-based deploys and connection management, you can:
 - Override preset Airflow connections on a per-Deployment basis to troubleshoot or customize your development environment.
 - Promote a Deployment to production as an admin by updating its Airflow connections to access production resources.
 
-This use case provides an example of how to set up a branch-based deployment workflow using [GitHub Actions](https://docs.github.com/en/actions) and the Astro Environment Manager. It includes a sample project that ingests cookie recipes from S3 into Snowflake.
-
-## Feature Overview
+## Feature overview
 
 This use case depends on three key Astro features to create a fully integrated CI/CD pipeline:
 
@@ -25,245 +23,33 @@ This use case depends on three key Astro features to create a fully integrated C
 
 ## Prerequisites
 
-Before trying this example, make sure you have:
+This use case assumes you have:
 
-- The [Astro CLI](https://docs.astronomer.io/astro/cli/overview).
-- An [Astro account](https://www.astronomer.io/try-astro/) with two [Astro Deployments](https://docs.astronomer.io/astro/create-deployment). 
-- A [GitHub account](https://github.com/).
-- An account in a SQL-based data warehouse. This example uses a Snowflake account, which has a [30-day free trial](https://trial.snowflake.com/?owner=SPN-PID-365384) available. 
-- An account in an object storage solution. This example uses an [AWS account](https://aws.amazon.com/). A [free tier](https://aws.amazon.com/free/) is available and sufficient for this project.
+- Two Astro Deployments, one for development and one for production.
+- A Git-based repository where you store your Astro project code.
+- A configured multi-branch CI/CD pipeline. See [CI/CD templates](ci-cd-templates.md)
 
-If you want to use other data warehouse or object storage solutions than Snowflake and AWS, you need to adapt the example code accordingly and add the relevant [Airflow provider](https://registry.astronomer.io/providers) packages to the `requirements.txt` file of the Astro project.
+However, you can extend this use case to encompass multiple development or production environments.
 
-:::info
+## Use case
 
-This example uses the following names for the Deployments and databases. You can use different names, but make sure to update the example code accordingly.
+The following workflow is an example of how you can manage Airflow connections between Deployment types using the Astro Environment Manager.
 
-- `conn-management-demo-dev`: The development Astro Deployment.
-- `conn-management-demo-prod`: The production Astro Deployment.
-- `CONN_DEMO_DEV`: The development Snowflake database.
-- `CONN_DEMO_PROD`: The production Snowflake database.
-- `COOKIES`: An empty schema present in the both Snowflake databases.
+- A Workspace Owner [creates an Airflow connection](https://docs.astronomer.io/astro/create-and-link-connections#create-a-connection) in the Astro Environment Manager that connects to external development resources. They share this connection to all Deployments by default by turning on the [**Linked to all Deployments** setting](https://docs.astronomer.io/astro/create-and-link-connections#configure-connection-sharing-for-a-workspace).
+- In the production Deployment, the Workspace Owner [overrides the linked connection](https://docs.astronomer.io/astro/create-and-link-connections#override-connection-fields) to instead connect to production resources on the same external system. Because the connection ID and code are the same, this override requires no updates at the DAG level. 
 
-:::
+After the connection is created, DAG authors can develop DAGs without needing to reconfigure connections between development and production.
 
-## Set up Airflow connections on Astro
+- A DAG author creates a new development branch of an Astro project. The CI/CD pipeline for the repository deploys their branch to the development Deployment on Astro. This is known as a [multi-branch CI/CD pipeline](https://docs.astronomer.io/astro/set-up-ci-cd#multiple-environments).
+- While the DAG author is testing in Astro, they have access to the development resources because the Workspace Author configured a default Airflow connection for the Deployment. The author can [pull this connection onto their local machine](https://docs.astronomer.io/astro/import-export-connections-variables.md#from-the-cloud-ui) for testing purposes, or test by deploying to the development Deployment on Astro.
+- When the DAG author finishes development, they merge their development branch into production. The CI/CD pipeline deploys this change to the production Deployment.
+- When the DAG author's code runs in the production Deployment, it now accesses production resources based on the overrides configured by the Workspace Owner. 
 
-The first part of this example shows how to set up Airflow connections in the Astro Environment Manager and make them available to multiple Deployments.
+This use case provides several benefits for both Workspace managers and DAG authors:
 
-### Step 1: Create your data warehouse connection in the Astro Environment Manager
-
-First, create two Airflow connections in the Astro Environment Manager for both Deployments to inherit.
-
-1. Log into your Astro account and navigate to the Astro Environment Manager. Click the **+ Connection** button to create a new connection.
-
-    ![Screenshot of the Astro UI showing the Astro Environment Manager and the + Connection button.](/img/docs/use-case-astro-connections_conn_one.png)
-
-2. Create a new connection to your data warehouse. This example uses Snowflake, but you can use any SQL-based data warehouse. If no connection type is available for your data warehouse, you can select the type **Generic**.
-
-3. Give the new connection the name `snowflake_conn_management_demo` and fill the connection form with your connection credentials. Make sure to provide the _development_ database to the `DATABASE` field in the connection form, you override this field later for the production Deployment. To make sure this connection is available to all existing and future Deployments in this Workspace, toggle the switch at the start of the form to **Linked to all**. 
-
-    ![Screenshot of the Connections Config menu in the Astro Environment Manager](/img/docs/use-case-astro-connections_conn_two.png)
-
-4. Click **Create Connection** to save your connection.
-
-5. View the connection in the Astro Environment Manager. You can see the connection listed with the name `snowflake_conn_management_demo`, which is applied to `All Deployments` in your Workspace.
-
-    ![Screenshot of the Astro Environment Manager with the `snowflake_conn_management_demo`](/img/docs/use-case-astro-connections_conn_all_deployments.png)
-
-:::info
-
-To use a connection defined in the Astro Environment manager in a Deployment, you need to install the relevant [Airflow provider](https://registry.astronomer.io/providers) package in that Deployment. 
-
-:::
-
-### Step 2: Override a connection field for a specific Deployment
-
-Currently, the `snowflake_conn_management_demo` connection points to the development database for all Deployments in your Workspace. In this step, you override the `DATABASE` field for the production Deployment to point to the production database. This feature allows you to define a single connection with one connection ID that is available to multiple Deployments, but can optionally configure different connection fields for each Deployment. Enabling you to use the same connection ID in your DAGs without having to change the code when deploying to different environments.
-
-1. In the Astro Environment Manager, click on the `snowflake_conn_management_demo` connection to open the connection details. You see a list of all Deployments this connection is available to. Since you linked this connection to all Deployments in the Workspace, you can see all Deployments of this Workspace listed. Click on the **Edit** button for the `conn-management-demo-prod` Deployment to override fields for this Deployment.
-
-    ![Screenshot of the connection details view with the **Edit** button for the conn-management-demo-prod Deployment highlighted.](/img/docs/use-case-astro-connections_conn_override_one.png)
-
-2. Change the `DATABASE` field to your production database. The new value overrides the default you defined for the connection in [Step 1](#step-1-create-your-data-warehouse-connection-in-the-astro-environment-manager).
-
-    ![Screenshot of the connection details view with the DATABASE field highlighted.](/img/docs/use-case-astro-connections_conn_override_two.png)
-
-3. Click **Update Connection Link** to save your changes. The connection details view now shows the number of overrides for this connection when applied to the `conn-management-demo-prod` Deployment.
-
-    ![Screenshot of the connection details view with the overrides highlighted.](/img/docs/use-case-astro-connections_conn_override_three.png)
-
-### Step 3: Create your AWS connection in the Astro Environment Manager
-
-Next, create an Airflow connection to AWS in the Astro Environment Manager.
-
-1. Click the **+ Connection** button to create a new connection.
-
-2. Create a new connection to AWS. This time, select the `AWS` connection type.
-
-3. Give the new connection the name `aws_conn_management_demo` and fill the connection form with your connection credentials. We want this connection to only be available to Deployments we explicitly link it to, so make sure to leave the switch at the start of the form at **Restricted**.
-
-    ![Screenshot of the Connections Config menu in the Astro Environment Manager](/img/docs/use-case-astro-connections_conn_aws.png)
-
-4. Click **Create Connection** to save your connection.
-
-5. View the connection in the Astro Environment Manager, where you can see the connection listed with the name `aws_conn_management_demo`, which is currently available to `0 Deployments` in your Workspace.
-
-    ![Screenshot of the Astro Environment Manager with the `aws_conn_management_demo`](/img/docs/use-case-astro-connections_conn_zero_deployments.png)
-
-### Step 4: Link the AWS connection to your Deployments
-
-Now that you created the AWS connection, you can link it to the `conn-management-demo-dev` and `conn-management-demo-prod` Deployments. Remember that you set the connection to **Restricted** in [Step 3](#step-3-create-your-aws-connection-in-the-astro-environment-manager), so it is not available to any Deployments by default.
-
-1. In the Astro Environment Manager, click on the `aws_conn_management_demo` connection to open the connection details. You see a list of all Deployments this connection is available to. Since you originally set the connection to **Restricted**, you don't see any Deployments listed. Click on the **+ Link Deployment** button to link the connection to a Deployment.
-
-    ![Screenshot of the connection details view with the **Link Deployment** button highlighted.](/img/docs/use-case-astro-connections_conn_link_deployment_one.png)
-
-2. Select your `conn-management-demo-dev` Deployment and link the connection. In this step, you can also override fields, but for this example, leave the connection fields as you originally configured them. Click **Link connection** to save your changes.
-
-    ![Screenshot of the connection link to Deployment form.](/img/docs/use-case-astro-connections_conn_link_deployment_two.png)
-
-3. Repeat the previous step for the `conn-management-demo-prod` Deployment. Now, you can see both both Deployments listed in the connection **Details** view.
-
-    ![Screenshot of the connection details view with the two linked Deployments highlighted.](/img/docs/use-case-astro-connections_conn_link_deployment_three.png)
-
-## Set up branch-based deploys with GitHub Actions
-
-After setting up the connections, create an automated, two branch CI/CD workflow for a small sample project that uses both connections defined in [Part 1](#set-up-airflow-connections-on-astro).
-
-### Step 1: Create your GitHub repository
-
-1. Go to the [Astronomer GitHub](https://github.com/astronomer/ce-conn-management-demo) and [fork the repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo) to your own GitHub account. This repository contains a small sample project ingesting data from S3 into Snowflake, using the connections defined in [Part 1](#set-up-airflow-connections-on-astro).
-
-2. [Clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) the forked repository to your local machine.
-
-3. On your local machine, navigate to the cloned repository directory and create a new branch called `dev`:
-
-    ```sh
-    git checkout -B dev
-    ```
-
-4. Push the new branch to your GitHub repository:
-
-    ```sh
-    git push origin dev
-    ```
-
-You now have a GitHub repository with two branches: `main` and `dev` that contain the same code.
-
-### Step 2: Configure GitHub Actions workflow
-
-The repository already has [a GitHub Actions script](https://github.com/astronomer/ce-conn-management-demo/blob/main/.github/workflows/deploy_to_astro.yaml) defined to run the CI/CD workflow that deploys changes to Astro. Any push to the `dev` branch triggers the workflow to deploy the code to the `conn-management-demo-dev` Deployment. Any merged PR to the `main` branch triggers the workflow to deploy the code to the `conn-management-demo-prod` Deployment.
-
-To configure the workflow for your own Astro account, you need to set two [GitHub Action secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) and two [GitHub Action variables](https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository) in your repository.
-
-1. Configure the following GitHub Action secrets in your repository:
-
-    - `DEV_ASTRO_API_TOKEN`: The API token of your development Deployment (`conn-management-demo-dev`). You can create Deployment API tokens in the Astro UI, see [Create and manage Deployment API tokens](https://docs.astronomer.io/astro/deployment-api-tokens).
-    - `PROD_ASTRO_API_TOKEN`: The API token of your production Deployment (`conn-management-demo-prod`).
-
-    ![Screenshot of the GitHub Actions secrets menu.](/img/docs/use-case-astro-connections_gh_secrets.png)
-
-2. Configure the following GitHub Action variables in your repository:
-
-    - `DEV_ASTRO_DEPLOYMENT_ID`: The ID of your development Deployment (`conn-management-demo-dev`). You can find the Deployment ID in the Astro UI and with the form of `cabcdef123456789abcdefghi1ab`.
-    - `PROD_ASTRO_DEPLOYMENT_ID`: Your production Deployment ID (`conn-management-demo-prod`).
-
-    ![Screenshot of the GitHub Action variables menu.](/img/docs/use-case-astro-connections_gh_variables.png)
-
-### Step 3: Trigger the branch-based deploy workflow
-
-Now that you configured your workflow, you can trigger it by pushing changes to the `dev` branch.
-
-1. Make a small change to the [`collect_cookie_recipes` DAG](https://github.com/astronomer/ce-conn-management-demo/blob/main/dags/collect_cookie_recipes.py), for example by adding a comment.
-
-2. Commit and push the changes to the `dev` branch:
-
-    ```sh
-    git add dags/collect_cookie_recipes.py
-    git commit -m "Add comment to DAG"
-    git push origin dev
-    ```
-
-3. Navigate to the **Actions** tab in your GitHub repository. You can now see a new workflow run triggered by the push to the `dev` branch.
-
-    ![Screenshot of the GitHub Actions workflow run.](/img/docs/use-case-astro-connections_gh_workflow_dev.png)
-
-
-4. Create a [pull request](https://docs.github.com/en/pull-requests) from your `dev` to your `main` branch and merge it. This triggers the workflow to deploy the code to the `conn-management-demo-prod` Deployment.
-
-## Run the DAGs
-
-Finally, you can run the DAGs without needing to change any code or set up any connections in the Airflow UI.
-
-### Step 1: Run the DAGs on Astro
-
-In [Step 7](#step-7-trigger-the-branch-based-deploy-workflow), you triggered a GitHub Actions workflow that deploys the Astro project to the `conn-management-demo-dev` and `conn-management-demo-prod` Deployments. Now you can run the DAGs on Astro.
-
-1. Navigate to the Astro UI and open the `conn-management-demo-dev` Deployment. Run the `upload_cookie_recipes` helper DAG to upload the sample data from [`include/recipes.json`](https://github.com/astronomer/ce-conn-management-demo/blob/main/include/recipes.json) to S3. The DAG uses the `aws_conn_management_demo` connection defined in [Step 1](#step-1-create-your-data-warehouse-connection-in-the-astro-environment-manager) to access S3.
-
-    ![Screenshot of the Astro UI showing the DAG run for the upload_cookie_recipes DAG.](/img/docs/use-case-astro-connections_upload_dag.png)
-
-2. Run the `collect_cookie_recipes` DAG to ingest the data from S3 into Snowflake. The `conn-management-demo-dev` Deployment uses the `snowflake_conn_management_demo` connection defined in [Step 1](#step-1-create-your-data-warehouse-connection-in-the-astro-environment-manager) to access Snowflake. Without any overrides this connection points to the `CONN_DEMO_DEV` database in Snowflake.
-
-    ![Screenshot of the Astro UI showing the DAG run for the collect_cookie_recipes DAG.](/img/docs/use-case-astro-connections_collect_dag.png)
-
-3. View the data in Snowflake. The `collect_cookie_recipes` DAG ingested the cookie recipes into the `COOKIES` schema in the `CONN_DEMO_DEV` database.
-
-    ![Screenshot of the Snowflake UI showing the COOKIES_RECIPE table in the CONN_DEMO_DEV database.](/img/docs/use-case-astro-connections_snowflake.png)
-
-4. Repeat the steps 1 through 3 for the `conn-management-demo-prod` Deployment. Due to the override defined in [Step 2](#step-2-override-a-connection-field-for-a-specific-deployment), the `snowflake_conn_management_demo` connection points to the `CONN_DEMO_PROD` database in Snowflake, where you can view the `COOKIES_RECIPES` table with the ingested data.
-
-### Step 2: (Optional) Run the DAGs locally
-
-You can also use the connections defined in the Astro Environment Manager when running the DAGs locally with the Astro CLI. This feature allows you to enable data professionals in your organization to use default connections without having to share connection configuration details or secrets. See also [Import and export Airflow connections and variables](https://docs.astronomer.io/astro/import-export-connections-variables).
-
-1. In the Astro UI, navigate to the `ORGANIZATION SETTINGS` of your organization and click **Edit Details**. Click the toggle to enable `ENVIRONMENT SECRETS FETCHING` and **Update Organization** so save your changes.
-
-    ![Screenshot of the Astro UI showing the organization settings Edit Details button.](/img/docs/use-case-astro-connections_organization_edit_2.png)
-
-2. Make sure you are logged into your Astro account with the Astro CLI by running the following command and authenticating with your Astro credentials:
-
-    ```sh
-    astro login
-    ```
-
-3. Enable local development access to connections created in the Astro Environment Manager by running the following command:
-
-    ```sh
-    astro config set -g disable_env_objects false
-    ```
-
-4. Find your Workspace ID by running:
-
-    ```sh 
-    astro workspace list
-    ```
-
-5. Start a local Airflow instance with the set of the connections defined for your Workspace by running the following command:
-
-    ```sh
-    astro dev start --workspace-id [workspace-id]
-    ```
-
-    You can view which connections were fetched from the Cloud in the console logs.
-
-    ```text
-    Airflow is starting up!
-    Added Connection: snowflake_conn_management_demo
-    Added Connection: aws_conn_management_demo
-
-    Project is running! All components are now available.
-
-    Airflow Webserver: http://localhost:8080
-    Postgres Database: localhost:5432/postgres
-    The default Airflow UI credentials are: admin:admin
-    The default Postgres DB credentials are: postgres:postgres
-    ```
-
-5. Run the `collect_cookie_recipes` DAG locally to confirm the connections were imported correctly.
-
-Congratulations! You have successfully set up Airflow connections on Astro and created a branch-based CI/CD workflow with GitHub Actions. You can now use this workflow as a template for your own projects.
+- Workspace Operators and Owners can manage connections without needing access to DAG code.
+- DAG authors only need a connection ID to connect their DAGs, meaning they can focus on data engineering instead of connection configuration.
+- Connection IDs don't need to be updated when you promote code to Deployment, reducing development timelines and reducing the number of resources to manage. 
 
 ## See also
 

--- a/astro/use-cases/connections-branch-deploys.md
+++ b/astro/use-cases/connections-branch-deploys.md
@@ -9,6 +9,7 @@ Airflow DAGs often interact with a multitude of external systems, such as data w
 Astro's [branch-based development](https://docs.astronomer.io/astro/automation-overview) and [connection management](https://docs.astronomer.io/astro/manage-connections-variables) features allow you to automatically share specific Airflow connections with Astro Deployments based on their development context. 
 
 When you combine branch-based deploys and connection management, you can:
+
 - Automatically create Deployments for development branches with a set of development Airflow connections.
 - Override preset Airflow connections on a per-Deployment basis to troubleshoot or customize your development environment.
 - Promote a Deployment to production as an admin by updating its Airflow connections to access production resources.
@@ -19,26 +20,36 @@ This use case depends on three key Astro features to create a fully integrated C
 
 - Configuring Airflow connections in the [Astro Environment Manager](https://docs.astronomer.io/astro/manage-connections-variables).
 - Branch-based, or multi-branch Deployments using [CI/CD](https://docs.astronomer.io/astro/set-up-ci-cd.md#multiple-environments).
-- Pulling connections into local development branches using [environment secrets fetching](https://docs.astronomer.io/astro/import-export-connections-variables.md#from-the-cloud-ui).
 
 ## Prerequisites
 
 This use case assumes you have:
 
-- Two Astro Deployments, one for development and one for production.
-- A Git-based repository where you store your Astro project code.
+- At least two Astro Deployments, one for development and one for production.
+- A Git-based repository where you manage an Astro project.
 - A configured multi-branch CI/CD pipeline. See [CI/CD templates](ci-cd-templates.md)
 
 However, you can extend this use case to encompass multiple development or production environments.
 
-## Use case
+## Implementation
 
-The following workflow is an example of how you can manage Airflow connections between Deployment types using the Astro Environment Manager.
+To implement this use case:
+
+1. As a Workspace Operator or Admin, create connections in the Astro Environment manager to your development-level resources. See [Create a connection](create-and-link-connections.md#create-a-connection).
+2. Set these connections to be available to all Deployments in the Workspace by default. See [Configure connection sharing for a Workspace](create-and-link-connections.md#configure-connection-sharing-for-a-workspace). Your DAG authors can now access external development and testing resources across all Deployments.
+3. Choose a Deployment in your Workspace that you want to run your production workflows. In the Deployment, override the connections you configured to instead connect to your production resources. See [Override connection fields](create-and-link-connections.md#override-connection-fields).
+4. In the Git repository for your Astro project, define a multi-branch CI/CD pipeline for deploying to Astro. For an example of how to do this in GitHub, see [CI/CD templates](/ci-cd-temploates/github-actions.md?tab=multibranch#deploy-action-templates).
+
+Now, when a DAG author deploys to either a production or development Deployment through CI/CD, they can run their DAGs in Astro without needing to configure connections. Additionally, because your override production connection shares the same connection ID as your default development connection, DAG authors don't have to update their code to point towards different connections when promoting their code to production.
+
+## Explanation
+
+Using branch-based Deployments with the Astro Environment Manager allows your team to focus on the parts of Astro that matter most for their roles. For example, using the Astro Environment Manager means that you only need one administrative user to manage connections across multiple Deployments:  
 
 - A Workspace Owner [creates an Airflow connection](https://docs.astronomer.io/astro/create-and-link-connections#create-a-connection) in the Astro Environment Manager that connects to external development resources. They share this connection to all Deployments by default by turning on the [**Linked to all Deployments** setting](https://docs.astronomer.io/astro/create-and-link-connections#configure-connection-sharing-for-a-workspace).
 - In the production Deployment, the Workspace Owner [overrides the linked connection](https://docs.astronomer.io/astro/create-and-link-connections#override-connection-fields) to instead connect to production resources on the same external system. Because the connection ID and code are the same, this override requires no updates at the DAG level. 
 
-After the connection is created, DAG authors can develop DAGs without needing to reconfigure connections between development and production.
+After a Workspace Owner creates connections, DAG authors can develop DAGs without needing to reconfigure connections between development and production:
 
 - A DAG author creates a new development branch of an Astro project. The CI/CD pipeline for the repository deploys their branch to the development Deployment on Astro. This is known as a [multi-branch CI/CD pipeline](https://docs.astronomer.io/astro/set-up-ci-cd#multiple-environments).
 - While the DAG author is testing in Astro, they have access to the development resources because the Workspace Author configured a default Airflow connection for the Deployment. The author can [pull this connection onto their local machine](https://docs.astronomer.io/astro/import-export-connections-variables.md#from-the-cloud-ui) for testing purposes, or test by deploying to the development Deployment on Astro.
@@ -53,6 +64,5 @@ This use case provides several benefits for both Workspace managers and DAG auth
 
 ## See also
 
-- Documentation: [Manage Airflow connections and variables](https://docs.astronomer.io/astro/manage-connections-variables) on Astro.
-- Documentation: [Automate actions on Astro](https://docs.astronomer.io/astro/automation-overview).
-- Guide: [Manage Airflow connections](https://docs.astronomer.io/learn/connections).
+- [Manage Airflow connections and variables](https://docs.astronomer.io/astro/manage-connections-variables)
+- [Automate actions on Astro](https://docs.astronomer.io/astro/automation-overview)

--- a/astro/use-cases/connections-branch-deploys.md
+++ b/astro/use-cases/connections-branch-deploys.md
@@ -1,6 +1,6 @@
 ---
 title: 'Manage Astro connections in branch-based deploy workflows'
-sidebar_label: 'Connections + branch-based deploys'
+sidebar_label: 'Connections and branch-based deploys'
 id: connections-branch-deploys
 ---
 
@@ -16,7 +16,7 @@ When you combine branch-based deploys and connection management, you can:
 
 ## Feature overview
 
-This use case depends on three key Astro features to create a fully integrated CI/CD pipeline:
+This use case depends on the following Astro features to create a fully integrated CI/CD pipeline:
 
 - Configuring Airflow connections in the [Astro Environment Manager](manage-connections-variables.md).
 - Branch-based, or multi-branch Deployments using [CI/CD](set-up-ci-cd.md#multiple-environments).
@@ -40,7 +40,7 @@ To implement this use case:
 3. Choose a Deployment in your Workspace that you want to run your production workflows. In the Deployment, override the connections you configured to instead connect to your production resources. See [Override connection fields](create-and-link-connections.md#override-connection-fields).
 4. In the Git repository for your Astro project, define a multi-branch CI/CD pipeline for deploying to Astro. For an example of how to do this in GitHub, see [CI/CD templates](/ci-cd-templates/github-actions.md?tab=multibranch#deploy-action-templates).
 
-Now, when a DAG author deploys to either a production or development Deployment through CI/CD, they can run their DAGs in Astro without needing to configure connections. Additionally, because your override production connection shares the same connection ID as your default development connection, DAG authors don't have to update their code to point towards different connections when promoting their code to production.
+Now, when a DAG author deploys to either a production or development Deployment through CI/CD, they can run their DAGs in Astro without needing to configure connections. Additionally, because your production connection shares the same connection ID as your default development connection, DAG authors don't have to update their code to point towards different connections when promoting their code to production.
 
 ## Explanation
 

--- a/astro/use-cases/connections-branch-deploys.md
+++ b/astro/use-cases/connections-branch-deploys.md
@@ -4,7 +4,7 @@ sidebar_label: 'Connections and branch-based deploys'
 id: connections-branch-deploys
 ---
 
-Airflow DAGs often interact with a multitude of external systems, such as data warehouses and APIs. DAGs access these systems using [Airflow connections](manage-connections-variables.md). A common logistical consideration when running Airflow at scale is deciding how to manage connections between development and production environments. Different environment types require different levels access to external resources. 
+Airflow DAGs often interact with a multitude of external systems, such as data warehouses and APIs. DAGs access these systems using [Airflow connections](manage-connections-variables.md). A common logistical consideration when running Airflow at scale is deciding how to manage connections between development and production environments. Different environment types require different levels of access to external resources. 
 
 Astro's [branch-based development](automation-overview.md) and [connection management](manage-connections-variables.md) features allow you to automatically share specific Airflow connections with Astro Deployments based on their development context. 
 
@@ -27,7 +27,7 @@ This use case assumes you have:
 
 - At least two Astro Deployments, one for development and one for production.
 - A Git-based repository where you manage an Astro project.
-- A configured multi-branch CI/CD pipeline. See [CI/CD templates](ci-cd-templates/template-overview.md)
+- A configured multi-branch CI/CD pipeline. See [CI/CD templates](ci-cd-templates/template-overview.md).
 
 However, you can extend this use case to encompass multiple development or production environments.
 
@@ -60,7 +60,7 @@ This use case provides several benefits for both Workspace managers and DAG auth
 
 - Workspace Operators and Owners can manage connections without needing access to DAG code.
 - DAG authors only need a connection ID to connect their DAGs, meaning they can focus on data engineering instead of connection configuration.
-- Connection IDs don't need to be updated when you promote code to Deployment, reducing development timelines and reducing the number of resources to manage. 
+- Connection IDs don't need to be updated when you promote code to production, reducing development timelines and reducing the number of resources to manage. 
 
 ## See also
 

--- a/astro/use-cases/connections-branch-deploys.md
+++ b/astro/use-cases/connections-branch-deploys.md
@@ -58,6 +58,7 @@ After a Workspace Owner creates connections, DAG authors can develop DAGs withou
 
 This use case provides several benefits for both Workspace managers and DAG authors:
 
+- When you use branch-based deploys, your CI/CD pipeline automatically deploys your branches to development Deployments. This saves resources and reduces the complexity of development for DAG authors.
 - Workspace Operators and Owners can manage connections without needing access to DAG code.
 - DAG authors only need a connection ID to connect their DAGs, meaning they can focus on data engineering instead of connection configuration.
 - Connection IDs don't need to be updated when you promote code to production, reducing development timelines and reducing the number of resources to manage. 

--- a/astro/use-cases/connections-branch-deploys.md
+++ b/astro/use-cases/connections-branch-deploys.md
@@ -12,7 +12,7 @@ When you combine branch-based deploys and connection management, you can:
 
 - Automatically create Deployments for development branches with a set of development Airflow connections.
 - Override preset Airflow connections on a per-Deployment basis to troubleshoot or customize your development environment.
-- Promote a Deployment to production as an admin by updating its Airflow connections to access production resources.
+- Run a development and production Deployment for the same project without changing Airflow connection names between the two contexts.
 
 ## Feature overview
 

--- a/astro/use-cases/connections-branch-deploys.md
+++ b/astro/use-cases/connections-branch-deploys.md
@@ -52,7 +52,7 @@ Using branch-based Deployments with the Astro Environment Manager allows your te
 After a Workspace Owner creates connections, DAG authors can develop DAGs without needing to reconfigure connections between development and production:
 
 - A DAG author creates a new development branch of an Astro project. The CI/CD pipeline for the repository deploys their branch to the development Deployment on Astro. This is known as a [multi-branch CI/CD pipeline](set-up-ci-cd.md#multiple-environments).
-- While the DAG author is testing in Astro, they have access to the development resources because the Workspace Author configured a default Airflow connection for the Deployment. The author can [pull this connection onto their local machine](import-export-connections-variables.md#from-the-cloud-ui) for testing purposes, or test by deploying to the development Deployment on Astro.
+- The DAG author has access to development resources because the Workspace Author configured a default Airflow connection for the Deployment. The author can [pull this connection onto their local machine](import-export-connections-variables.md#from-the-cloud-ui) for testing purposes, or test by deploying to the development Deployment on Astro.
 - When the DAG author finishes development, they merge their development branch into production. The CI/CD pipeline deploys this change to the production Deployment.
 - When the DAG author's code runs in the production Deployment, it now accesses production resources based on the overrides configured by the Workspace Owner. 
 

--- a/sidebarsAstro.js
+++ b/sidebarsAstro.js
@@ -345,13 +345,8 @@ module.exports = {
     {
       type: 'category',
       label: 'Use cases',
-      link: {
-        type: 'generated-index',
-        title: 'Use cases',
-        description: 'Best practices and example use cases on Astro.'
-      },
       items: [
-        'astro-use-case/use-case-astro-connections',
+        'use-cases/connections-branch-deploys',
       ],
     },
   ],

--- a/sidebarsAstro.js
+++ b/sidebarsAstro.js
@@ -310,6 +310,13 @@ module.exports = {
       ],
     },
     {
+      type: 'category',
+      label: 'Use cases',
+      items: [
+        'use-cases/connections-branch-deploys',
+      ],
+    },
+    {
       type: "category",
       label: "Reference",
       items: [
@@ -340,13 +347,6 @@ module.exports = {
           ],
         },
         "astro-glossary"
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Use cases',
-      items: [
-        'use-cases/connections-branch-deploys',
       ],
     },
   ],

--- a/static/_redirects
+++ b/static/_redirects
@@ -297,7 +297,7 @@
 /astro/deployment-metrics#export-airflow-metrics-to-datadog /astro/export-task-logs-to-datadog
 /astro/view-logs#export-task-logs-to-aws-cloudwatch /astro/export-cloudwatch
 /astro/manage-connections-variables#cloud-ui-connections /astro/manage-connections-variables#astro-cloud-ui-environment-manager 301
-
+/astro/astro-use-case/use-case-astro-connections /astro/use-cases/connections-branch-deploys 301
 
 
 # redirect links out in the wild (beyond our control)


### PR DESCRIPTION
This PR attempts to hone the purpose of the new Astro "use case" section by simplifying the content of each document. When reading through the current doc, I noticed some potential improvements that could be made to the format:

- The current doc is long, and Astro customers might be turned off from seeing a multitude of steps and explanations for something we want to promote as a simplified solution.
- The example project only works with select technologies. For Astro customers that are more locked in to specific clouds and services, seeing a mention of S3 might turn them off from reading the use case altogether.
- The current titles for steps are really similar to base Astro documentation, and I could see users getting confused about the purpose of this doc when these steps also exist elsewhere in documentation.

This new format relies more on linking out to other docs, but has more dedicated content explaining the benefit of the use case. 