### PR TITLE
Add details about the alert payload when using DAG Trigger

### DIFF
--- a/astro/alerts.md
+++ b/astro/alerts.md
@@ -134,31 +134,29 @@ This feature is in [Private Preview](https://docs.astronomer.io/astro/feature-pr
 
 :::
 
-The **DAG Trigger** communication channel works differently from other communication channel types. Instead of sending a pre-formatted alert message, Astro makes a generic request through Airflow's [DagRuns REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#operation/post_dag_run) to trigger a DAG on Astro. You can configure the triggered DAG to complete any action, such as sending a message to your own incident management system or writing data about an incident to a table. 
+The **DAG Trigger** communication channel works differently from other communication channel types. Instead of sending a pre-formatted alert message, Astro makes a generic request through the `DagRuns` endpoint of the [Airflow REST API](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#operation/post_dag_run) to trigger any DAG in your Workspace. You can configure the triggered DAG to complete any action, such as sending a message to your own incident management system or writing data about an incident to a table. 
 
-The following parameters are passed in the API call that hold the metadata about the Alert:
+The following parameters are used to pass metadata about the alert in the API call:
 
 - `conf`: This parameter holds the alert payload:
-  - `alertId`: A unique alert ID
-  - `alertType`: The type of alert triggered
-  - `dagName`: The name of the DAG that triggered the alert
-  - `message`: The detailed message with the cause of the alert
+  - `alertId`: A unique alert ID.
+  - `alertType`: The type of alert triggered.
+  - `dagName`: The name of the DAG that triggered the alert.
+  - `message`: The detailed message with the cause of the alert.
+  - `note`: By default, this is `Triggering DAG on Airflow <url>`.
   
-  
-  An example alert payload:
-  
-  ```json
-    {
-      "dagName": "fail_dag",
-      "alertType": "PIPELINE_FAILURE",
-      "alertId": "d75e7517-88cc-4bab-b40f-660dd79df216",
-      "message": "[Astro Alerts] Pipeline failure detected on DAG fail_dag. \\nStart time: 2023-11-17 17:32:54 UTC. \\nFailed at: 2023-11-17 17:40:10 UTC. \\nAlert notification time: 2023-11-17 17:40:10 UTC. \\nClick link to investigate in Astro UI: https://cloud.astronomer.io/clkya6zgv000401k8zafabcde/dags/clncyz42l6957401bvfuxn8zyxw/fail_dag/c6fbe201-a3f1-39ad-9c5c-817cbf99d123?utm_source=alert\"\\n"
-    }
+The following is an example alert payload that would be passed through the API:
 
-  ```
-- `note`: This parameter is set to `Triggering DAG on Airflow <url>`
+```json
+{
+  "dagName": "fail_dag",
+  "alertType": "PIPELINE_FAILURE",
+  "alertId": "d75e7517-88cc-4bab-b40f-660dd79df216",
+  "message": "[Astro Alerts] Pipeline failure detected on DAG fail_dag. \\nStart time: 2023-11-17 17:32:54 UTC. \\nFailed at: 2023-11-17 17:40:10 UTC. \\nAlert notification time: 2023-11-17 17:40:10 UTC. \\nClick link to investigate in Astro UI: https://cloud.astronomer.io/clkya6zgv000401k8zafabcde/dags/clncyz42l6957401bvfuxn8zyxw/fail_dag/c6fbe201-a3f1-39ad-9c5c-817cbf99d123?utm_source=alert\"\\n"
+}
+```
 
-These parameters are accessible in the triggered DAG using the DAG params.
+These parameters are accessible in the triggered DAG using [DAG params](https://docs.astronomer.io/learn/airflow-params).
 
 1. Create a DAG that you want to run when the alert is triggered. For example, you can use the following DAG to run arbitrary Python code when the alert is triggered:
 


### PR DESCRIPTION
When DAG Trigger is used as the notification channel, Airflow's REST API is used to trigger a DAG and it also sends a payload with the details of the alert .

Also, @lzdanski / @jwitz , oane thing that I noticed that in the current docs this para is repeated (exactly same) once in the [main page](https://docs.astronomer.io/astro/alerts#communication-channels) and once in the [DAG Trigger tab](https://docs.astronomer.io/astro/alerts?tab=DAG#step-1-configure-your-communication-channel).

`The DAG Trigger communication channel works differently from other communication channel types. Instead of sending a pre-formatted alert message, Astro makes a generic request through the Airflow REST API to trigger a DAG on Astro. You can configure the triggered DAG to complete any action, such as sending a message to your own incident management system or writing data about an incident to a table.`

Not sure that is intentional or not, but just wanted to highlight it.

[OG Slack thread](https://astronomer.slack.com/archives/C01UA03TPV1/p1711734314345389)

