### PR TITLE
Replace (my|your)?company.com with example.com (rfc6761), fix whitespace

### DIFF
--- a/archived_software_docs/version-0.16/houston-api.md
+++ b/archived_software_docs/version-0.16/houston-api.md
@@ -119,7 +119,7 @@ To query for information about a user on the platform (e.g. "When was this user 
 
 ```graphql
 query User {
-  users(user: { email: "<name@mycompany.com>"} )
+  users(user: { email: "<name@example.com>"} )
   {
     id
     roleBindings {role}
@@ -380,7 +380,7 @@ With that information, run the following:
 mutation WorkspaceAddUser {
 	workspaceAddUser (
     workspaceUuid: "<workspace-id>"
-    email: "<email@mycompany.com>"
+    email: "<email@example.com>"
     role: WORKSPACE_ADMIN
   ) {
     users {emails {address} }

--- a/archived_software_docs/version-0.16/platform-alerts.md
+++ b/archived_software_docs/version-0.16/platform-alerts.md
@@ -53,8 +53,8 @@ alertmanager:
     platform:
       email_configs:
         - smarthost: smtp.sendgrid.net:587
-          from: <your-astronomer-alert-email@company.com>
-          to: <your-email@company.com>
+          from: <your-astronomer-alert-email@example.com>
+          to: <your-email@example.com>
           auth_username: apikey
           auth_password: SG.myapikey1234567891234abcdef_bKY
           send_resolved: true

--- a/archived_software_docs/version-0.23/houston-api.md
+++ b/archived_software_docs/version-0.23/houston-api.md
@@ -118,7 +118,7 @@ To query for information about a user on the platform (e.g. "When was this user 
 
 ```graphql
 query User {
-  users(user: { email: "<name@mycompany.com>"} )
+  users(user: { email: "<name@example.com>"} )
   {
     id
     roleBindings {role}
@@ -379,7 +379,7 @@ With that information, run the following:
 mutation WorkspaceAddUser {
 	workspaceAddUser (
     workspaceUuid: "<workspace-id>"
-    email: "<email@mycompany.com>"
+    email: "<email@example.com>"
     role: WORKSPACE_ADMIN
   ) {
     users {emails {address} }

--- a/archived_software_docs/version-0.23/platform-alerts.md
+++ b/archived_software_docs/version-0.23/platform-alerts.md
@@ -51,8 +51,8 @@ alertmanager:
     platform:
       email_configs:
         - smarthost: smtp.sendgrid.net:587
-          from: <your-astronomer-alert-email@company.com>
-          to: <your-email@company.com>
+          from: <your-astronomer-alert-email@example.com>
+          to: <your-email@example.com>
           auth_username: apikey
           auth_password: SG.myapikey1234567891234abcdef_bKY
           send_resolved: true

--- a/archived_software_docs/version-0.25/houston-api.md
+++ b/archived_software_docs/version-0.25/houston-api.md
@@ -118,7 +118,7 @@ To query for information about a user on the platform (e.g. "When was this user 
 
 ```graphql
 query User {
-  users(user: { email: "<name@mycompany.com>"} )
+  users(user: { email: "<name@example.com>"} )
   {
     id
     roleBindings {role}
@@ -409,7 +409,7 @@ With that information, run the following:
 mutation WorkspaceAddUser {
 	workspaceAddUser (
     workspaceUuid: "<workspace-id>"
-    email: "<email@mycompany.com>"
+    email: "<email@example.com>"
     role: WORKSPACE_ADMIN
   ) {
     users {emails {address} }

--- a/archived_software_docs/version-0.25/platform-alerts.md
+++ b/archived_software_docs/version-0.25/platform-alerts.md
@@ -51,8 +51,8 @@ alertmanager:
     platform:
       email_configs:
         - smarthost: smtp.sendgrid.net:587
-          from: <your-astronomer-alert-email@company.com>
-          to: <your-email@company.com>
+          from: <your-astronomer-alert-email@example.com>
+          to: <your-email@example.com>
           auth_username: apikey
           auth_password: SG.myapikey1234567891234abcdef_bKY
           send_resolved: true

--- a/archived_software_docs/version-0.26/houston-api.md
+++ b/archived_software_docs/version-0.26/houston-api.md
@@ -119,7 +119,7 @@ To query for information about a user on the platform (e.g. "When was this user 
 
 ```graphql
 query User {
-  users(user: { email: "<name@mycompany.com>"} )
+  users(user: { email: "<name@example.com>"} )
   {
     id
     roleBindings {role}
@@ -410,7 +410,7 @@ With that information, run the following:
 mutation WorkspaceAddUser {
 	workspaceAddUser (
     workspaceUuid: "<workspace-id>"
-    email: "<email@mycompany.com>"
+    email: "<email@example.com>"
     role: WORKSPACE_ADMIN
   ) {
     users {emails {address} }

--- a/archived_software_docs/version-0.27/houston-api.md
+++ b/archived_software_docs/version-0.27/houston-api.md
@@ -119,7 +119,7 @@ To query for information about a user on the platform (e.g. "When was this user 
 
 ```graphql
 query User {
-  users(user: { email: "<name@mycompany.com>"} )
+  users(user: { email: "<name@example.com>"} )
   {
     id
     roleBindings {role}
@@ -410,7 +410,7 @@ With that information, run the following:
 mutation WorkspaceAddUser {
 	workspaceAddUser (
     workspaceUuid: "<workspace-id>"
-    email: "<email@mycompany.com>"
+    email: "<email@example.com>"
     role: WORKSPACE_ADMIN
   ) {
     users {emails {address} }

--- a/archived_software_docs/version-0.27/install-airgapped.md
+++ b/archived_software_docs/version-0.27/install-airgapped.md
@@ -251,7 +251,7 @@ To configure a self-hosted Helm chart, add the following configuration to your `
 ```yaml
 # Example URL - replace with your own repository destination
 global:
-  helmRepo: "http://artifactory.company.com:32775/artifactory/astro-helm-chart"
+  helmRepo: "http://artifactory.example.com:32775/artifactory/astro-helm-chart"
 ```
 
 :::info

--- a/archived_software_docs/version-0.27/platform-alerts.md
+++ b/archived_software_docs/version-0.27/platform-alerts.md
@@ -51,8 +51,8 @@ alertmanager:
     platform:
       email_configs:
         - smarthost: smtp.sendgrid.net:587
-          from: <your-astronomer-alert-email@company.com>
-          to: <your-email@company.com>
+          from: <your-astronomer-alert-email@example.com>
+          to: <your-email@example.com>
           auth_username: apikey
           auth_password: SG.myapikey1234567891234abcdef_bKY
           send_resolved: true

--- a/archived_software_docs/version-0.28/airflow-api.md
+++ b/archived_software_docs/version-0.28/airflow-api.md
@@ -22,7 +22,7 @@ You can use the Software UI or the Astro CLI to create a Service Account.
 
 :::info
 
-If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service Account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.yourcompany.com/token`) and skip to Step 2.
+If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service Account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.example.com/token`) and skip to Step 2.
 
 :::
 

--- a/archived_software_docs/version-0.28/houston-api.md
+++ b/archived_software_docs/version-0.28/houston-api.md
@@ -119,7 +119,7 @@ To query for information about a user on the platform (e.g. "When was this user 
 
 ```graphql
 query User {
-  users(user: { email: "<name@mycompany.com>"} )
+  users(user: { email: "<name@example.com>"} )
   {
     id
     roleBindings {role}
@@ -410,7 +410,7 @@ With that information, run the following:
 mutation WorkspaceAddUser {
 	workspaceAddUser (
     workspaceUuid: "<workspace-id>"
-    email: "<email@mycompany.com>"
+    email: "<email@example.com>"
     role: WORKSPACE_ADMIN
   ) {
     users {emails {address} }

--- a/archived_software_docs/version-0.28/install-airgapped.md
+++ b/archived_software_docs/version-0.28/install-airgapped.md
@@ -122,7 +122,7 @@ To configure a self-hosted Helm chart, add the following configuration to your `
 ```yaml
 # Example URL - replace with your own repository destination
 global:
-  helmRepo: "http://artifactory.company.com:32775/artifactory/astro-helm-chart"
+  helmRepo: "http://artifactory.example.com:32775/artifactory/astro-helm-chart"
 ```
 
 :::info

--- a/archived_software_docs/version-0.28/platform-alerts.md
+++ b/archived_software_docs/version-0.28/platform-alerts.md
@@ -51,8 +51,8 @@ alertmanager:
     platform:
       email_configs:
         - smarthost: smtp.sendgrid.net:587
-          from: <your-astronomer-alert-email@company.com>
-          to: <your-email@company.com>
+          from: <your-astronomer-alert-email@example.com>
+          to: <your-email@example.com>
           auth_username: apikey
           auth_password: SG.myapikey1234567891234abcdef_bKY
           send_resolved: true

--- a/archived_software_docs/version-0.29/airflow-api.md
+++ b/archived_software_docs/version-0.29/airflow-api.md
@@ -20,7 +20,7 @@ You can use the Software UI or the Astro CLI to create a Service account.
 
 :::info
 
-If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.yourcompany.com/token`) and skip to Step 2.
+If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.example.com/token`) and skip to Step 2.
 
 :::
 

--- a/archived_software_docs/version-0.29/houston-api.md
+++ b/archived_software_docs/version-0.29/houston-api.md
@@ -116,7 +116,7 @@ To query for information about a user on the platform (e.g. "When was this user 
 
 ```graphql
 query User {
-  users(user: { email: "<name@mycompany.com>"} )
+  users(user: { email: "<name@example.com>"} )
   {
     id
     roleBindings {role}
@@ -407,7 +407,7 @@ With that information, run the following:
 mutation WorkspaceAddUser {
 	workspaceAddUser (
     workspaceUuid: "<workspace-id>"
-    email: "<email@mycompany.com>"
+    email: "<email@example.com>"
     role: WORKSPACE_ADMIN
   ) {
     users {emails {address} }

--- a/archived_software_docs/version-0.29/install-airgapped.md
+++ b/archived_software_docs/version-0.29/install-airgapped.md
@@ -131,7 +131,7 @@ To configure a self-hosted Helm chart, add the following configuration to your `
 ```yaml
 # Example URL - replace with your own repository destination
 global:
-  helmRepo: "http://artifactory.company.com:32775/artifactory/astro-helm-chart"
+  helmRepo: "http://artifactory.example.com:32775/artifactory/astro-helm-chart"
 ```
 
 :::info

--- a/archived_software_docs/version-0.29/platform-alerts.md
+++ b/archived_software_docs/version-0.29/platform-alerts.md
@@ -49,8 +49,8 @@ alertmanager:
     platform: |
       email_configs:
         - smarthost: smtp.sendgrid.net:587
-          from: <your-astronomer-alert-email@company.com>
-          to: <your-email@company.com>
+          from: <your-astronomer-alert-email@example.com>
+          to: <your-email@example.com>
           auth_username: apikey
           auth_password: SG.myapikey1234567891234abcdef_bKY
           send_resolved: true

--- a/archived_software_docs/version-0.31/airflow-api.md
+++ b/archived_software_docs/version-0.31/airflow-api.md
@@ -20,7 +20,7 @@ You can use the Software UI or the Astro CLI to create a Service account.
 
 :::info
 
-If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.yourcompany.com/token`) and skip to Step 2.
+If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.example.com/token`) and skip to Step 2.
 
 :::
 

--- a/archived_software_docs/version-0.31/houston-api.md
+++ b/archived_software_docs/version-0.31/houston-api.md
@@ -119,7 +119,7 @@ To query for information about a user on the platform (e.g. "When was this user 
 
 ```graphql
 query User {
-  users(user: { email: "<name@mycompany.com>"} )
+  users(user: { email: "<name@example.com>"} )
   {
     id
     roleBindings {role}
@@ -410,7 +410,7 @@ With that information, run the following:
 mutation WorkspaceAddUser {
 	workspaceAddUser (
     workspaceUuid: "<workspace-id>"
-    email: "<email@mycompany.com>"
+    email: "<email@example.com>"
     role: WORKSPACE_ADMIN
   ) {
     users {emails {address} }

--- a/archived_software_docs/version-0.31/install-airgapped.md
+++ b/archived_software_docs/version-0.31/install-airgapped.md
@@ -143,7 +143,7 @@ To configure a self-hosted Helm chart, add the following configuration to your `
 ```yaml
 # Example URL - replace with your own repository destination
 global:
-  helmRepo: "http://artifactory.company.com:32775/artifactory/astro-helm-chart"
+  helmRepo: "http://artifactory.example.com:32775/artifactory/astro-helm-chart"
 ```
 
 :::info

--- a/archived_software_docs/version-0.31/integrate-auth-system.md
+++ b/archived_software_docs/version-0.31/integrate-auth-system.md
@@ -118,7 +118,7 @@ Follow these steps to configure Azure AD as your OIDC provider.
         - Web / `https://houston.BASEDOMAIN/v1/oauth/redirect/`.
         - Web / `https://houston.BASEDOMAIN/v1/oauth/callback/`.
 
-    Replace `BASEDOMAIN` with your own. For example, if your base domain is `mycompany.com`, your redirect URIs should be `https://houston.mycompany.com/v1/oauth/redirect/` and `https://houston.mycompany.com/v1/oauth/callback/`.
+    Replace `BASEDOMAIN` with your own. For example, if your base domain is `example.com`, your redirect URIs should be `https://houston.example.com/v1/oauth/redirect/` and `https://houston.example.com/v1/oauth/callback/`.
 
 3. Click **Register**.
 

--- a/archived_software_docs/version-0.31/platform-alerts.md
+++ b/archived_software_docs/version-0.31/platform-alerts.md
@@ -49,8 +49,8 @@ alertmanager:
     platform: 
       email_configs:
         - smarthost: smtp.sendgrid.net:587
-          from: <your-astronomer-alert-email@company.com>
-          to: <your-email@company.com>
+          from: <your-astronomer-alert-email@example.com>
+          to: <your-email@example.com>
           auth_username: apikey
           auth_password: SG.myapikey1234567891234abcdef_bKY
           send_resolved: true

--- a/astro/api/get-started.md
+++ b/astro/api/get-started.md
@@ -30,7 +30,7 @@ If the command was successful, then you receive a response that begins similarly
 {
   "organizations": [
     {
-      "billingEmail": "billing@company.com",
+      "billingEmail": "billing@example.com",
       "createdAt": "2022-11-22T04:37:12T",
       "createdBySubject": {
         "apiTokenName": "my-token",
@@ -38,7 +38,7 @@ If the command was successful, then you receive a response that begins similarly
         "fullName": "Jane Doe",
         "id": "clm8qv74h000008mlf08scq7k",
         "subjectType": "USER",
-        "username": "user1@company.com"
+        "username": "user1@example.com"
       },
       "id": "clmaxoarx000008l2c5ayb9pt",
       "isScimEnabled": false,
@@ -75,7 +75,7 @@ If the command succeeds, the API returns a list of Workspaces similar to the fol
         "fullName": "Jane Doe",
         "id": "clm8qv74h000008mlf08scq7k",
         "subjectType": "USER",
-        "username": "user1@company.com"
+        "username": "user1@example.com"
       },
       "description": "This is a test workspace",
       "id": "clm8t5u4q000008jq4qoc3036",
@@ -89,7 +89,7 @@ If the command succeeds, the API returns a list of Workspaces similar to the fol
         "fullName": "Jane Doe",
         "id": "clm8qv74h000008mlf08scq7k",
         "subjectType": "USER",
-        "username": "user1@company.com"
+        "username": "user1@example.com"
       }
     }
   ]

--- a/astro/cli/private-python-packages.md
+++ b/astro/cli/private-python-packages.md
@@ -169,7 +169,7 @@ Make sure that the name of any privately hosted Python package doesn’t conflic
 Create a new file called `indexurl.txt` that contains the extra index URL used to access your private PuPI index. For example:
 
 ```text
-https://myuser:mycompany.com/api/pypi/pypi/simple
+https://myuser:example.com/api/pypi/pypi/simple
 ```
 
 Ensure that this file is accessible from your Astro project. You will mount this value as a secret when you build your Astro project image.

--- a/software/airflow-api.md
+++ b/software/airflow-api.md
@@ -20,7 +20,7 @@ You can use the Software UI or the Astro CLI to create a Service account.
 
 :::info
 
-If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.yourcompany.com/token`) and skip to Step 2.
+If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.example.com/token`) and skip to Step 2.
 
 :::
 

--- a/software/houston-api.md
+++ b/software/houston-api.md
@@ -116,7 +116,7 @@ To query for information about a user on the platform (e.g. "When was this user 
 
 ```graphql
 query User {
-  users(user: { email: "<name@mycompany.com>"} )
+  users(user: { email: "<name@example.com>"} )
   {
     id
     roleBindings {role}
@@ -563,7 +563,7 @@ With that information, run the following:
 mutation WorkspaceAddUser {
 	workspaceAddUser (
     workspaceUuid: "<workspace-id>"
-    email: "<email@mycompany.com>"
+    email: "<email@example.com>"
     role: WORKSPACE_ADMIN
   ) {
     users {emails {address} }

--- a/software/install-airgapped.md
+++ b/software/install-airgapped.md
@@ -56,10 +56,10 @@ The images and tags which are required for your Software installation depend on 
 1. Run the following command to template the Astronomer Helm chart and fetch all of its rendered image tags. Make sure to substitute `<your-basedomain>` and `<your-astronomer-version>` with your information.
 
     ```bash
-    helm template --version <your-astronomer-version> astronomer/astronomer --set global.dagOnlyDeployment.enabled=True --set global.loggingSidecar.enabled=True --set global.postgresqlEnabled=True --set global.authSidecar.enabled=True --set global.baseDomain=<your-basedomain> | grep "image: " | sed -e 's/"//g' -e 's/image:[ ]//' -e 's/^ *//g' | sort | uniq                           
+    helm template --version <your-astronomer-version> astronomer/astronomer --set global.dagOnlyDeployment.enabled=True --set global.loggingSidecar.enabled=True --set global.postgresqlEnabled=True --set global.authSidecar.enabled=True --set global.baseDomain=<your-basedomain> | grep "image: " | sed -e 's/"//g' -e 's/image:[ ]//' -e 's/^ *//g' | sort | uniq
     ```
-    
-    This command sets all possible Helm values that could impact which images are required for your installation. By fetching all images now, you save time by eliminating the risk of missing an image. 
+
+    This command sets all possible Helm values that could impact which images are required for your installation. By fetching all images now, you save time by eliminating the risk of missing an image.
 2. Run the following command to template the Airflow Helm chart and fetch its rendered image tags:
 
     ```shell
@@ -88,31 +88,31 @@ This configuration automatically pulls most Docker images required in the Astron
 
 ```yaml
 astronomer:
-    houston:
-      config:
-        deployments:
-          helm:
-            runtimeImages:
-              airflow:
-                repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/astro-runtime
-              flower:
-                repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/astro-runtime
+  houston:
+    config:
+      deployments:
+        helm:
+          runtimeImages:
             airflow:
-              defaultAirflowRepository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-airflow
-              defaultRuntimeRepository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/astro-runtime
-              images:
-                airflow:
-                  repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-airflow
-                statsd:
-                  repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-statsd-exporter
-                redis:
-                  repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-redis
-                pgbouncer:
-                  repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-pgbouncer
-                pgbouncerExporter:
-                  repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-pgbouncer-exporter
-                gitSync:
-                  repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-git-sync
+              repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/astro-runtime
+            flower:
+              repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/astro-runtime
+          airflow:
+            defaultAirflowRepository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-airflow
+            defaultRuntimeRepository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/astro-runtime
+            images:
+              airflow:
+                repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-airflow
+              statsd:
+                repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-statsd-exporter
+              redis:
+                repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-redis
+              pgbouncer:
+                repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-pgbouncer
+              pgbouncerExporter:
+                repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-pgbouncer-exporter
+              gitSync:
+                repository: 012345678910.dkr.ecr.us-east-1.amazonaws.com/myrepo/astronomer/ap-git-sync
 ```
 
 ## Step 4: Fetch Airflow Helm charts
@@ -143,7 +143,7 @@ To configure a self-hosted Helm chart, add the following configuration to your `
 ```yaml
 # Example URL - replace with your own repository destination
 global:
-  helmRepo: "http://artifactory.company.com:32775/artifactory/astro-helm-chart"
+  helmRepo: "http://artifactory.example.com:32775/artifactory/astro-helm-chart"
 ```
 
 :::info
@@ -299,7 +299,7 @@ No matter what option you choose, the commands that you run should return the up
 
 ### Configuring a custom updates JSON URL
 
-After you have made the updates JSON accessible within your premises, you must configure the Helm chart to fetch updates from the custom URL:  
+After you have made the updates JSON accessible within your premises, you must configure the Helm chart to fetch updates from the custom URL:
 
 ```yaml
 astronomer:

--- a/software/integrate-auth-system.md
+++ b/software/integrate-auth-system.md
@@ -59,7 +59,7 @@ The following setups assume that you are using the default Astronomer [implicit 
         - Web / `https://houston.BASEDOMAIN/v1/oauth/redirect/`.
         - Web / `https://houston.BASEDOMAIN/v1/oauth/callback/`.
 
-    Replace `BASEDOMAIN` with your own. For example, if your base domain is `mycompany.com`, your redirect URIs should be `https://houston.mycompany.com/v1/oauth/redirect/` and `https://houston.mycompany.com/v1/oauth/callback/`.
+    Replace `BASEDOMAIN` with your own. For example, if your base domain is `example.com`, your redirect URIs should be `https://houston.example.com/v1/oauth/redirect/` and `https://houston.example.com/v1/oauth/callback/`.
 
 3. Click **Register**.
 

--- a/software/platform-alerts.md
+++ b/software/platform-alerts.md
@@ -49,8 +49,8 @@ alertmanager:
     platform: 
       email_configs:
         - smarthost: smtp.sendgrid.net:587
-          from: <your-astronomer-alert-email@company.com>
-          to: <your-email@company.com>
+          from: <your-astronomer-alert-email@example.com>
+          to: <your-email@example.com>
           auth_username: apikey
           auth_password: SG.myapikey1234567891234abcdef_bKY
           send_resolved: true

--- a/software_versioned_docs/version-0.30/airflow-api.md
+++ b/software_versioned_docs/version-0.30/airflow-api.md
@@ -20,7 +20,7 @@ You can use the Software UI or the Astro CLI to create a Service account.
 
 :::info
 
-If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.yourcompany.com/token`) and skip to Step 2.
+If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.example.com/token`) and skip to Step 2.
 
 :::
 

--- a/software_versioned_docs/version-0.30/houston-api.md
+++ b/software_versioned_docs/version-0.30/houston-api.md
@@ -116,7 +116,7 @@ To query for information about a user on the platform (e.g. "When was this user 
 
 ```graphql
 query User {
-  users(user: { email: "<name@mycompany.com>"} )
+  users(user: { email: "<name@example.com>"} )
   {
     id
     roleBindings {role}
@@ -407,7 +407,7 @@ With that information, run the following:
 mutation WorkspaceAddUser {
 	workspaceAddUser (
     workspaceUuid: "<workspace-id>"
-    email: "<email@mycompany.com>"
+    email: "<email@example.com>"
     role: WORKSPACE_ADMIN
   ) {
     users {emails {address} }

--- a/software_versioned_docs/version-0.30/install-airgapped.md
+++ b/software_versioned_docs/version-0.30/install-airgapped.md
@@ -141,7 +141,7 @@ To configure a self-hosted Helm chart, add the following configuration to your `
 ```yaml
 # Example URL - replace with your own repository destination
 global:
-  helmRepo: "http://artifactory.company.com:32775/artifactory/astro-helm-chart"
+  helmRepo: "http://artifactory.example.com:32775/artifactory/astro-helm-chart"
 ```
 
 :::info

--- a/software_versioned_docs/version-0.30/platform-alerts.md
+++ b/software_versioned_docs/version-0.30/platform-alerts.md
@@ -49,8 +49,8 @@ alertmanager:
     platform:
       email_configs:
         - smarthost: smtp.sendgrid.net:587
-          from: <your-astronomer-alert-email@company.com>
-          to: <your-email@company.com>
+          from: <your-astronomer-alert-email@example.com>
+          to: <your-email@example.com>
           auth_username: apikey
           auth_password: SG.myapikey1234567891234abcdef_bKY
           send_resolved: true

--- a/software_versioned_docs/version-0.32/airflow-api.md
+++ b/software_versioned_docs/version-0.32/airflow-api.md
@@ -20,7 +20,7 @@ You can use the Software UI or the Astro CLI to create a Service account.
 
 :::info
 
-If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.yourcompany.com/token`) and skip to Step 2.
+If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.example.com/token`) and skip to Step 2.
 
 :::
 

--- a/software_versioned_docs/version-0.32/houston-api.md
+++ b/software_versioned_docs/version-0.32/houston-api.md
@@ -116,7 +116,7 @@ To query for information about a user on the platform (e.g. "When was this user 
 
 ```graphql
 query User {
-  users(user: { email: "<name@mycompany.com>"} )
+  users(user: { email: "<name@example.com>"} )
   {
     id
     roleBindings {role}
@@ -547,7 +547,7 @@ With that information, run the following:
 mutation WorkspaceAddUser {
 	workspaceAddUser (
     workspaceUuid: "<workspace-id>"
-    email: "<email@mycompany.com>"
+    email: "<email@example.com>"
     role: WORKSPACE_ADMIN
   ) {
     users {emails {address} }

--- a/software_versioned_docs/version-0.32/install-airgapped.md
+++ b/software_versioned_docs/version-0.32/install-airgapped.md
@@ -143,7 +143,7 @@ To configure a self-hosted Helm chart, add the following configuration to your `
 ```yaml
 # Example URL - replace with your own repository destination
 global:
-  helmRepo: "http://artifactory.company.com:32775/artifactory/astro-helm-chart"
+  helmRepo: "http://artifactory.example.com:32775/artifactory/astro-helm-chart"
 ```
 
 :::info

--- a/software_versioned_docs/version-0.32/integrate-auth-system.md
+++ b/software_versioned_docs/version-0.32/integrate-auth-system.md
@@ -119,7 +119,7 @@ Follow these steps to configure Microsoft Entra ID as your OIDC provider.
         - Web / `https://houston.BASEDOMAIN/v1/oauth/redirect/`.
         - Web / `https://houston.BASEDOMAIN/v1/oauth/callback/`.
 
-    Replace `BASEDOMAIN` with your own. For example, if your base domain is `mycompany.com`, your redirect URIs should be `https://houston.mycompany.com/v1/oauth/redirect/` and `https://houston.mycompany.com/v1/oauth/callback/`.
+    Replace `BASEDOMAIN` with your own. For example, if your base domain is `example.com`, your redirect URIs should be `https://houston.example.com/v1/oauth/redirect/` and `https://houston.example.com/v1/oauth/callback/`.
 
 3. Click **Register**.
 

--- a/software_versioned_docs/version-0.32/platform-alerts.md
+++ b/software_versioned_docs/version-0.32/platform-alerts.md
@@ -49,8 +49,8 @@ alertmanager:
     platform: 
       email_configs:
         - smarthost: smtp.sendgrid.net:587
-          from: <your-astronomer-alert-email@company.com>
-          to: <your-email@company.com>
+          from: <your-astronomer-alert-email@example.com>
+          to: <your-email@example.com>
           auth_username: apikey
           auth_password: SG.myapikey1234567891234abcdef_bKY
           send_resolved: true

--- a/software_versioned_docs/version-0.33/airflow-api.md
+++ b/software_versioned_docs/version-0.33/airflow-api.md
@@ -20,7 +20,7 @@ You can use the Software UI or the Astro CLI to create a Service account.
 
 :::info
 
-If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.yourcompany.com/token`) and skip to Step 2.
+If you just need to call the Airflow REST API once, you can create a temporary Authentication Token (_expires in 24 hours_) on Astronomer in place of a long-lasting Service account. To do so, go to: `https://app.<BASE-DOMAIN>/token` (e.g. `https://app.astronomer.example.com/token`) and skip to Step 2.
 
 :::
 

--- a/software_versioned_docs/version-0.33/houston-api.md
+++ b/software_versioned_docs/version-0.33/houston-api.md
@@ -116,7 +116,7 @@ To query for information about a user on the platform (e.g. "When was this user 
 
 ```graphql
 query User {
-  users(user: { email: "<name@mycompany.com>"} )
+  users(user: { email: "<name@example.com>"} )
   {
     id
     roleBindings {role}
@@ -547,7 +547,7 @@ With that information, run the following:
 mutation WorkspaceAddUser {
 	workspaceAddUser (
     workspaceUuid: "<workspace-id>"
-    email: "<email@mycompany.com>"
+    email: "<email@example.com>"
     role: WORKSPACE_ADMIN
   ) {
     users {emails {address} }

--- a/software_versioned_docs/version-0.33/install-airgapped.md
+++ b/software_versioned_docs/version-0.33/install-airgapped.md
@@ -142,7 +142,7 @@ To configure a self-hosted Helm chart, add the following configuration to your `
 ```yaml
 # Example URL - replace with your own repository destination
 global:
-  helmRepo: "http://artifactory.company.com:32775/artifactory/astro-helm-chart"
+  helmRepo: "http://artifactory.example.com:32775/artifactory/astro-helm-chart"
 ```
 
 :::info

--- a/software_versioned_docs/version-0.33/integrate-auth-system.md
+++ b/software_versioned_docs/version-0.33/integrate-auth-system.md
@@ -61,7 +61,7 @@ The following setups assume that you are using the default Astronomer [implicit 
         - Web / `https://houston.BASEDOMAIN/v1/oauth/redirect/`.
         - Web / `https://houston.BASEDOMAIN/v1/oauth/callback/`.
 
-    Replace `BASEDOMAIN` with your own. For example, if your base domain is `mycompany.com`, your redirect URIs should be `https://houston.mycompany.com/v1/oauth/redirect/` and `https://houston.mycompany.com/v1/oauth/callback/`.
+    Replace `BASEDOMAIN` with your own. For example, if your base domain is `example.com`, your redirect URIs should be `https://houston.example.com/v1/oauth/redirect/` and `https://houston.example.com/v1/oauth/callback/`.
 
 3. Click **Register**.
 

--- a/software_versioned_docs/version-0.33/platform-alerts.md
+++ b/software_versioned_docs/version-0.33/platform-alerts.md
@@ -49,8 +49,8 @@ alertmanager:
     platform: 
       email_configs:
         - smarthost: smtp.sendgrid.net:587
-          from: <your-astronomer-alert-email@company.com>
-          to: <your-email@company.com>
+          from: <your-astronomer-alert-email@example.com>
+          to: <your-email@example.com>
           auth_username: apikey
           auth_password: SG.myapikey1234567891234abcdef_bKY
           send_resolved: true

--- a/src/components/NewsletterForm/index.js
+++ b/src/components/NewsletterForm/index.js
@@ -183,13 +183,13 @@ export default function NewsletterForm(
             aria-label="Email Address"
             type="email"
             name="email"
-            placeholder="you@company.com"
+            placeholder="you@example.com"
             value={email}
             autoComplete="email"
             onChange={(e) => setEmail(e.target.value.trim().toLowerCase())}
             pattern="^.+@.+\..+$"
             required
-            title="you@company.com"
+            title="you@example.com"
           />
           <button type="submit" disabled={disableButton}>{buttonText || content.buttonText}</button>
         </div>


### PR DESCRIPTION
- Fix whitespace in sample yaml file
- Regex replace `s/\b(my|your)?company\.com/example.com/g` to comply with [rfc6761](https://www.rfc-editor.org/rfc/rfc6761) because:
```
$ host yourcompany.com
yourcompany.com has address 64.190.63.222
yourcompany.com mail is handled by 0 localhost.
$ host mycompany.com
mycompany.com has address 52.5.196.34
$ host company.com
company.com has address 35.71.162.193
company.com has address 52.223.45.27
company.com mail is handled by 10 mx1.emailsrvr.com.
```