### PR TITLE
Clarity on DAG-only Deploys & CI/CD Enforcement

### DIFF
--- a/astro/deployment-details.md
+++ b/astro/deployment-details.md
@@ -43,20 +43,6 @@ By default, any user can deploy code either directly from the Astro CLI or from 
 
 After you enable CI/CD enforcement on a Deployment, the Deployment accepts a deploy only if the deploy is authenticated using a Deployment API token, Workspace API token, or Organization API token. Astronomer recommends enabling this setting for all production environments.
 
-:::info
-
-When CI/CD enforcement is enabled for a Deployment, you cannot enable or disable [DAG-only deploys](deploy-dags.md) for the Deployment.
-
-To enable or disable DAG-only deploys when CI/CD enforcement is turned on:
-
-1. Turn **CI/CD Enforcement** to **Off**.
-2. Enable or disable the DAG-only deploy feature. See [Enable or disable DAG-only deploys](deploy-dags.md#enable-or-disable-dag-only-deploys).
-3. Turn **CI/CD Enforcememt** to **On**.
-
-You have to only complete these steps once. Once the DAG-only deploy feature is enabled or disabled, you can turn CI/CD enforcement on or off at any time.
-
-:::
-
 1. In the Cloud UI, select a Workspace, click **Deployments**, and then select a Deployment.
 
 2. Click the **Options** menu of the Deployment you want to update, and select **Edit Deployment**.
@@ -66,6 +52,20 @@ You have to only complete these steps once. Once the DAG-only deploy feature is 
 3. In the **Advanced** section, find **CI/CD Enforcement** and click the toggle to **On**.
 
 You can also update your Workspace so that any new Deployments in the Workspace enforce CI/CD deploys by default. See [Update general Workspace settings](manage-workspaces.md#update-general-workspace-settings).
+
+:::info
+
+When CI/CD enforcement is enabled for a Deployment, you cannot enable or disable [DAG-only deploys](deploy-dags.md) for the Deployment.
+
+To enable or disable DAG-only deploys when CI/CD enforcement is turned on:
+
+1. Turn **CI/CD Enforcement** to **Off**.
+2. Enable or disable the DAG-only deploy feature. See [Enable or disable DAG-only deploys](deploy-dags.md#enable-or-disable-dag-only-deploys).
+3. Turn **CI/CD Enforcememt** back to **On**.
+
+You have to only complete these steps once. Once the DAG-only deploy feature is enabled or disabled, you can turn CI/CD enforcement on or off at any time.
+
+:::
 
 ## Delete a Deployment
 

--- a/astro/deployment-details.md
+++ b/astro/deployment-details.md
@@ -39,17 +39,21 @@ In addition to alert emails for your Deployments, Astronomer recommends configur
 
 ## Enforce CI/CD deploys
 
-By default, Deployments accept code deploys from any authenticated source. This means that by default, any individual user can deploy code either directly from the Astro CLI or from a CI/CD process that is authenticated with an API token. To help your team protect production environments from manual code deploys that circumvent your organization's CI/CD processes and checks, Astronomer supports a Deployment-level setting called **CI/CD Enforcement**. When you enforce CI/CD deploys for a Deployment, the Deployment accepts code deploys only if the deploys are triggered with a Deployment API token, Workspace API token, or Organization API token. Astronomer recommends enabling this setting for all production environments.
+By default, any user can deploy code either directly from the Astro CLI or from a CI/CD process that is authenticated with an API token. To help your team protect production environments from manual code deploys that circumvent your organization's CI/CD processes and checks, you can configure a Deployment so that users can't deploy code manually using the Astro CLI. 
+
+After you enable CI/CD enforcement on a Deployment, the Deployment accepts a deploy only if the deploy is authenticated using a Deployment API token, Workspace API token, or Organization API token. Astronomer recommends enabling this setting for all production environments.
 
 :::info
 
-When CI/CD enforcement is enabled for a Deployment, you can't enable [DAG-only deploys](deploy-dags.md) for the Deployment. To use both of these features, Astronomer recommends that you:
+When CI/CD enforcement is enabled for a Deployment, you cannot enable or disable [DAG-only deploys](deploy-dags.md) for the Deployment.
+
+To enable or disable DAG-only deploys when CI/CD enforcement is turned on:
 
 1. Turn **CI/CD Enforcement** to **Off**.
-2. Enable the DAG-only deploy feature. See [Enable DAG-only deploys](deploy-dags.md#enable-dag-only-deploys).
+2. Enable or disable the DAG-only deploy feature. See [Enable or disable DAG-only deploys](deploy-dags.md#enable-or-disable-dag-only-deploys).
 3. Turn **CI/CD Enforcememt** to **On**.
 
-You have to only complete these steps once. Once the DAG-only deploy feature is enabled, you can turn CI/CD enforcement on or off at any time.
+You have to only complete these steps once. Once the DAG-only deploy feature is enabled or disabled, you can turn CI/CD enforcement on or off at any time.
 
 :::
 

--- a/astro/deployment-details.md
+++ b/astro/deployment-details.md
@@ -39,10 +39,19 @@ In addition to alert emails for your Deployments, Astronomer recommends configur
 
 ## Enforce CI/CD deploys
 
-By default, Deployments accept code deploys from any authenticated source. When you enforce CI/CD deploys for a Deployment:
+By default, Deployments accept code deploys from any authenticated source. This means that by default, any individual user can deploy code either directly from the Astro CLI or from a CI/CD process that is authenticated with an API token. To help your team protect production environments from manual code deploys that circumvent your organization's CI/CD processes and checks, Astronomer supports a Deployment-level setting called **CI/CD Enforcement**. When you enforce CI/CD deploys for a Deployment, the Deployment accepts code deploys only if the deploys are triggered with a Deployment API token, Workspace API token, or Organization API token. Astronomer recommends enabling this setting for all production environments.
 
-- The Deployment accepts code deploys only if the deploys are triggered with a Deployment API token, Workspace API token, or Organization API token.
-- You can't enable [DAG-only deploys](deploy-dags.md) for the Deployment.
+:::info
+
+When CI/CD enforcement is enabled for a Deployment, you can't enable [DAG-only deploys](deploy-dags.md) for the Deployment. To use both of these features, Astronomer recommends that you:
+
+1. Turn **CI/CD Enforcement** to **Off**.
+2. Enable the DAG-only deploy feature. See [Enable DAG-only deploys](deploy-dags.md#enable-dag-only-deploys).
+3. Turn **CI/CD Enforcememt** to **On**.
+
+You have to only complete these steps once. Once the DAG-only deploy feature is enabled, you can turn CI/CD enforcement on or off at any time.
+
+:::
 
 1. In the Cloud UI, select a Workspace, click **Deployments**, and then select a Deployment.
 


### PR DESCRIPTION
Did a few things here:

- Added more language around why a user would want to enforce CI/CD
- Clarified what happens when CI/CD enforcement is turned on and when Astronomer recommends using it
- Pulled out the DAG-only deploy restriction to an "info" note
- Added sequential steps that makes it clear when you enable vs. disable the things