### PR TITLE
Make instructions for private registry cred request more generic

### DIFF
--- a/astro/kubernetespodoperator.md
+++ b/astro/kubernetespodoperator.md
@@ -168,12 +168,7 @@ By default, the KubernetesPodOperator expects to pull a Docker image that's host
 
 To run Docker images from a private registry on Astro, a Kubernetes Secret that contains credentials to your registry must be created. Injecting this secret into your Deployment's namespace will give your tasks access to Docker images within your private registry.
 
-1. Log in to your Docker registry and follow the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#log-in-to-docker-hub) to produce a `/.docker/config.json` file. If the generated `/docker/config.json` does not contain any credentials, copy your registry URL, username, and password.
-2. In the Astro UI, select a Workspace and then select the Deployment you want to use the KubernetesPodOperator with.
-3. Copy the value in the **NAMESPACE** field.
-4. Contact [Astronomer support](https://cloud.astronomer.io/open-support-request) and provide the namespace of the Deployment.
-
-Astronomer Support will give you instructions on how to securely send your credentials. Do not send this file by email, as it contains sensitive credentials to your registry. Astronomer will use these credentials to create a Kubernetes secret in your Deployment's namespace.
+Submit a request to [Astronomer support](https://cloud.astronomer.io/open-support-request) for creating a Kubernetes Secret to enable pulling images from private registries. Astronomer Support provide give you the necessary instructions on how to generate and securely send the credentials.
 
 #### Step 2: Specify the Kubernetes Secret in your DAG
 


### PR DESCRIPTION
The current set of instructions is not really detailed enough to help a customer provide the necessary information that the support agent needs to complete the request. Ideally, once a request comes in, the support agent will provide the full set of instructions for creating and sending the credentials.

I am not opposed to providing the full instructions on the docs site. The only concern is that the instructions may be too detailed and may bloat the page.

---

Here are the full set of instructions.

Please follow these instructions to obtain the necessary information for creating a Kubernetes Secret to contain the credential to the private registry.
* Generate the private registry credentials
* Choose the name of the Kubernetes Secret
* Obtain the Name and ID of the Deployment where the private registry credentials will be used


To retrieve the private registry credentials, follow the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#log-in-to-docker-hub) to get the contents of `~/.docker/config.json`. If the file does not contain credentials similar to the examples below, you will need to create the credentials manually.


To create the credential:

Retrieve the username and password used to authenticate to the private registry
Replace the values in `echo -n '<username>:<password>' | base64` and run the command to generate the auth key, which is a base64 encoded string of the user and password.

Replace the value for the private registry server and auth key in the below credential template.

```
{
  "auths": {
    "<private-registry-server>": {
      "auth": "<auth_key>"
    }
  }
}
```

You should have something like this.

```
{
  "auths": {
    "https://index.docker.io/v1/": {
      "auth": "c3R...zE2"
    }
  }
}
```
Next, store the credential in a secure location to share with the support agent. Astronomer recommends sharing the value through [secrets.procore](https://secrets.procore.com/).



To conclude, you should now present the following information to the support agent for us to complete your request.

* Link for the support agent to access the private registry credentials
* Name of the Kubernetes Secret
* Name and ID of the Deployment where the private registry credentials will be used
