### PR TITLE
Remove links to the forum

### DIFF
--- a/astro/astro-support.md
+++ b/astro/astro-support.md
@@ -5,17 +5,14 @@ id: astro-support
 description: Get Astro support when you need it.
 ---
 
-In addition to product documentation, the following resources are available to help you resolve issues:
-
-- [Astronomer Forum](https://forum.astronomer.io)
-- [Airflow Guides](https://docs.astronomer.io/learn/)
-
 If you're experiencing an issue or have a question that requires Astronomer expertise, use one of the following methods to contact Astronomer support:
 
 - Submit a support request in the [Astro UI](https://cloud.astronomer.io/open-support-request).
 - Submit a support request on the [Astronomer support portal](https://support.astronomer.io/hc/en-us).
 - Send an email to [support@astronomer.io](mailto:support@astronomer.io).
 - Submit a support request by phone at +1 (831) 777-2768.
+
+In addition to product documentation, the [Airflow Guides](https://docs.astronomer.io/learn/) are available to help you resolve issues.
 
 ## Best practices for support request submissions
 
@@ -73,7 +70,7 @@ If you've already copied task logs or Airflow component logs, send them as a par
 
 ### Check recommended support articles
 
-If you draft your support ticket on the [Astronomer support portal](https://support.astronomer.io), the portal automatically recommends support articles to you based on the content in your ticket. Astronomer recommends looking through these recommendations to see if your issue has a documented solution before submitting your ticket. 
+If you draft your support ticket on the [Astronomer support portal](https://support.astronomer.io), the portal automatically recommends support articles to you based on the content in your ticket. Astronomer recommends looking through these recommendations to see if your issue has a documented solution before submitting your ticket.
 
 You can also proactively search support articles without submitting a support ticket on the [Astronomer knowledge base](https://support.astronomer.io/hc/en-us).
 
@@ -86,14 +83,14 @@ You can also proactively search support articles without submitting a support ti
     Alternatively, you can directly access the support form by going to `https://cloud.astronomer.io/open-support-request`.
 
 2. Select a **Request Type**. Your request type determines which other fields appear in the support request.
-3. Complete the rest of the support request. 
+3. Complete the rest of the support request.
 4. Click **Submit**.
 
     You'll receive an email when your ticket is created and follow-up emails as Astronomer support replies to your request. To check the status of a support request, you can also sign in to the [Astronomer support portal](https://support.astronomer.io).
 
 ## Submit a support request on the Astronomer support portal
 
-Astronomer recommends that you submit support requests in the Astro UI. If you can't access the Astro UI, sign in to the [Astronomer support portal](https://support.astronomer.io) and create a new support request. 
+Astronomer recommends that you submit support requests in the Astro UI. If you can't access the Astro UI, sign in to the [Astronomer support portal](https://support.astronomer.io) and create a new support request.
 
 If you're new to Astronomer, you'll need to create an account on the Astronomer support portal to submit a support request. Astronomer recommends that you create an account with the same email address that you use to access Astro. This allows you to view support tickets from other team members that have email addresses with the same domain.
 
@@ -114,6 +111,6 @@ To add a teammate to an existing support request, cc them when replying on the s
 
 ## Book office hours
 
-If you don't require break-fix support, Astronomer recommends scheduling a meeting with the Astronomer Data Engineering team during office hours. In an office hours meeting, you can ask questions, make feature requests, or get expert advice for your data pipelines. 
+If you don't require break-fix support, Astronomer recommends scheduling a meeting with the Astronomer Data Engineering team during office hours. In an office hours meeting, you can ask questions, make feature requests, or get expert advice for your data pipelines.
 
 For more information about booking an office hour meeting, see [Book an office hours appointment](office-hours.md#book-an-office-hours-appointment).

--- a/astro/astro-support.md
+++ b/astro/astro-support.md
@@ -5,14 +5,16 @@ id: astro-support
 description: Get Astro support when you need it.
 ---
 
+In addition to product documentation, the following resources are available to help you resolve issues:
+
+- [Astronomer knowledge base](https://support.astronomer.io/hc/en-us)
+- [Airflow guides](https://docs.astronomer.io/learn/)
 If you're experiencing an issue or have a question that requires Astronomer expertise, use one of the following methods to contact Astronomer support:
 
 - Submit a support request in the [Astro UI](https://cloud.astronomer.io/open-support-request).
 - Submit a support request on the [Astronomer support portal](https://support.astronomer.io/hc/en-us).
 - Send an email to [support@astronomer.io](mailto:support@astronomer.io).
 - Submit a support request by phone at +1 (831) 777-2768.
-
-In addition to product documentation, the [Airflow Guides](https://docs.astronomer.io/learn/) are available to help you resolve issues.
 
 ## Best practices for support request submissions
 

--- a/astro/office-hours.md
+++ b/astro/office-hours.md
@@ -29,7 +29,7 @@ During an office hours meeting, you can:
 
 ## Book an office hours appointment
 
-Before you book an office hours appointment, please browse the documentation, [Astronomer Academy](https://academy.astronomer.io/), [Airflow Guides](https://docs.astronomer.io/learn/), or discussion on the [Astronomer Forum](https://forum.astronomer.io) to see if there are existing guides or resources that answer your question.
+Before you book an office hours appointment, please browse the documentation, [Astronomer Academy](https://academy.astronomer.io/), [Airflow Guides](https://docs.astronomer.io/learn/), or past discussions on the [Astronomer Forum](https://forum.astronomer.io) to see if there are existing guides or resources that answer your question.
 
 To book office hours, click **Book office hours** in the documentation sidebar navigation. Then, schedule a 30-minute virtual meeting on the Calendly form. In the form, provide details about any issues and questions that you want to discuss during the meeting.
 

--- a/software/install-aws-standard.md
+++ b/software/install-aws-standard.md
@@ -21,7 +21,7 @@ To install Astronomer on EKS, you'll need access to the following tools and perm
 * Permission to create and modify resources on AWS.
 * Permission to generate a certificate (not self-signed) that covers a defined set of subdomains.
 * PostgreSQL superuser permissions.
-* An AWS Load Balancer Controller for the IP target type is required for all private Network Load Balancers (NLBs). See [Installing the AWS Load Balancer Controller add-on](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html).  
+* An AWS Load Balancer Controller for the IP target type is required for all private Network Load Balancers (NLBs). See [Installing the AWS Load Balancer Controller add-on](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html).
 * If you use Kubernetes version 1.23 or later, the [Amazon EBS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html).
 * Optional. [`eksctl`](https://eksctl.io/) for creating and managing your Astronomer cluster on EKS.
 
@@ -129,10 +129,10 @@ Depending on your organization, you may receive either a globally trusted certif
 
 ### Option 3: Use the AWS Certificate Manager as the certificate provider
 
-AWS Certificate Manager (ACM) terminates TLS at the Load Balancer level and does not encrypt the internal traffic inside the cluster. The ACM ingress controller requires an `astronomer-tls` secret with a certificate and private key to encrypt internal traffic. 
+AWS Certificate Manager (ACM) terminates TLS at the Load Balancer level and does not encrypt the internal traffic inside the cluster. The ACM ingress controller requires an `astronomer-tls` secret with a certificate and private key to encrypt internal traffic.
 
 Because ACM relies on annotations attached to Kubernetes resources and does not issue certificates or private key files, you must complete one of the following options to create the `astronomer-tls` secret:
- 
+
 - Create a [self-signed certificate](self-signed-certificate.md). Self-signed certificates are ideal for privately hosted internal applications, as well as in development and testing environments. Avoid using self-signed certificates in installations where the trust and identity of the certificate issuer are important.
 - Create a certificate with [AWS Certificate Manager Private CA](https://aws.amazon.com/blogs/containers/setting-up-end-to-end-tls-encryption-on-amazon-eks-with-the-new-aws-load-balancer-controller/).
 - Create a certificate with [Let's Encrypt](renew-tls-cert.md#automatically-renew-tls-certificates-using-lets-encrypt).
@@ -142,7 +142,7 @@ After you create the certificate, add the following configuration block to your 
     ```yaml
     nginx:
       loadBalancerIP: ~
-      privateLoadBalancer: true  # this does affect aws-load-balancer-type: external 
+      privateLoadBalancer: true  # this does affect aws-load-balancer-type: external
       ingressAnnotations:
         service.beta.kubernetes.io/aws-load-balancer-type: external
         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
@@ -175,7 +175,7 @@ If you received a globally trusted certificate or created a self-signed certific
 kubectl create secret tls astronomer-tls --cert <your-certificate-filepath> --key <your-private-key-filepath> -n astronomer
 ```
 
-If you created a certificate using Let's Encrypt, the `astronomer-tls` secret already exists in your Kubernetes cluster. Run the following command to confirm it exists: 
+If you created a certificate using Let's Encrypt, the `astronomer-tls` secret already exists in your Kubernetes cluster. Run the following command to confirm it exists:
 
 ```bash
 kubectl describe secret astronomer-tls --namespace astronomer
@@ -250,7 +250,7 @@ kubectl create secret generic astronomer-bootstrap \
 
 ## Step 8: Configure your Helm chart
 
-:::info 
+:::info
 
 To use a third-party ingress controller for Astronomer, see [Third-Party Ingress Controllers](third-party-ingress-controllers.md).
 
@@ -295,7 +295,7 @@ global:
   # encrypt client/server communication
   # between databases and the Astronomer platform.
   # If your database enforces SSL for connections,
-  # change this value to true. Incluster postgres only supports 
+  # change this value to true. Incluster postgres only supports
   # sslmode.enabled = false.
   ssl:
     enabled: false
@@ -310,7 +310,7 @@ nginx:
   # Dict of arbitrary annotations to add to the nginx ingress. For full configuration options, see https://docs.nginx.com/nginx-ingress-controller/configuration/ingress-resources/advanced-configuration-with-annotations/
   ingressAnnotations: {service.beta.kubernetes.io/aws-load-balancer-type: nlb} # Change to 'elb' if your node group is private and doesn't utilize a NAT gateway
   # If all subnets are private, auto-discovery may fail.
-  # You must enter the subnet IDs manually in the annotation below. 
+  # You must enter the subnet IDs manually in the annotation below.
   # service.beta.kubernetes.io/aws-load-balancer-subnets: subnet-id-1,subnet-id-2
 astronomer:
   houston:
@@ -377,25 +377,25 @@ After you run the previous commands, a set of Kubernetes pods are generated in y
 
 ### Alternative ArgoCD installation
 
-You can install Astronomer with [ArgoCD](https://argo-cd.readthedocs.io/en/stable/), which is an open source continuous delivery tool for Kubernetes, as an alternative to using `helm install`. 
+You can install Astronomer with [ArgoCD](https://argo-cd.readthedocs.io/en/stable/), which is an open source continuous delivery tool for Kubernetes, as an alternative to using `helm install`.
 
 Because ArgoCD doesn't support sync wave dependencies for [app of apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#app-of-apps-pattern) structures, installing Astronomer requires some additional steps compared to the standard ArgoCD workflow:
 
 1. Under the `global` section of your `config.yaml` file, add `enableArgoCDAnnotation: true`.
-   
+
 2. Create a new ArgoCD app. When creating the app, configure the following:
 
     - **Path**: The filepath of your `config.yaml` file
     - **Namespace**: The namespace you want to use for Astronomer
-    - **Cluster**: The Kubernetes cluster in which you're installing Astronomer 
+    - **Cluster**: The Kubernetes cluster in which you're installing Astronomer
     - **Repository URL**: `https://helm.astronomer.io`
 
 3. Sync the ArgoCD app with every component of the Astronomer platform selected. See [Sync (Deploy) the Application](https://argo-cd.readthedocs.io/en/stable/getting_started/#7-sync-deploy-the-application).
-   
-4. Stop the sync when you see that `astronomer-houston-db-migrations` has completed in the Argo UI. 
-   
+
+4. Stop the sync when you see that `astronomer-houston-db-migrations` has completed in the Argo UI.
+
 5. Sync the application a second time, but this time clear `astronomer-alertmanager` in the Argo UI while keeping all other components selected. Wait for this sync to finish completely.
-   
+
 6. Sync the ArgoCD app a third time with all Astronomer platform components selected.
 
 ## Step 10: Verify Pods are up
@@ -546,7 +546,7 @@ Check the Airflow namespace. If pods are changing at all, then the Houston API t
 If you have Airflow pods in the state `ImagePullBackoff`, check the pod description. If you see an x509 error, ensure that you have:
 
 - Configured containerd’s `config_path` to point to `/etc/containerd/certs.d`.
-- Added the `privateCaCertsAddToHost` key-value pairs to your Helm chart. 
+- Added the `privateCaCertsAddToHost` key-value pairs to your Helm chart.
 
 If you missed these steps during installation, follow the steps in [Apply a config change](apply-platform-config.md) to add them after installation. If you are using a base image such as CoreOS that does not permit values to be changed, or you otherwise can't modify `config.yaml`, contact [Astronomer support](https://support.astronomer.io) for additional configuration assistance.
 
@@ -562,7 +562,7 @@ To help you make the most of Astronomer Software, check out the following additi
 
 If you have any feedback or need help during this process and aren't in touch with our team already, a few resources to keep in mind:
 
-* [Community Forum](https://forum.astronomer.io): General Airflow + Astronomer FAQs
+* [Community Forum](https://forum.astronomer.io): Search previously asked questions about Airflow + Astronomer FAQs
 * [Astronomer Support Portal](https://support.astronomer.io/hc/en-us/): Platform or Airflow issues
 
 For detailed guidelines on reaching out to Astronomer Support, reference our guide [here](support.md).

--- a/software/install-azure-standard.md
+++ b/software/install-azure-standard.md
@@ -265,7 +265,7 @@ A few additional configuration notes:
 
 ## Step 8: Configure Your Helm chart
 
-:::info 
+:::info
 
 To use a third-party ingress controller for Astronomer, see [Third-Party Ingress Controllers](third-party-ingress-controllers.md).
 
@@ -311,7 +311,7 @@ global:
   # For development or proof-of-concept, you can use an in-cluster database
   postgresqlEnabled: false # Keep True if deploying a database on your AKS cluster.
 
-# SSL support for using SSL connections to encrypt client/server communication between database and Astronomer platform. Enable SSL if provisioning Azure Database for PostgreSQL - Flexible Server as it enforces SSL. Incluster postgres only supports sslmode.enabled = false. Change the setting with respect to the database provisioned. 
+# SSL support for using SSL connections to encrypt client/server communication between database and Astronomer platform. Enable SSL if provisioning Azure Database for PostgreSQL - Flexible Server as it enforces SSL. Incluster postgres only supports sslmode.enabled = false. Change the setting with respect to the database provisioned.
   ssl:
     enabled: true
     mode: "prefer"
@@ -393,25 +393,25 @@ After you run the previous commands, a set of Kubernetes pods are generated in y
 
 ### Alternative ArgoCD installation
 
-You can install Astronomer with [ArgoCD](https://argo-cd.readthedocs.io/en/stable/), which is an open source continuous delivery tool for Kubernetes, as an alternative to using `helm install`. 
+You can install Astronomer with [ArgoCD](https://argo-cd.readthedocs.io/en/stable/), which is an open source continuous delivery tool for Kubernetes, as an alternative to using `helm install`.
 
 Because ArgoCD doesn't support sync wave dependencies for [app of apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#app-of-apps-pattern) structures, installing Astronomer requires some additional steps compared to the standard ArgoCD workflow:
 
 1. Under the `global` section of your `config.yaml` file, add `enableArgoCDAnnotation: true`.
-   
+
 2. Create a new ArgoCD app. When creating the app, configure the following:
 
     - **Path**: The filepath of your `config.yaml` file
     - **Namespace**: The namespace you want to use for Astronomer
-    - **Cluster**: The Kubernetes cluster in which you're installing Astronomer 
+    - **Cluster**: The Kubernetes cluster in which you're installing Astronomer
     - **Repository URL**: `https://helm.astronomer.io`
 
 3. Sync the ArgoCD app with every component of the Astronomer platform selected. See [Sync (Deploy) the Application](https://argo-cd.readthedocs.io/en/stable/getting_started/#7-sync-deploy-the-application).
-   
-4. Stop the sync when you see that `astronomer-houston-db-migrations` has completed in the Argo UI. 
-   
+
+4. Stop the sync when you see that `astronomer-houston-db-migrations` has completed in the Argo UI.
+
 5. Sync the application a second time, but this time clear `astronomer-alertmanager` in the Argo UI while keeping all other components selected. Wait for this sync to finish completely.
-   
+
 6. Sync the ArgoCD app a third time with all Astronomer platform components selected.
 
 
@@ -560,7 +560,7 @@ Check the Airflow namespace. If pods are changing at all, then the Houston API t
 If you have Airflow pods in the state `ImagePullBackoff`, check the pod description. If you see an x509 error, ensure that you have:
 
 - Configured containerd’s `config_path` to point to `/etc/containerd/certs.d`.
-- Added the `privateCaCertsAddToHost` key-value pairs to your Helm chart. 
+- Added the `privateCaCertsAddToHost` key-value pairs to your Helm chart.
 
 If you missed these steps during installation, follow the steps in [Apply a config change](apply-platform-config.md) to add them after installation. If you are using a base image such as CoreOS that does not permit values to be changed, or you otherwise can't modify `config.yaml`, contact [Astronomer support](https://support.astronomer.io) for additional configuration assistance.
 
@@ -577,7 +577,7 @@ To help you make the most of Astronomer Software, Astronomer recommends reviewin
 
 If you have feedback or need help during the installation process, here are some recommended resources:
 
-* [Community Forum](https://forum.astronomer.io): General Airflow + Astronomer FAQs
+* [Community Forum](https://forum.astronomer.io): Search previously asked questions about Airflow + Astronomer FAQs
 * [Astronomer Support Portal](https://support.astronomer.io/hc/en-us/): Platform or Airflow issues
 
 For guidelines on contacting Astronomer Support, see [Submit a support request](support.md).

--- a/software/install-gcp-standard.md
+++ b/software/install-gcp-standard.md
@@ -26,7 +26,7 @@ To install Astronomer on GCP, you'll need access to the following tools and perm
 
 There is a known bug on GCP GKE Dataplane V2 clusters that affects Astronomer Software installations. When Astronomer Software is installed on a GCP GKE Dataplane V2 cluster, the interaction between the Astronomer Nginx ingress controller and Cilium can cause dropped connections, dropped packets, and intermittent 504 timeout errors when accessing the Astronomer UI or Houston API.
 
-To avoid these issues, Astronomer recommends installing Astronomer Software on a GKE Dataplane V1 cluster. 
+To avoid these issues, Astronomer recommends installing Astronomer Software on a GKE Dataplane V1 cluster.
 
 :::
 
@@ -268,7 +268,7 @@ kubectl create secret generic astronomer-bootstrap \
 
 ## Step 8: Configure your Helm chart
 
-:::info 
+:::info
 
 To use a third-party ingress controller for Astronomer, see [Third-Party Ingress Controllers](third-party-ingress-controllers.md).
 
@@ -396,25 +396,25 @@ After you run the previous commands, a set of Kubernetes pods are generated in y
 
 ### Alternative ArgoCD installation
 
-You can install Astronomer with [ArgoCD](https://argo-cd.readthedocs.io/en/stable/), which is an open source continuous delivery tool for Kubernetes, as an alternative to using `helm install`. 
+You can install Astronomer with [ArgoCD](https://argo-cd.readthedocs.io/en/stable/), which is an open source continuous delivery tool for Kubernetes, as an alternative to using `helm install`.
 
 Because ArgoCD doesn't support sync wave dependencies for [app of apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#app-of-apps-pattern) structures, installing Astronomer requires some additional steps compared to the standard ArgoCD workflow:
 
 1. Under the `global` section of your `config.yaml` file, add `enableArgoCDAnnotation: true`.
-   
+
 2. Create a new ArgoCD app. When creating the app, configure the following:
 
     - **Path**: The filepath of your `config.yaml` file
     - **Namespace**: The namespace you want to use for Astronomer
-    - **Cluster**: The Kubernetes cluster in which you're installing Astronomer 
+    - **Cluster**: The Kubernetes cluster in which you're installing Astronomer
     - **Repository URL**: `https://helm.astronomer.io`
 
 3. Sync the ArgoCD app with every component of the Astronomer platform selected. See [Sync (Deploy) the Application](https://argo-cd.readthedocs.io/en/stable/getting_started/#7-sync-deploy-the-application).
-   
-4. Stop the sync when you see that `astronomer-houston-db-migrations` has completed in the Argo UI. 
-   
+
+4. Stop the sync when you see that `astronomer-houston-db-migrations` has completed in the Argo UI.
+
 5. Sync the application a second time, but this time clear `astronomer-alertmanager` in the Argo UI while keeping all other components selected. Wait for this sync to finish completely.
-   
+
 6. Sync the ArgoCD app a third time with all Astronomer platform components selected.
 
 ## Step 10: Verify that all Pods are up
@@ -553,8 +553,8 @@ Check the Airflow namespace. If pods are changing at all, then the Houston API t
 
 If you have Airflow pods in the state `ImagePullBackoff`, check the pod description. If you see an x509 error, ensure that you have:
 
-- Configured containerd’s `config_path` to point to `/etc/containerd/certs.d`. 
-- Added the `privateCaCertsAddToHost` key-value pairs to your Helm chart. 
+- Configured containerd’s `config_path` to point to `/etc/containerd/certs.d`.
+- Added the `privateCaCertsAddToHost` key-value pairs to your Helm chart.
 
 If you missed these steps during installation, follow the steps in [Apply a config change](apply-platform-config.md) to add them after installation. If you are using a base image such as CoreOS that does not permit values to be changed, or you otherwise can't modify `config.yaml`, contact [Astronomer support](https://support.astronomer.io) for additional configuration assistance.
 
@@ -572,7 +572,7 @@ To help you make the most of Astronomer Software, check out the following additi
 
 If you have any feedback or need help during this process and aren't in touch with our team already, a few resources to keep in mind:
 
-* [Community Forum](https://forum.astronomer.io): General Airflow + Astronomer FAQs
+* [Community Forum](https://forum.astronomer.io): Search previously asked questions about Airflow + Astronomer FAQs
 * [Astronomer Support Portal](https://support.astronomer.io/hc/en-us/): Platform or Airflow issues
 
 For detailed guidelines on reaching out to Astronomer Support, reference our guide [here](support.md).

--- a/software/support.md
+++ b/software/support.md
@@ -5,16 +5,13 @@ id: support
 description: Get Astronomer Software support when you need it.
 ---
 
-In addition to product documentation, the following resources are available to help you resolve issues:
-
-- [Astronomer Forum](https://forum.astronomer.io)
-- [Airflow guides](https://docs.astronomer.io/learn/)
-
 If you're experiencing an issue or have a question that requires Astronomer expertise, you can use one of the following methods to contact Astronomer support:
 
 - Submit a support request on the [Astronomer support portal](https://support.astronomer.io/hc/en-us)
 - Send an email to [support@astronomer.io](mailto:support@astronomer.io)
 - Call +1 (831) 777-2768
+
+In addition to product documentation, the [Airflow guides](https://docs.astronomer.io/learn/) are available to help you resolve issues.
 
 ## Best practices for support request submissions
 
@@ -69,7 +66,7 @@ If you've already copied task logs or Airflow component logs, send them as a par
 
 ### Check recommended support articles
 
-If you draft your support ticket on the [Astronomer support portal](https://support.astronomer.io), the portal automatically recommends support articles to you based on the content in your ticket. Astronomer recommends looking through these recommendations to see if your issue has a documented solution before submitting your ticket. 
+If you draft your support ticket on the [Astronomer support portal](https://support.astronomer.io), the portal automatically recommends support articles to you based on the content in your ticket. Astronomer recommends looking through these recommendations to see if your issue has a documented solution before submitting your ticket.
 
 You can also proactively search support articles without submitting a support ticket on the [Astronomer knowledge base](https://support.astronomer.io/hc/en-us).
 

--- a/software/support.md
+++ b/software/support.md
@@ -5,13 +5,15 @@ id: support
 description: Get Astronomer Software support when you need it.
 ---
 
+In addition to product documentation, the following resources are available to help you resolve issues:
+
+- [Astronomer knowledge base](https://support.astronomer.io/hc/en-us)
+- [Airflow guides](https://docs.astronomer.io/learn/)
 If you're experiencing an issue or have a question that requires Astronomer expertise, you can use one of the following methods to contact Astronomer support:
 
 - Submit a support request on the [Astronomer support portal](https://support.astronomer.io/hc/en-us)
 - Send an email to [support@astronomer.io](mailto:support@astronomer.io)
 - Call +1 (831) 777-2768
-
-In addition to product documentation, the [Airflow guides](https://docs.astronomer.io/learn/) are available to help you resolve issues.
 
 ## Best practices for support request submissions
 


### PR DESCRIPTION
Resolves #3582 

- Removed links to the forum with recommendations for asking questions there (office hours + support page)
- Edited links to recommend reading past posts + FAQs on the forum
- Left links to specific posts in the docs will remain