### PR TITLE
Update dbt Core guidance in airflow-dbt tutorial for Q2 platform release

### DIFF
--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -38,7 +38,7 @@ DbtTaskGroup(
 
 :::tip dbt on Astro
 
-Astro supports direct deployment of dbt projects using the Astro CLI. With a single command, you can deploy any valid dbt project to an Astro Deployment. For more information, see [NEW DOC TITLE](https://www.astronomer.io/docs/astro/deploy-dbt-project).
+Astro supports direct deployment of dbt projects using the Astro CLI. With a single command, you can deploy any valid dbt project to an Astro Deployment. For more information, see [Deploy dbt projects to Astro](https://www.astronomer.io/docs/astro/deploy-dbt-project).
 
 :::
 

--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -6,6 +6,9 @@ sidebar_custom_props: { icon: 'img/integrations/dbt.png' }
 descriptions: "Learn how to use Cosmos to orchestrate dbt Core jobs with Airflow."
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 import CodeBlock from '@theme/CodeBlock';
 import cosmos_dag from '!!raw-loader!../code-samples/dags/airflow-dbt/cosmos_dag.py';
 import airflow_dbt_bashoperator from '!!raw-loader!../code-samples/dags/airflow-dbt/airflow_dbt_bashoperator.py';
@@ -109,6 +112,16 @@ To use dbt with Airflow install dbt Core in a virtual environment and Cosmos in 
 
 ## Step 2: Prepare your dbt project
 
+<Tabs
+    defaultValue="open-source"
+    groupId="preparing-your-dbt-project"
+    values={[
+        {label: 'Open-source Airflow', value: 'open-source'},
+        {label: 'Astro', value: 'astro'},
+    ]}>
+
+<TabItem value="open-source">
+
 To integrate your dbt project with Airflow, you need to add the project folder to your Airflow environment. For this step you can either add your own project in a new `dbt` folder in your `dags` directory, or follow the steps below to create a simple project using two models.
 
 1. Create a folder called `dbt` in your `dags` folder. 
@@ -139,7 +152,7 @@ To integrate your dbt project with Airflow, you need to add the project folder t
 
     `model1.sql` selects the variable `my_name`. `model2.sql` depends on `model1.sql` and selects everything from the upstream model.
 
-You should now have the following structure within your Astro project:
+You should now have the following structure within your Airflow environment:
 
 ```text
 .
@@ -151,6 +164,14 @@ You should now have the following structure within your Astro project:
                ├── model1.sql
                └── model2.sql
 ```
+</TabItem>
+
+<TabItem value="astro">
+
+On Astro, you do not need to maintain your dbt project in your Astro project, so you can complete this step in the dbt environment of your choice.
+
+</TabItem>
+</Tabs>   
 
 ## Step 3: Create an Airflow connection to your data warehouse
 

--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -15,6 +15,8 @@ import airflow_dbt_bashoperator from '!!raw-loader!../code-samples/dags/airflow-
 
 [dbt Core](https://docs.getdbt.com/) is an open-source library for analytics engineering that helps users build interdependent SQL models for in-warehouse data transformation, using ephemeral compute of data warehouses. 
 
+### dbt on Airflow with Cosmos and the Astro CLI
+
 The open-source provider package [Cosmos](https://astronomer.github.io/astronomer-cosmos/) allows you to integrate dbt jobs into Airflow by automatically creating Airflow tasks from dbt models. You can turn your dbt Core projects into an Airflow task group with just a few lines of code:
 
 ```python
@@ -37,6 +39,12 @@ DbtTaskGroup(
 )
 ```
 
+:::tip dbt on Astro
+
+Astro supports direct deployment of dbt projects using the Astro CLI. With a single command, you can deploy any valid dbt project to an Astro Deployment. For more information, see [LINK TO NEW DOC].
+
+:::
+
 :::tip Other ways to learn
 
 There are multiple resources for learning about this topic. See also:
@@ -50,7 +58,9 @@ For a tutorial on how to use dbt Cloud with Airflow, see [Orchestrate dbt Cloud 
 
 ## Why use Airflow with dbt Core?
 
-dbt Core offers the possibility to build modular, reuseable SQL components with built-in dependency management and [incremental builds](https://docs.getdbt.com/docs/build/incremental-models). With [Cosmos](https://astronomer.github.io/astronomer-cosmos/) you can integrate dbt jobs into your Airflow orchestration environment as a standalone DAG or as a task group within a DAG. 
+dbt Core offers the possibility to build modular, reuseable SQL components with built-in dependency management and [incremental builds](https://docs.getdbt.com/docs/build/incremental-models). 
+
+With [Cosmos](https://astronomer.github.io/astronomer-cosmos/), you can integrate dbt jobs into your open-source Airflow orchestration environment as standalone DAGs or as task groups within DAGs.
 
 The benefits of using Airflow with dbt Core include:
 
@@ -59,6 +69,8 @@ The benefits of using Airflow with dbt Core include:
 - Run `dbt test` on tables created by individual models immediately after a model has completed. Catch issues before moving downstream and integrate additional [data quality checks](data-quality.md) with your preferred tool to run alongside dbt tests.
 - Run dbt projects using [Airflow connections](connections.md) instead of dbt profiles. You can store all your connections in one place, directly within Airflow or by using a [secrets backend](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html).
 - Leverage native support for installing and running dbt in a virtual environment to avoid dependency conflicts with Airflow.
+
+With Astro, you get all the benefits above without having to modify your Airflow environment or create connections. You can deploy directly from a dbt project using the Astro CLI.
 
 ## Time to complete
 
@@ -112,16 +124,6 @@ To use dbt with Airflow install dbt Core in a virtual environment and Cosmos in 
 
 ## Step 2: Prepare your dbt project
 
-<Tabs
-    defaultValue="open-source"
-    groupId="preparing-your-dbt-project"
-    values={[
-        {label: 'Open-source Airflow', value: 'open-source'},
-        {label: 'Astro', value: 'astro'},
-    ]}>
-
-<TabItem value="open-source">
-
 To integrate your dbt project with Airflow, you need to add the project folder to your Airflow environment. For this step you can either add your own project in a new `dbt` folder in your `dags` directory, or follow the steps below to create a simple project using two models.
 
 1. Create a folder called `dbt` in your `dags` folder. 
@@ -164,14 +166,6 @@ You should now have the following structure within your Airflow environment:
                ├── model1.sql
                └── model2.sql
 ```
-</TabItem>
-
-<TabItem value="astro">
-
-On Astro, you do not need to maintain your dbt project in your Astro project, so you can complete this step in the dbt environment of your choice.
-
-</TabItem>
-</Tabs>   
 
 ## Step 3: Create an Airflow connection to your data warehouse
 

--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -38,7 +38,7 @@ DbtTaskGroup(
 
 :::tip dbt on Astro
 
-Astro supports direct deployment of dbt projects using the Astro CLI. With a single command, you can deploy any valid dbt project to an Astro Deployment. For more information, see [LINK TO NEW DOC].
+Astro supports direct deployment of dbt projects using the Astro CLI. With a single command, you can deploy any valid dbt project to an Astro Deployment. For more information, see [NEW DOC TITLE](https://www.astronomer.io/docs/astro/deploy-dbt-project).
 
 :::
 

--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -6,10 +6,7 @@ sidebar_custom_props: { icon: 'img/integrations/dbt.png' }
 descriptions: "Learn how to use Cosmos to orchestrate dbt Core jobs with Airflow."
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-import CodeBlock from '@theme/CodeBlock';
+iimport CodeBlock from '@theme/CodeBlock';
 import cosmos_dag from '!!raw-loader!../code-samples/dags/airflow-dbt/cosmos_dag.py';
 import airflow_dbt_bashoperator from '!!raw-loader!../code-samples/dags/airflow-dbt/airflow_dbt_bashoperator.py';
 

--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -6,7 +6,7 @@ sidebar_custom_props: { icon: 'img/integrations/dbt.png' }
 descriptions: "Learn how to use Cosmos to orchestrate dbt Core jobs with Airflow."
 ---
 
-iimport CodeBlock from '@theme/CodeBlock';
+import CodeBlock from '@theme/CodeBlock';
 import cosmos_dag from '!!raw-loader!../code-samples/dags/airflow-dbt/cosmos_dag.py';
 import airflow_dbt_bashoperator from '!!raw-loader!../code-samples/dags/airflow-dbt/airflow_dbt_bashoperator.py';
 

--- a/learn/airflow-dbt.md
+++ b/learn/airflow-dbt.md
@@ -14,27 +14,7 @@ import airflow_dbt_bashoperator from '!!raw-loader!../code-samples/dags/airflow-
 
 ### dbt on Airflow with Cosmos and the Astro CLI
 
-The open-source provider package [Cosmos](https://astronomer.github.io/astronomer-cosmos/) allows you to integrate dbt jobs into Airflow by automatically creating Airflow tasks from dbt models. You can turn your dbt Core projects into an Airflow task group with just a few lines of code:
-
-```python
-from cosmos import DbtTaskGroup, ProjectConfig, ProfileConfig, ExecutionConfig
-from cosmos.profiles import PostgresUserPasswordProfileMapping
-
-profile_config = ProfileConfig(
-    profile_name="default",
-    target_name="dev",
-    profile_mapping=PostgresUserPasswordProfileMapping(
-        conn_id="my_db_conn",
-        profile_args={"schema": "my_schema"},
-    ),
-)
-
-DbtTaskGroup(
-    project_config=ProjectConfig("path/to/my_project"),
-    profile_config=profile_config,
-    default_args={"retries": 2},
-)
-```
+The open-source provider package [Cosmos](https://astronomer.github.io/astronomer-cosmos/) allows you to integrate dbt jobs into Airflow by automatically creating Airflow tasks from dbt models. You can turn your dbt Core projects into an Airflow task group with just a few lines of code.
 
 :::tip dbt on Astro
 
@@ -67,7 +47,7 @@ The benefits of using Airflow with dbt Core include:
 - Run dbt projects using [Airflow connections](connections.md) instead of dbt profiles. You can store all your connections in one place, directly within Airflow or by using a [secrets backend](https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html).
 - Leverage native support for installing and running dbt in a virtual environment to avoid dependency conflicts with Airflow.
 
-With Astro, you get all the benefits above without having to modify your Airflow environment or create connections. You can deploy directly from a dbt project using the Astro CLI.
+With Astro, you get all the above benefits without having to modify your Airflow environment or create connections. You can deploy directly from a dbt project using the Astro CLI. For more information, see [Deploy dbt projects to Astro](https://www.astronomer.io/docs/astro/deploy-dbt-project).
 
 ## Time to complete
 


### PR DESCRIPTION
The tutorial needs some small changes to make it consistent with the dbt on Astro feature.

The context and flow for the new feature are entirely different from open-source, so alternative step-by-step guidance doesn't make sense here. Instead, this adds a note at the top with a link to the new doc.