### PR TITLE
0.35.1 release notes

### DIFF
--- a/software/release-lifecycle-policy.md
+++ b/software/release-lifecycle-policy.md
@@ -89,7 +89,6 @@ The following tables contain the exact lifecycle for each published version of A
 
 | Software Version | Release Date      | End of Maintenance Date |
 | ---------------- | ----------------- | ----------------------- |
-| 0.33             | October 13, 2023  | June 2024               |
 | 0.34             | February 13, 2024 | August 2025             |
 | 0.35             | July 1, 2024      | January 2025            |
 
@@ -105,3 +104,4 @@ The following tables contain the exact lifecycle for each published version of A
 | ---------------- | ----------------- | ----------------------- |
 | 0.30             | Aug 29, 2022      | August 2023             |
 | 0.32             | April 28, 2023    | April 2024              |
+| 0.33             | October 13, 2023  | June 2024               |

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -28,31 +28,25 @@ If you're upgrading to receive a specific change, ensure the release note for th
 
 ## 0.35.1
 
-Release date: July 16, 2024
+Release date: July 15, 2024
+
+### Security fix for DAG-only deploys
+
+Fixed an issue where if you had DAG-only deploys enabled, it was possible for users to access DAGs across different namespaces or Airflow deployments without proper permissions. Each pod requires a network policy to prevent cross-namespace interactions. This policy was not added to the DAG server component, leading to the security implication of cross-namespace DAG access. This issue occurs in Software versions 0.34.0-0.34.2 and 0.35. To mitigate the issue you can:
+
+- Not enable DAG-only deploys in your Deployments
+- Upgrade to 0.35.1 from 0.35
+- If you are not using Software versions 0.34.0-0.34.2 or 0.35, wait to upgrade until the next major release.
+
+See [Upgrade considerations for 0.34 and 0.35](https://www.astronomer.io/docs/software/upgrade-astronomer#upgrade-to-astronomer-software-034-or-035) for more details about the security fix.
 
 ### Bug fixes
-- Fixed a bug where if you had DAG-only deploys enabled, it was possible for users in one Deployment to access DAGs in other Deployments, even if the user did not have access to other DAG-only Deployments.
 
 - Resolved the following vulnerabilities:
-    - [CVE-2021-33194](https://nvd.nist.gov/vuln/detail/CVE-2021-33194)
-    - [CVE-2021-38561](https://nvd.nist.gov/vuln/detail/CVE-2021-38561)
-    - [CVE-2022-21698](https://nvd.nist.gov/vuln/detail/CVE-2022-21698)
-    - [CVE-2023-1370](https://www.cve.org/CVERecord?id=CVE-2023-1370)
-    - [CVE-2023-39325](https://nvd.nist.gov/vuln/detail/CVE-2023-39325)
-    - [CVE-2023-45283](https://nvd.nist.gov/vuln/detail/CVE-2023-45283)
-    - [CVE-2023-45288](https://nvd.nist.gov/vuln/detail/CVE-2023-45288)
-    - [CVE-2023-50868](https://nvd.nist.gov/vuln/detail/CVE-2023-50868)
-    - [CVE-2023-50387](https://nvd.nist.gov/vuln/detail/CVE-2023-50387)
-    - [CVE-2024-2961](https://nvd.nist.gov/vuln/detail/CVE-2024-2961)
-    - [CVE-2024-21626](https://nvd.nist.gov/vuln/detail/CVE-2024-21626)
-    - [CVE-2024-24790](https://nvd.nist.gov/vuln/detail/CVE-2024-24790)
-    - [CVE-2024-25710](https://nvd.nist.gov/vuln/detail/CVE-2024-25710)
-    - [CVE-2024-26308](https://nvd.nist.gov/vuln/detail/CVE-2024-26308)
-    - [CVE-2024-28757](https://nvd.nist.gov/vuln/detail/CVE-2024-28757)
-    - [CVE-2024-33599](https://nvd.nist.gov/vuln/detail/CVE-2024-33599)
-    - [GHSA-xpw8-rcwv-8f8p](https://github.com/advisories/GHSA-xpw8-rcwv-8f8p)
-    - [GHSA-36jr-mh4h-2g58](https://github.com/advisories/GHSA-36jr-mh4h-2g58)
-    - [GHSA-m425-mq94-257g](https://github.com/advisories/GHSA-m425-mq94-257g)
+   - [CVE-2023-45283](https://github.com/advisories/GHSA-vvjp-q62m-2vph)
+   - [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m)
+   - [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g)
+   - [CVE-2023-39325](https://github.com/advisories/GHSA-4374-p667-p6c8)
 
 ## 0.35.0
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -32,7 +32,7 @@ Release date: July 15, 2024
 
 ### Security fix for DAG-only deploys
 
-Fixed an issue where if you had a DAG-only deploy, it was possible for users to access its dag-server from any other kubernetes namespace. See [Upgrade considerations for 0.35](https://www.astronomer.io/docs/software/upgrade-astronomer#upgrade-to-astronomer-software-034-or-035) for more details about the security fix.
+Fixed an issue where if you had a DAG-only deploy, it was possible for users to access its dag-server from any other kubernetes namespace. See [Upgrade considerations for 0.35](https://www.astronomer.io/docs/software/upgrade-astronomer#upgrade-to-astronomer-software-035) for more details about the security fix.
 
 ### Bug fixes
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -36,16 +36,13 @@ Release date: July 16, 2024
 - Resolved the following vulnerabilities:
     - [CVE-2021-33194](https://nvd.nist.gov/vuln/detail/CVE-2021-33194)
     - [CVE-2021-38561](https://nvd.nist.gov/vuln/detail/CVE-2021-38561)
-
     - [CVE-2022-21698](https://nvd.nist.gov/vuln/detail/CVE-2022-21698)
-
     - [CVE-2023-1370](https://www.cve.org/CVERecord?id=CVE-2023-1370)
     - [CVE-2023-39325](https://nvd.nist.gov/vuln/detail/CVE-2023-39325)
     - [CVE-2023-45283](https://nvd.nist.gov/vuln/detail/CVE-2023-45283)
     - [CVE-2023-45288](https://nvd.nist.gov/vuln/detail/CVE-2023-45288)
     - [CVE-2023-50868](https://nvd.nist.gov/vuln/detail/CVE-2023-50868)
     - [CVE-2023-50387](https://nvd.nist.gov/vuln/detail/CVE-2023-50387)
-
     - [CVE-2024-2961](https://nvd.nist.gov/vuln/detail/CVE-2024-2961)
     - [CVE-2024-21626](https://nvd.nist.gov/vuln/detail/CVE-2024-21626)
     - [CVE-2024-24790](https://nvd.nist.gov/vuln/detail/CVE-2024-24790)
@@ -53,10 +50,9 @@ Release date: July 16, 2024
     - [CVE-2024-26308](https://nvd.nist.gov/vuln/detail/CVE-2024-26308)
     - [CVE-2024-28757](https://nvd.nist.gov/vuln/detail/CVE-2024-28757)
     - [CVE-2024-33599](https://nvd.nist.gov/vuln/detail/CVE-2024-33599)
-
-    - [GHSA-xpw8-rcwv-8f8p](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
-    - [GHSA-36jr-mh4h-2g58](https://security.snyk.io/vuln/SNYK-JS-D3COLOR-1076592)
-    - [GHSA-m425-mq94-257g]() -> https://nvd.nist.gov/vuln/detail/CVE-2023-44487 ?
+    - [GHSA-xpw8-rcwv-8f8p](https://github.com/advisories/GHSA-xpw8-rcwv-8f8p)
+    - [GHSA-36jr-mh4h-2g58](https://github.com/advisories/GHSA-36jr-mh4h-2g58)
+    - [GHSA-m425-mq94-257g](https://github.com/advisories/GHSA-m425-mq94-257g)
 
 ## 0.35.0
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -31,6 +31,7 @@ If you're upgrading to receive a specific change, ensure the release note for th
 Release date: July 16, 2024
 
 ### Bug fixes
+- Fixed a bug where if you had DAG-only deploys enabled, it was possible for users in one Deployment to access DAGs in other Deployments, even if the user did not have access to other DAG-only Deployments.
 
 - Resolved the following vulnerabilities:
     - [CVE-2021-33194](https://nvd.nist.gov/vuln/detail/CVE-2021-33194)
@@ -44,7 +45,6 @@ Release date: July 16, 2024
     - [CVE-2023-45288](https://nvd.nist.gov/vuln/detail/CVE-2023-45288)
     - [CVE-2023-50868](https://nvd.nist.gov/vuln/detail/CVE-2023-50868)
     - [CVE-2023-50387](https://nvd.nist.gov/vuln/detail/CVE-2023-50387)
-
 
     - [CVE-2024-2961](https://nvd.nist.gov/vuln/detail/CVE-2024-2961)
     - [CVE-2024-21626](https://nvd.nist.gov/vuln/detail/CVE-2024-21626)

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -32,7 +32,7 @@ Release date: July 15, 2024
 
 ### Security fix for DAG-only deploys
 
-Fixed an issue where if you had DAG-only deploys enabled, it was possible for users to access DAGs across different namespaces or Airflow deployments without proper permissions. See [Upgrade considerations for 0.34 and 0.35](https://www.astronomer.io/docs/software/upgrade-astronomer#upgrade-to-astronomer-software-034-or-035) for more details about the security fix.
+Fixed an issue where if you had a DAG-only deploy, it was possible for users to access its dag-server from any other kubernetes namespace. See [Upgrade considerations for 0.35](https://www.astronomer.io/docs/software/upgrade-astronomer#upgrade-to-astronomer-software-034-or-035) for more details about the security fix.
 
 ### Bug fixes
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -32,13 +32,7 @@ Release date: July 15, 2024
 
 ### Security fix for DAG-only deploys
 
-Fixed an issue where if you had DAG-only deploys enabled, it was possible for users to access DAGs across different namespaces or Airflow deployments without proper permissions. Each pod requires a network policy to prevent cross-namespace interactions. This policy was not added to the DAG server component, leading to the security implication of cross-namespace DAG access. This issue occurs in Software versions 0.34.0-0.34.2 and 0.35. To mitigate the issue you can:
-
-- Not enable DAG-only deploys in your Deployments
-- Upgrade to 0.35.1 from 0.35
-- If you are not using Software versions 0.34.0-0.34.2 or 0.35, wait to upgrade until the next major release.
-
-See [Upgrade considerations for 0.34 and 0.35](https://www.astronomer.io/docs/software/upgrade-astronomer#upgrade-to-astronomer-software-034-or-035) for more details about the security fix.
+Fixed an issue where if you had DAG-only deploys enabled, it was possible for users to access DAGs across different namespaces or Airflow deployments without proper permissions. See [Upgrade considerations for 0.34 and 0.35](https://www.astronomer.io/docs/software/upgrade-astronomer#upgrade-to-astronomer-software-034-or-035) for more details about the security fix.
 
 ### Bug fixes
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -26,6 +26,38 @@ If you're upgrading to receive a specific change, ensure the release note for th
 
 :::
 
+## 0.35.1
+
+Release date: July 16, 2024
+
+### Bug fixes
+
+- Resolved the following vulnerabilities:
+    - [CVE-2021-33194](https://nvd.nist.gov/vuln/detail/CVE-2021-33194)
+    - [CVE-2021-38561](https://nvd.nist.gov/vuln/detail/CVE-2021-38561)
+
+    - [CVE-2022-21698](https://nvd.nist.gov/vuln/detail/CVE-2022-21698)
+
+    - [CVE-2023-1370](https://www.cve.org/CVERecord?id=CVE-2023-1370)
+    - [CVE-2023-39325](https://nvd.nist.gov/vuln/detail/CVE-2023-39325)
+    - [CVE-2023-45283](https://nvd.nist.gov/vuln/detail/CVE-2023-45283)
+    - [CVE-2023-45288](https://nvd.nist.gov/vuln/detail/CVE-2023-45288)
+    - [CVE-2023-50868](https://nvd.nist.gov/vuln/detail/CVE-2023-50868)
+    - [CVE-2023-50387](https://nvd.nist.gov/vuln/detail/CVE-2023-50387)
+
+
+    - [CVE-2024-2961](https://nvd.nist.gov/vuln/detail/CVE-2024-2961)
+    - [CVE-2024-21626](https://nvd.nist.gov/vuln/detail/CVE-2024-21626)
+    - [CVE-2024-24790](https://nvd.nist.gov/vuln/detail/CVE-2024-24790)
+    - [CVE-2024-25710](https://nvd.nist.gov/vuln/detail/CVE-2024-25710)
+    - [CVE-2024-26308](https://nvd.nist.gov/vuln/detail/CVE-2024-26308)
+    - [CVE-2024-28757](https://nvd.nist.gov/vuln/detail/CVE-2024-28757)
+    - [CVE-2024-33599](https://nvd.nist.gov/vuln/detail/CVE-2024-33599)
+
+    - [GHSA-xpw8-rcwv-8f8p](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)
+    - [GHSA-36jr-mh4h-2g58](https://security.snyk.io/vuln/SNYK-JS-D3COLOR-1076592)
+    - [GHSA-m425-mq94-257g]() -> https://nvd.nist.gov/vuln/detail/CVE-2023-44487 ?
+
 ## 0.35.0
 
 Release date: July 1, 2024

--- a/software/runtime-image-architecture.mdx
+++ b/software/runtime-image-architecture.mdx
@@ -148,28 +148,77 @@ In Airflow, the executor is responsible for determining how and where a task is 
 
 In all local environments created with the Astro CLI, Astro Runtime runs the [Local executor](https://airflow.apache.org/docs/apache-airflow/stable/executor/local.html). On Astro and Astronomer Software, you can use either the Celery executor or the Kubernetes executor.
 
-## Distribution
+## Image types
 
-Astro Runtime is distributed as a Debian-based Docker image. For a list of all Astro Runtime Docker images, see [Quay.io](https://quay.io/repository/astronomer/astro-runtime?tab=tags).
+Astro Runtime is distributed as a Debian-based Docker image. An Astro Runtime image must be specified in the `Dockerfile` of your Astro project. The default image tag is:
 
-### Base distributions
+```
+quay.io/astronomer/astro-runtime:<version>
+```
 
-The base Astro Runtime Docker images have the following format:
+You can modify this image tag in your Astro project Dockerfile to use different versions of Astro Runtime. The following sections explain each image type and how to specify them. For a list of all Astro Runtime Docker images, see [Quay.io](https://quay.io/repository/astronomer/astro-runtime?tab=tags).
 
-- `quay.io/astronomer/astro-runtime:<version>`
-- `quay.io/astronomer/astro-runtime:<version>-base`
+### Base images
 
-An Astro Runtime image must be specified in the `Dockerfile` of your Astro project. Astronomer recommends using non-`base` images, which incorporate ONBUILD commands that copy and scaffold your Astro project directory so you can more easily pass those files to the containers running each core Airflow component. A `base` Astro Runtime image is recommended for complex use cases that require additional customization, such as [installing Python packages from private sources](https://docs.astronomer.io/astro/cli/private-python-packages).
+The base Astro Runtime Docker image has the following format:
 
-### Python version distributions
+```
+quay.io/astronomer/astro-runtime:<version>-base
+```
 
-Starting with Astro Runtime 9, Astronomer maintains different distributions Astro Runtime for each supported Python version. Python version distribution images have the following format:
+A `base` Astro Runtime image is recommended for complex use cases that require additional customization, such as [installing Python packages from private sources](https://docs.astronomer.io/astro/cli/private-python-packages).
+
+For all other cases, Astronomer recommends using non-`base` images, which incorporate ONBUILD commands that copy and scaffold your Astro project directory so you can more easily pass those files to the images running each core Airflow component.
+
+### Python version images
+
+Starting with Astro Runtime 9, Astronomer maintains different Astro Runtime images for each supported Python version. Python version images have the following format:
 
 ```text
 quay.io/astronomer/astro-runtime:<runtime-version>-python-<python-version>
 ```
 
-Each Python distribution also has an alternative `quay.io/astronomer/astro-runtime:<version>-base` distribution that you can use to further customize the image.
+### Slim images
+
+Starting with Astro Runtime 11, Astronomer maintains a slim Astro Runtime image. Slim Astro Runtime images only include the dependencies required for the basic functionality of Astro. Providers marked with an asterisk (\*) are also installed by default on open source Apache Airflow. The providers installed in the slim image are:
+
+- Common IO [`apache-airflow-providers-common-io`](https://pypi.org/project/apache-airflow-providers-common-io/)\*
+- Common SQL [`apache-airflow-providers-common-sql`](https://pypi.org/project/apache-airflow-providers-common-sql/)\*
+- FAB [`apache-airflow-providers-fab`](https://pypi.org/project/apache-airflow-providers-fab/)\*
+- FTP [`apache-airflow-providers-ftp`](https://pypi.org/project/apache-airflow-providers-ftp/)\*
+- HTTP [`apache-airflow-providers-http`](https://pypi.org/project/apache-airflow-providers-http/)\*
+- IMAP [`apache-airflow-providers-imap`](https://pypi.org/project/apache-airflow-providers-imap/)\*
+- SMTP [`apache-airflow-providers-smtp`](https://pypi.org/project/apache-airflow-providers-smtp/)\*
+- SQLite [`apache-airflow-providers-sqlite`](https://pypi.org/project/apache-airflow-providers-sqlite/)\*
+- Celery [`apache-airflow-providers-celery`](https://pypi.org/project/apache-airflow-providers-celery/)
+- Elasticsearch [`apache-airflow-providers-elasticsearch`](https://pypi.org/project/apache-airflow-providers-elasticsearch/)
+- MySQL [`apache-airflow-providers-mysql`](https://pypi.org/project/apache-airflow-providers-mysql/)
+- PostgreSQL (Postgres) [`apache-airflow-providers-postgres`](https://pypi.org/project/apache-airflow-providers-postgres/)
+- `astronomer-kubernetes-executor`
+
+Use the slim Astro Runtime image if you want faster local builds and deploys, smaller footprint for security vulnerabilities and dependency conflicts, or you don't require the packages included in the default Astro Runtime distribution.
+
+### Combine image types
+
+Image types are additive, meaning that you can combine multiple types in your image tag to specify an image with multiple variations.
+
+Types must be specified in a specific order in your image tag. The order and format multi-type image tag is:
+
+```
+quay.io/astronomer/astro-runtime:<astro-runtime-version>-<python-version-type>-<slim-type>-<base-type>
+```
+
+You can add or remove any types as needed. For example, to use the base, slim Astro Runtime image with Python 3.11, your image tag would be:
+
+```
+quay.io/astronomer/astro-runtime:11.0.0-python-3.11-slim-base
+```
+
+If you wanted the same base image using Python 3.11, but you didn't want it to be slim, you would remove the `-slim-` from the image tag like in the following example:
+
+```
+quay.io/astronomer/astro-runtime:11.0.0-python-3.11-base
+```
 
 ## System distribution
 
@@ -187,7 +236,6 @@ The following table lists the operating systems and architectures supported by e
 | 11            | 2.9                    | Debian 11.8 (bullseye) | AMD64 and ARM64 |
 
 Astro Runtime 6.0.4 and later images are multi-arch and support AMD64 and ARM64 processor architectures for local development. Docker automatically uses the correct processor architecture based on the computer you are using.
-
 
 ## Related documentation
 

--- a/software/upgrade-astronomer.md
+++ b/software/upgrade-astronomer.md
@@ -230,7 +230,7 @@ To mitigate this issue:
 
 - Do not use DAG-only Deploys if you use version 0.35
 - If you have not upgraded to version 0.35, wait until the next major release to upgrade your Software version
-- If you use version 0.35, upgrade to 0.35.1 as soon as they are available.
+- If you use version 0.35, upgrade to 0.35.1 as soon as they are available
 
 ### Upgrade to Astronomer Software 0.32
 

--- a/software/upgrade-astronomer.md
+++ b/software/upgrade-astronomer.md
@@ -12,7 +12,7 @@ Follow this guide to upgrade to any version of Astronomer Software. For informat
 A few notes before you get started:
 - The upgrade process will not affect running Airflow tasks as long as `upgradeDeployments.enabled=false` is set in your upgrade script.
 - Updates will not cause any downtime to Astronomer services, including the Software UI, the Astro CLI, and the Houston API.
-- To avoid potential complications, perform Astronomer Software upgrades in order and include all minor versions in your upgrade sequence. 
+- To avoid potential complications, perform Astronomer Software upgrades in order and include all minor versions in your upgrade sequence.
 
 :::info Upgrading Kubernetes
 
@@ -22,7 +22,7 @@ To avoid extended service disruptions, Astronomer recommends upgrading Astronome
 
 ## Step 1: Review upgrade considerations
 
-The [Upgrade considerations](upgrade-astronomer.md#upgrade-considerations) section of this document contains upgrade information for specific Astronomer versions. Review these notes before starting the upgrade process. To avoid potential complications, perform Astronomer Software upgrades in order and include all minor versions in your upgrade sequence. 
+The [Upgrade considerations](upgrade-astronomer.md#upgrade-considerations) section of this document contains upgrade information for specific Astronomer versions. Review these notes before starting the upgrade process. To avoid potential complications, perform Astronomer Software upgrades in order and include all minor versions in your upgrade sequence.
 
 ## Step 2: Check permissions
 
@@ -120,20 +120,20 @@ If you do not specify a patch version above, the script will automatically pull 
 
 ### Upgrade with ArgoCD
 
-You can upgrade Astronomer with ArgoCD, which is an open source continuous delivery tool for Kubernetes, as an alternative to using `helm upgrade`. 
+You can upgrade Astronomer with ArgoCD, which is an open source continuous delivery tool for Kubernetes, as an alternative to using `helm upgrade`.
 
 Because ArgoCD doesn't support sync wave dependencies for [app of apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#app-of-apps-pattern) structures, upgrading Astronomer requires some additional steps compared to the standard ArgoCD workflow:
 
 1. Make sure `enableArgoCDAnnotation: true` and `astronomer.houston.upgradeDeployments.enabled=false` are set in your `values.yaml` file.
-   
+
 2. In your ArgoCD application, choose the version of Astronomer Software you want to upgrade to from `astronomer/astronomer`.
-   
+
 3. Sync the ArgoCD app with every component of the Astronomer platform selected. See [Sync (Deploy) the Application](https://argo-cd.readthedocs.io/en/stable/getting_started/#7-sync-deploy-the-application).
-   
-4. Stop the sync when you see that `astronomer-houston-db-migrations` has completed in the Argo UI. 
-   
+
+4. Stop the sync when you see that `astronomer-houston-db-migrations` has completed in the Argo UI.
+
 5. Sync the application a second time, but this time clear `astronomer-alertmanager` in the Argo UI while keeping all other components selected. Wait for this sync to finish completely.
-   
+
 6. Sync the ArgoCD app a third time with all Astronomer platform components selected.
 
 ## Step 8: Confirm that the installation was successful
@@ -172,16 +172,16 @@ This topic contains information about upgrading to specific versions of Astronom
 
 To avoid extended service disruptions, Astronomer recommends upgrading Astronomer Software to a compatible version before you upgrade Kubernetes. To view Astronomer Software and Kubernetes compatibility information, see [Version compatibility reference for Astronomer Software](version-compatibility-reference.md#astronomer-software).
 
-### Supported upgrade paths 
+### Supported upgrade paths
 
-If you're upgrading through multiple Astronomer Software versions in a single upgrade process, review the following table to ensure that you're following the correct upgrade path. If your combination of **Current version** and **Target version** isn't listed, you can upgrade directly from your current version to the target version. 
+If you're upgrading through multiple Astronomer Software versions in a single upgrade process, review the following table to ensure that you're following the correct upgrade path. If your combination of **Current version** and **Target version** isn't listed, you can upgrade directly from your current version to the target version.
 
-| Current version | Target version | Upgrade path         |
-| --------------- | -------------- | -------------------- |
-| 0.29            | 0.31 or later  | 0.29 -> 0.30 -> 0.34 |
-| 0.27            | 0.29 or later  | 0.27 -> 0.28 -> 0.34 |
-| 0.26            | 0.29 or later  | 0.26 -> 0.28 -> 0.34 |
-| 0.25            | 0.29 or later  | 0.25 -> 0.28 -> 0.34 |
+| Current version | Target version | Upgrade path           |
+| --------------- | -------------- | ---------------------- |
+| 0.29            | 0.31 or later  | 0.29 -> 0.30 -> 0.35.1 |
+| 0.27            | 0.29 or later  | 0.27 -> 0.28 -> 0.35.1 |
+| 0.26            | 0.29 or later  | 0.26 -> 0.28 -> 0.35.1 |
+| 0.25            | 0.29 or later  | 0.25 -> 0.28 -> 0.35.1 |
 
 ### Upgrade to Kubernetes 1.25
 
@@ -220,6 +220,20 @@ If you're upgrading to Astronomer Software 0.29 or later and Kubernetes 1.22 at 
     ```
 3. Upgrade Kubernetes to version 1.22.
 
+### Upgrade to Astronomer Software 0.34 or 0.35
+
+#### Security issue with DAG-only deploys resolved in 0.35.1
+
+Due to a missing network policy in the [DAG-only Deploy](deploy-dags.md#configure-dag-only-deploys-on-a-deployment) feature in Astronomer Software version 0.34.0-0.34.2 and 0.35, there is a risk that users could potentially access DAGs across different namespaces or Airflow deployments without proper permissions. Each pod requires a network policy to prevent cross-namespace interactions. This policy was not added to the DAG server component, leading to the security implication of cross-namespace DAG access.
+
+This issue does not affect Deployments that do not use DAG-only deploys, because the DAG Server component only exists in Deployments with DAG-only deploys enabled.
+
+To mitigate this issue:
+
+- Do not use DAG-only Deploys if you use versions 0.34.0-0.34.2 or 0.35
+- If you have not upgraded to version 0.34.0-0.34.2 and 0.35, wait until the next major release to upgrade your Software version
+- If you use version 0.34.0-0.34.2 and 0.35, upgrade to the 0.34.3 or 0.35.1 as soon as they are available.
+
 ### Upgrade to Astronomer Software 0.32
 
 #### Upgrade to Postgres 15
@@ -255,9 +269,9 @@ helm upgrade --namespace $NAMESPACE \
             astronomer/astronomer
 ```
 
-#### New default resource limits and requests 
+#### New default resource limits and requests
 
-Astronomer Software 0.31 includes new default resource limits and requests on the following resources: 
+Astronomer Software 0.31 includes new default resource limits and requests on the following resources:
 
 - Alertmanager
 - Elasticsearch
@@ -299,7 +313,7 @@ There is an [unresolved Kubernetes bug](https://github.com/kubernetes/kubernetes
 
 To preserve duplicate keys in your Helm chart, you can either reapply the values after upgrade or ensure that you use the `--reset-values` flag when running the upgrade script in Step 7.
 
-#### Resync Astronomer's signing certificate  
+#### Resync Astronomer's signing certificate
 
 As part of the 0.29 release, Astronomer deprecated its usage of [kubed](https://appscode.com/products/kubed/) for performance and security reasons. Kubed was responsible for syncing Astronomer's signing certificate to Deployment namespaces and is now replaced by an in-house utility. While this change does not directly affect users, you need to run a one-time command to reset Astronomer's signing certificate as part of the upgrade process to 0.29.
 

--- a/software/upgrade-astronomer.md
+++ b/software/upgrade-astronomer.md
@@ -224,13 +224,13 @@ If you're upgrading to Astronomer Software 0.29 or later and Kubernetes 1.22 at 
 
 #### Security issue with DAG-only deploys resolved in 0.35.1
 
-Due to an issue with the [DAG-only Deploy](deploy-dags.md#configure-dag-only-deploys-on-a-deployment) feature in Astronomer Software version 0.34.0-0.34.2 and 0.35, there is a risk that users could potentially access DAGs across different namespaces or Airflow deployments without proper permissions. This issue does not affect Deployments that do not use DAG-only deploys.
+Due to an issue with the [DAG-only Deploy](deploy-dags.md#configure-dag-only-deploys-on-a-deployment) feature in Astronomer Software version 0.35.0, there is a risk that users could potentially access DAGs across different namespaces or Airflow deployments without proper permissions. This issue does not affect Deployments that do not use DAG-only deploys.
 
 To mitigate this issue:
 
-- Do not use DAG-only Deploys if you use versions 0.34.0-0.34.2 or 0.35
-- If you have not upgraded to version 0.34.0-0.34.2 and 0.35, wait until the next major release to upgrade your Software version
-- If you use version 0.34.0-0.34.2 and 0.35, upgrade to the 0.34.3 or 0.35.1 as soon as they are available.
+- Do not use DAG-only Deploys if you use version 0.35
+- If you have not upgraded to version 0.35, wait until the next major release to upgrade your Software version
+- If you use version 0.35, upgrade to 0.35.1 as soon as they are available.
 
 ### Upgrade to Astronomer Software 0.32
 

--- a/software/upgrade-astronomer.md
+++ b/software/upgrade-astronomer.md
@@ -220,7 +220,7 @@ If you're upgrading to Astronomer Software 0.29 or later and Kubernetes 1.22 at 
     ```
 3. Upgrade Kubernetes to version 1.22.
 
-### Upgrade to Astronomer Software 0.34 or 0.35
+### Upgrade to Astronomer Software 0.35
 
 #### Security issue with DAG-only deploys resolved in 0.35.1
 

--- a/software/upgrade-astronomer.md
+++ b/software/upgrade-astronomer.md
@@ -224,9 +224,7 @@ If you're upgrading to Astronomer Software 0.29 or later and Kubernetes 1.22 at 
 
 #### Security issue with DAG-only deploys resolved in 0.35.1
 
-Due to a missing network policy in the [DAG-only Deploy](deploy-dags.md#configure-dag-only-deploys-on-a-deployment) feature in Astronomer Software version 0.34.0-0.34.2 and 0.35, there is a risk that users could potentially access DAGs across different namespaces or Airflow deployments without proper permissions. Each pod requires a network policy to prevent cross-namespace interactions. This policy was not added to the DAG server component, leading to the security implication of cross-namespace DAG access.
-
-This issue does not affect Deployments that do not use DAG-only deploys, because the DAG Server component only exists in Deployments with DAG-only deploys enabled.
+Due to an issue with the [DAG-only Deploy](deploy-dags.md#configure-dag-only-deploys-on-a-deployment) feature in Astronomer Software version 0.34.0-0.34.2 and 0.35, there is a risk that users could potentially access DAGs across different namespaces or Airflow deployments without proper permissions. This issue does not affect Deployments that do not use DAG-only deploys.
 
 To mitigate this issue:
 

--- a/software/version-compatibility-reference.md
+++ b/software/version-compatibility-reference.md
@@ -52,7 +52,7 @@ See the following table for all supported Kubernetes versions in each maintained
 |       0.33.3        |                 |                 |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |                 |
 |       0.34.0        |                 |                 |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |                 |                 |
 |   0.34.1 - 0.34.2   |                 |                 |                 |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |                 |
-|       0.35.0        |                 |                 |                 |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |
+|   0.35.0 -0.35.1    |                 |                 |                 |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |
 
 For more information on upgrading Kubernetes versions, follow the guidelines offered by your cloud provider.
 
@@ -93,6 +93,7 @@ Use the following table to see the Airflow Helm chart version for each supported
 | 0.34.1                      | 1.10.0                                |
 | 0.34.2                      | 1.10.2                                |
 | 0.35.0                      | 1.11.0                                |
+| 0.35.1                      | 1.11.0                                |
 
 ## Legacy version compatibility reference
 

--- a/software/version-compatibility-reference.md
+++ b/software/version-compatibility-reference.md
@@ -13,7 +13,7 @@ While the tables below reference the minimum compatible versions, we typically r
 
 <!--- Version-specific -->
 
-The following table shows version compatibility information for all currently supported versions of Astronomer Software and some legacy versions. Check [Astro Software lifecycle schedule](release-lifecycle-policy.md#software-lifecycle-schedule) for more information about supported versions of Astro Software.
+The following table shows version compatibility information for all currently supported versions of Astronomer Software and some legacy versions. Check [Astronomer Software lifecycle schedule](release-lifecycle-policy.md#software-lifecycle-schedule) for more information about supported versions of Astronomer Software.
 
 | Astronomer Platform | Postgres | Python                                         | Astro Runtime        |
 | ------------------- | -------- | ---------------------------------------------- | -------------------- |

--- a/software/version-compatibility-reference.md
+++ b/software/version-compatibility-reference.md
@@ -13,7 +13,7 @@ While the tables below reference the minimum compatible versions, we typically r
 
 <!--- Version-specific -->
 
-The following table shows version compatibility information for all currently supported versions of Astronomer Software:
+The following table shows version compatibility information for all currently supported versions of Astronomer Software and some legacy versions. Check [Astro Software lifecycle schedule](release-lifecycle-policy.md#software-lifecycle-schedule) for more information about supported versions of Astro Software.
 
 | Astronomer Platform | Postgres | Python                                         | Astro Runtime        |
 | ------------------- | -------- | ---------------------------------------------- | -------------------- |


### PR DESCRIPTION
Resolves https://github.com/astronomer/docs/issues/3925

- Choosing to leave the detailed table with regards to Kubernetes versions to include legacy versions until I have time to properly adapt this page. It's just not user-friendly to condense it into https://www.astronomer.io/docs/software/version-compatibility-reference#legacy-version-compatibility-reference
