### PR TITLE
Quick Fix - Small Update to Netlify Function for Developer Updates Form

### DIFF
--- a/src/components/NewsletterForm/index.js
+++ b/src/components/NewsletterForm/index.js
@@ -151,7 +151,7 @@ export default function NewsletterForm(
 
     body.anonId = getSegmentUser() || email;
 
-    fetch(`/.netlify/functions/submit-form`, {
+    fetch(`/docs/.netlify/functions/submit-form`, {
       // eslint-disable-line
       method: "POST",
       body: JSON.stringify(body),


### PR DESCRIPTION
This PR is a very small quick fix so the Netlify function for the Developer Updates form at the bottom of pages works post migration under the /docs directory.