### PR TITLE
Sidebar and Runtime upgrades guide title fix 

### DIFF
--- a/astro/best-practices/upgrading-astro-runtime.md
+++ b/astro/best-practices/upgrading-astro-runtime.md
@@ -1,5 +1,5 @@
 ---
-title: "Best practices for upgrading Astro Runtime"
+title: "Best practices for upgrading Astro Runtime on Astro"
 sidebar_label: "Astro Runtime upgrades"
 description: "A list of best practices to ensure that your Astro Runtime upgrades are safe and easy."
 id: upgrading-astro-runtime

--- a/sidebarsAstro.js
+++ b/sidebarsAstro.js
@@ -327,11 +327,11 @@ module.exports = {
       type: 'category',
       label: 'Best practices',
       items: [
+        'best-practices/upgrading-astro-runtime',
         'best-practices/airflow-vs-astro-alerts',
         'best-practices/connections-branch-deploys',
         'best-practices/cross-deployment-dependencies',
         'best-practices/manage-dev-deployments',
-        'best-practices/upgrading-astro-runtime',
       ],
     },
     {


### PR DESCRIPTION
This alphabetizes links in the sidebar and revises this guide's title to clarify that it pertains to Astro Hosted only.