### PR TITLE
Clarify post-trial instructions

### DIFF
--- a/astro/trial.md
+++ b/astro/trial.md
@@ -42,7 +42,7 @@ An Astro trial provides you a level of access to Deployment resources that Astro
 During a 14-day Astro trial, you can:
 
 - Create one Workspace
-- Create up to two Deployments
+- Create one Deployment
 - Configure **Worker Count** to a maximum of 5 workers per worker queue
 - Use A5, A10, or A20 workers
 
@@ -58,6 +58,7 @@ All Deployment configurations are preserved during hibernation for 30 days from 
 
 If you need additional time to evaluate Astro, or you need to copy your configuration for future use, you can:
 
+- [Add a payment method](manage-billing#update-billing-details) to continue on the [pay-as-you-go Developer tier](https://astronomer.io/pricing/).
 - Contact [sales](https://astronomer.io/contact/) to request a trial extension.
 - Run `astro deployment inspect` with the Astro CLI to save your existing Deployment configuration as a JSON or YAML file. See [Astro CLI command reference](cli/astro-deployment-inspect.md).
 - Open the Astro UI and [schedule office hours](office-hours.md) with an Astronomer engineer.

--- a/astro/trial.md
+++ b/astro/trial.md
@@ -58,6 +58,6 @@ All Deployment configurations are preserved during hibernation for 30 days from 
 
 If you need additional time to evaluate Astro, or you need to copy your configuration for future use, you can:
 
-- [Add a payment method](manage-billing#update-billing-details) to maintain your deployment on our Developer tier. [View pay-as-you-go pricing.](https://astronomer.io/pricing/)
+- [Add a payment method](manage-billing#update-billing-details) to maintain your Deployment on our Developer tier. [View pay-as-you-go pricing.](https://astronomer.io/pricing/).
 - Contact [sales](https://astronomer.io/contact/) to request a trial extension.
 - Run `astro deployment inspect` with the Astro CLI to save your existing Deployment configuration as a JSON or YAML file. See [Astro CLI command reference](cli/astro-deployment-inspect.md).

--- a/astro/trial.md
+++ b/astro/trial.md
@@ -58,7 +58,6 @@ All Deployment configurations are preserved during hibernation for 30 days from 
 
 If you need additional time to evaluate Astro, or you need to copy your configuration for future use, you can:
 
-- [Add a payment method](manage-billing#update-billing-details) to continue on the [pay-as-you-go Developer tier](https://astronomer.io/pricing/).
+- [Add a payment method](manage-billing#update-billing-details) to maintain your deployment on our Developer tier. [View pay-as-you-go pricing.](https://astronomer.io/pricing/)
 - Contact [sales](https://astronomer.io/contact/) to request a trial extension.
 - Run `astro deployment inspect` with the Astro CLI to save your existing Deployment configuration as a JSON or YAML file. See [Astro CLI command reference](cli/astro-deployment-inspect.md).
-- Open the Astro UI and [schedule office hours](office-hours.md) with an Astronomer engineer.


### PR DESCRIPTION
Updates docs page relating to the Astro free trial:
- Instructions for continuing on the pay-go tier
- update deployment limits