### PR TITLE
Update airflow-advanced-cluster-policies.md

### DIFF
--- a/learn/airflow-advanced-cluster-policies.md
+++ b/learn/airflow-advanced-cluster-policies.md
@@ -180,7 +180,7 @@ plugin/
 │
 ├── src/
 │   ├── __init__.py
-│   └── plugin_package/
+│   └── policy_plugin/
 │       ├── __init__.py
 │       └── policy.py
 │


### PR DESCRIPTION
Directory name did not match reference in `pyproject.toml`, would lead to error when starting Astro project.