### PR TITLE
[Tiny PR] Fix the KPO formatting error and use role instead of profile

### DIFF
--- a/astro/kubernetespodoperator.md
+++ b/astro/kubernetespodoperator.md
@@ -409,8 +409,8 @@ To launch Pods in external clusters from a local Airflow environment, you must a
         - get-token
         - --cluster-name
         - <name of your cluster>
-        - --profile
-        - default
+        - --role
+        - <your-assume-role-arn>
         command: aws
         interactiveMode: IfAvailable
         provideClusterInfo: false
@@ -443,6 +443,7 @@ run_on_EKS = KubernetesPodOperator(
     get_logs=True,
     startup_timeout_seconds=240,
 )
+```
 
 ### Example DAG
 

--- a/astro/manage-billing.md
+++ b/astro/manage-billing.md
@@ -8,10 +8,6 @@ import HostedBadge from '@site/src/components/HostedBadge';
 
 <HostedBadge/>
 
-import HostedBadge from '@site/src/components/HostedBadge';
-
-<HostedBadge/>
-
 Astro Hosted meters and bills based on consumption of cloud resources associated with clusters, Deployments, and workers. Pricing is charged at an hourly rate, but is measured by the second. See [Pricing](https://www.astronomer.io/pricing/) for complete pricing and billing details.
 
 You can configure payment information and check your total Astro spend from the Cloud UI so that you don't go over your budget for running Airflow.


### PR DESCRIPTION
This PR fixes the folllowing:
- there were missing ``` in the code in [this section](https://docs.astronomer.io/astro/kubernetespodoperator#step-4-configure-your-task) 
- I missed this during review, but we are not using the `role` in the kubeconfig file that was created in the first step. It is not recommended to use the `profile` in a production setup or in an Astro Deployment
- Manage Billing page was giving an error on my local, removed duplicate hostedbadge import.