### PR TITLE
Add tip about minimum required Deployment permissions to run astro deploy

### DIFF
--- a/astro/customize-deployment-roles.md
+++ b/astro/customize-deployment-roles.md
@@ -44,9 +44,11 @@ Deployment roles are additive, meaning that a user with multiple Deployment role
 
 5. In the **Permissions** table, check the boxes of all permissions that you want the new role to have. See [Deployment role permission reference](deployment-role-reference.md) for more information about each available permission.
 
-    :::tip
-
     Use the dropdown menu above the permissions table to automatically load the permissions of a templated role or an existing custom role as the basis for your new role. See [Deployment role templates](#deployment-role-templates) for more information about the available default templates.
+
+    :::tip Custom Deployment role permissions
+
+    To deploy with the Astro CLI when using a Deployment API token and a custom Deployment role, the minimum required permissions are [`deployment.get`](https://www.astronomer.io/docs/api/platform-api-reference/deployment/get-deployment) and [`deployment.deploys.create`](https://www.astronomer.io/docs/api/platform-api-reference/deploy/create-deploy).
 
     :::
 
@@ -80,7 +82,7 @@ By default, a custom role is available to use in all Workspaces. After you creat
 
 2. Go to **Access Management**, then click **Roles**.
 
-3. Click **Custom**, then select the custom role that you want to restrict. 
+3. Click **Custom**, then select the custom role that you want to restrict.
 
 4. In the menu that appears, click **Restricted Workspaces**, then click **Edit**.
 

--- a/astro/customize-deployment-roles.md
+++ b/astro/customize-deployment-roles.md
@@ -48,7 +48,7 @@ Deployment roles are additive, meaning that a user with multiple Deployment role
 
     :::tip Custom Deployment role permissions
 
-    To deploy with the Astro CLI when using a Deployment API token and a custom Deployment role, the minimum required permissions are [`deployment.get`](https://www.astronomer.io/docs/api/platform-api-reference/deployment/get-deployment) and [`deployment.deploys.create`](https://www.astronomer.io/docs/api/platform-api-reference/deploy/create-deploy).
+    To deploy with the Astro CLI when using a Deployment API token and a custom Deployment role, the minimum required permissions are [`deployment.get`](deployment-role-reference.md#deployment) and [`deployment.deploys.create`](deployment-role-reference.md#deployment-deploys).
 
     :::
 

--- a/astro/customize-deployment-roles.md
+++ b/astro/customize-deployment-roles.md
@@ -48,7 +48,7 @@ Deployment roles are additive, meaning that a user with multiple Deployment role
 
     :::tip Custom Deployment role permissions
 
-    To deploy with the Astro CLI when using a Deployment API token and a custom Deployment role, the minimum required permissions are [`deployment.get`](deployment-role-reference.md#deployment) and [`deployment.deploys.create`](deployment-role-reference.md#deployment-deploys).
+    To deploy with the Astro CLI when using a Deployment API token with a custom Deployment role, the minimum required permissions for the token's Deployment role are [`deployment.get`](deployment-role-reference.md#deployment) and [`deployment.deploys.create`](deployment-role-reference.md#deployment-deploys).
 
     :::
 

--- a/astro/set-up-ci-cd.md
+++ b/astro/set-up-ci-cd.md
@@ -26,7 +26,7 @@ There are many benefits to configuring a CI/CD workflow on Astro. Specifically, 
 
 :::tip
 
-To run `astro deploy` with the Astro CLI when using a Deployment API token in combination with a [custom Deployment role](customize-deployment-roles.md), the minimum required permissions are [`deployment.get`](https://www.astronomer.io/docs/api/platform-api-reference/deployment/get-deployment) and [`deployment.deploys.create`](https://www.astronomer.io/docs/api/platform-api-reference/deploy/create-deploy).
+To run `astro deploy` with the Astro CLI when using a Deployment API token in combination with a [custom Deployment role](customize-deployment-roles.md), the minimum required permissions are [`deployment.get`](deployment-role-reference.md#deployment) and [`deployment.deploys.create`](deployment-role-reference.md#deployment-deploys).
 
 :::
 

--- a/astro/set-up-ci-cd.md
+++ b/astro/set-up-ci-cd.md
@@ -26,7 +26,7 @@ There are many benefits to configuring a CI/CD workflow on Astro. Specifically, 
 
 :::tip
 
-When using a Deployment API token in combination with a [custom Deployment role](customize-deployment-roles.md) to deploy to Astro, the minimum required permissions are `deployment.get` and `deployment.deploys.create`.
+When using a Deployment API token in combination with a [custom Deployment role](customize-deployment-roles.md) to run `astro deploy`, the minimum required permissions are `deployment.get` and `deployment.deploys.create`.
 
 :::
 

--- a/astro/set-up-ci-cd.md
+++ b/astro/set-up-ci-cd.md
@@ -26,7 +26,7 @@ There are many benefits to configuring a CI/CD workflow on Astro. Specifically, 
 
 :::tip
 
-To run `astro deploy` with the Astro CLI when using a Deployment API token in combination with a [custom Deployment role](customize-deployment-roles.md), the minimum required permissions are [`deployment.get`](deployment-role-reference.md#deployment) and [`deployment.deploys.create`](deployment-role-reference.md#deployment-deploys).
+If you use [custom Deployment roles](customize-deployment-roles.md) and Deployment API tokens, the minimum required permissions are [`deployment.get`](deployment-role-reference.md#deployment) and [`deployment.deploys.create`](deployment-role-reference.md#deployment-deploys) to run `astro deploy` with the Astro CLI.
 
 :::
 

--- a/astro/set-up-ci-cd.md
+++ b/astro/set-up-ci-cd.md
@@ -26,7 +26,7 @@ There are many benefits to configuring a CI/CD workflow on Astro. Specifically, 
 
 :::tip
 
-When using a Deployment API token in combination with a [custom Deployment role](customize-deployment-roles.md) to run `astro deploy`, the minimum required permissions are `deployment.get` and `deployment.deploys.create`.
+To run `astro deploy` with the Astro CLI when using a Deployment API token in combination with a [custom Deployment role](customize-deployment-roles.md), the minimum required permissions are [`deployment.get`](https://www.astronomer.io/docs/api/platform-api-reference/deployment/get-deployment) and [`deployment.deploys.create`](https://www.astronomer.io/docs/api/platform-api-reference/deploy/create-deploy).
 
 :::
 

--- a/astro/set-up-ci-cd.md
+++ b/astro/set-up-ci-cd.md
@@ -24,6 +24,12 @@ There are many benefits to configuring a CI/CD workflow on Astro. Specifically, 
 - Automate promoting code across development and production environments on Astro when pull requests to certain branches are merged.
 - Enforce automated testing, which increases code quality and allows your team to respond quickly in case of an error or a failure.
 
+:::tip
+
+When using a Deployment API token in combination with a [custom Deployment role](customize-deployment-roles.md) to deploy to Astro, the minimum required permissions are `deployment.get` and `deployment.deploys.create`.
+
+:::
+
 ## Choose a deploy strategy
 
 You can set up CI/CD pipelines to manage multiple Deployments and repositories based on your team structure. Before you create your pipeline, you need to determine how many project environments and repositories you want to maintain.

--- a/astro/set-up-ci-cd.md
+++ b/astro/set-up-ci-cd.md
@@ -26,7 +26,7 @@ There are many benefits to configuring a CI/CD workflow on Astro. Specifically, 
 
 :::tip
 
-If you use [custom Deployment roles](customize-deployment-roles.md) and Deployment API tokens, the minimum required permissions are [`deployment.get`](deployment-role-reference.md#deployment) and [`deployment.deploys.create`](deployment-role-reference.md#deployment-deploys) to run `astro deploy` with the Astro CLI.
+If you use [custom Deployment roles](customize-deployment-roles.md) and Deployment API tokens, you might need to configure custom permissions instead of using a template. See [Create a custom Deployment role](customize-deployment-roles.md#create-a-custom-deployment-role) for more information.
 
 :::
 


### PR DESCRIPTION
Not sure if this is the right place in the docs, but I think it's good to document the minimum required custom Deployment permissions for security-conscious users following the principle of least privilege.