### PR TITLE
Quick Fix for Segment Bug

### DIFF
--- a/segment-page.mjs
+++ b/segment-page.mjs
@@ -8,7 +8,9 @@ export default (function () {
   return {
     onRouteDidUpdate() {
       if (!window.analytics) return;
-      window.analytics.page();
+      setTimeout(() => {
+        window.analytics.page();
+      }, 0);
     },
   };
 })();


### PR DESCRIPTION
Hey team, this PR is super small and super quick for a bug related to #3478 where page events are occasionally firing with the previous page's info (e.g. visiting `/astro` then `/astro/astro-architecture`). Wrapping the page view event in `setTimeout` set to `0` fixes this issue by giving `window` just enough time to update info before Segment fires.