### PR TITLE
Update GCP connect doc to include more actionable instructions for client

### DIFF
--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -99,7 +99,7 @@ You can check if the service that you want to connect Airflow to is available th
 ```bash
 gcloud services list --available --filter="name:googleapis.com"
 ```
-If you don't see your service listed, please open a support case with [Astronomer support](astro-support.md) to set up the necessary PSC connectivity. 
+If you don't see your service listed, open a support case with [Astronomer support](astro-support.md) to set up the necessary PSC connectivity. 
 
 </TabItem>
 

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -95,11 +95,11 @@ Use Private Service Connect (PSC) to create private connections from Astro to GC
 
 Astro clusters are by default configured with a PSC endpoint with a target of [All Google APIs](https://cloud.google.com/vpc/docs/configure-private-service-connect-apis#supported-apis). To provide a secure-by-default configuration, a DNS zone is created with a resource record that will route all requests made to `*.googleapis.com` through this PSC endpoint. This ensures that requests made to these services are made over PSC without any additional user configuration. As an example, requests to `storage.googleapis.com` will be routed through this PSC endpoint.
 
-A list of Google services and their associated service names are provided in the [Google APIs Explorer Directory](https://developers.google.com/apis-explorer). Alternatively, you can run the following command in the Google Cloud CLI to return a list of Google services and their associated service names:
-
+You can check if the service to which you’re attempting to connect Airflows is available through the All Google APIs target by running: 
 ```bash
 gcloud services list --available --filter="name:googleapis.com"
 ```
+If you do NOT see your service listed, please open a support case with Astronomer support to set up the necessary PSC connectivity. 
 
 </TabItem>
 

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -95,11 +95,11 @@ Use Private Service Connect (PSC) to create private connections from Astro to GC
 
 Astro clusters are by default configured with a PSC endpoint with a target of [All Google APIs](https://cloud.google.com/vpc/docs/configure-private-service-connect-apis#supported-apis). To provide a secure-by-default configuration, a DNS zone is created with a resource record that will route all requests made to `*.googleapis.com` through this PSC endpoint. This ensures that requests made to these services are made over PSC without any additional user configuration. As an example, requests to `storage.googleapis.com` will be routed through this PSC endpoint.
 
-You can check if the service to which you’re attempting to connect Airflows is available through the All Google APIs target by running: 
+You can check if the service that you want to connect Airflow to is available through the **All Google APIs** target by running the following command: 
 ```bash
 gcloud services list --available --filter="name:googleapis.com"
 ```
-If you do NOT see your service listed, please open a support case with Astronomer support to set up the necessary PSC connectivity. 
+If you don't see your service listed, please open a support case with [Astronomer support](astro-support.md) to set up the necessary PSC connectivity. 
 
 </TabItem>
 


### PR DESCRIPTION
Current GCP connectivity doc does not provide adequate instructions for how to set up PSC connectivity, nor does it provide a description for when such configs are necessary and when to reach out to Astronomer support. This change attempts to address this.