### PR TITLE
Metrics Wordage

### DIFF
--- a/astro/universal-metrics-export.md
+++ b/astro/universal-metrics-export.md
@@ -26,9 +26,9 @@ While [Deployment Analytics](deployment-metrics.md), [Deployment health incident
 
 You can use this information to right-size Celery workers, optimize your usage of the Kubernetes executor, and stay informed about task execution status.
 
-## Metric types
+## Metric categories
 
-There are two types of metrics that you can export using the Universal Metrics Exporter:
+There are two categories of metrics that you can export using the Universal Metrics Exporter:
 
 - Airflow application level metrics
 - Infrastructure level metrics


### PR DESCRIPTION
Can we move away from the term "metric types" and use "metric categories" instead? "Metric types" is already a term used in this field to describe the datatypes like Counter, Gauge, Histogram etc. This change should disambiguate from using that term to describe categories.