### PR TITLE
Add secrets backend preview deployment info

### DIFF
--- a/astro/ci-cd-templates/github-actions.md
+++ b/astro/ci-cd-templates/github-actions.md
@@ -278,7 +278,7 @@ You can choose to use
 3. In your project repository, create a new YAML file in `.github/workflows` named `create-deployment-preview.yml` that includes the following configuration. You can choose to use either a Secrets backend or to store your `ASTRO_API_TOKEN` as a GitHub secret.
 
   <Tabs
-    defaultValue="standard"
+    defaultValue="github-secret"
     groupId= "store-secrets"
     values={[
         {label: 'GitHub Secret', value: 'github-secret'},

--- a/astro/ci-cd-templates/github-actions.md
+++ b/astro/ci-cd-templates/github-actions.md
@@ -85,7 +85,7 @@ To automate code deploys to a single Deployment using [GitHub Actions](https://g
         runs-on: ubuntu-latest
         steps:
         - name: Deploy to Astro
-          uses: astronomer/deploy-action@v0.2
+          uses: astronomer/deploy-action@v0.4
           with:
             deployment-id: <your-deployment-id>
     ```
@@ -131,7 +131,7 @@ The following template can be used to create a multiple branch CI/CD pipeline us
         runs-on: ubuntu-latest
         steps:
         - name: Deploy to Astro
-          uses: astronomer/deploy-action@v0.2
+          uses: astronomer/deploy-action@v0.4
           with:
             deployment-id: <dev-deployment-id>
       prod-push:
@@ -142,7 +142,7 @@ The following template can be used to create a multiple branch CI/CD pipeline us
         runs-on: ubuntu-latest
         steps:
         - name: Deploy to Astro
-          uses: astronomer/deploy-action@v0.2
+          uses: astronomer/deploy-action@v0.4
           with:
             deployment-id: <prod-deployment-id>
     ```
@@ -198,7 +198,7 @@ If your Astro project requires additional build-time arguments to build an image
             build-args: |
               <your-build-arguments>
         - name: Deploy to Astro
-          uses: astronomer/deploy-action@v0.2
+          uses: astronomer/deploy-action@v0.4
           with:
             deployment-id: <your-deployment-id>
             image-name: ${{ steps.image_tag.outputs.image_tag }}
@@ -240,7 +240,7 @@ If your Astro project requires additional build-time arguments to build an image
             ssh: |
               github=${{ env.SSH_AUTH_SOCK }
         - name: Deploy to Astro
-          uses: astronomer/deploy-action@v0.2
+          uses: astronomer/deploy-action@v0.4
           with:
             deployment-id: <your-deployment-id>
             image-name: ${{ steps.image_tag.outputs.image_tag }}
@@ -298,7 +298,7 @@ The standard Deployment preview template uses GitHub secrets and an Astro Deploy
         runs-on: ubuntu-latest
         steps:
         - name: Create preview Deployment
-          uses: astronomer/deploy-action@v0.2
+          uses: astronomer/deploy-action@v0.4
           with:
             action: create-deployment-preview
             deployment-id: <main-deployment-id>
@@ -323,7 +323,7 @@ The standard Deployment preview template uses GitHub secrets and an Astro Deploy
         runs-on: ubuntu-latest
         steps:
         - name: Deploy code to preview
-          uses: astronomer/deploy-action@v0.2
+          uses: astronomer/deploy-action@v0.4
           with:
             action: deploy-deployment-preview
             deployment-id: <main-deployment-id>
@@ -347,7 +347,7 @@ The standard Deployment preview template uses GitHub secrets and an Astro Deploy
         runs-on: ubuntu-latest
         steps:
         - name: Delete preview Deployment
-          uses: astronomer/deploy-action@v0.2
+          uses: astronomer/deploy-action@v0.4
           with:
             action: delete-deployment-preview
             deployment-id: <main-deployment-id>
@@ -372,7 +372,7 @@ The standard Deployment preview template uses GitHub secrets and an Astro Deploy
         runs-on: ubuntu-latest
         steps:
         - name: Deploy code to main Deployment
-          uses: astronomer/deploy-action@v0.2
+          uses: astronomer/deploy-action@v0.4
           with:
             deployment-id: <main-deployment-id>
     ```
@@ -451,7 +451,7 @@ This template makes use of the `AIRFLOW__SECRETS__BACKEND_KWARGS` environment va
         runs-on: ubuntu-latest
         steps:
         - name: Deploy code to preview
-          uses: astronomer/deploy-action@v0.2
+          uses: astronomer/deploy-action@v0.4
           with:
             action: deploy-deployment-preview
             deployment-id: <main-deployment-id>
@@ -475,7 +475,7 @@ This template makes use of the `AIRFLOW__SECRETS__BACKEND_KWARGS` environment va
         runs-on: ubuntu-latest
         steps:
         - name: Delete preview Deployment
-          uses: astronomer/deploy-action@v0.2
+          uses: astronomer/deploy-action@v0.4
           with:
             action: delete-deployment-preview
             deployment-id: <main-deployment-id>
@@ -500,7 +500,7 @@ This template makes use of the `AIRFLOW__SECRETS__BACKEND_KWARGS` environment va
         runs-on: ubuntu-latest
         steps:
         - name: Deploy code to main Deployment
-          uses: astronomer/deploy-action@v0.2
+          uses: astronomer/deploy-action@v0.4
           with:
             deployment-id: <main-deployment-id>
     ```

--- a/astro/ci-cd-templates/github-actions.md
+++ b/astro/ci-cd-templates/github-actions.md
@@ -259,11 +259,11 @@ If your Astro project requires additional build-time arguments to build an image
 
 The Astronomer [Deploy Action](https://github.com/astronomer/deploy-action/tree/deployment-preview#deployment-preview-templates) includes several sub-actions that can be used together to create a complete [Deployment preview](ci-cd-templates/template-overview.md#preview-deployment-templates) pipeline.
 
-When you set up a Standard Deployment preview templates with the Deploy Action, it uses GitHub Secrets to manage the credentials needed for your CI/CD pipeline. However, you can also use GitHub Secrets to store the credentials necessary to integrate your [preview deployment pipeline with a secrets backend](#deployment-preview-template-with-secrets-backend-implementation), so you can access environment variables, connections, and other resources that are managed by your organization's [secrets backend](secrets-backend.md).
+The Deployment preview templates use GitHub secrets to manage the credentials needed for GitHub to authenticate to Astro. You can also use a secret to store the credentials for your [secrets backend](secrets-backend.md) so that preview Deployments have access to secret Airflow variables or connections for testing purposes. See [Deployment preview template with secrets backend implementation](#deployment-preview-template-with-secrets-backend-implementation).
 
 ### Standard Deployment preview template
 
-The standard Deployment preview uses GitHub secrets and an Astro Deployment API token to create a preview Deployment as part of your CI/CD pipeline.
+The standard Deployment preview template uses GitHub secrets and an Astro Deployment API token to create a preview Deployment whenever you create a new feature branch off of your main branch.
 
 #### Prerequisites
 
@@ -381,26 +381,26 @@ The standard Deployment preview uses GitHub secrets and an Astro Deployment API 
 
 ### Deployment preview template with secrets backend implementation
 
-If you use a [secrets backend](secrets-backend.md) to manage your access credentials and other sensitive information, you can configure your Github Action to grant preview Deployments access to your secrets backend. This means that DAGs in the preview Deployment can access secrets such as Airflow variables and connections for testing purposes.
+If you use a [secrets backend](secrets-backend.md) to manage Airflow objects such as variables and connections, you can configure your action to grant preview Deployments access to your secrets backend. This means that DAGs in the preview Deployment can access your secret Airflow objects for testing purposes.
 
-Unlike the standard Deployment preview setup, you need to add some additional configuration to GitHub including information. Specifically, this template makes use of the `AIRFLOW__SECRETS__BACKEND_KWARGS` environment variable to store information and credentials for your secrets backend.
+This template makes use of the `AIRFLOW__SECRETS__BACKEND_KWARGS` environment variable to store information and credentials for your secrets backend.
 
 #### Prerequisites
 
 - An Astro project hosted in a GitHub repository.
 - A [Workspace API token](workspace-api-tokens.md).
 - A [Deployment](create-deployment.md).
-- A [Secrets backend](secrets-backend.md).
+- A [secrets backend](secrets-backend.md).
 
 #### Setup
 
 1. Copy and save the Deployment ID for your Astro deployment.
 2. Set the following [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) in the repository hosting your Astro project. This includes your Astro API Token, so that GitHub has permissions to deploy code to your Deployments or Workspaces, and your secrets backend information stored in `AIRFLOW__SECRETS__BACKEND_KWARGS`. See [Configure a secrets backend](secrets-backend.md) for more information about configuring your secrets backend as an environment variable.
 
-  - Key 1: `ASTRO_API_TOKEN`
-  - Secret 1: `<your-token>`
-  - Key 2: `AIRFLOW__SECRETS__BACKEND_KWARGS`
-  - Secret 2: `<your-kwargs>`
+    - **Key 1**: `ASTRO_API_TOKEN`
+    - **Secret 1**: `<your-token>`
+    - **Key 2**: `AIRFLOW__SECRETS__BACKEND_KWARGS`
+    - **Secret 2**: `<your-kwargs>`
 
 3. In your project repository, create a new YAML file in `.github/workflows` named `create-deployment-preview.yml` that includes the following configuration.
 
@@ -430,7 +430,7 @@ Unlike the standard Deployment preview setup, you need to add some additional co
           - name: Create Secret Variables
             run: |
               astro deployment variable update --deployment-id ${{steps.create-dep-prev.outputs.preview-id}} AIRFLOW__SECRETS__BACKEND_KWARGS=${{ secrets.AIRFLOW__SECRETS__BACKEND_KWARGS }} --secret
-  ```
+    ```
 
 4. In the same folder, create a new YAML file named `deploy-to-preview.yml` that includes the following configuration:
 

--- a/astro/ci-cd-templates/github-actions.md
+++ b/astro/ci-cd-templates/github-actions.md
@@ -259,7 +259,7 @@ If your Astro project requires additional build-time arguments to build an image
 
 The Astronomer [Deploy Action](https://github.com/astronomer/deploy-action/tree/deployment-preview#deployment-preview-templates) includes several sub-actions that can be used together to create a complete [Deployment preview](ci-cd-templates/template-overview.md#preview-deployment-templates) pipeline.
 
-You can choose to save your access credential information in either Github Secrets or with your own secrets backend. If you use a [secrets backend](secrets-backend.md) to manage your credentials, you can configure your Github Action to use and store them.
+When you set up a Standard Deployment preview templates with the Deploy Action, it uses GitHub Secrets to manage the credentials needed for your CI/CD pipeline. However, you can also use GitHub Secrets to store the credentials necessary to integrate your [preview deployment pipeline with a secrets backend](#deployment-preview-template-with-secrets-backend-implementation), so you can access environment variables, connections, and other resources that are managed by your organization's [secrets backend](secrets-backend.md).
 
 ### Standard Deployment preview template
 

--- a/astro/ci-cd-templates/github-actions.md
+++ b/astro/ci-cd-templates/github-actions.md
@@ -261,7 +261,9 @@ The Astronomer [Deploy Action](https://github.com/astronomer/deploy-action/tree/
 
 You can choose to save your access credential information in either Github Secrets or with your own secrets backend. If you use a [secrets backend](secrets-backend.md) to manage your credentials, you can configure your Github Action to use and store them.
 
-### Deployment preview implementation
+### Standard Deployment preview
+
+The standard Deployment preview uses GitHub secrets and an Astro Deployment API token to create a preview Deployment as part of your CI/CD pipeline.
 
 #### Prerequisites
 
@@ -302,15 +304,7 @@ You can choose to save your access credential information in either Github Secre
             deployment-id: <main-deployment-id>
     ```
 
-4. (Optional) If you want to use a secrets backend instead of GitHub secrets, add the following code to the end of the `steps` section in your `create-deployment-preview.yml` file.
-
-  ```yaml
-            - name: Create Secret Variables
-            run: |
-              astro deployment variable update --deployment-id ${{steps.create-dep-prev.outputs.preview-id}} AIRFLOW__SECRETS__BACKEND_KWARGS=${{ secrets.AIRFLOW__SECRETS__BACKEND_KWARGS }} --secret
-  ```
-
-5. In the same folder, create a new YAML file named `deploy-to-preview.yml` that includes the following configuration:
+4. In the same folder, create a new YAML file named `deploy-to-preview.yml` that includes the following configuration:
 
     ```yaml
     name: Astronomer CI - Deploy code to preview
@@ -335,7 +329,7 @@ You can choose to save your access credential information in either Github Secre
             deployment-id: <main-deployment-id>
     ```
 
-6. In the same folder, create a new YAML file named `delete-preview-deployment.yml` that includes the following configuration:
+5. In the same folder, create a new YAML file named `delete-preview-deployment.yml` that includes the following configuration:
 
     ```yaml
     name: Astronomer CI - Delete Preview Deployment
@@ -359,7 +353,7 @@ You can choose to save your access credential information in either Github Secre
             deployment-id: <main-deployment-id>
     ```
 
-7. In the same folder, create a new YAML file named `deploy-to-main-deployment.yml` that includes the following configuration:
+6. In the same folder, create a new YAML file named `deploy-to-main-deployment.yml` that includes the following configuration:
 
     ```yaml
     name: Astronomer CI - Deploy code to main Deployment
@@ -385,7 +379,11 @@ You can choose to save your access credential information in either Github Secre
 
     All four workflow files must have the same Deployment ID specified. The actions use this Deployment ID to create and delete preview Deployments based on your main Deployment.
 
-### Deployment preview and secrets backend implementation
+### Secrets backend Deployment preview
+
+If you use a [secrets backend](secrets-backend.md) to manage your access credentials and other sensitive information, you can configure your Github Action to use and store them while working with Deployment previews.
+
+Unlike the standard Deployment preview setup, you need to add some additional configuration information to both your GitHub Secrets and GitHub workflow include information about your Secrets Backend kwargs. This information instructs the CI/CD pipeline to refer to your Secrets Backend to read and write access credentials.
 
 #### Prerequisites
 

--- a/astro/ci-cd-templates/github-actions.md
+++ b/astro/ci-cd-templates/github-actions.md
@@ -399,7 +399,6 @@ Unlike the standard Deployment preview setup, you need to add some additional co
 
   - Key: `ASTRO_API_TOKEN`
   - Secret: `<your-token>`
-
   - Key: `AIRFLOW__SECRETS__BACKEND_KWARGS`
   - Secret: `<your-kwargs>`
 

--- a/astro/ci-cd-templates/github-actions.md
+++ b/astro/ci-cd-templates/github-actions.md
@@ -259,7 +259,7 @@ If your Astro project requires additional build-time arguments to build an image
 
 The Astronomer [Deploy Action](https://github.com/astronomer/deploy-action/tree/deployment-preview#deployment-preview-templates) includes several sub-actions that can be used together to create a complete [Deployment preview](ci-cd-templates/template-overview.md#preview-deployment-templates) pipeline.
 
-You can choose to use
+You can choose to save your access credential information in either Github Secrets or with your own secrets backend. If you use a [secrets backend](secrets-backend.md) to manage your credentials, you can configure your Github Action to use and store them.
 
 ### Prerequisites
 
@@ -275,16 +275,7 @@ You can choose to use
   - Key: `ASTRO_API_TOKEN`
   - Secret: `<your-token>`
 
-3. In your project repository, create a new YAML file in `.github/workflows` named `create-deployment-preview.yml` that includes the following configuration. You can choose to use either a Secrets backend or to store your `ASTRO_API_TOKEN` as a GitHub secret.
-
-  <Tabs
-    defaultValue="github-secret"
-    groupId= "store-secrets"
-    values={[
-        {label: 'GitHub Secret', value: 'github-secret'},
-        {label: 'Secrets Backend', value: 'secrets-backend'},
-    ]}>
-  <TabItem value="github-secret">
+3. In your project repository, create a new YAML file in `.github/workflows` named `create-deployment-preview.yml` that includes the following configuration.
 
     ```yaml
     name: Astronomer CI - Create preview Deployment
@@ -295,7 +286,7 @@ You can choose to use
           - "**"
 
     env:
-      ## Set your API token as a GitHub secret
+      ## Sets Deployment API key credentials as environment variables or GitHub Secret depending on your configuration
       ASTRO_API_TOKEN: ${{ secrets.ASTRO_API_TOKEN }}
 
     jobs:
@@ -308,37 +299,16 @@ You can choose to use
             action: create-deployment-preview
             deployment-id: <main-deployment-id>
     ```
-  </TabItem>
-  <TabItem value="secrets-backend">
 
-    ```yaml
-    create:
-      branches:
-      - '**'
-      - '!main'
+4. (Optional) If you want to use a secrets backend instead of GitHub secrets, add the following code to the end of the `steps` section in your `create-deployment-preview.yml` file.
 
-      env:
-        ## Sets Deployment API key credentials as environment variables
-        ASTRO_API_TOKEN: ${{ secrets.ASTRO_API_TOKEN }}
-
-      jobs:
-        deploy:
-          runs-on: ubuntu-latest
-          steps:
-          - name: Create Deployment Preview
-            uses: astronomer/deploy-action@v0.3
-            with:
-              action: create-deployment-preview
-              deployment-name: "test"
-            id: create-dep-prev
-          - name: Create Secret Variables
+  ```yaml
+            - name: Create Secret Variables
             run: |
               astro deployment variable update --deployment-id ${{steps.create-dep-prev.outputs.preview-id}} AIRFLOW__SECRETS__BACKEND_KWARGS=${{ secrets.AIRFLOW__SECRETS__BACKEND_KWARGS }} --secret
-      ```
-    </TabItem>
-    </Tabs>
+  ```
 
-4. In the same folder, create a new YAML file named `deploy-to-preview.yml` that includes the following configuration:
+5. In the same folder, create a new YAML file named `deploy-to-preview.yml` that includes the following configuration:
 
     ```yaml
     name: Astronomer CI - Deploy code to preview
@@ -363,7 +333,7 @@ You can choose to use
             deployment-id: <main-deployment-id>
     ```
 
-5. In the same folder, create a new YAML file named `delete-preview-deployment.yml` that includes the following configuration:
+6. In the same folder, create a new YAML file named `delete-preview-deployment.yml` that includes the following configuration:
 
     ```yaml
     name: Astronomer CI - Delete Preview Deployment
@@ -387,7 +357,7 @@ You can choose to use
             deployment-id: <main-deployment-id>
     ```
 
-6. In the same folder, create a new YAML file named `deploy-to-main-deployment.yml` that includes the following configuration:
+7. In the same folder, create a new YAML file named `deploy-to-main-deployment.yml` that includes the following configuration:
 
     ```yaml
     name: Astronomer CI - Deploy code to main Deployment
@@ -412,8 +382,6 @@ You can choose to use
     ```
 
     All four workflow files must have the same Deployment ID specified. The actions use this Deployment ID to create and delete preview Deployments based on your main Deployment.
-
-### Use a secrets backend for preview Deployment
 
 ## Private network templates
 

--- a/astro/ci-cd-templates/github-actions.md
+++ b/astro/ci-cd-templates/github-actions.md
@@ -407,7 +407,7 @@ Unlike the standard Deployment preview setup, you need to add some additional co
 3. In your project repository, create a new YAML file in `.github/workflows` named `create-deployment-preview.yml` that includes the following configuration.
 
     ```yaml
-    name: Astronomer CI - Create preview Deployment
+    name: Astronomer CI - Create preview Deployment with Secrets Backend
 
     on:
       create:
@@ -422,12 +422,14 @@ Unlike the standard Deployment preview setup, you need to add some additional co
       deploy:
         runs-on: ubuntu-latest
         steps:
-        - name: Create preview Deployment
-          uses: astronomer/deploy-action@v0.2
-          with:
-            action: create-deployment-preview
-            deployment-id: <main-deployment-id>
-            - name: Create Secret Variables
+        - steps:
+          - name: Create Deployment Preview
+            uses: astronomer/deploy-action@v0.3
+            with:
+              action: create-deployment-preview
+              deployment-name: "test"
+              id: create-dep-prev
+          - name: Create Secret Variables
             run: |
               astro deployment variable update --deployment-id ${{steps.create-dep-prev.outputs.preview-id}} AIRFLOW__SECRETS__BACKEND_KWARGS=${{ secrets.AIRFLOW__SECRETS__BACKEND_KWARGS }} --secret
   ```

--- a/astro/ci-cd-templates/github-actions.md
+++ b/astro/ci-cd-templates/github-actions.md
@@ -261,7 +261,7 @@ The Astronomer [Deploy Action](https://github.com/astronomer/deploy-action/tree/
 
 You can choose to save your access credential information in either Github Secrets or with your own secrets backend. If you use a [secrets backend](secrets-backend.md) to manage your credentials, you can configure your Github Action to use and store them.
 
-### Standard Deployment preview
+### Standard Deployment preview template
 
 The standard Deployment preview uses GitHub secrets and an Astro Deployment API token to create a preview Deployment as part of your CI/CD pipeline.
 
@@ -379,11 +379,11 @@ The standard Deployment preview uses GitHub secrets and an Astro Deployment API 
 
     All four workflow files must have the same Deployment ID specified. The actions use this Deployment ID to create and delete preview Deployments based on your main Deployment.
 
-### Secrets backend Deployment preview
+### Deployment preview template with secrets backend implementation
 
-If you use a [secrets backend](secrets-backend.md) to manage your access credentials and other sensitive information, you can configure your Github Action to use and store them while working with Deployment previews.
+If you use a [secrets backend](secrets-backend.md) to manage your access credentials and other sensitive information, you can configure your Github Action to grant preview Deployments access to your secrets backend. This means that DAGs in the preview Deployment can access secrets such as Airflow variables and connections for testing purposes.
 
-Unlike the standard Deployment preview setup, you need to add some additional configuration information to both your GitHub Secrets and GitHub workflow include information about your Secrets Backend kwargs. This information instructs the CI/CD pipeline to refer to your Secrets Backend to read and write access credentials.
+Unlike the standard Deployment preview setup, you need to add some additional configuration to GitHub including information. Specifically, this template makes use of the `AIRFLOW__SECRETS__BACKEND_KWARGS` environment variable to store information and credentials for your secrets backend.
 
 #### Prerequisites
 
@@ -395,14 +395,12 @@ Unlike the standard Deployment preview setup, you need to add some additional co
 #### Setup
 
 1. Copy and save the Deployment ID for your Astro deployment.
-2. Set the following [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) in the repository hosting your Astro project. This includes your Astro API Token, so that GitHub has permissions to deploy code to your Deployments or Workspaces, and your `AIRFLOW__SECRETS__BACKEND_KWARGS`. You can find these values in your Astro project's `.env`file, replacing `<your-token>` and `<your-kwargs>` with your unique values.
+2. Set the following [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) in the repository hosting your Astro project. This includes your Astro API Token, so that GitHub has permissions to deploy code to your Deployments or Workspaces, and your secrets backend information stored in `AIRFLOW__SECRETS__BACKEND_KWARGS`. See [Configure a secrets backend](secrets-backend.md) for more information about configuring your secrets backend as an environment variable.
 
-  - Key: `ASTRO_API_TOKEN`
-  - Secret: `<your-token>`
-  - Key: `AIRFLOW__SECRETS__BACKEND_KWARGS`
-  - Secret: `<your-kwargs>`
-
-  Refer to the [secrets backend](secrets-backend.md) overview and procedures docs to learn more about setting up a secrets backend and defining your `AIRFLOW__SECRETS__BACKEND_KWARGS`.
+  - Key 1: `ASTRO_API_TOKEN`
+  - Secret 1: `<your-token>`
+  - Key 2: `AIRFLOW__SECRETS__BACKEND_KWARGS`
+  - Secret 2: `<your-kwargs>`
 
 3. In your project repository, create a new YAML file in `.github/workflows` named `create-deployment-preview.yml` that includes the following configuration.
 

--- a/astro/ci-cd-templates/template-overview.md
+++ b/astro/ci-cd-templates/template-overview.md
@@ -1,8 +1,8 @@
 ---
-sidebar_label: Template overview
-title: Template overview
+sidebar_label: Template options
+title: Template options
 id: template-overview
-description: Use pre-built templates to get started with automating code Deploys 
+description: Use pre-built templates to get started with automating code deploys
 ---
 
 Astronomer CI/CD templates are customizable, pre-built code samples that help you configure automated workflows with popular CI/CD tools, such as GitHub Actions or Jenkins. Use the templates to create a workflow that automates deploying code to Astro according to your team's CI/CD requirements and strategy.
@@ -30,7 +30,7 @@ CI/CD templates that use the DAG deploy workflow:
     - If only DAG files in the `dags` folder have changed, run `astro deploy --dags`. This pushes your `dags` folder to your Deployment.
     - If any file not in the `dags` folder has changed, run `astro deploy`. This triggers two subprocesses. One that creates a Docker image for your Astro project, authenticates to Astro using your Deployment API token, and pushes the image to your Deployment. A second that pushes your `dags` folder to your Deployment.
 
-This process is equivalent to the following shell script: 
+This process is equivalent to the following shell script:
 
 ```bash
 # Set Deployment API token credentials as environment variables
@@ -60,7 +60,7 @@ then
 fi
 ```
 
-## Image deploy templates  
+## Image deploy templates
 
 _Image based templates_ build a Docker image and push it to Astro whenever you update any file in your Astro project. This type of template works well for development workflows that include complex Docker customization or logic.
 
@@ -89,7 +89,7 @@ To implement this feature, you need a CI/CD workflow that:
 
 - Creates the preview Deployment when you create a new branch.
 - Deploys code changes to Astro when you make updates in the branch.
-- Deletes the preview Deployment when you delete the branch. 
+- Deletes the preview Deployment when you delete the branch.
 - Deploys your changes to your base Deployment after you merge your changes into your main branch.
 
 If you use GitHub Actions as your CI/CD tool, you can find preview Deployment templates as part of the [Astronomer GitHub action in the GitHub Marketplace](https://github.com/astronomer/deploy-action/tree/deployment-preview#deployment-preview-templates). This GitHub action includes sub-actions for each of these four steps. To learn more, see [GitHub Actions](ci-cd-templates/github-actions.md).
@@ -98,7 +98,7 @@ To configure your own automated workflow for preview Deployments with another CI
 
 #### Create a preview Deployment
 
-In a Deployment preview CI/CD pipeline, you run this script when you create a feature branch off of the main branch of your Astro project. 
+In a Deployment preview CI/CD pipeline, you run this script when you create a feature branch off of the main branch of your Astro project.
 
 ```bash
 # Install the Astro CLI
@@ -118,7 +118,7 @@ sed -i "s|  name:.*|  name: $BRANCH_DEPLOYMENT_NAME}|g"  deployment-preview-temp
 # Create new preview Deployment based on the Deployment template file
 astro deployment create --deployment-file deployment-preview-template.yaml
 
-# Deploy new code to the deployment preview 
+# Deploy new code to the deployment preview
 astro deploy -n $BRANCH_DEPLOYMENT_NAME
 ```
 


### PR DESCRIPTION
Resolves #3248 

@jwitz - need some feedback about this draft -?
- Needs some more explanation about what this is and why/when to use it?
- Is this the right place for it to live? Or should it be in the existing Secrets backend docs (https://docs.astronomer.io/astro/secrets-backend section) or over in the Preview deployments section (https://docs.astronomer.io/astro/ci-cd-templates/template-overview#preview-deployment-templates)?