### PR TITLE
Fix: CONTRIBUTING.md Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ GitHub issues are triaged by the Astronomer team and addressed promptly. Once yo
 
 ## Contribute
 
-See [CONTRIBUTING.MD](https://github.com/astronomer/docs/blob/main/contributing.md) for guidance on how to contribute to Astronomer documentation.
+See [CONTRIBUTING.MD](https://github.com/astronomer/docs/blob/main/CONTRIBUTING.md) for guidance on how to contribute to Astronomer documentation.
 
 Do you have an idea for a new doc to contribute, but don't know where to start? Review the [Doc templates](https://github.com/astronomer/docs/blob/main/doc-templates) to see our standards for how to structure the content you want to contribute.


### PR DESCRIPTION
CONTRIBUTING.md Link is not working
<img width="2168" alt="스크린샷 2024-02-07 오후 4 55 45" src="https://github.com/astronomer/docs/assets/54111883/9ac6f74d-acdd-45aa-a810-b4039c0dda3a">
CONTRIBUTING.md is the right link, not contributing.md .