### PR TITLE
correct astro init commands in software install

### DIFF
--- a/software/install-aws-standard.md
+++ b/software/install-aws-standard.md
@@ -537,7 +537,7 @@ Finally, try running `$ astro deploy` on a test deployment. Create a deployment 
 ```sh
 mkdir demo
 cd demo
-astro dev init --use-astronomer-certified
+astro dev init
 astro deploy -f
 ```
 

--- a/software/install-azure-standard.md
+++ b/software/install-azure-standard.md
@@ -552,7 +552,7 @@ Finally, try running `$ astro deploy` on a test deployment. Create a deployment 
 ```sh
 $ mkdir demo
 $ cd demo
-$ astro dev init --use-astronomer-certified
+$ astro dev init
 $ astro deploy -f
 ```
 Check the Airflow namespace. If pods are changing at all, then the Houston API trusts the registry.

--- a/software/install-gcp-standard.md
+++ b/software/install-gcp-standard.md
@@ -545,7 +545,7 @@ Finally, try running `$ astro deploy` on a test deployment. Create a deployment 
 ```sh
 $ mkdir demo
 $ cd demo
-$ astro airflow init
+$ astro dev init
 $ astro deploy -f
 ```
 


### PR DESCRIPTION
The final stages of a Software install where a user is supposed to test a deploy is outdated. Updated with correct CLI commands