### PR TITLE
[Tiny PR] Add hosted only badge in 2 places

### DIFF
--- a/astro/deploy-github-integration.md
+++ b/astro/deploy-github-integration.md
@@ -8,6 +8,8 @@ description: Learn how to automatically deploy Apache Airflow code to Astro from
 :::publicpreview
 :::
 
+<HostedBadge/>
+
 Astronomer's built-in GitHub integration is the fastest way to implement CI/CD for Apache Airflow and deploy code to Astro. Astro’s automatic deploy system eliminates both the need to implement GitHub Actions and gives you greater visibility into the code you’re running on Astro.
 
 To deploy code through an integrated GitHub repository, you first connect a GitHub repository with your Astro project to an Astro Workspace. Then, you map a Git branch in that repository to an Astro Deployment. When a pull request is merged into your mapped branch, your code is automatically deployed to Astro.

--- a/astro/deploy-github-integration.md
+++ b/astro/deploy-github-integration.md
@@ -5,6 +5,8 @@ id: deploy-github-integration
 description: Learn how to automatically deploy Apache Airflow code to Astro from GitHub with a built-in integration.
 ---
 
+import HostedBadge from '@site/src/components/HostedBadge';
+
 :::publicpreview
 :::
 

--- a/astro/deploy-github-integration.md
+++ b/astro/deploy-github-integration.md
@@ -7,10 +7,10 @@ description: Learn how to automatically deploy Apache Airflow code to Astro from
 
 import HostedBadge from '@site/src/components/HostedBadge';
 
+<HostedBadge/>
+
 :::publicpreview
 :::
-
-<HostedBadge/>
 
 Astronomer's built-in GitHub integration is the fastest way to implement CI/CD for Apache Airflow and deploy code to Astro. Astro’s automatic deploy system eliminates both the need to implement GitHub Actions and gives you greater visibility into the code you’re running on Astro.
 

--- a/astro/deploy-history.md
+++ b/astro/deploy-history.md
@@ -5,6 +5,8 @@ id: deploy-history
 description: View a historical record of code deploys to an Astro Deployment and roll back to specific deploys when something goes wrong.
 ---
 
+<HostedBadge/>
+
 The **Deploy History** tab in the Astro UI shows you a record of all code deploys to your Deployment. Use this page to track the development of a Deployment and to pinpoint when your team made key changes to code.
 
 Astronomer stores the image and DAGs for all deploys made in the last 90 days. You can trigger a rollback to any of these deploys so that your Deployment starts running a previous version of your code.

--- a/astro/deploy-history.md
+++ b/astro/deploy-history.md
@@ -5,6 +5,8 @@ id: deploy-history
 description: View a historical record of code deploys to an Astro Deployment and roll back to specific deploys when something goes wrong.
 ---
 
+import HostedBadge from '@site/src/components/HostedBadge';
+
 <HostedBadge/>
 
 The **Deploy History** tab in the Astro UI shows you a record of all code deploys to your Deployment. Use this page to track the development of a Deployment and to pinpoint when your team made key changes to code.


### PR DESCRIPTION
Feel free to ignore if there is a reason why the badge is not on these docs. :) 

For deployment rollbacks the info that it isnt on hybrid is from the comparison doc https://www.astronomer.io/docs/astro/hosted-hybrid-reference, for the GH integration from the Slack channel. 