### PR TITLE
Remove listener code and guidance from cross-deployment best practices guide

### DIFF
--- a/astro/best-practices/cross-deployment-dependencies.md
+++ b/astro/best-practices/cross-deployment-dependencies.md
@@ -104,7 +104,7 @@ While you can also use the HttpOperator or a custom Python function in an `@task
 1. In your upstream Deployment, which is the Deployment for which you did **not** create an API Token, use **Variables** in the Astro UI to create an environment variable for your API token, and use `API_TOKEN` for the key.
 2. For your downstream Deployment, follow the guidance in [Make requests to the Airflow REST API - Step 2](https://docs.astronomer.io/astro/airflow-api#step-2-retrieve-the-deployment-url) to obtain the Deployment URL for your downstream Deployment. The Deployment URL should be in the format of `clq52ag32000108i8e3v3acml.astronomer.run/dz3uu847`. 
 3. In your upstream Deployment, use Variables in the Astro UI to create an environment variable where you can store your downstream Deployment URL, using `DEPLOYMENT_URL` for the key.
-4. In the upstream Deployment, add the following DAG to your Astro project running in the upstream Deployment. In the `get_bear` task, the TaskFlow API automatically registers `MY_DATASET` as an outlet Dataset. The dependent `on_dataset_changed` task creates or updates the Dataset via a request to the Airflow API Datasets endpoint.
+4. In the upstream Deployment, add the following DAG to your Astro project running in the upstream Deployment. In the `get_bear` task, the TaskFlow API automatically registers `MY_DATASET` as an outlet Dataset. This creates an update to this Dataset in the _same_ Airflow deployment. The dependent `on_dataset_changed` task creates or updates the Dataset via a request to the Airflow API Datasets endpoint in a _different_ Airflow deployment.
 
 ```python
 from airflow.datasets import Dataset
@@ -124,12 +124,12 @@ DEPLOYMENT_URL = os.environ.get("DEPLOYMENT_URL")
     doc_md=__doc__,
 )
 def producer_dag():
-    @task()
+    @task
     def get_bear():
         print("Update the bears dataset")
         return MY_DATASET
 
-    @task()
+    @task
     def on_dataset_changed(dataset: Dataset):        
         print('Oh! This is the bears dataset!')
         payload = {

--- a/astro/best-practices/cross-deployment-dependencies.md
+++ b/astro/best-practices/cross-deployment-dependencies.md
@@ -89,7 +89,7 @@ To use Airflow Datasets to create cross-deployment dependencies, you should have
 
 ### Implementation
 
-This section explains how to use a listener in combination with the [Airflow API's Datasets endpoint](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Dataset) to trigger the downstream DAG in another deployment when a dataset is updated. Typical dataset implementation only works for DAGs in the same Airflow deployment, but by using the Airflow API, this pattern can be implemented across deployments.
+This section explains how to use the [Airflow API's Datasets endpoint](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Dataset) to trigger the downstream DAG in another deployment when a dataset is updated. Typical dataset implementation only works for DAGs in the same Airflow deployment, but by using the Airflow API, you can implement this pattern across deployments.
 
 While you can also use the HttpOperator or a custom Python function in an `@task` decorated task to make the API request to update the dataset, an advantage of using a listener is that the dataset is updated and the downstream DAG runs whenever _any_ DAG updates the dataset. This means you don't need to implement an API call in every upstream DAG that updates the same dataset.
  
@@ -104,68 +104,18 @@ While you can also use the HttpOperator or a custom Python function in an `@task
 1. In your upstream Deployment, which is the Deployment for which you did **not** create an API Token, use **Variables** in the Astro UI to create an environment variable for your API token, and use `API_TOKEN` for the key.
 2. For your downstream Deployment, follow the guidance in [Make requests to the Airflow REST API - Step 2](https://docs.astronomer.io/astro/airflow-api#step-2-retrieve-the-deployment-url) to obtain the Deployment URL for your downstream Deployment. The Deployment URL should be in the format of `clq52ag32000108i8e3v3acml.astronomer.run/dz3uu847`. 
 3. In your upstream Deployment, use Variables in the Astro UI to create an environment variable where you can store your downstream Deployment URL, using `DEPLOYMENT_URL` for the key.
-4. In the upstream Deployment, implement a listener following the guidance in Step 2 and 3 of the [Create Airflow listeners tutorial](https://docs.astronomer.io/learn/airflow-listeners). Use the following code in place of the `listeners_code.py` and `listener_plugin.py` code provided there.
-
-:::note
-
-Although this listener is designed to make an API request only for updates to the specific dataset in this example, the conditional statement `if dataset.uri ...` can be removed or adjusted if you would like to apply the function for updates to multiple datasets or all datasets in a deployment.
-
-:::
-
-```python
-# listeners_code.py
-
-from airflow.datasets import Dataset
-from airflow.listeners import hookimpl
-import requests
-import os
-
-TOKEN = os.environ.get("API_TOKEN")
-DEPLOYMENT_URL = os.environ.get("DEPLOYMENT_URL")
-
-@hookimpl
-def on_dataset_changed(dataset: Dataset):
-    """
-    Execute if a specific dataset is updated. Remove or adjust the if statement 
-    to apply the function to multiple datasets.
-    """
-    if dataset.uri == "file://include/bears":
-        payload = {
-            "dataset_uri": dataset.uri
-        }
-        response = requests.post(
-            url=f"https://{DEPLOYMENT_URL}/api/v1/datasets/events",
-            headers={
-                "Authorization": f"Bearer {TOKEN}",
-                "Content-Type": "application/json",
-                "Accept": "application/json"
-            },
-            json=payload
-        )
-        print(response.json())
-
-```
-
-```python
-# listener_plugin.py
-
-from airflow.plugins_manager import AirflowPlugin
-from plugins import listener_code
-
-class MyListenerPlugin(AirflowPlugin):
-    name = "my_listener_plugin"
-    listeners = [listener_code]
-```
-
-4. Add the following DAG to your Astro project running in the upstream Deployment.
+4. In the upstream Deployment, add the following DAG to your Astro project running in the upstream Deployment. In the `get_bear` task, the TaskFlow API automatically registers `MY_DATASET` as an outlet Dataset. The dependent `on_dataset_changed` task creates or updates the Dataset via a request to the Airflow API Datasets endpoint.
 
 ```python
 from airflow.datasets import Dataset
 from airflow.decorators import dag, task
 from pendulum import datetime
+import os
 
 URI = "file://include/bears"
 MY_DATASET = Dataset(URI)
+TOKEN = os.environ.get("API_TOKEN")
+DEPLOYMENT_URL = os.environ.get("DEPLOYMENT_URL")
 
 @dag(
     start_date=datetime(2023, 12, 1),
@@ -174,13 +124,30 @@ MY_DATASET = Dataset(URI)
     doc_md=__doc__,
 )
 def producer_dag():
-    @task(
-        outlets=[MY_DATASET],
-    )
+    @task()
     def get_bear():
         print("Update the bears dataset")
+        return MY_DATASET
 
-    get_bear()
+    @task()
+    def on_dataset_changed(dataset: Dataset):        
+        print('Oh! This is the bears dataset!')
+        payload = {
+            'dataset_uri': dataset.uri
+        }
+        response = requests.post(
+            url=f'https://{DEPLOYMENT_URL}/api/v1/datasets/events',
+            headers={
+                'Authorization': f'Bearer {TOKEN}',
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            },
+            json=payload
+        )
+        print(response.json())
+
+    bear = get_bear()
+    on_dataset_changed(bear)
 
 producer_dag()
 
@@ -217,7 +184,7 @@ consumer_dag()
 
 ```
 
-After deploying both projects to their respective Deployments on Astro, you should see runs of your `producer_dag` trigger your `consumer_dag` automatically. If the downstream DAG is not firing, verify that the upstream Deployment's environment variables, the API token and deployment URL, correspond to the downstream Deployment's API Token and Deployment URL. Also, a properly functioning listener will emit an API response payload containing DAG run information related to the dataset. Check the task logs for output that looks similar to this:
+After deploying both projects to their respective Deployments on Astro, you should see runs of your `producer_dag` trigger your `consumer_dag` automatically. If the downstream DAG is not firing, verify that the upstream Deployment's environment variables, the API token and deployment URL, correspond to the downstream Deployment's API Token and Deployment URL. Also, a successful request to the Airflow API will emit a payload containing DAG run information related to the dataset. Check the task logs for output that looks similar to this:
 
 ```text
 [2024-05-13, 11:21:06 UTC] {logging_mixin.py:188} INFO - {'created_dagruns': [], 'dataset_id': 1, 'dataset_uri': 'file://include/bears', 'extra': {'from_rest_api': True}, 'id': 4, 'source_dag_id': None, 'source_map_index': -1, 'source_run_id': None, 'source_task_id': None, 'timestamp': '2024-05-13T11:21:06.252976+00:00'}


### PR DESCRIPTION
As @vatsrahul1001 discovered, failing calls to the dataset/event endpoint in a listener cause tasks to fail and become zombie tasks. Subsequent calls to the dataset/event endpoint result in HTTP 500 errors.

This removes the listener implementation from the cross-deployment guide, moving the API request in the listener to a new dependent task in the DAG.