### PR TITLE
Astronomer Software: improve instructions for dag-deployment and airgapped install

### DIFF
--- a/software/deploy-dags.md
+++ b/software/deploy-dags.md
@@ -28,7 +28,7 @@ When you [update a Deployment](#configure-dag-only-deploys-on-a-deployment) to s
 
 ## Enable the feature on an Astronomer cluster
 
-By default, DAG-only deploys are disabled for all Deployments on Astronomer Software. To enable the feature, set `global.dagOnlyDeployment.enabled` to `true` in your `config.yaml` file, e.g.:
+By default, DAG-only deploys are disabled for all Deployments on Astronomer Software. To enable the feature, set `global.dagOnlyDeployment.enabled` to `true` in your `config.yaml` file:
 
 ```yaml
 global:

--- a/software/deploy-dags.md
+++ b/software/deploy-dags.md
@@ -36,9 +36,9 @@ global:
     enabled: true
 ```
 
-## Additional configurable options
+:::info 
 
-You may configure certain other configurable options related to dag-deployment, including the amount of resources available to the container as per the example below:
+If you need to customize the resources available to the DAG deploy mechanism on your Astronomer Software cluster, update your configuration to include the following values:
 
 ```yaml
 global:
@@ -46,15 +46,19 @@ global:
     enabled: true
     resources:
       requests:
+        # Update values as required for your cluster
         cpu: "100m"
         memory: "256Mi"
       limits:
+        # Update values as required for your cluster
         cpu: "500m"
         memory: "1024Mi"
     image: quay.io/astronomer/ap-dag-deploy:0.3.2
     securityContext:
       fsGroup: 50000
 ```
+
+:::
 
 :::info
 

--- a/software/deploy-dags.md
+++ b/software/deploy-dags.md
@@ -28,22 +28,32 @@ When you [update a Deployment](#configure-dag-only-deploys-on-a-deployment) to s
 
 ## Enable the feature on an Astronomer cluster
 
-By default, DAG-only deploys are disabled for all Deployments on Astronomer Software. To enable the feature, add the following configuration to your `config.yaml` file:
+By default, DAG-only deploys are disabled for all Deployments on Astronomer Software. To enable the feature, set `global.dagOnlyDeployment.enabled` to `true` in your `config.yaml` file, e.g.:
 
 ```yaml
-dagOnlyDeployment:
+global:
+  dagOnlyDeployment:
     enabled: true
-    image: quay.io/astronomer/ap-dag-deploy:0.3.2
-    securityContext:
-      fsGroup: 50000
-    resources: {
+```
+
+## Additional configurable options
+
+You may configure certain other configurable options related to dag-deployment, including the amount of resources available to the container as per the example below:
+
+```yaml
+global:
+  dagOnlyDeployment:
+    enabled: true
+    resources:
       requests:
         cpu: "100m"
         memory: "256Mi"
       limits:
         cpu: "500m"
         memory: "1024Mi"
-    }
+    image: quay.io/astronomer/ap-dag-deploy:0.3.2
+    securityContext:
+      fsGroup: 50000
 ```
 
 :::info

--- a/software/install-airgapped.md
+++ b/software/install-airgapped.md
@@ -56,7 +56,7 @@ The images and tags which are required for your Software installation depend on 
 1. Run the following command to template the Astronomer Helm chart and fetch all of its rendered image tags. Make sure to substitute `<your-basedomain>` and `<your-astronomer-version>` with your information.
 
     ```bash
-    helm template --version <your-astronomer-version> astronomer/astronomer --set global.loggingSidecar.enabled=True --set global.postgresqlEnabled=True --set global.authSidecar.enabled=True --set global.baseDomain=<your-basedomain> | grep "image: " | sed -e 's/"//g' -e 's/image:[ ]//' -e 's/^ *//g' | sort | uniq                           
+    helm template --version <your-astronomer-version> astronomer/astronomer --set global.dagOnlyDeployment.enabled=True --set global.loggingSidecar.enabled=True --set global.postgresqlEnabled=True --set global.authSidecar.enabled=True --set global.baseDomain=<your-basedomain> | grep "image: " | sed -e 's/"//g' -e 's/image:[ ]//' -e 's/^ *//g' | sort | uniq                           
     ```
     
     This command sets all possible Helm values that could impact which images are required for your installation. By fetching all images now, you save time by eliminating the risk of missing an image. 

--- a/software/install-airgapped.md
+++ b/software/install-airgapped.md
@@ -99,6 +99,7 @@ astronomer:
                 repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/astro-runtime
             airflow:
               defaultAirflowRepository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-airflow
+              defaultRuntimeRepository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/astro-runtime
               images:
                 airflow:
                   repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-airflow


### PR DESCRIPTION
Correct a wrong configuration path that would prevent dag deployments from being enabled.
Break out optional dag-deployment settings from the initial example of enabling the feature.
Add defaultRuntimeRepository to the standard example configuration for airgapped installations.
Add configuration settings to example so that the dag-downloader sidecar gets included in the list of images customers mirror for airgapped installations.