### PR TITLE
Add a note to the Kafka tutorial about restarting for the `apply_function`

### DIFF
--- a/learn/airflow-kafka.md
+++ b/learn/airflow-kafka.md
@@ -176,7 +176,7 @@ Airflow can run a function when a specific message appears in your Kafka topic. 
 
 :::info
 
-When working locally, you need to restart your Airflow instance to apply changes to the `apply_function` of the AwaitMessageTriggerFunctionSensor because the function is imported into the [Triggerer](https://docs.astronomer.io/learn/deferrable-operators#terms-and-concepts), which does not periodically restart. To do so, run `astro dev restart` in your terminal. Changes to the `event_triggered_function` of the AwaitMessageTriggerFunctionSensor do not require a restart of your Airflow instance.
+When working locally, you need to restart your Airflow instance to apply changes to the `apply_function` of the AwaitMessageTriggerFunctionSensor because the function is imported into the [Triggerer](https://docs.astronomer.io/learn/deferrable-operators#terms-and-concepts), which does not periodically restart. To restart Airflow, run `astro dev restart` in your terminal. Changes to the `event_triggered_function` of the AwaitMessageTriggerFunctionSensor do not require a restart of your Airflow instance.
 
 On Astro, the Triggerer is restarted automatically when a new image is deployed, but not on dag-only deploys, see [Deploy DAGs to Astro](https://docs.astronomer.io/astro/deploy-dags).
 

--- a/learn/airflow-kafka.md
+++ b/learn/airflow-kafka.md
@@ -176,7 +176,7 @@ Airflow can run a function when a specific message appears in your Kafka topic. 
 
 :::info
 
-Since the function provided to the `apply_function` parameter is being imported into the [Triggerer](https://docs.astronomer.io/learn/deferrable-operators#terms-and-concepts) compoment of Airflow, which does not periodically restart, you need to restart your Airflow instance to apply changes to the `apply_function` of the AwaitMessageTriggerFunctionSensor when working locally. To do so run `astro dev restart` in your terminal. Changes to the `event_triggered_function` of the AwaitMessageTriggerFunctionSensor do not require a restart of your Airflow instance.
+When working locally, you need to restart your Airflow instance to apply changes to the `apply_function` of the AwaitMessageTriggerFunctionSensor because the function is imported into the [Triggerer](https://docs.astronomer.io/learn/deferrable-operators#terms-and-concepts), which does not periodically restart. To do so, run `astro dev restart` in your terminal. Changes to the `event_triggered_function` of the AwaitMessageTriggerFunctionSensor do not require a restart of your Airflow instance.
 
 :::
 

--- a/learn/airflow-kafka.md
+++ b/learn/airflow-kafka.md
@@ -174,6 +174,11 @@ Airflow can run a function when a specific message appears in your Kafka topic. 
 
     The AwaitMessageTriggerFunctionSensor always runs and listens. If the task fails, like if a malformed message is consumed, the DAG completes as `failed` and automatically starts its next DAG run because of the [`@continuous` schedule](scheduling-in-airflow.md#continuous-timetable).
 
+:::info
+
+Since the function provided to the `apply_function` parameter is being imported into the [Triggerer](https://docs.astronomer.io/learn/deferrable-operators#terms-and-concepts) compoment of Airflow, which does not periodically restart, you need to restart your Airflow instance to apply changes to the `apply_function` of the AwaitMessageTriggerFunctionSensor when working locally. To do so run `astro dev restart` in your terminal. Changes to the `event_triggered_function` of the AwaitMessageTriggerFunctionSensor do not require a restart of your Airflow instance.
+
+:::
 
 ## Step 5: Create a downstream DAG
 

--- a/learn/airflow-kafka.md
+++ b/learn/airflow-kafka.md
@@ -178,6 +178,8 @@ Airflow can run a function when a specific message appears in your Kafka topic. 
 
 When working locally, you need to restart your Airflow instance to apply changes to the `apply_function` of the AwaitMessageTriggerFunctionSensor because the function is imported into the [Triggerer](https://docs.astronomer.io/learn/deferrable-operators#terms-and-concepts), which does not periodically restart. To do so, run `astro dev restart` in your terminal. Changes to the `event_triggered_function` of the AwaitMessageTriggerFunctionSensor do not require a restart of your Airflow instance.
 
+On Astro, the Triggerer is restarted automatically when a new image is deployed, but not on dag-only deploys, see [Deploy DAGs to Astro](https://docs.astronomer.io/astro/deploy-dags).
+
 :::
 
 ## Step 5: Create a downstream DAG


### PR DESCRIPTION
Thanks to @manmeetkaur for pointing out I forgot to mention this :) 

I asked in #product-astro about how Triggerer restarting is handled in case of dag-only deploys. Depending on the answer I might add another sentence about where to put the function. 