### PR TITLE
CLI release notes v1.27.0

### DIFF
--- a/astro/cli/release-notes.md
+++ b/astro/cli/release-notes.md
@@ -20,28 +20,33 @@ This document provides a summary of all changes made to the [Astro CLI](cli/over
 
 ## Astro CLI 1.27.0
 
-Release date: April 24, 2024
+Release date: May 16, 2024
 
-### New Flags for the Deployment Logs Commands: 
+### New flags for the Deployment logs commands: 
 
-Introducing new flags (`--webserver`, `--scheduler`, `--triggerer`, `--worker`) for the `astro deployment logs` command. Now users can parse logs for specific components, providing granular insights into Deployments and enhancing monitoring capabilities.
+You can now parse logs for specific components, providing granular insights into Deployments and enhancing monitoring capabilities, with the following new flags for the `astro deployment logs` command:
 
-### Exclude DAG Files from Parse Test
+- `--webserver`
+- `--scheduler`
+- `--triggerer`
+- `--worker`
 
-Users can now exclude DAG files from testing with `astro dev parse` command. To get the new test, delete the `.astro/test_dag_integrity_default.py` file and run `astro dev init`. A new default test file will be created along with a `.astro/dag_integrity_exceptions.txt`. You can add dag files you want to be excluded to this text file. This allows you to exclude tests that you know do not pass the `astro dev parse` test.
+### Exclude DAG files from parse test
+
+You can exclude DAG files from testing with `astro dev parse` command. 
+
+To get this new test option for an existing project, delete the `.astro/test_dag_integrity_default.py` file and run `astro dev init`. After you run this command, the Astro CLI creates a new default test file along with a `.astro/dag_integrity_exceptions.txt` text file. You can also add DAG files that you want to be excluded to the `dag_integrity_exceptions.txt` file, which allows you to exclude tests that you know do not pass the `astro dev parse` test.
 
 ### Additional improvements
 
-- The `astro deploy --image` command can now be used to deploy to deployments without pre-existing DAGs.
-- Users can now append `2>/dev/null | head` to commands to disregard upgrade messages. For example, running `astro completion bash 2>/dev/null | head`ensures that resulting bash script remains unaffected by the upgrade message.
-- New flag `astro deployment update --development-mode disable` to turn off development mode for an existing deployment. Note that you still cannot turn on development mode for an existing deployment.
-- New error message for expired API tokens.
-
+- The `astro deploy --image` command can now be used to deploy to Deployments without pre-existing DAGs.
+- You can now append `2>/dev/null | head` to commands to disregard upgrade messages. For example, running `astro completion bash 2>/dev/null | head` ensures that resulting bash script remains unaffected by the upgrade message.
+- A new flag is available, `astro deployment update --development-mode disable`, to turn off development mode for an existing deployment. Note that you still cannot turn on development mode for an existing deployment.
 
 ### Bug fixes
 
-- Fixed an issue where deployments with identical names across different workspaces couldn't be created
-- The upgrade-test command now returns the correct error code, ensuring accurate feedback during testing and CI/CD.
+- Fixed an issue where Deployments with identical names across different Workspaces couldn't be created
+- The `upgrade-test` command now returns the correct error code, ensuring accurate feedback during testing and CI/CD.
 
 ## Astro CLI 1.26.0
 

--- a/astro/cli/release-notes.md
+++ b/astro/cli/release-notes.md
@@ -24,7 +24,7 @@ Release date: May 16, 2024
 
 ### New flags for the Deployment logs commands: 
 
-You can now parse logs for specific components, providing granular insights into Deployments and enhancing monitoring capabilities, with the following new flags for the `astro deployment logs` command:
+You can now filter logs for specific Deployment components using the following new flags for `astro deployment logs`:
 
 - `--webserver`
 - `--scheduler`
@@ -33,19 +33,21 @@ You can now parse logs for specific components, providing granular insights into
 
 ### Exclude DAG files from parse test
 
-You can exclude DAG files from testing with the `astro dev parse` command. 
+You can now exclude DAG files from being tested when you run `astro dev parse`. 
 
-To use this new testing option for an existing project, delete the `.astro/test_dag_integrity_default.py` file and run `astro dev init`. After you run this command, the Astro CLI creates a new default test file along with a `.astro/dag_integrity_exceptions.txt` text file. You can also add DAG files that you want to be excluded to the `dag_integrity_exceptions.txt` file, which allows you to exclude tests that you know do not pass the `astro dev parse` test.
+All new Astro projects that you create with `astro dev init` now include a file named `.astro/dag_integrity_exceptions.txt`. Add the names of DAGs to this file to exclude them from being tested when you run `astro dev parse`. This allows you to exclude DAGs that you know will not pass your tests.
+
+To use this feature in an existing Astro project, delete the `.astro/test_dag_integrity_default.py` file  in your Astro project, then run `astro dev init`. After you run this command, the Astro CLI creates a new default test file along with a `.astro/dag_integrity_exceptions.txt` text file. 
 
 ### Additional improvements
 
-- The `astro deploy --image` command can now be used to deploy to Deployments without pre-existing DAGs.
-- You can now append `2>/dev/null | head` to commands to disregard upgrade messages. For example, running `astro completion bash 2>/dev/null | head` ensures that resulting bash script remains unaffected by the upgrade message.
-- A new flag is available, `astro deployment update --development-mode disable`, to turn off development mode for an existing deployment. Note that you still cannot turn on development mode for an existing deployment.
+- Astro projects no longer have to include DAGs in order to run `astro deploy --image`.
+- You can now append `2>/dev/null | head` to commands to disregard upgrade messages. For example, running `astro completion bash 2>/dev/null | head` ensures that the resulting bash script remains unaffected by the upgrade message.
+- You can now use the `--development-mode disable` flag with `astro deployment update` to turn off [development mode](https://docs.astronomer.io/astro/deployment-resources#hibernate-a-development-deployment) for an existing Deployment. Note that you still cannot turn on development mode for an existing Deployment.
 
 ### Bug fixes
 
-- Fixed an issue where Deployments with identical names across different Workspaces couldn't be created.
+- Fixed an issue where you couldn't create two Deployments with identical names across different Workspaces. 
 - The `upgrade-test` command now returns the correct error code, ensuring accurate feedback during testing and CI/CD.
 
 ## Astro CLI 1.26.0

--- a/astro/cli/release-notes.md
+++ b/astro/cli/release-notes.md
@@ -33,9 +33,9 @@ You can now parse logs for specific components, providing granular insights into
 
 ### Exclude DAG files from parse test
 
-You can exclude DAG files from testing with `astro dev parse` command. 
+You can exclude DAG files from testing with the `astro dev parse` command. 
 
-To get this new test option for an existing project, delete the `.astro/test_dag_integrity_default.py` file and run `astro dev init`. After you run this command, the Astro CLI creates a new default test file along with a `.astro/dag_integrity_exceptions.txt` text file. You can also add DAG files that you want to be excluded to the `dag_integrity_exceptions.txt` file, which allows you to exclude tests that you know do not pass the `astro dev parse` test.
+To use this new testing option for an existing project, delete the `.astro/test_dag_integrity_default.py` file and run `astro dev init`. After you run this command, the Astro CLI creates a new default test file along with a `.astro/dag_integrity_exceptions.txt` text file. You can also add DAG files that you want to be excluded to the `dag_integrity_exceptions.txt` file, which allows you to exclude tests that you know do not pass the `astro dev parse` test.
 
 ### Additional improvements
 
@@ -45,7 +45,7 @@ To get this new test option for an existing project, delete the `.astro/test_dag
 
 ### Bug fixes
 
-- Fixed an issue where Deployments with identical names across different Workspaces couldn't be created
+- Fixed an issue where Deployments with identical names across different Workspaces couldn't be created.
 - The `upgrade-test` command now returns the correct error code, ensuring accurate feedback during testing and CI/CD.
 
 ## Astro CLI 1.26.0

--- a/astro/cli/release-notes.md
+++ b/astro/cli/release-notes.md
@@ -18,6 +18,31 @@ This document provides a summary of all changes made to the [Astro CLI](cli/over
 
 - **Stable versions**: {{CLI_VER_LATEST}}, {{CLI_VER_2}}, and {{CLI_VER_3}}. See [Astro CLI release and lifecycle policy](cli/release-lifecycle-policy.md) for more information about support for CLI versions.
 
+## Astro CLI 1.27.0
+
+Release date: April 24, 2024
+
+### New Flags for the Deployment Logs Commands: 
+
+Introducing new flags (`--webserver`, `--scheduler`, `--triggerer`, `--worker`) for the `astro deployment logs` command. Now users can parse logs for specific components, providing granular insights into Deployments and enhancing monitoring capabilities.
+
+### Exclude DAG Files from Parse Test
+
+Users can now exclude DAG files from testing with `astro dev parse` command. To get the new test, delete the `.astro/test_dag_integrity_default.py` file and run `astro dev init`. A new default test file will be created along with a `.astro/dag_integrity_exceptions.txt`. You can add dag files you want to be excluded to this text file. This allows you to exclude tests that you know do not pass the `astro dev parse` test.
+
+### Additional improvements
+
+- The `astro deploy --image` command can now be used to deploy to deployments without pre-existing DAGs.
+- Users can now append `2>/dev/null | head` to commands to disregard upgrade messages. For example, running `astro completion bash 2>/dev/null | head`ensures that resulting bash script remains unaffected by the upgrade message.
+- New flag `astro deployment update --development-mode disable` to turn off development mode for an existing deployment. Note that you still cannot turn on development mode for an existing deployment.
+- New error message for expired API tokens.
+
+
+### Bug fixes
+
+- Fixed an issue where deployments with identical names across different workspaces couldn't be created
+- The upgrade-test command now returns the correct error code, ensuring accurate feedback during testing and CI/CD.
+
 ## Astro CLI 1.26.0
 
 Release date: April 24, 2024

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,9 +15,9 @@ module.exports = {
     preprocessor: ({ filePath, fileContent }) => {
       function updateValues() {
         var mapObj = {
-          '{{CLI_VER_LATEST}}': "1.26.0",
-          '{{CLI_VER_2}}': "1.25.0",
-          '{{CLI_VER_3}}': "1.24.1",
+          '{{CLI_VER_LATEST}}': "1.27.0",
+          '{{CLI_VER_2}}': "1.26.0",
+          '{{CLI_VER_3}}': "1.25.0",
           '{{RUNTIME_VER}}': "11.3.0",
         };
         var re = new RegExp(Object.keys(mapObj).join("|"), "gi");


### PR DESCRIPTION
CLI release notes v1.27.0 for CLI release tomorrow. We can add additional new documentation in a separate PR after the release.