### PR TITLE
Update kubepod-operator.md - Fix local kube config creation command

### DIFF
--- a/learn/kubepod-operator.md
+++ b/learn/kubepod-operator.md
@@ -126,7 +126,7 @@ The latest versions of Docker for Windows and Mac let you run a single node Kube
 
     ```bash
     kubectl config set-context docker-desktop
-    kubectl config view -- minify --raw > <Astro project directory>/include/.kube
+    kubectl config view --minify --raw > <Astro project directory>/include/.kube/config
     ```
 
     After running these commands, you will find a `config` file in the `/include/.kube/` folder of your Astro project which resembles this example:


### PR DESCRIPTION
Typo in `--minify` as well as needing to specify the full `config` file path, not doing so results in:

```
❯ k config view -- minify --raw > ~/code/astro-runtime/9.4.0/include/.kube/
zsh: is a directory: /Users/seanmuth/code/astro-runtime/9.4.0/include/.kube/

❯ k config view -- minify --raw > ~/code/astro-runtime/9.4.0/include/.kube/config
error: unexpected arguments: [minify --raw]
See 'kubectl config view -h' for help and examples 
```