### PR TITLE
Automate API changelog generation

### DIFF
--- a/.github/workflows/manualspecgeneration.yml
+++ b/.github/workflows/manualspecgeneration.yml
@@ -1,0 +1,21 @@
+name: Reload API spec
+
+on: workflow_dispatch
+
+jobs:
+  updatespec:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Put current date into a variable
+      run: |
+        $NOW=& Get-Date -format yyyy-MM-dd
+        echo "NOW=$NOW" >> $env:GITHUB_ENV
+    - name: Checkout repo
+      uses: actions/checkout@v4
+    - run: curl https://api.astronomer.io/spec/iam/v1beta1 > api/fern/apis/iam/openapi/openapi.yaml 
+    - run: curl https://api.astronomer.io/spec/platform/v1beta1 > api/fern/apis/platform/openapi/openapi.yaml 
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v6
+      with:
+        git-token: ${{ secrets.API_PAT }}
+        title: '${{env.NOW}} - Generate API spec and changelog'

--- a/.github/workflows/weeklyspecgeneration.yml
+++ b/.github/workflows/weeklyspecgeneration.yml
@@ -1,0 +1,25 @@
+name: Reload API spec
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 6 * * 3"
+
+jobs:
+  updatespec:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Put current date into a variable
+      run: |
+        $NOW=& Get-Date -format yyyy-MM-dd
+        echo "NOW=$NOW" >> $env:GITHUB_ENV
+    - name: Checkout repo
+      uses: actions/checkout@v4
+    - run: curl https://api.astronomer.io/spec/iam/v1beta1 > api/fern/apis/iam/openapi/openapi.yaml 
+    - run: curl https://api.astronomer.io/spec/platform/v1beta1 > api/fern/apis/platform/openapi/openapi.yaml 
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v6
+      with:
+        git-token: ${{ secrets.API_PAT }}
+        title: '${{env.NOW}} - Generate API spec and changelog'

--- a/api/fern/docs.yml
+++ b/api/fern/docs.yml
@@ -11,6 +11,8 @@ navigation:
         path: ./docs/pages/get-started.mdx
       - page: Versioning and support
         path: ./docs/pages/versioning-and-support.mdx
+      - page: Changelog
+        path: ./docs/pages/changelog.mdx
   - api: Platform API Reference
     api-name: platform
   - api: IAM API Reference

--- a/api/fern/docs.yml
+++ b/api/fern/docs.yml
@@ -11,8 +11,6 @@ navigation:
         path: ./docs/pages/get-started.mdx
       - page: Versioning and support
         path: ./docs/pages/versioning-and-support.mdx
-      - page: Changelog
-        path: ./docs/pages/changelog.mdx
   - api: Platform API Reference
     api-name: platform
   - api: IAM API Reference

--- a/api/fern/docs/pages/changelog.mdx
+++ b/api/fern/docs/pages/changelog.mdx
@@ -1,5 +1,0 @@
----
-title: Astro API Changelog
-description: Learn about new additions and changes to the Astro API in each release.
-slug: changelog
----

--- a/api/fern/docs/pages/changelog.mdx
+++ b/api/fern/docs/pages/changelog.mdx
@@ -1,0 +1,5 @@
+---
+title: Astro API Changelog
+description: Learn about new additions and changes to the Astro API in each release.
+slug: changelog
+---


### PR DESCRIPTION
This PR creates a new changelog for the Astro API. The general workflow is as follows:

1. A weekly OpenAPI spec generator runs every Wednesday, which is typically after the production Astro release is cut. The action pulls the new OpenAPI specs into our docs and generates PRs for the changes.
    - If the Astro release is delayed, a writer can also manually trigger the spec generation for whenever the API changes release. 
2. In the PR, Fern's bot will submit a summary of changes between the existing OpenAPI specs and the PR'd OpenAPI specs. This is the basis for the week's changelog.
3. A writer will review the generated changelog and add its content to `api/fern/docs/pages/changelog.mdx`, following the pattern of previous weeks. This change could be committed to the same PR that the GitHub Action generated, or it could be PR'd separately.
4.  After review of the changelog is complete, the writer merges both the updated spec changes and the changelog content.