### PR TITLE
Astro runtime 11.0

### DIFF
--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -41,7 +41,7 @@ Astro Runtime 11.0.0 includes same-day support for Apache Airflow 2.9, which inc
 - New data-aware scheduling functionality includes using conditional logic (AND and OR) or combining both dataset dependencies and time-based schedules.
 - You can now create your own labels for dynamically mapped tasks with templates, instead of identifying them by searching through index numbers.
 - Added the ability to store XComs in an object storage supported backend.
-- UI improvements that include filtering, viewing, and creating Datasets through the UI, the ability to localize `dag_id` and `task_id` names, task log grouping, and improvements to DAG-level views such as calendar, run duration, and the audit log.
+- Delivered several significant improvements to the Airflow UI. For example, you can now filter, view, and create datasets through the Airflow UI..
 
 For more information about the major changes in this release, see the [Airflow Blog](https://airflow.apache.org/blog/airflow-2.9.0/) or the [Airflow release notes](https://airflow.apache.org/docs/apache-airflow/2.9.0/release_notes.html#airflow-2-9-0-2024-04-08).
 

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -50,7 +50,7 @@ For more information about the major changes in this release, see the [Airflow B
 
 #### Upgrade to Python 3.12
 
-Astro Runtime now supports Python 3.12. However, [Pendulum](https://pendulum.eustace.io/) 2 does not support Python 3.12. If you upgrade to Python 3.12 and want to use Airflow, you also need to upgrade to Pendulum 3.
+Airflow now supports Python 3.12. However, [Pendulum](https://pendulum.eustace.io/) 2 does not support Python 3.12. If you upgrade to Python 3.12 and want to use Airflow, you also need to upgrade to Pendulum 3.
 
 Refer to the [Airflow release notes](https://airflow.apache.org/docs/apache-airflow/2.9.0/release_notes.html#official-support-for-python-3-12-38025) for more information about any limitations in Python 3.12 support.
 

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -42,20 +42,25 @@ Astro Runtime 11.0.0 includes same-day support for Apache Airflow 2.9, which inc
 - You can now create your own labels for dynamically mapped tasks with templates, instead of identifying them by searching through index numbers.
 - UI improvements that include filtering, viewing, and creating Datasets through the UI, the ability to localize `dag_id` and `task_id` names, task log grouping, and improvements to DAG-level views such as calendar, run duration, and the audit log.
 
-For more information about the major changes in this release, see the [Airflow Blog](https://airflow.apache.org/blog/airflow-2.9.0/).
+For more information about the major changes in this release, see the [Airflow Blog](https://airflow.apache.org/blog/airflow-2.9.0/) or the [Airflow release notes](https://airflow.apache.org/docs/apache-airflow/2.9.0/release_notes.html#airflow-2-9-0-2024-04-08).
 
 ### Upgrade to Python 3.12
 
 Airflow and the Astro Runtime now support Python 3.12. However, Pendulum 2 does not support Python 3.12. If you upgrade to Python 3.12 and want to use Airflow, you also need to upgrade to Pendulum 3.
 
+Refer to the [Airflow release notes](https://airflow.apache.org/docs/apache-airflow/2.9.0/release_notes.html#official-support-for-python-3-12-38025) for more information about any limitations in Python 3.12 support.
+
 ### Additional improvements
 
-- New Listener API methods are considered stable and suitable for use in production
-
+- New Listener API methods are considered stable and suitable for use in production. <!--https://github.com/apache/airflow/pull/36376-->
+- Added the ability to automatically set a DAG to `off` after a pre-defined number of sequentially failed runs. <!--https://github.com/apache/airflow/pull/36935-->
+- Dataset URIs are validated when you enter them, and must conform to the rules set in AIP-60. See the [Dataset documentation](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/datasets.html) for more information.<!--https://github.com/apache/airflow/pull/37005-->
 
 ### Bug fixes
 
-
+- Fix a bug where after a task failed, and no longer exists in a DAG, you can now still access details about the DAG in the Grid View of the Airflow UI. <!--https://github.com/apache/airflow/pull/38511-->
+- Fix a bug where Airflow would show `failed_upstream` when a dynamically mapped task was `skipped`. <!--https://github.com/apache/airflow/pull/37498-->
+- In the Python task decorator, you can only have `None` as the default parameter for context parameters. <!--https://github.com/apache/airflow/pull/38015-->
 
 ## Astro Runtime 10.6.0
 

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -53,7 +53,7 @@ Refer to the [Airflow release notes](https://airflow.apache.org/docs/apache-airf
 ### Additional improvements
 
 - New Listener API methods are considered stable and suitable for use in production. <!--https://github.com/apache/airflow/pull/36376-->
-- Added the ability to automatically set a DAG to `off` after a pre-defined number of sequentially failed runs. <!--https://github.com/apache/airflow/pull/36935-->
+- Added the ability to automatically pause a DAG after a pre-defined number of sequentially failed runs.
 - Dataset URIs are validated when you enter them, and must conform to the rules set in AIP-60. See the [Dataset documentation](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/datasets.html) for more information.<!--https://github.com/apache/airflow/pull/37005-->
 
 ### Bug fixes

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -40,6 +40,7 @@ Astro Runtime 11.0.0 includes same-day support for Apache Airflow 2.9, which inc
 
 - New data-aware scheduling functionality includes using conditional logic (AND and OR) or combining both dataset dependencies and time-based schedules.
 - You can now create your own labels for dynamically mapped tasks with templates, instead of identifying them by searching through index numbers.
+- Added the ability to store XComs in an object storage supported backend.
 - UI improvements that include filtering, viewing, and creating Datasets through the UI, the ability to localize `dag_id` and `task_id` names, task log grouping, and improvements to DAG-level views such as calendar, run duration, and the audit log.
 
 For more information about the major changes in this release, see the [Airflow Blog](https://airflow.apache.org/blog/airflow-2.9.0/) or the [Airflow release notes](https://airflow.apache.org/docs/apache-airflow/2.9.0/release_notes.html#airflow-2-9-0-2024-04-08).
@@ -52,15 +53,15 @@ Refer to the [Airflow release notes](https://airflow.apache.org/docs/apache-airf
 
 ### Additional improvements
 
-- New Listener API methods are considered stable and suitable for use in production. <!--https://github.com/apache/airflow/pull/36376-->
+- New Listener API methods are considered stable and suitable for use in production.
 - Added the ability to automatically pause a DAG after a pre-defined number of sequentially failed runs.
-- Dataset URIs are validated when you enter them, and must conform to the rules set in AIP-60. See the [Dataset documentation](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/datasets.html) for more information.<!--https://github.com/apache/airflow/pull/37005-->
+- Dataset URIs are validated when you enter them, and must conform to the rules set in AIP-60. See the [Dataset documentation](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/datasets.html) for more information.
 
 ### Bug fixes
 
-- Fix a bug where after a task failed, and no longer exists in a DAG, you can now still access details about the DAG in the Grid View of the Airflow UI. <!--https://github.com/apache/airflow/pull/38511-->
-- Fix a bug where Airflow would show `failed_upstream` when a dynamically mapped task was `skipped`. <!--https://github.com/apache/airflow/pull/37498-->
-- In the Python task decorator, you can only have `None` as the default parameter for context parameters. <!--https://github.com/apache/airflow/pull/38015-->
+- Fix a bug where after a task failed, and no longer exists in a DAG, you can now still access details about the DAG in the Grid View of the Airflow UI.
+- Fix a bug where Airflow would show `failed_upstream` when a dynamically mapped task was `skipped`.
+- In the Python task decorator, you can only have `None` as the default parameter for context parameters.
 
 ## Astro Runtime 10.6.0
 

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -54,10 +54,10 @@ Airflow now supports Python 3.12. However, [Pendulum](https://pendulum.eustace.i
 
 Refer to the [Airflow release notes](https://airflow.apache.org/docs/apache-airflow/2.9.0/release_notes.html#official-support-for-python-3-12-38025) for more information about any limitations in Python 3.12 support.
 
-#### Airflow bug fixes
+#### Bug fixes
 
-- Fix a bug where after a task failed, and no longer exists in a DAG, you can now still access details about the DAG in the Grid View of the Airflow UI.([#38511](https://github.com/apache/airflow/pull/38511))
-- Fix a bug where Airflow would show `failed_upstream` when a dynamically mapped task was `skipped`.
+- Fixed a bug where after a task failed, and no longer exists in a DAG, you can now still access details about the DAG in the Grid View of the Airflow UI.
+- Fixed a bug where Airflow would show `failed_upstream` when a dynamically mapped task was `skipped`.
 - In the Python task decorator, you can only have `None` as the default parameter for context parameters.
 
 ## Astro Runtime 10.6.0

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -29,6 +29,34 @@ If you're upgrading to receive a specific change, ensure the release note for th
 
 :::
 
+## Astro Runtime 11.0.0
+
+- Release date: April 8, 2024
+- Airflow version: 2.9.0
+
+### Airflow 2.9.0
+
+Astro Runtime 11.0.0 includes same-day support for Apache Airflow 2.9, which includes a number of new features and improvements. Airflow 2.9 includes the following changes:
+
+- New data-aware scheduling functionality includes using conditional logic (AND and OR) or combining both dataset dependencies and time-based schedules.
+- You can now create your own labels for dynamically mapped tasks with templates, instead of identifying them by searching through index numbers.
+- UI improvements that include filtering, viewing, and creating Datasets through the UI, the ability to localize `dag_id` and `task_id` names, task log grouping, and improvements to DAG-level views such as calendar, run duration, and the audit log.
+
+For more information about the major changes in this release, see the [Airflow Blog](https://airflow.apache.org/blog/airflow-2.9.0/).
+
+### Upgrade to Python 3.12
+
+Airflow and the Astro Runtime now support Python 3.12. However, Pendulum 2 does not support Python 3.12. If you upgrade to Python 3.12 and want to use Airflow, you also need to upgrade to Pendulum 3.
+
+### Additional improvements
+
+- New Listener API methods are considered stable and suitable for use in production
+
+
+### Bug fixes
+
+
+
 ## Astro Runtime 10.6.0
 
 - Release date: March 26, 2024

--- a/astro/runtime-release-notes.md
+++ b/astro/runtime-release-notes.md
@@ -38,28 +38,25 @@ If you're upgrading to receive a specific change, ensure the release note for th
 
 Astro Runtime 11.0.0 includes same-day support for Apache Airflow 2.9, which includes a number of new features and improvements. Airflow 2.9 includes the following changes:
 
-- New data-aware scheduling functionality includes using conditional logic (AND and OR) or combining both dataset dependencies and time-based schedules.
-- You can now create your own labels for dynamically mapped tasks with templates, instead of identifying them by searching through index numbers.
-- Added the ability to store XComs in an object storage supported backend.
-- Delivered several significant improvements to the Airflow UI. For example, you can now filter, view, and create datasets through the Airflow UI..
-
-For more information about the major changes in this release, see the [Airflow Blog](https://airflow.apache.org/blog/airflow-2.9.0/) or the [Airflow release notes](https://airflow.apache.org/docs/apache-airflow/2.9.0/release_notes.html#airflow-2-9-0-2024-04-08).
-
-### Upgrade to Python 3.12
-
-Airflow and the Astro Runtime now support Python 3.12. However, Pendulum 2 does not support Python 3.12. If you upgrade to Python 3.12 and want to use Airflow, you also need to upgrade to Pendulum 3.
-
-Refer to the [Airflow release notes](https://airflow.apache.org/docs/apache-airflow/2.9.0/release_notes.html#official-support-for-python-3-12-38025) for more information about any limitations in Python 3.12 support.
-
-### Additional improvements
-
+- New data-aware scheduling lets you use conditional logic (AND / OR) to schedule DAGs.
+- You can now create your own labels for dynamically mapped tasks with templates, which makes it easier to search through mapped task instances.
+- External XCom backends can now be configured to use object storage.
+- Delivered several significant improvements to the Airflow UI. For example, you can now filter, view, and create datasets through the Airflow UI.
 - New Listener API methods are considered stable and suitable for use in production.
 - Added the ability to automatically pause a DAG after a pre-defined number of sequentially failed runs.
 - Dataset URIs are validated when you enter them, and must conform to the rules set in AIP-60. See the [Dataset documentation](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/datasets.html) for more information.
 
-### Bug fixes
+For more information about the major changes in this release, see the [Airflow Blog](https://airflow.apache.org/blog/airflow-2.9.0/) or the [Airflow release notes](https://airflow.apache.org/docs/apache-airflow/2.9.0/release_notes.html#airflow-2-9-0-2024-04-08).
 
-- Fix a bug where after a task failed, and no longer exists in a DAG, you can now still access details about the DAG in the Grid View of the Airflow UI.
+#### Upgrade to Python 3.12
+
+Astro Runtime now supports Python 3.12. However, [Pendulum](https://pendulum.eustace.io/) 2 does not support Python 3.12. If you upgrade to Python 3.12 and want to use Airflow, you also need to upgrade to Pendulum 3.
+
+Refer to the [Airflow release notes](https://airflow.apache.org/docs/apache-airflow/2.9.0/release_notes.html#official-support-for-python-3-12-38025) for more information about any limitations in Python 3.12 support.
+
+#### Airflow bug fixes
+
+- Fix a bug where after a task failed, and no longer exists in a DAG, you can now still access details about the DAG in the Grid View of the Airflow UI.([#38511](https://github.com/apache/airflow/pull/38511))
 - Fix a bug where Airflow would show `failed_upstream` when a dynamically mapped task was `skipped`.
 - In the Python task decorator, you can only have `None` as the default parameter for context parameters.
 

--- a/docs-partials/runtime-image-architecture.mdx
+++ b/docs-partials/runtime-image-architecture.mdx
@@ -113,7 +113,7 @@ astro dev bash pip freeze | grep astronomer-providers
 | 8             | 2.6                    | 3.10           |
 | 9             | 2.7                    | 3.11           |
 | 10            | 2.8                    | 3.11           |
-| 11            | 2.9                    | 3.12           |
+| 11            | 2.9                    | 3.11           |
 
 Starting with Astro Runtime 9, if you require a different version of Python than what's included in the base distribution, you can use a Python distribution of Astro Runtime. See [Distribution](#distribution).
 

--- a/docs-partials/runtime-image-architecture.mdx
+++ b/docs-partials/runtime-image-architecture.mdx
@@ -37,6 +37,7 @@ This table lists Astro Runtime releases and their associated Apache Airflow vers
 | 8             | 2.6                    |
 | 9             | 2.7                    |
 | 10            | 2.8                    |
+| 11            | 2.9                    |
 
 For version compatibility information, see the [Runtime release notes](https://docs.astronomer.io/astro/runtime-release-notes).
 
@@ -112,6 +113,7 @@ astro dev bash pip freeze | grep astronomer-providers
 | 8             | 2.6                    | 3.10           |
 | 9             | 2.7                    | 3.11           |
 | 10            | 2.8                    | 3.11           |
+| 11            | 2.9                    | 3.12           |
 
 Starting with Astro Runtime 9, if you require a different version of Python than what's included in the base distribution, you can use a Python distribution of Astro Runtime. See [Distribution](#distribution).
 
@@ -131,6 +133,7 @@ The following table shows which versions Postgres are compatible with each versi
 | 8             | 2.6                    | 11-15             |
 | 9             | 2.7                    | 11-15             |
 | 10            | 2.8                    | 12-16             |
+| 11            | 2.9                    | 12-16             |
 
 ## Executors
 
@@ -174,5 +177,6 @@ The following table lists the operating systems and architectures supported by e
 | 8             | 2.6                    | Debian 11.7 (bullseye) | AMD64 and ARM64 |
 | 9             | 2.7                    | Debian 11.7 (bullseye) | AMD64 and ARM64 |
 | 10            | 2.8                    | Debian 11.8 (bullseye) | AMD64 and ARM64 |
+| 11            | 2.9                    | Debian 11.8 (bullseye) | AMD64 and ARM64 |
 
 Astro Runtime 6.0.4 and later images are multi-arch and support AMD64 and ARM64 processor architectures for local development. Docker automatically uses the correct processor architecture based on the computer you are using.

--- a/docs-partials/runtime-lifecycle-table.mdx
+++ b/docs-partials/runtime-lifecycle-table.mdx
@@ -6,6 +6,7 @@ The following table contains the exact lifecycle for each published version of A
 | [6](https://docs.astronomer.io/astro/runtime-release-notes#astro-runtime-600)  - Latest Patch (LTS) | 2.4             | September 19, 2022 | March 2024              |
 | [9](https://docs.astronomer.io/astro/runtime-release-notes#astro-runtime-900)  - Latest Patch (LTS) | 2.7             | August 18, 2023    | January 2025            |
 | [10](https://docs.astronomer.io/astro/runtime-release-notes#astro-runtime-1000) - Latest Patch      | 2.8             | December 18, 2023  | June 2024               |
+| [11](https://docs.astronomer.io/astro/runtime-release-notes#astro-runtime-1100) - Latest Patch      | 2.9             | April 8, 2024  | October 2024               |
 
 If you have any questions or concerns, contact [Astronomer support](https://cloud.astronomer.io/open-support-request).
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,7 +18,7 @@ module.exports = {
           '{{CLI_VER_LATEST}}': "1.25.0",
           '{{CLI_VER_2}}': "1.24.1",
           '{{CLI_VER_3}}': "1.23.0",
-          '{{RUNTIME_VER}}': "10.6.0",
+          '{{RUNTIME_VER}}': "11.0.0",
         };
         var re = new RegExp(Object.keys(mapObj).join("|"), "gi");
         return fileContent.replaceAll(re, function (matched) {


### PR DESCRIPTION
- Astro runtime release (https://github.com/astronomer/astro-runtime/pull/1375)
- Airflow 2.9 Release notes (https://airflow.apache.org/docs/apache-airflow/2.9.0/release_notes.html#airflow-2-9-0-2024-04-08)
- Airflow 2.9 blog post (https://airflow.apache.org/blog/airflow-2.9.0/)