### PR TITLE
3884: Link to astro org audit logs from astro-org category sidebar

### DIFF
--- a/sidebarsAstro.js
+++ b/sidebarsAstro.js
@@ -604,6 +604,7 @@ module.exports = {
             description: 'Use `astro organization` commands to manage users and their Organization-level permissions.'
           },
           items: [
+            "audit-logs",
             "cli/astro-organization-list",
             "cli/astro-organization-switch",
             "cli/astro-organization-role-list",


### PR DESCRIPTION
Fixes: https://github.com/astronomer/docs/issues/3884

Since Docusaurus is [generating the page](https://docusaurus.io/docs/sidebar/items#generated-index-page) based on frontmatter, I'm not sure there's a way to adjust how it appears on this page, but if that's where @wolfier and other user's are looking for it, could be worth it.

<img width="1136" alt="SCR-20240718-twfh-2" src="https://github.com/user-attachments/assets/066e8792-ced4-47e1-9733-df8a83d93571">
