### PR TITLE
Add cleanup DAG to Best Practices

### DIFF
--- a/astro/best-practices/cleanup-dag.md
+++ b/astro/best-practices/cleanup-dag.md
@@ -5,7 +5,7 @@ id: cleanup-dag
 ---
 
 ```python
-"""A Cleanup DAG maintained by Astronomer."""
+"""A Cleanup DAG maintained by Astronomer. Note that the database statement timeout is set to 5 minutes. This is to prevent the cleanup from hindering other operations. If you have large tables you want to clean, you may need to run the cleanup in smaller batches."""
 
 from datetime import UTC, datetime, timedelta
 

--- a/astro/best-practices/cleanup-dag.md
+++ b/astro/best-practices/cleanup-dag.md
@@ -1,0 +1,35 @@
+---
+title: 'Cleaning up your Airflow Database with a Cleanup DAG'
+sidebar_label: 'Cleanup DAG'
+id: cleanup-dag
+---
+
+```python
+"""A Cleanup DAG used and maintained by Astronomer. All tasks in this DAG are executed by workers in the default worker queue."""
+
+from datetime import timedelta
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+
+with DAG(
+    dag_id="astronomer_cleanup_dag",
+    schedule_interval=None,
+    start_date=days_ago(2),
+    catchup=False,
+    is_paused_upon_creation=False,
+    dagrun_timeout=timedelta(minutes=30),
+    description=__doc__,
+    doc_md=__doc__,
+    tags=["cleanup"],
+) as dag:
+    clean_db = BashOperator(
+        task_id="clean_db",
+        bash_command="airflow db clean --clean-before-timestamp {{ macros.ds_add(ds, -90) }} --verbose --yes",
+        depends_on_past=False,
+        priority_weight=2**31 - 1,
+        do_xcom_push=False,
+    )
+
+```

--- a/astro/best-practices/db-cleanup-dag.md
+++ b/astro/best-practices/db-cleanup-dag.md
@@ -1,11 +1,11 @@
 ---
-title: "Cleaning up your Airflow Database with a Cleanup DAG"
-sidebar_label: "Cleanup DAG"
-id: cleanup-dag
+title: "Cleaning up your Airflow Database with a DAG"
+sidebar_label: "DB Cleanup DAG"
+id: db-cleanup-dag
 ---
 
 ```python
-"""A Cleanup DAG maintained by Astronomer. Note that the database statement timeout is set to 5 minutes. This is to prevent the cleanup from hindering other operations. If you have large tables you want to clean, you may need to run the cleanup in smaller batches."""
+"""A DB Cleanup DAG maintained by Astronomer. Note that there is a global database statement timeout of 5 minutes, so if you have large tables you want to clean, you may need to run the cleanup in smaller batches."""
 
 from datetime import UTC, datetime, timedelta
 
@@ -16,7 +16,7 @@ from airflow.operators.bash import BashOperator
 
 
 @dag(
-    dag_id="astronomer_cleanup_dag",
+    dag_id="astronomer_db_cleanup_dag",
     schedule_interval=None,
     start_date=datetime(2024, 1, 1),
     catchup=False,
@@ -44,7 +44,7 @@ from airflow.operators.bash import BashOperator
         ),
     },
 )
-def astronomer_cleanup_dag():
+def astronomer_db_cleanup_dag():
     BashOperator(
         task_id="clean_db",
         bash_command="""\
@@ -64,6 +64,6 @@ def astronomer_cleanup_dag():
     )
 
 
-astronomer_cleanup_dag()
+astronomer_db_cleanup_dag()
 
 ```


### PR DESCRIPTION
closes: https://github.com/astronomer/laminar/issues/1773

> As an iterative approach for auto-cleaning every-growing Metadata DB, build an official CleanUp DAG that we can add to our docsite that CRE and Field teams can refer too when users deployments get sluggish due to build-up of records and indexes for DB tables.

This DAG uses the official airflow [db clean](https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html#clean) CLI command to purge old records in meta store tables.

> [!NOTE]  
> Please see the issue above if you are interested in why I chose this implementation.

> [!NOTE]  
> This becomes optional once https://github.com/astronomer/astro/issues/13887 is implemented.