### PR TITLE
0.35.2 Release Notes

### DIFF
--- a/software/manage-airflow-versions.md
+++ b/software/manage-airflow-versions.md
@@ -188,9 +188,9 @@ If an Astro Runtime version isn't included in this section, then there are no sp
 
 #### Runtime 11 (Airflow 2.9)
 
-##### Restricted versions of Runtime 11
+##### Yanked versions of Runtime 11
 
-You cannot create new Deployments or upgrade to the following versions of Runtime 11, which are `yanked`. These [restricted runtime versions](runtime-version-lifecycle-policy.mdx#restricted-runtime-versions) prevent you from upgrading to or creating a Deployment with a version that contains a known limitation or bug.
+Use caution if you create new Deployments or upgrade to the following versions of Runtime 11, which are `yanked`. These [Runtime versions](runtime-version-lifecycle-policy.mdx#restricted-runtime-versions) warn you about upgrading to or creating a Deployment with a version that contains a known limitation or bug.
 
 - 11.0.0
 - 11.1.0
@@ -201,9 +201,9 @@ In Airflow 2.9, a bug affecting custom actions in Airflow plugins ([#39421](http
 
 #### Runtime 9 (Airflow 2.7)
 
-##### Restricted versions of Runtime 9
+##### Yanked versions of Runtime 9
 
-You cannot create new Deployments or upgrade to the following versions of Runtime 9, which are `yanked`. These [restricted runtime versions](runtime-version-lifecycle-policy.mdx#restricted-runtime-versions) prevent you from upgrading to or creating a Deployment with a version that contains a known limitation or bug.
+Use caution if you create new Deployments or upgrade to the following versions of Runtime 9, which are `yanked`. These [Runtime versions](runtime-version-lifecycle-policy.mdx#restricted-runtime-versions) warn you about upgrading to or creating a Deployment with a version that contains a known limitation or bug.
 
 - 9.0.0
 - 9.1.0
@@ -231,7 +231,7 @@ To continue using these packages with a compatible version of Python, upgrade to
 
 #### Runtime 8 (Airflow 2.6)
 
-Astro Runtime version 8.0.0 is a restricted version of the Astro Runtime (`yanked`), which means you can't create Deployments on Astro with this runtime version. These [restricted runtime versions](runtime-version-lifecycle-policy.mdx#restricted-runtime-versions) prevent you from upgrading to or creating a Deployment with a version that contains a known limitation or bug.
+Astro Runtime version 8.0.0 is a `yanked` version of the Astro Runtime, which means you are advised not to create Deployments with this runtime version. These [Runtime versions](runtime-version-lifecycle-policy.mdx#restricted-runtime-versions) warn you about upgrading to or creating a Deployment with a version that contains a known limitation or bug.
 
 ##### Breaking change to `apache-airflow-providers-cncf-kubernetes` in version 8.4.0
 

--- a/software/manage-airflow-versions.md
+++ b/software/manage-airflow-versions.md
@@ -5,8 +5,6 @@ id: manage-airflow-versions
 description: Adjust and upgrade Airflow versions on Astronomer Software.
 ---
 
-
-
 ## Overview
 
 Regularly upgrading your Software Deployments ensures that your Deployments continue to be supported and that your Airflow instance has the latest features and functionality.
@@ -188,7 +186,32 @@ If an Astro Runtime version isn't included in this section, then there are no sp
 
 :::
 
+#### Runtime 11 (Airflow 2.9)
+
+##### Restricted versions of Runtime 11
+
+You cannot create new Deployments or upgrade to the following versions of Runtime 11, which are `yanked`. These [restricted runtime versions](runtime-version-lifecycle-policy.mdx#restricted-runtime-versions) prevent you from upgrading to or creating a Deployment with a version that contains a known limitation or bug.
+
+- 11.0.0
+- 11.1.0
+
+##### Bug affecting users running a local Astro Runtime environment
+
+In Airflow 2.9, a bug affecting custom actions in Airflow plugins ([#39421](https://github.com/apache/airflow/pull/39421)) prevented users from running the Astro Runtime environment locally for Astro Runtime versions 11.0.0, 11.1.0, and 11.2.0. Deployments running these versions on Astro are not affected.
+
 #### Runtime 9 (Airflow 2.7)
+
+##### Restricted versions of Runtime 9
+
+You cannot create new Deployments or upgrade to the following versions of Runtime 9, which are `yanked`. These [restricted runtime versions](runtime-version-lifecycle-policy.mdx#restricted-runtime-versions) prevent you from upgrading to or creating a Deployment with a version that contains a known limitation or bug.
+
+- 9.0.0
+- 9.1.0
+- 9.2.0
+- 9.3.0
+- 9.4.0
+- 9.5.0
+- 9.6.0
 
 ##### Connection testing in the Airflow UI disabled by default
 
@@ -207,6 +230,8 @@ The base distribution of Astro Runtime 9 uses Python 3.11 by default. Some provi
 To continue using these packages with a compatible version of Python, upgrade to the [Astro Runtime Python distribution](runtime-image-architecture.mdx#python-version-images) for your desired Python version.
 
 #### Runtime 8 (Airflow 2.6)
+
+Astro Runtime version 8.0.0 is a restricted version of the Astro Runtime (`yanked`), which means you can't create Deployments on Astro with this runtime version. These [restricted runtime versions](runtime-version-lifecycle-policy.mdx#restricted-runtime-versions) prevent you from upgrading to or creating a Deployment with a version that contains a known limitation or bug.
 
 ##### Breaking change to `apache-airflow-providers-cncf-kubernetes` in version 8.4.0
 

--- a/software/migrate-to-runtime.md
+++ b/software/migrate-to-runtime.md
@@ -34,10 +34,15 @@ See [Runtime Architecture](runtime-image-architecture.mdx) for more detailed inf
 Only AC Versions that are 2.2.5 and greater have equivalent Runtime versions. To see the equivalent version of Astro Runtime for a Deployment running AC in the **Deployment Settings** page, you need to set the following configuration:
 
 ```yaml
- enableListAllRuntimeVersions: true
+astronomer:
+  houston:
+    config:
+      deployments:
+        enableListAllRuntimeVersions: true
 ```
 
-After enabling this configuration, the System Administrator can see the equivalent version of Astro Runtime in the **Migrate to Runtime-[Version number]** button. Note that all AC equivalent Runtime versions are deprecated other than version 2.2.5 and greater.
+If you use the dotted notation, use the configuration `astronomer.houston.config.deployments.enableListAllRuntimeVersions=true`. 
+After enabling this configuration, the System Administrator can see the equivalent version of Astro Runtime in the **Migrate to Runtime-[Version number]** button. Note that all AC equivalent Runtime versions prior to 2.2.5 are deprecated.
 
 ## Astronomer Houston API migration considerations
 

--- a/software/migrate-to-runtime.md
+++ b/software/migrate-to-runtime.md
@@ -31,7 +31,13 @@ Astro Runtime includes additional features which are not available in AC images,
 
 See [Runtime Architecture](runtime-image-architecture.mdx) for more detailed information about Runtime's distribution and features.
 
-All versions of AC have an equivalent version of Astro Runtime. To see the equivalent version of Astro Runtime for a Deployment running AC, open the Deployment in the Software UI and go to **Settings**. The equivalent version of Astro Runtime is shown in the **Migrate to Runtime-[Version number]** button.
+Only AC Versions that are 2.2.5 and greater have equivalent Runtime versions. To see the equivalent version of Astro Runtime for a Deployment running AC in the **Deployment Settings** page, you need to set the following configuration:
+
+```yaml
+ enableListAllRuntimeVersions: true
+```
+
+After enabling this configuration, the System Administrator can see the equivalent version of Astro Runtime in the **Migrate to Runtime-[Version number]** button. Note that all AC equivalent Runtime versions are deprecated other than version 2.2.5 and greater.
 
 ## Astronomer Houston API migration considerations
 

--- a/software/migrate-to-runtime.md
+++ b/software/migrate-to-runtime.md
@@ -41,7 +41,6 @@ astronomer:
         enableListAllRuntimeVersions: true
 ```
 
-If you use the dotted notation, use the configuration `astronomer.houston.config.deployments.enableListAllRuntimeVersions=true`. 
 After enabling this configuration, the System Administrator can see the equivalent version of Astro Runtime in the **Migrate to Runtime-[Version number]** button. Note that all AC equivalent Runtime versions prior to 2.2.5 are deprecated.
 
 ## Astronomer Houston API migration considerations

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -59,8 +59,6 @@ Kubernetes versions 1.25 and 1.26 are not supported in Software version 0.35.2 a
             enableListAllRuntimeVersions: true
     ```
 
-Or use the alternative dot notation configuration, `astronomer.houston.config.deployments.enableListAllRuntimeVersions=true`.
-
 ### Bug fixes
 
 - Fixed a bug where the DAG server on Openshift platform failed to replace default security context Helm values.

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -53,9 +53,9 @@ Kubernetes versions 1.25 and 1.26 are not supported in Software version 0.35.2 a
 
     ```yaml
     astronomer:
-    houston:
+      houston:
         config:
-        deployments:
+          deployments:
             enableListAllRuntimeVersions: true
     ```
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -52,6 +52,17 @@ Kubernetes versions 1.25 and 1.26 are not supported in Software version 0.35.2 a
       extraEnv:
         RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR: 1
     ```
+- Added persistence section to the DAG server config, which can be passed to the Airflow Helm chart.
+
+    ```yaml
+    global:
+      dagOnlyDeployment:
+        enabled: true
+        persistence:
+          persistentVolumeClaimRetentionPolicy:
+            whenDeleted: Delete
+            whenScaled: Retain
+    ```
 
 ### Behavior changes
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -37,7 +37,7 @@ Kubernetes versions 1.25 and 1.26 are not supported in Software version 0.35.2 a
 ### Additional improvements
 
 - The Astronomer Software UI now lists yanked versions of the Astro Runtime. These versions contain potential bugs and are to be used as per user discretion. See [Restricted Runtime versions](https://www.astronomer.io/docs/software/runtime-version-lifecycle-policy#restricted-runtime-versions) for more information about yanked versions.
-- Updated the configuration so that code deploy revision data and DAG folder PVC cleanup jobs are enabled per Deployment, if you use the deploy rollback feature.
+- Updated the configuration so that code deploy revision data and DAG folder PVC cleanup jobs are enabled per Deployment if you use the deploy rollback feature.
 - Added `priorityClass` support for `fluentd` and `prometheus-node-exporter` daemonsets. Include the following configuration to use:
 
     ```yaml
@@ -51,10 +51,10 @@ Kubernetes versions 1.25 and 1.26 are not supported in Software version 0.35.2 a
 
 ### Bug fixes
 
-- Fixed a bug where the DAG server on Openshift platform fails to replace default security context Helm values.
-- Fixed a bug that causes DAG-only deplooys to fail when rollbacks were disabled.
+- Fixed a bug where the DAG server on Openshift platform failed to replace default security context Helm values.
+- Fixed a bug that causes DAG-only deploys to fail when rollbacks were disabled.
 - Fixed a bug in DAG-only deploys that were causing unhandled exceptions.
-- Fixed a bug that caused the DAG folder PVC to be depleted when a user switches from a DAG-only deploys to any other code deploy type.
+- Fixed a bug that caused the DAG folder PVC to be depleted when a user switches from DAG-only deploys to any other code deploy type.
 - Fixed a bug in the deploy revision history page in the Astro Software UI that caused the date range query to fail if you set it to less than 90 days for the cleanup policy.
 
 ## 0.35.1

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -26,6 +26,28 @@ If you're upgrading to receive a specific change, ensure the release note for th
 
 :::
 
+## 0.35.2
+
+Release date: July 31, 2024
+
+### End of support for k8s versions 1.25 and 1.26
+
+k8s versions 1.25 and 1.26 are not supported in Software version 0.35.2 and future versions.
+
+### Additional improvements
+
+- Added `priorityClass` support for `fluentd` and `prometheus-node-exporter` daemonsets. See [ADD LINK TO ENV VAR UPDATE].
+- The Astronomer Software UI now lists yanked versions of the Astro Runtime. These versions contain potential bugs and are to be used as per user disccretion. See [ADD LINK Version compatibility reference] for more information about yanked and restricted versions.
+- Updated the configuration so that code deploy revision data and DAG folder PVC cleanup jobs are enabled per Deployment if you use the deploy rollback feature.
+
+### Bug fixes
+
+- Fixed a bug where the DAG server on Openshift platform fails to replace default security context Helm values.
+- Fixed a bug that causes DAG-only deplooys to fail when rollbacks were disabled.
+- Fixed a bug in DAG-only deploys that were causing unhandled exceptions.
+- Fixed a bug that caused the DAG folder PVC to be depleted when a user switches from a DAG-only deploys to any other code deploy type.
+- Fixed a bug in the deploy revision history page in the Astro Software UI that caused the date range query to fail if you set it to less than 90 days for the cleanup policy.
+
 ## 0.35.1
 
 Release date: July 15, 2024

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -30,15 +30,24 @@ If you're upgrading to receive a specific change, ensure the release note for th
 
 Release date: July 31, 2024
 
-### End of support for k8s versions 1.25 and 1.26
+### End of support for Kubernetes versions 1.25 and 1.26
 
-k8s versions 1.25 and 1.26 are not supported in Software version 0.35.2 and future versions.
+Kubernetes versions 1.25 and 1.26 are not supported in Software version 0.35.2 and future versions. See [Kubernetes version support table and policy](https://www.astronomer.io/docs/software/version-compatibility-reference#kubernetes-version-support-table-and-policy) for a full list of supported Kubernetes versions and the Software versions they correspond to.
 
 ### Additional improvements
 
-- Added `priorityClass` support for `fluentd` and `prometheus-node-exporter` daemonsets. See [ADD LINK TO ENV VAR UPDATE].
-- The Astronomer Software UI now lists yanked versions of the Astro Runtime. These versions contain potential bugs and are to be used as per user disccretion. See [ADD LINK Version compatibility reference] for more information about yanked and restricted versions.
-- Updated the configuration so that code deploy revision data and DAG folder PVC cleanup jobs are enabled per Deployment if you use the deploy rollback feature.
+- The Astronomer Software UI now lists yanked versions of the Astro Runtime. These versions contain potential bugs and are to be used as per user discretion. See [Restricted Runtime versions](https://www.astronomer.io/docs/software/runtime-version-lifecycle-policy#restricted-runtime-versions) for more information about yanked versions.
+- Updated the configuration so that code deploy revision data and DAG folder PVC cleanup jobs are enabled per Deployment, if you use the deploy rollback feature.
+- Added `priorityClass` support for `fluentd` and `prometheus-node-exporter` daemonsets. Include the following configuration to use:
+
+    ```yaml
+
+    fluentd:
+        priorityClassName: <valid-class-name>
+    prometheus-node-exporter:
+        priorityClassName: <valid-class-name>
+
+  ```
 
 ### Bug fixes
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -45,14 +45,21 @@ Kubernetes versions 1.25 and 1.26 are not supported in Software version 0.35.2 a
       priorityClassName: <valid-class-name>
     prometheus-node-exporter:
       priorityClassName: <valid-class-name>
+    ```
 
 ### Behavior changes
 
 - When [migrating to an Astro Runtime from Astronomer Certified (AC)](https://www.astronomer.io/docs/software/migrate-to-runtime#differences-between-astro-runtime-and-astronomer-certified), only AC Versions that are 2.2.5 and greater have equivalent Runtime versions. Previously, you could see equivalent versions of the Astro Runtime you could choose to migrate to in the UI. Now, to see the equivalent version of Astro Runtime for a Deployment running AC in the **Deployment Settings** page, you need to set the following configuration:
 
     ```yaml
-    enableListAllRuntimeVersions: true
+    astronomer:
+    houston:
+        config:
+        deployments:
+            enableListAllRuntimeVersions: true
     ```
+
+Or use the alternative dot notation configuration, `astronomer.houston.config.deployments.enableListAllRuntimeVersions=true`.
 
 ### Bug fixes
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -41,13 +41,10 @@ Kubernetes versions 1.25 and 1.26 are not supported in Software version 0.35.2 a
 - Added `priorityClass` support for `fluentd` and `prometheus-node-exporter` daemonsets. Include the following configuration to use this functionality.
 
     ```yaml
-
     fluentd:
-        priorityClassName: <valid-class-name>
+      priorityClassName: <valid-class-name>
     prometheus-node-exporter:
-        priorityClassName: <valid-class-name>
-
-  ```
+      priorityClassName: <valid-class-name>
 
 ### Behavior changes
 
@@ -63,7 +60,7 @@ Kubernetes versions 1.25 and 1.26 are not supported in Software version 0.35.2 a
 - Fixed a bug that causes DAG-only deploys to fail when rollbacks were disabled.
 - Fixed a bug in DAG-only deploys that were causing unhandled exceptions.
 - Fixed a bug that caused the DAG folder PVC to be depleted when a user switches from DAG-only deploys to any other code deploy type.
-- Fixed a bug in the deploy revision history page in the Astro Software UI that caused the date range query to fail if you set it to less than 90 days for the cleanup policy.
+- Fixed a bug in the deploy revision history page in the Astronomer Software UI that caused the date range query to fail if you set it to less than 90 days for the cleanup policy.
 
 ## 0.35.1
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -38,7 +38,7 @@ Kubernetes versions 1.25 and 1.26 are not supported in Software version 0.35.2 a
 
 - The Astronomer Software UI now lists yanked versions of the Astro Runtime. These versions contain potential bugs and are to be used as per user discretion. See [Restricted Runtime versions](https://www.astronomer.io/docs/software/runtime-version-lifecycle-policy#restricted-runtime-versions) for more information about yanked versions.
 - Updated the configuration so that code deploy revision data and DAG folder PVC cleanup jobs are enabled per Deployment if you use the deploy rollback feature.
-- Added `priorityClass` support for `fluentd` and `prometheus-node-exporter` daemonsets. Include the following configuration to use:
+- Added `priorityClass` support for `fluentd` and `prometheus-node-exporter` daemonsets. Include the following configuration to use this functionality.
 
     ```yaml
 
@@ -48,6 +48,14 @@ Kubernetes versions 1.25 and 1.26 are not supported in Software version 0.35.2 a
         priorityClassName: <valid-class-name>
 
   ```
+
+### Behavior changes
+
+- When [migrating to an Astro Runtime from Astronomer Certified (AC)](https://www.astronomer.io/docs/software/migrate-to-runtime#differences-between-astro-runtime-and-astronomer-certified), only AC Versions that are 2.2.5 and greater have equivalent Runtime versions. Previously, you could see equivalent versions of the Astro Runtime you could choose to migrate to in the UI. Now, to see the equivalent version of Astro Runtime for a Deployment running AC in the **Deployment Settings** page, you need to set the following configuration:
+
+    ```yaml
+    enableListAllRuntimeVersions: true
+    ```
 
 ### Bug fixes
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -28,7 +28,7 @@ If you're upgrading to receive a specific change, ensure the release note for th
 
 ## 0.35.2
 
-Release date: July 31, 2024
+Release date: August 1, 2024
 
 ### End of support for Kubernetes versions 1.25 and 1.26
 

--- a/software/release-notes.md
+++ b/software/release-notes.md
@@ -37,7 +37,6 @@ Kubernetes versions 1.25 and 1.26 are not supported in Software version 0.35.2 a
 ### Additional improvements
 
 - The Astronomer Software UI now lists yanked versions of the Astro Runtime. These versions contain potential bugs and are to be used as per user discretion. See [Restricted Runtime versions](https://www.astronomer.io/docs/software/runtime-version-lifecycle-policy#restricted-runtime-versions) for more information about yanked versions.
-- Updated the configuration so that code deploy revision data and DAG folder PVC cleanup jobs are enabled per Deployment if you use the deploy rollback feature.
 - Added `priorityClass` support for `fluentd` and `prometheus-node-exporter` daemonsets. Include the following configuration to use this functionality.
 
     ```yaml
@@ -45,6 +44,13 @@ Kubernetes versions 1.25 and 1.26 are not supported in Software version 0.35.2 a
       priorityClassName: <valid-class-name>
     prometheus-node-exporter:
       priorityClassName: <valid-class-name>
+    ```
+- Added support for `extraEnv` to `fluentd` so that you can pass custom variables. You can use the following configuration for this functionality:
+
+    ```yaml
+    fluentd:
+      extraEnv:
+        RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR: 1
     ```
 
 ### Behavior changes

--- a/software/runtime-version-lifecycle-policy.mdx
+++ b/software/runtime-version-lifecycle-policy.mdx
@@ -51,6 +51,20 @@ When the maintenance window for a given version of Runtime ends, the following i
 
 Maintenance is discontinued the last day of the month for a given version. For example, if the maintenance window for a version of Astro Runtime is January - June of a given year, that version will be maintained by Astronomer until the last day of June.
 
+### Restricted runtime versions
+
+There are some restricted versions of the Astro runtime that have known bugs and can't be used even if you enabled [deprecated Astro Runtime versions](https://docs.astronomer.io/astro/upgrade-runtime#run-a-deprecated-astro-runtime-version).
+
+#### Yanked versions
+
+| Runtime version | Yanked reason                                           |
+| --------------- | ------------------------------------------------------- |
+| 8.0.0           | Does not apply cluster policies defined through pluggy. |
+| 9.0.0 - 9.6.0   | Has significant scheduling performance issues.          |
+| 11.0.0 - 11.1.0 | Has db migration issues when you have running triggers. |
+
+You can find a comprehensive list of available, deprecated, and restricted versions of the Astro Runtime versions at [`updates.astronomer.io`](https://updates.astronomer.io/astronomer-runtime). Restricted versions of the Astro Runtime have the status `"yanked":true` and include a description about why the version is unavailable.
+
 ## Security
 
 Astronomer continuously checks for available security fixes for software used in Astro Runtime. This process includes scanning language dependencies, container images, and open source threat intelligence sources. When a security fix is available, Astronomer evaluates potential risks for organizations using Astro Runtime and determines deployment priority. Low priority fixes are deployed following the regular maintenance policy as described in [Astro Runtime maintenance policy](runtime-version-lifecycle-policy.mdx#astro-runtime-maintenance-policy).

--- a/software/runtime-version-lifecycle-policy.mdx
+++ b/software/runtime-version-lifecycle-policy.mdx
@@ -63,7 +63,7 @@ There are some restricted versions of the Astro runtime that have known bugs and
 | 9.0.0 - 9.6.0   | Has significant scheduling performance issues.          |
 | 11.0.0 - 11.1.0 | Has db migration issues when you have running triggers. |
 
-You can find a comprehensive list of available, deprecated, and restricted versions of the Astro Runtime versions at [`updates.astronomer.io`](https://updates.astronomer.io/astronomer-runtime). Restricted versions of the Astro Runtime have the status `"yanked":true` and include a description about why the version is unavailable.
+You can find a comprehensive list of available, deprecated, and restricted versions of the Astro Runtime versions at [`updates.astronomer.io`](https://updates.astronomer.io/astronomer-runtime). Restricted versions of the Astro Runtime have the status `"yanked":true` and include a description of why the version is unavailable.
 
 ## Security
 

--- a/software/runtime-version-lifecycle-policy.mdx
+++ b/software/runtime-version-lifecycle-policy.mdx
@@ -53,7 +53,7 @@ Maintenance is discontinued the last day of the month for a given version. For e
 
 ### Restricted runtime versions
 
-There are some restricted versions of the Astro runtime that have known bugs and can't be used even if you enabled [deprecated Astro Runtime versions](https://docs.astronomer.io/astro/upgrade-runtime#run-a-deprecated-astro-runtime-version).
+There are some restricted versions of the Astro runtime that have known bugs and shouldn't be used.
 
 #### Yanked versions
 
@@ -63,7 +63,7 @@ There are some restricted versions of the Astro runtime that have known bugs and
 | 9.0.0 - 9.6.0   | Has significant scheduling performance issues.          |
 | 11.0.0 - 11.1.0 | Has db migration issues when you have running triggers. |
 
-You can find a comprehensive list of available, deprecated, and restricted versions of the Astro Runtime versions at [`updates.astronomer.io`](https://updates.astronomer.io/astronomer-runtime). Restricted versions of the Astro Runtime have the status `"yanked":true` and include a description of why the version is unavailable.
+You can find a comprehensive list of available, deprecated, and restricted versions of the Astro Runtime versions at [`updates.astronomer.io`](https://updates.astronomer.io/astronomer-runtime). Yanked versions of the Astro Runtime have the status `"yanked":true` and include a description of why it isn't recommended that you use this version .
 
 ## Security
 

--- a/software/version-compatibility-reference.md
+++ b/software/version-compatibility-reference.md
@@ -53,7 +53,7 @@ See the following table for all supported Kubernetes versions in each maintained
 |       0.34.0        |                 |                 |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |                 |                 |
 |   0.34.1 - 0.34.2   |                 |                 |                 |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |                 |
 |   0.35.0 -0.35.1    |                 |                 |                 |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |
-
+|       0.35.2        |                 |                 |                 |                 |                 |       ✔️        |       ✔️        |       ✔️        |       ✔️        |
 
 ### General recommendations for Kubernetes upgrades
 
@@ -101,6 +101,7 @@ Use the following table to see the Airflow Helm chart version for each supported
 | 0.34.2                      | 1.10.2                                |
 | 0.35.0                      | 1.11.0                                |
 | 0.35.1                      | 1.11.0                                |
+| 0.35.2                      | 1.11.0                                |
 
 ## Legacy version compatibility reference
 

--- a/software_versioned_docs/version-0.34/version-compatibility-reference.md
+++ b/software_versioned_docs/version-0.34/version-compatibility-reference.md
@@ -53,6 +53,7 @@ See the following table for all supported Kubernetes versions in each maintained
 |       0.34.0        |                 |                 |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |                 |                 |
 |   0.34.1 - 0.34.3   |                 |                 |                 |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |                 |
 |   0.35.0 -0.35.1    |                 |                 |                 |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |       ✔️        |
+|       0.35.2        |                 |                 |                 |                 |                 |       ✔️        |       ✔️        |       ✔️        |       ✔️        |
 
 
 For more information on upgrading Kubernetes versions, follow the guidelines offered by your cloud provider.
@@ -96,6 +97,7 @@ Use the following table to see the Airflow Helm chart version for each supported
 | 0.34.3                      | 1.10.2                                |
 | 0.35.0                      | 1.11.0                                |
 | 0.35.1                      | 1.11.0                                |
+| 0.35.2                      | 1.11.0                                |
 
 ## Legacy version compatibility reference
 


### PR DESCRIPTION
Changes include:

* Added yanked version information to `manage-airflow-versions.md` + `runtime-version-lifecycle-policy.md` with approved text used for Astro in https://github.com/astronomer/docs/pull/3736
* Added K8s version change for `0.35.2` to no longer support 1.25 or 1.26 in `version-compatibility-reference.md`
* Added `0.35.2`  to ` Airflow chart compatibility reference` chart in  `version-compatibility-reference.md`
* Added behavior changes related to migrating to Astro Runtime from AC in `migrate-to-runtime.md`
* Added release notes