### PR TITLE
Clarification on where to create the IAM role

### DIFF
--- a/astro/authorize-deployments-to-your-cloud.md
+++ b/astro/authorize-deployments-to-your-cloud.md
@@ -52,7 +52,7 @@ To grant a Deployment access to a service that is running in an AWS account not 
 To authorize your Deployment, create an IAM role that is assumed by the Deployment's workload identity:
 
 1. In the Astro UI, select your Deployment and then click **Details**. Copy the Deployment's **Workload Identity**.
-2. Create an IAM role in the AWS account that contains your AWS service. See [Creating a role to delegate permissions to an AWS service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html).
+2. In the AWS account that contains your AWS service, create an IAM role. See [Creating a role to delegate permissions to an AWS service](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html).
 3. In the AWS Management Console, go to the Identity and Access Management (IAM) dashboard.
 4. Click **Roles** and in the **Role name** column, select the role you created in Step 2.
 5. Click **Trust relationships**.


### PR DESCRIPTION
This step was being mis-interpreted as "In your account, create an IAM role. The IAM role should contain your AWS service", rather than the (intended) "In your account, create an IAM role. The account should contain your AWS service".

If there's any better way of clarifying this, and it doesn't end up with three steps starting with "In", I'm happy for you to change it.