### PR TITLE
Quick Fix - Update Fern URL Subpath to /docs/api

### DIFF
--- a/api/fern/docs.yml
+++ b/api/fern/docs.yml
@@ -1,5 +1,5 @@
 instances:
-  - url: astronomer.docs.buildwithfern.com/api
+  - url: astronomer.docs.buildwithfern.com/docs/api
     custom-domain: www.astronomer.io/docs/api
 title: Astro API Reference
 navigation:

--- a/src/components/NewsletterForm/index.js
+++ b/src/components/NewsletterForm/index.js
@@ -151,7 +151,7 @@ export default function NewsletterForm(
 
     body.anonId = getSegmentUser() || email;
 
-    fetch(`/.netlify/functions/submit-form`, {
+    fetch(`/docs/.netlify/functions/submit-form`, {
       // eslint-disable-line
       method: "POST",
       body: JSON.stringify(body),


### PR DESCRIPTION
This PR is a quick fix to update fern to work with our new docs location at www.astronomer.io/docs