### PR TITLE
Fixed Astro CLI Release notes link

### DIFF
--- a/astro/release-notes.md
+++ b/astro/release-notes.md
@@ -19,7 +19,7 @@ import BusinessBadge from '@site/src/components/BusinessBadge';
 
 Astronomer is committed to continuous delivery of both features and bug fixes to Astro. To keep your team up to date on what's new, this document will provide a regular summary of all changes released to Astro.
 
-**Latest Astro CLI Version**: {{CLI_VER_LATEST}} ([Release notes](runtime-release-notes.md))
+**Latest Astro CLI Version**: {{CLI_VER_LATEST}} ([Release notes](cli/release-notes.md))
 
 **Latest Astro Runtime Version**: {{RUNTIME_VER}} ([Release notes](runtime-release-notes.md))
 


### PR DESCRIPTION
Updated link so it points to CLI release notes instead of Runtime release notes.