### PR TITLE
Remove "latest patch" from runtime version table

### DIFF
--- a/docs-partials/runtime-lifecycle-table.mdx
+++ b/docs-partials/runtime-lifecycle-table.mdx
@@ -2,10 +2,10 @@ The following table contains the exact lifecycle for each published version of A
 
 | Runtime version                                                       | Airflow version | Release date       | End of maintenance date |
 | --------------------------------------------------------------------- | --------------- | ------------------ | ----------------------- |
-| [5](https://docs.astronomer.io/astro/runtime-release-notes#astro-runtime-500) - Latest Patch (LTS)  | 2.3             | April 30, 2022     | April 2024              |
-| [9](https://docs.astronomer.io/astro/runtime-release-notes#astro-runtime-900)  - Latest Patch (LTS) | 2.7             | August 18, 2023    | January 2025            |
-| [10](https://docs.astronomer.io/astro/runtime-release-notes#astro-runtime-1000) - Latest Patch      | 2.8             | December 18, 2023  | June 2024               |
-| [11](https://docs.astronomer.io/astro/runtime-release-notes#astro-runtime-1100) - Latest Patch      | 2.9             | April 8, 2024  | October 2024               |
+| [5](https://docs.astronomer.io/astro/runtime-release-notes#astro-runtime-500) (LTS) | 2.3             | April 30, 2022     | April 2024              |
+| [9](https://docs.astronomer.io/astro/runtime-release-notes#astro-runtime-900) (LTS) | 2.7             | August 18, 2023    | January 2025            |
+| [10](https://docs.astronomer.io/astro/runtime-release-notes#astro-runtime-1000)     | 2.8             | December 18, 2023  | June 2024               |
+| [11](https://docs.astronomer.io/astro/runtime-release-notes#astro-runtime-1100)     | 2.9             | April 8, 2024      | October 2024            |
 
 If you have any questions or concerns, contact [Astronomer support](https://cloud.astronomer.io/open-support-request).
 


### PR DESCRIPTION
I feel this is extra noise in this table. We already state this:

> For each supported major Runtime version, bug fixes are delivered only through new minor.patch versions.

Context: https://astronomer.slack.com/archives/C015V2JFKT5/p1706862862426869?thread_ts=1706106411.144149&cid=C015V2JFKT5