### PR TITLE
Revert "fix code typo (#3555)"

### DIFF
--- a/software/install-airgapped.md
+++ b/software/install-airgapped.md
@@ -323,7 +323,7 @@ astronomer:
       deployments:
         helm:
           airflow:
-            extraEnv: |
+            extraEnv:
             - name: AIRFLOW__ASTRONOMER__UPDATE_URL
               value: http://astronomer-releases.astronomer.svc.cluster.local/astronomer-runtime
 ```


### PR DESCRIPTION
This reverts commit 4a363a40011afe9c49300b9ae27316728914d7e2.

Was not broken. Doesn't work with change with change on current or prior version, I think original is correct.