### PR TITLE
add separate dag processor service account

### DIFF
--- a/astro/authorize-deployments-to-your-cloud.md
+++ b/astro/authorize-deployments-to-your-cloud.md
@@ -89,6 +89,7 @@ Available for both Standard and Dedicated clusters. If your organization does no
         "StringLike": {
             "<clusterOIDCIssuerUrl>:aud": "sts.amazonaws.com",
             "<clusterOIDCIssuerUrl>:sub": "system:serviceaccount:<DeploymentNamespace>:<DeploymentNamespace>-kpo"
+            "<clusterOIDCIssuerUrl>:sub": "system:serviceaccount:<DeploymentNamespace>:<DeploymentNamespace>-dag-processor-serviceaccount"
             "<clusterOIDCIssuerUrl>:sub": "system:serviceaccount:<DeploymentNamespace>:<DeploymentNamespace>-scheduler-serviceaccount"
             "<clusterOIDCIssuerUrl>:sub": "system:serviceaccount:<DeploymentNamespace>:<DeploymentNamespace>-triggerer-serviceaccount"
             "<clusterOIDCIssuerUrl>:sub": "system:serviceaccount:<DeploymentNamespace>:<DeploymentNamespace>-webserver-serviceaccount"


### PR DESCRIPTION
Updates instructions for configuring custom workload identity on AWS to account for upcoming introduction of a separate DAG processor. Users will need to give their AWS Custom Workload Identity access to the dag-processor service. 

Affected docs: https://www.astronomer.io/docs/astro/authorize-deployments-to-your-cloud#attach-an-iam-role-to-your-deployment