### PR TITLE
Add section for configuring custom menu items in Astro

### DIFF
--- a/learn/using-airflow-plugins.md
+++ b/learn/using-airflow-plugins.md
@@ -159,6 +159,7 @@ If you want to use custom menu items in an Airflow environment hosted on Astro, 
     You can then specify the menu item, in this example `my_new_endpoint` in `appbuilder_menu_items`.
 
 ```
+:::
 
 The screenshot below shows the additional menu items in the Airflow UI.
 


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/3653

I thought it would make more sense to put all of this info in the Learn guide, rather than have an Astro-specific section that only explains what code to add.

I'll link out to here from the release note after we publish