### PR TITLE
Remove MSSQL from supported DBs

### DIFF
--- a/astro/cli/develop-project.md
+++ b/astro/cli/develop-project.md
@@ -281,5 +281,5 @@ An alternative to using `airflow.cfg` is to set Airflow environment variables in
 
 For more advanced project configurations, see:
 
-- [Customize your Astro project Dockerfile](cli/customize-your-astro-project-dockerfile.md)
+- [Customize your Astro project Dockerfile](cli/customize-dockerfile.md)
 - [Install Python packages from private sources](cli/private-python-packages.md)

--- a/learn/airflow-components.md
+++ b/learn/airflow-components.md
@@ -25,7 +25,7 @@ The following Apache Airflow core components are running at all times:
 
 - **Webserver:** A Flask server running with Gunicorn that serves the [Airflow UI](airflow-ui.md).
 - **[Scheduler](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/scheduler.html):** A Daemon responsible for scheduling jobs. This is a multi-threaded Python process that determines what tasks need to be run, when they need to be run, and where they are run.
-- **[Database](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html):** A database where all DAG and task metadata are stored. This is typically a Postgres database, but MySQL, MsSQL, and SQLite are also supported.
+- **[Database](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html):** A database where all DAG and task metadata are stored. This is typically a Postgres database, but MySQL and SQLite are also supported.
 - **[Executor](https://airflow.apache.org/docs/apache-airflow/stable/executor/index.html):** The mechanism for running tasks. An executor is running within the scheduler whenever Airflow is operational.
 
 If you run Airflow locally using the [Astro CLI](https://docs.astronomer.io/astro/install-cli), you'll notice that when you start Airflow using `astrocloud dev start`, it will spin up three containers, one for each of the core components.

--- a/learn/airflow-database.md
+++ b/learn/airflow-database.md
@@ -30,7 +30,6 @@ Airflow uses SQLAlchemy and Object Relational Mapping (ORM) in Python to connect
 
 - Postgres
 - MySQL
-- MSSQL
 - SQLite
 
 While SQLite is the default on Apache Airflow, Postgres is by far the most common choice and is recommended for most use cases by the Airflow community. Astronomer uses Postgres for all of its Airflow environments, including local environments running with the Astro CLI and deployed environments on the cloud.

--- a/learn/intro-to-airflow.md
+++ b/learn/intro-to-airflow.md
@@ -115,7 +115,7 @@ The following Airflow components must be running at all times:
 
 - **Webserver**: A Flask server running with Gunicorn that serves the [Airflow UI](airflow-ui.md).
 - **[Scheduler](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/scheduler.html)**: A Daemon responsible for scheduling jobs. This is a multi-threaded Python process that determines what tasks need to be run, when they need to be run, and where they are run.
-- **[Database](airflow-database.md)**: A database where all DAG and task metadata are stored. This is typically a Postgres database, but MySQL, MsSQL, and SQLite are also supported.
+- **[Database](airflow-database.md)**: A database where all DAG and task metadata are stored. This is typically a Postgres database, but MySQL and SQLite are also supported.
 - **[Executor](airflow-executors-explained.md)**: The mechanism that defines how the available computing resources are used to execute tasks. An executor is running within the scheduler whenever Airflow is up.
 
 Additionally, you may also have the following situational components:


### PR DESCRIPTION
MSSQL support will soon be dropped (I'm not 100% sure when exactly), so I suggest removing it from our docs.

Resources:

- https://lists.apache.org/thread/pgcgmhf6560k8jbsmz8nlyoxosvltph2
- https://lists.apache.org/thread/37q5kbqx7o03fkfoyq1x6oc85h5mghvh
- https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html#choosing-database-backend