### PR TITLE
Add warning about EPO example not working on Astro

### DIFF
--- a/learn/external-python-operator.md
+++ b/learn/external-python-operator.md
@@ -17,6 +17,12 @@ In this tutorial, you'll learn how to use the [ExternalPythonOperator](https://a
 
 Snowpark requires Python 3.8, while the [Astro Runtime](https://docs.astronomer.io/astro/runtime-image-architecture) uses Python 3.9. The ExternalPythonOperator can run your Snowpark query in a Python 3.8 virtual environment, allowing you to use a different Python version for your task than in the Airflow environment. You can use these same general steps for any use case for running a task in a reusable Python virtual environment.
 
+:::warning
+
+The example in this tutorial works when running Airflow locally with the Astro CLI, but will not run on Astro. An updated example for Astro users is coming soon.
+
+:::
+
 :::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:


### PR DESCRIPTION
The current example does not run on Astro and this has caused confusion for some customers. We will be updating the guide shortly, but want to add this in the meantime to help reduce any headaches.