### PR TITLE
Add notes about cluster type and networking

### DIFF
--- a/astro/connect-aws.md
+++ b/astro/connect-aws.md
@@ -24,7 +24,7 @@ Standard clusters have different connection options than dedicated clusters.
 
 Standard clusters can connect to AWS in the following ways:
 
-- Using [static external IP addresses](#allowlist-external-ip-addresses)
+- Using [static external IP addresses](#allowlist-a-deployments-external-ip-addresses-on-aws)
 - Using PrivateLink to connect with the following endpoints:
     - [Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html) - Gateway Endpoint
     - [Amazon Elastic Compute Cloud (Amazon EC2) Autoscaling](https://docs.aws.amazon.com/general/latest/gr/as.html) - Interface Endpoint
@@ -42,20 +42,21 @@ If you require a private connection between Astro and AWS, Astronomer recommends
 
 ## Access a public AWS endpoint
 
-All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. When you create a Deployment in your workspace, Astro assigns it one of these external IP addresses. To facilitate communication between Astro and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your AWS resources through a valid Airflow connection.
+All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. When you create a Deployment in your workspace, Astro assigns the external IP addresses to it. To facilitate communication between Astro and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your AWS resources through a valid Airflow connection.
 
-### Allowlist external IP addresses
+### Allowlist a Deployment's external IP addresses on AWS
 
 1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
 2. Select the **Details** tab.
 3. In the **Other** section, you can find the **External IPs** associated with the Deployment.
+4. Add the IP addresses to the allowlist of any external services that you want your Deployment to access. 
 
 When you use publicly accessible endpoints to connect to AWS, traffic moves directly between your Astro cluster and the AWS API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them.
 
 <details>
   <summary><strong>Dedicated cluster external IP addresses</strong></summary>
 
-If you use Dedicated clusters and want to allowlist external IP addresses at the cluster level, instead of per-Deployment, you can find the list of external IP addresses the cluster uses in your **Organization settings**.
+If you use Dedicated clusters and want to allowlist external IP addresses at the cluster level instead of at the Deployment level, you can find the list cluster-level external IP addresses in your **Organization settings**.
 
 1. In the Astro UI, click your Workspace name in the upper left corner, then click **Organization Settings**.
 2. Click **Clusters**, then select a cluster.

--- a/astro/connect-aws.md
+++ b/astro/connect-aws.md
@@ -42,22 +42,28 @@ If you require a private connection between Astro and AWS, Astronomer recommends
 
 ## Access a public AWS endpoint
 
-All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. To facilitate communication between an Astro cluster and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your AWS resources through a valid Airflow connection.
+All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. When you create a Deployment in your workspace, Astro assigns it one of these external IP addresses. To facilitate communication between Astro and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your AWS resources through a valid Airflow connection.
 
-:::tip
+### Allowlist external IP addresses
 
-While you can find an external IP address for your Deployment, these IP addresses are dynamically generated, which means that your connection might fail if the IP address changes. A cluster-level external IP address persists, ensuring your cluster can access your cloud resources as long as the cluster exists.
+1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
+2. Select the **Details** tab.
+3. In the **Other** section, you can find the **External IPs** associated with the Deployment.
 
-:::
+When you use publicly accessible endpoints to connect to AWS, traffic moves directly between your Astro cluster and the AWS API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them.
 
-### Allowlist external IP addresses for a cluster
+<details>
+  <summary><strong>Dedicated cluster external IP addresses</strong></summary>
+
+If you use Dedicated clusters and want to allowlist external IP addresses at the cluster level, instead of per-Deployment, you can find the list of external IP addresses the cluster uses in your **Organization settings**.
 
 1. In the Astro UI, click your Workspace name in the upper left corner, then click **Organization Settings**.
 2. Click **Clusters**, then select a cluster.
 3. In the Details page, copy the IP addresses listed under **External IPs**.
 4. Add the IP addresses to the allowlist of any external services that you want your cluster to access. You can also access these IP addresses from the **Details** page of any Deployment in the cluster.
 
-After you allowlist a cluster's IP addresses, all Deployments in that cluster have network connectivity to AWS. When you use publicly accessible endpoints to connect to AWS, traffic moves directly between your Astro cluster and the AWS API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them.
+After you allowlist a cluster's IP addresses, all Deployments in that cluster have network connectivity to AWS.
+</details>
 
 ## Create a private connection between Astro and AWS
 

--- a/astro/connect-aws.md
+++ b/astro/connect-aws.md
@@ -49,9 +49,9 @@ All Astro clusters include a set of external IP addresses that persist for the l
 1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
 2. Select the **Details** tab.
 3. In the **Other** section, you can find the **External IPs** associated with the Deployment.
-4. Add the IP addresses to the allowlist of any external services that you want your Deployment to access. 
+4. Add the IP addresses to the allowlist of any external services that you want your Deployment to access.
 
-When you use publicly accessible endpoints to connect to AWS, traffic moves directly between your Astro cluster and the AWS API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them.
+When you use publicly accessible endpoints to connect to AWS, traffic moves directly between your Astro cluster and the AWS API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them. For example, you can [Authorize deployments to your cloud with workload identity](authorize-deployments-to-your-cloud.md) so that you can avoid adding passwords or other access credentials to your Airflow connections.
 
 <details>
   <summary><strong>Dedicated cluster external IP addresses</strong></summary>

--- a/astro/connect-aws.md
+++ b/astro/connect-aws.md
@@ -44,6 +44,12 @@ If you require a private connection between Astro and AWS, Astronomer recommends
 
 All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. To facilitate communication between an Astro cluster and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your AWS resources through a valid Airflow connection.
 
+:::tip
+
+While you can find an external IP address for your Deployment, these IP addresses are dynamically generated, which means that your connection might fail if the IP address changes. A cluster-level external IP address persists, ensuring your cluster can access your cloud resources as long as the cluster exists.
+
+:::
+
 ### Allowlist external IP addresses for a cluster
 
 1. In the Astro UI, click your Workspace name in the upper left corner, then click **Organization Settings**.
@@ -97,20 +103,20 @@ To set up a private connection between an Astro VPC and an AWS VPC, you can crea
     - VPC ID of the external VPC
     - CIDR block of the external VPC
 
-2. In the Astro UI, click your Workspace name in the upper left corner, then click **Organization Settings**. 
+2. In the Astro UI, click your Workspace name in the upper left corner, then click **Organization Settings**.
 
 3. Click **Clusters**, select your cluster, click **VPC Peering Connections**, then click **+ VPC Peering Connection**.
 
 4. Configure the following values for your VPC peering connection using the information you copied in Step 1:
 
-    - **Peering Name**: Provide a name for the VPC peering connection. 
+    - **Peering Name**: Provide a name for the VPC peering connection.
     - **AWS account ID**: Enter the account ID of the external VPC.
     - **Destination VPC ID**: Enter the VPC ID.
     - **Destination VPC region**: Enter the region of the external VPC.
     - **Destination VPC CIDR block**: Enter the CIDR block of the external VPC.
 
 5. Click **Create Connection**. The connection appears as **Pending**.
-6. Wait a few minutes for the **Complete Activation** button to appear, then click **Complete Activation link**. 
+6. Wait a few minutes for the **Complete Activation** button to appear, then click **Complete Activation link**.
 7. In the modal that appears, follow the instructions to accept the connection from your external VPC and create routes from the external VPC to Astro.
 
 A few minutes after you complete the instructions in the modal, the connection status changes from **Pending** to **Active**. A new default route appears in **Routes** with your configured CIDR block.
@@ -177,9 +183,9 @@ Your initial VPC connection connects Astro to your external VPC through a primar
 
 2. Configure the following details for your route:
 
-    - **Route ID**: Provide a name for the route. 
+    - **Route ID**: Provide a name for the route.
     - **Destination**: Enter the subnet of the service in the external VPC.
-    - **Target**: Select the VPC peering connection you configured. 
+    - **Target**: Select the VPC peering connection you configured.
 
 3. Click **Create Route**, then wait a few minutes for the route to be created.
 

--- a/astro/connect-aws.md
+++ b/astro/connect-aws.md
@@ -24,7 +24,7 @@ Standard clusters have different connection options than dedicated clusters.
 
 Standard clusters can connect to AWS in the following ways:
 
-- Using [static external IP addresses](#allowlist-external-ip-addresses-for-a-cluster)
+- Using [static external IP addresses](#allowlist-external-ip-addresses)
 - Using PrivateLink to connect with the following endpoints:
     - [Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html) - Gateway Endpoint
     - [Amazon Elastic Compute Cloud (Amazon EC2) Autoscaling](https://docs.aws.amazon.com/general/latest/gr/as.html) - Interface Endpoint

--- a/astro/connect-azure.md
+++ b/astro/connect-azure.md
@@ -35,22 +35,29 @@ If you require a private connection between Astro and Azure, Astronomer recommen
 
 ## Access a public Azure endpoint
 
-All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. To facilitate communication between an Astro cluster and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your Azure resources through a valid Airflow connection.
+All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. When you create a Deployment in your workspace, Astro assigns it one of these external IP addresses. To facilitate communication between Astro and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your Azure resources through a valid Airflow connection.
 
-:::tip
+### Allowlist external IP addresses
 
-While you can find an external IP address for your Deployment, these IP addresses are dynamically generated, which means that your connection might fail if the IP address changes. A cluster-level external IP address persists, ensuring your cluster can access your cloud resources as long as the cluster exists.
+1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
+2. Select the **Details** tab.
+3. In the **Other** section, you can find the **External IPs** associated with the Deployment.
 
-:::
+When you use publicly accessible endpoints to connect to Azure, traffic moves directly between your Astro cluster and the Azure API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them.
 
-### Allowlist external IP addresses for a cluster
+<details>
+  <summary><strong>Dedicated cluster external IP addresses</strong></summary>
+
+If you use Dedicated clusters and want to allowlist external IP addresses at the cluster level, instead of per-Deployment, you can find the list of external IP addresses the cluster uses in your **Organization settings**.
 
 1. In the Astro UI, click your Workspace name in the upper left corner, then click **Organization Settings**.
 2. Click **Clusters**, then select a cluster.
 3. In the Details page, copy the IP addresses listed under **External IPs**.
 4. Add the IP addresses to the allowlist of any external services that you want your cluster to access. You can also access these IP addresses from the **Details** page of any Deployment in the cluster.
 
-After you allowlist a cluster's IP addresses, all Deployments in that cluster have network connectivity to Azure. When you use publicly accessible endpoints to connect to Azure, traffic moves directly between your Astro cluster and the Azure API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them.
+Note that you still might also need to authorize your Deployment to some resources before it can access them.
+
+</details>
 
 ## Create a private connection between Astro and Azure
 

--- a/astro/connect-azure.md
+++ b/astro/connect-azure.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 Use this document to learn how you can grant an Astro cluster and its Deployments access to your external Azure resources.
 
-Publicly accessible endpoints allow you to quickly connect your Astro clusters or Deployments to Azure through an Airflow connection. If your cloud restricts IP addresses, you can add the external IPs of your Deployment or cluster to an Azure resource's allowlist. 
+Publicly accessible endpoints allow you to quickly connect your Astro clusters or Deployments to Azure through an Airflow connection. If your cloud restricts IP addresses, you can add the external IPs of your Deployment or cluster to an Azure resource's allowlist.
 
 If you have stricter security requirements, you can [create a private connection](#create-a-private-connection-between-astro-and-azure) to Azure in a few different ways.
 
@@ -37,6 +37,12 @@ If you require a private connection between Astro and Azure, Astronomer recommen
 
 All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. To facilitate communication between an Astro cluster and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your Azure resources through a valid Airflow connection.
 
+:::tip
+
+While you can find an external IP address for your Deployment, these IP addresses are dynamically generated, which means that your connection might fail if the IP address changes. A cluster-level external IP address persists, ensuring your cluster can access your cloud resources as long as the cluster exists.
+
+:::
+
 ### Allowlist external IP addresses for a cluster
 
 1. In the Astro UI, click your Workspace name in the upper left corner, then click **Organization Settings**.
@@ -60,7 +66,7 @@ The option that you choose is determined by the security requirements of your co
 
 <TabItem value="VNet peering">
 
-:::info 
+:::info
 
 This connection option is only available for dedicated Astro Hosted clusters and Astro Hybrid.
 
@@ -82,7 +88,7 @@ After receiving your request, Astronomer support initiates a peering request and
 
 <TabItem value="Azure Private Link">
 
-:::info 
+:::info
 
 This connection option is only available for dedicated Astro Hosted clusters and Astro Hybrid.
 
@@ -104,7 +110,7 @@ For example, to connect with Azure Container Registry:
 2. Follow the [Azure documentation](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-private-link#create-a-private-endpoint---new-registry) to create a private endpoint for your container registry. Then, copy the name of the **Data endpoint**.
 3. Then, from the left panel, go to **Overview** menu, and click on JSON view in **Essentials**, to copy the resource ID. You can also run Azure CLI command `az acr show -n myRegistry` to get the resource ID.
 4. Contact [Astronomer Support](https://cloud.astronomer.io/open-support-request) with your request to connect. Provide the resource name, data endpoint name, and resource ID.
-5. When Astronomer support adds an Azure private endpoint, corresponding private DNS zone and Canonical Name (CNAME) records are created to allow you to address the service by its private link name. Astronomer support will send the connection request in Azure Portal's [Private Link Center](https://portal.azure.com/#view/Microsoft_Azure_Network/PrivateLinkCenterBlade/~/pendingconnections). 
+5. When Astronomer support adds an Azure private endpoint, corresponding private DNS zone and Canonical Name (CNAME) records are created to allow you to address the service by its private link name. Astronomer support will send the connection request in Azure Portal's [Private Link Center](https://portal.azure.com/#view/Microsoft_Azure_Network/PrivateLinkCenterBlade/~/pendingconnections).
 6. Approve the connection requests from your Azure portal, then confirm that you've completed this in your support ticket. Astronomer support will then test whether the DNS resolves the endpoint correctly.
 
 After Astronomer configures the connection, you can create Airflow connections to your resource. In some circumstances, you might need to modify your DAGs to address the service by its private link name (For example, `StorageAccountA.privatelink.blob.core.windows.net` instead of `StorageAccountA.blob.core.windows.net`).

--- a/astro/connect-azure.md
+++ b/astro/connect-azure.md
@@ -42,9 +42,9 @@ All Astro clusters include a set of external IP addresses that persist for the l
 1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
 2. Select the **Details** tab.
 3. In the **Other** section, you can find the **External IPs** associated with the Deployment.
-4. Add the IP addresses to the allowlist of any external services that you want your Deployment to access. 
+4. Add the IP addresses to the allowlist of any external services that you want your Deployment to access.
 
-When you use publicly accessible endpoints to connect to Azure, traffic moves directly between your Astro cluster and the Azure API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them.
+When you use publicly accessible endpoints to connect to Azure, traffic moves directly between your Astro cluster and the Azure API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them. For example, you can [Authorize deployments to your cloud with workload identity](authorize-deployments-to-your-cloud.md) so that you can avoid adding passwords or other access credentials to your Airflow connections.
 
 <details>
   <summary><strong>Dedicated cluster external IP addresses</strong></summary>
@@ -56,8 +56,7 @@ If you use Dedicated clusters and want to allowlist external IP addresses at the
 3. In the Details page, copy the IP addresses listed under **External IPs**.
 4. Add the IP addresses to the allowlist of any external services that you want your cluster to access. You can also access these IP addresses from the **Details** page of any Deployment in the cluster.
 
-Note that you still might also need to authorize your Deployment to some resources before it can access them.
-
+After you allowlist a cluster's IP addresses, all Deployments in that cluster have network connectivity to Azure.
 </details>
 
 ## Create a private connection between Astro and Azure

--- a/astro/connect-azure.md
+++ b/astro/connect-azure.md
@@ -24,7 +24,7 @@ Standard clusters have different connection options than dedicated clusters.
 
 Standard clusters can connect to Azure in the following ways:
 
-- Using [static external IP addresses](#allowlist-external-ip-addresses).
+- Using [static external IP addresses](#allowlist-a deployments-external-ip-addresses-on-azure).
 
 Dedicated clusters can also connect to Azure using static IP addresses. Additionally, they support a number of private connectivity options including:
 
@@ -37,18 +37,19 @@ If you require a private connection between Astro and Azure, Astronomer recommen
 
 All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. When you create a Deployment in your workspace, Astro assigns it one of these external IP addresses. To facilitate communication between Astro and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your Azure resources through a valid Airflow connection.
 
-### Allowlist external IP addresses
+### Allowlist a Deployment's external IP addresses on Azure
 
 1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
 2. Select the **Details** tab.
 3. In the **Other** section, you can find the **External IPs** associated with the Deployment.
+4. Add the IP addresses to the allowlist of any external services that you want your Deployment to access. 
 
 When you use publicly accessible endpoints to connect to Azure, traffic moves directly between your Astro cluster and the Azure API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them.
 
 <details>
   <summary><strong>Dedicated cluster external IP addresses</strong></summary>
 
-If you use Dedicated clusters and want to allowlist external IP addresses at the cluster level, instead of per-Deployment, you can find the list of external IP addresses the cluster uses in your **Organization settings**.
+If you use Dedicated clusters and want to allowlist external IP addresses at the cluster level instead of at the Deployment level, you can find the list cluster-level external IP addresses in your **Organization settings**.
 
 1. In the Astro UI, click your Workspace name in the upper left corner, then click **Organization Settings**.
 2. Click **Clusters**, then select a cluster.

--- a/astro/connect-azure.md
+++ b/astro/connect-azure.md
@@ -24,7 +24,7 @@ Standard clusters have different connection options than dedicated clusters.
 
 Standard clusters can connect to Azure in the following ways:
 
-- Using [static external IP addresses](#allowlist-external-ip-addresses-for-a-cluster).
+- Using [static external IP addresses](#allowlist-external-ip-addresses).
 
 Dedicated clusters can also connect to Azure using static IP addresses. Additionally, they support a number of private connectivity options including:
 

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -35,22 +35,28 @@ If you require a private connection between Astro and GCP, Astronomer recommends
 
 ## Access a public GCP endpoint
 
-All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. To facilitate communication between an Astro cluster and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your GCP resources through a valid Airflow connection.
-
-:::tip
-
-While you can find an external IP address for your Deployment, these IP addresses are dynamically generated, which means that your connection might fail if the IP address changes. A cluster-level external IP address persists, ensuring your cluster can access your cloud resources as long as the cluster exists.
-
-:::
+All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. When you create a Deployment in your workspace, Astro assigns it one of these external IP addresses. To facilitate communication between Astro and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your GCP resources through a valid Airflow connection.
 
 ### Allowlist external IP addresses for a cluster
+
+1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
+2. Select the **Details** tab.
+3. In the **Other** section, you can find the **External IPs** associated with the Deployment.
+
+When you use publicly accessible endpoints to connect to GCP, traffic moves directly between your Astro cluster and the GCP API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them.
+
+<details>
+  <summary><strong>Dedicated cluster external IP addresses</strong></summary>
+
+If you use Dedicated clusters and want to allowlist external IP addresses at the cluster level, instead of per-Deployment, you can find the list of external IP addresses the cluster uses in your **Organization settings**.
 
 1. In the Astro UI, click your Workspace name in the upper left corner, then click **Organization Settings**.
 2. Click **Clusters**, then select a cluster.
 3. In the Details page, copy the IP addresses listed under **External IPs**.
 4. Add the IP addresses to the allowlist of any external services that you want your cluster to access. You can also access these IP addresses from the **Details** page of any Deployment in the cluster.
 
-After you allowlist a cluster's IP addresses, all Deployments in that cluster have network connectivity to GCP. When you use publicly accessible endpoints to connect to GCP, traffic moves directly between your Astro cluster and the GCP API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them.
+After you allowlist a cluster's IP addresses, all Deployments in that cluster have network connectivity to GCP.
+</details>
 
 ## Create a private connection between Astro and GCP
 

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -24,7 +24,7 @@ Standard clusters have different connection options than dedicated clusters.
 
 Standard clusters can connect to GCP in the following ways:
 
-- Using [static external IP addresses](#allowlist-external-ip-addresses-for-a-cluster).
+- Using [static external IP addresses](#allowlist-external-ip-addresses).
 - Using Private Service Connect to all managed [Google APIs](https://cloud.google.com/vpc/docs/private-service-connect-compatibility#google-apis-global).
 
 Dedicated clusters can use all of the same connection options as standard clusters. Additionally, they support a number of private connectivity options including:
@@ -37,7 +37,7 @@ If you require a private connection between Astro and GCP, Astronomer recommends
 
 All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. When you create a Deployment in your workspace, Astro assigns it one of these external IP addresses. To facilitate communication between Astro and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your GCP resources through a valid Airflow connection.
 
-### Allowlist external IP addresses for a cluster
+### Allowlist external IP addresses
 
 1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
 2. Select the **Details** tab.

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -42,9 +42,9 @@ All Astro clusters include a set of external IP addresses that persist for the l
 1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
 2. Select the **Details** tab.
 3. In the **Other** section, you can find the **External IPs** associated with the Deployment.
-4. Add the IP addresses to the allowlist of any external services that you want your Deployment to access. 
+4. Add the IP addresses to the allowlist of any external services that you want your Deployment to access.
 
-When you use publicly accessible endpoints to connect to GCP, traffic moves directly between your Astro cluster and the GCP API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them.
+When you use publicly accessible endpoints to connect to GCP, traffic moves directly between your Astro cluster and the GCP API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them. For example, you can [Authorize deployments to your cloud with workload identity](authorize-deployments-to-your-cloud.md) so that you can avoid adding passwords or other access credentials to your Airflow connections.
 
 <details>
   <summary><strong>Dedicated cluster external IP addresses</strong></summary>

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -37,6 +37,12 @@ If you require a private connection between Astro and GCP, Astronomer recommends
 
 All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. To facilitate communication between an Astro cluster and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your GCP resources through a valid Airflow connection.
 
+:::tip
+
+While you can find an external IP address for your Deployment, these IP addresses are dynamically generated, which means that your connection might fail if the IP address changes. A cluster-level external IP address persists, ensuring your cluster can access your cloud resources as long as the cluster exists.
+
+:::
+
 ### Allowlist external IP addresses for a cluster
 
 1. In the Astro UI, click your Workspace name in the upper left corner, then click **Organization Settings**.

--- a/astro/connect-gcp.md
+++ b/astro/connect-gcp.md
@@ -24,7 +24,7 @@ Standard clusters have different connection options than dedicated clusters.
 
 Standard clusters can connect to GCP in the following ways:
 
-- Using [static external IP addresses](#allowlist-external-ip-addresses).
+- Using [static external IP addresses](#allowlist-a-deployments-external-ip-addresses-on-gcp).
 - Using Private Service Connect to all managed [Google APIs](https://cloud.google.com/vpc/docs/private-service-connect-compatibility#google-apis-global).
 
 Dedicated clusters can use all of the same connection options as standard clusters. Additionally, they support a number of private connectivity options including:
@@ -37,18 +37,19 @@ If you require a private connection between Astro and GCP, Astronomer recommends
 
 All Astro clusters include a set of external IP addresses that persist for the lifetime of the cluster. When you create a Deployment in your workspace, Astro assigns it one of these external IP addresses. To facilitate communication between Astro and your cloud, you can allowlist these external IPs in your cloud. If you have no other security restrictions, this means that any cluster with an allowlisted external IP address can access your GCP resources through a valid Airflow connection.
 
-### Allowlist external IP addresses
+### Allowlist a Deployment's external IP addresses on GCP
 
 1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
 2. Select the **Details** tab.
 3. In the **Other** section, you can find the **External IPs** associated with the Deployment.
+4. Add the IP addresses to the allowlist of any external services that you want your Deployment to access. 
 
 When you use publicly accessible endpoints to connect to GCP, traffic moves directly between your Astro cluster and the GCP API endpoint. Data in this traffic never reaches the Astronomer managed control plane. Note that you still might also need to authorize your Deployment to some resources before it can access them.
 
 <details>
   <summary><strong>Dedicated cluster external IP addresses</strong></summary>
 
-If you use Dedicated clusters and want to allowlist external IP addresses at the cluster level, instead of per-Deployment, you can find the list of external IP addresses the cluster uses in your **Organization settings**.
+If you use Dedicated clusters and want to allowlist external IP addresses at the cluster level instead of at the Deployment level, you can find the list cluster-level external IP addresses in your **Organization settings**.
 
 1. In the Astro UI, click your Workspace name in the upper left corner, then click **Organization Settings**.
 2. Click **Clusters**, then select a cluster.

--- a/astro/deployment-details.md
+++ b/astro/deployment-details.md
@@ -84,16 +84,14 @@ When you delete a Deployment, all infrastructure resources assigned to the Deplo
 
 ## Find a Deployment's external IP address
 
-Deployments have an associated external IP address, that is dynamically generated.
+Deployments have associated external IP addresses.
 
 1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
 2. Select the **Details** tab.
 3. In the **Other** section, you can find the **External IPs** associated with the Deployment.
 
-:::tip
+:::note
 
-Deployments have dynamically generated external IP addresses. If you want to [set up a networking connection](networking-overview.md#standard-and-dedicated-cluster-support) with a static IP address, you need the cluster-level external IP address, which persists as long as the cluster exists.
+If you are using a Standard Cluster and need to look up your external IP address for your cluster, you can use the Deployment External IP address.
 
 :::
-
-

--- a/astro/deployment-details.md
+++ b/astro/deployment-details.md
@@ -89,9 +89,3 @@ Each Astro Deployment has its own external IP addresses. Allowlist these address
 1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
 2. Select the **Details** tab.
 3. In the **Other** section, you can find the **External IPs** associated with the Deployment.
-
-:::info
-
-On standard clusters, the external IP address for the cluster is identical to the external IP address for all Deployments in the cluster.
-
-:::

--- a/astro/deployment-details.md
+++ b/astro/deployment-details.md
@@ -82,16 +82,16 @@ When you delete a Deployment, all infrastructure resources assigned to the Deplo
 
 3. Enter `Delete` and click **Yes, Continue**.
 
-## Find a Deployment's external IP address
+## Find Deployment external IP addresses
 
-Deployments have associated external IP addresses.
+Each Astro Deployment has its own external IP addresses. Allowlist these addresses on any external service as a first step to create a connection between the Deployment and the service.
 
 1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
 2. Select the **Details** tab.
 3. In the **Other** section, you can find the **External IPs** associated with the Deployment.
 
-:::note
+:::info
 
-If you are using a Standard Cluster and need to look up your external IP address for your cluster, you can use the Deployment External IP address.
+On standard clusters, the external IP address for the cluster is identical to the external IP address for all Deployments in the cluster.
 
 :::

--- a/astro/deployment-details.md
+++ b/astro/deployment-details.md
@@ -13,7 +13,7 @@ Deployment details define how users can view and interact with your Deployment. 
 
 1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
 
-2. Click the **Options** menu of the Deployment you want to update, and select **Edit Deployment**.
+2. Click the **More Actions** menu of the Deployment you want to update, and select **Edit Deployment**.
 
     <img src={require("../static/img/docs/edit-deployment.png").default} alt="Edit Deployment in options menu" style={{ width: "60%", maxWidth: "400px", height: "auto" }} />
 
@@ -49,7 +49,7 @@ After you enable CI/CD enforcement on a Deployment, the Deployment accepts a dep
 
 1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
 
-2. Click the **Options** menu of the Deployment you want to update, and select **Edit Deployment**.
+2. Click the **More Actions** menu of the Deployment you want to update, and select **Edit Deployment**.
 
     <img src={require("../static/img/docs/edit-deployment.png").default} alt="Edit Deployment in options menu" style={{ width: "60%", maxWidth: "400px", height: "auto" }} />
 
@@ -76,8 +76,24 @@ You have to only complete these steps once. Once the DAG-only deploy feature is 
 When you delete a Deployment, all infrastructure resources assigned to the Deployment are immediately deleted. However, the Kubernetes namespace and metadata database for the Deployment are retained for 30 days. Deleted Deployments can't be restored. If you accidentally delete a Deployment, contact [Astronomer support](https://cloud.astronomer.io/open-support-request).
 
 1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
-2. Click the **Options** menu of the Deployment you want to delete, and select **Delete Deployment**.
+2. Click the **More Actions** menu of the Deployment you want to delete, and select **Delete Deployment**.
 
     <img src={require("../static/img/docs/delete-deployment.png").default} alt="Delete Deployment in options menu" style={{ width: "60%", maxWidth: "400px", height: "auto" }} />
 
 3. Enter `Delete` and click **Yes, Continue**.
+
+## Find a Deployment's external IP address
+
+Deployments have an associated external IP address, that is dynamically generated.
+
+1. In the Astro UI, select a Workspace, click **Deployments**, and then select a Deployment.
+2. Select the **Details** tab.
+3. In the **Other** section, you can find the **External IPs** associated with the Deployment.
+
+:::tip
+
+Deployments have dynamically generated external IP addresses. If you want to [set up a networking connection](networking-overview.md#standard-and-dedicated-cluster-support) with a static IP address, you need the cluster-level external IP address, which persists as long as the cluster exists.
+
+:::
+
+

--- a/astro/networking-overview.md
+++ b/astro/networking-overview.md
@@ -23,8 +23,6 @@ Astronomer can support alternative networking solutions that are not covered in 
 
 If you're just starting out on Astro and you're working with publicly available services and testing data, you only need a public connection. For example, if you're accessing a publicly available API, you only need to configure an [HTTP Airflow connection](https://airflow.apache.org/docs/apache-airflow-providers-http/stable/connections/http.html) to establish a connection between your Deployment and the API.
 
-Depending on the type of cloud provider you want to create a networking connection with and whether you have a standard or a dedicated cluster in your Astro Deployment, you have different configuration options.
-
 To access or write data on your company's cloud, Astronomer strongly recommends establishing a private network connection between Astro and your cloud. For most use cases, Astronomer recommends creating a VPC peering connection between Astro and your cloud. After the connection is established, you can authorize individual Deployments to specific resources using workload identity. This method is simple to set up and ensures private and secure connectivity between Astro and any support cloud provider.
 
 To create a VPC peering connection to Astro, you must use a dedicated cluster. In general, dedicated clusters support more secure networking types, such as AWS PrivateLink and Azure VNet peering. See:

--- a/astro/networking-overview.md
+++ b/astro/networking-overview.md
@@ -38,3 +38,13 @@ After you create your VPC peering connection, follow the steps in [Authorize you
 Astronomer monitors the health of Deployments and DAGs, but it doesn't monitor the status of network connections because they exist outside of Astronomer's observable control plane and data plane.
 
 :::
+
+## Standard and dedicated cluster support
+
+Depending on the type of cloud provider you want to create a networking connection with and whether you have a standard or a dedicated cluster in your Astro Deployment, you have different configuration options.
+
+To learn more about networking connection support and cluster options, see:
+
+- [AWS: Standard and dedicated cluster support](connect-aws.md#standard-and-dedicated-cluster-support-for-aws-networking)
+- [GCP: Standard and dedicated cluster support](connect-gcp.md#standard-and-dedicated-cluster-support-for-gcp-networking)
+- [Azure: Standard and dedicated cluster support](connect-azure.md#standard-and-dedicated-cluster-support-for-azure-networking)

--- a/astro/networking-overview.md
+++ b/astro/networking-overview.md
@@ -23,9 +23,11 @@ Astronomer can support alternative networking solutions that are not covered in 
 
 If you're just starting out on Astro and you're working with publicly available services and testing data, you only need a public connection. For example, if you're accessing a publicly available API, you only need to configure an [HTTP Airflow connection](https://airflow.apache.org/docs/apache-airflow-providers-http/stable/connections/http.html) to establish a connection between your Deployment and the API.
 
+Depending on the type of cloud provider you want to create a networking connection with and whether you have a standard or a dedicated cluster in your Astro Deployment, you have different configuration options.
+
 To access or write data on your company's cloud, Astronomer strongly recommends establishing a private network connection between Astro and your cloud. For most use cases, Astronomer recommends creating a VPC peering connection between Astro and your cloud. After the connection is established, you can authorize individual Deployments to specific resources using workload identity. This method is simple to set up and ensures private and secure connectivity between Astro and any support cloud provider.
 
-To create a VPC peering connection on each support cloud see:
+To create a VPC peering connection to Astro, you must use a dedicated cluster. In general, dedicated clusters support more secure networking types, such as AWS PrivateLink and Azure VNet peering. See:
 
 - [AWS: Create a private connection between Astro and AWS](connect-aws.md?tab=VPC%20peering#create-a-private-connection-between-astro-and-aws)
 - [GCP: Create a private connection between Astro and GCP](connect-gcp.md?tab=VPC%20peering#create-a-private-connection-between-astro-and-gcp)
@@ -38,13 +40,3 @@ After you create your VPC peering connection, follow the steps in [Authorize you
 Astronomer monitors the health of Deployments and DAGs, but it doesn't monitor the status of network connections because they exist outside of Astronomer's observable control plane and data plane.
 
 :::
-
-## Standard and dedicated cluster support
-
-Depending on the type of cloud provider you want to create a networking connection with and whether you have a standard or a dedicated cluster in your Astro Deployment, you have different configuration options.
-
-To learn more about networking connection support and cluster options, see:
-
-- [AWS: Standard and dedicated cluster support](connect-aws.md#standard-and-dedicated-cluster-support-for-aws-networking)
-- [GCP: Standard and dedicated cluster support](connect-gcp.md#standard-and-dedicated-cluster-support-for-gcp-networking)
-- [Azure: Standard and dedicated cluster support](connect-azure.md#standard-and-dedicated-cluster-support-for-azure-networking)


### PR DESCRIPTION
Resolves #3470 

We've had a couple of reports about the External IP to use in allowlisting being a little confusing and difficult to find. 

- The external IP information was originally removed from the Networking Overview because there are different connection options that depend on 1. The cloud provider  and 2. whether its a connection with a standard or a dedicated cluster. 
- Instead of adding too much provider-specific content to the networking overview, I added a small section that redirects users to the correct section of each cloud-specific doc. 
- Added a note to the Allowlist procedure section to clarify why a user needs the cluster-level IP address instead of the Deployment-level. 